### PR TITLE
Redesign PCS modal with Apple-style sheet layout

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -221,6 +221,16 @@ function toggleNotifPanel() {
   if (open) { fetchAndRenderNotifications(); markAllNotificationsRead(); }
 }
 
+// -- PCS Activity toggle -----------------------
+function togglePCSActivity() {
+  const body = document.getElementById('pcs-activity-body');
+  const section = document.getElementById('pcs-history-section');
+  if (!body) return;
+  const isOpen = body.style.display !== 'none';
+  body.style.display = isOpen ? 'none' : 'block';
+  if (section) section.classList.toggle('expanded', !isOpen);
+}
+
 // -- Zen mode ----------------------------------
 function openZen(title, comments) {
   const overlay = document.getElementById('zen-overlay');

--- a/index.html
+++ b/index.html
@@ -694,32 +694,37 @@
 <div id="pcs-overlay" onclick="if(event.target===this)closePCS()">
   <div id="pcs-screen">
 
-    <!-- Header: back (abs) | centered title + subtitle | menu (abs) -->
+    <!-- Header: close (left) | delete (right), centered title + metadata -->
     <div class="pcs-header">
-      <button class="pcs-back" onclick="closePCS()">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+      <button class="pcs-close-btn" onclick="closePCS()" aria-label="Close">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <button class="pcs-delete-btn" onclick="pcsConfirmDelete()" aria-label="Delete">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
       </button>
       <div class="pcs-header-center">
         <div class="pcs-title" id="pcs-topbar-title"></div>
         <div class="pcs-subtitle" id="pcs-subtitle"></div>
       </div>
-      <button class="pcs-menu" onclick="pcsConfirmDelete()">⋯</button>
     </div>
 
     <!-- Scrollable content -->
     <div class="pcs-scroll" id="pcs-scroll">
-      <!-- Stage progress -->
-      <div id="pcs-progress-wrap"></div>
-      <!-- Primary action (Canva / LinkedIn) -->
-      <div id="pcs-action-btn-wrap"></div>
-      <!-- Next action button -->
-      <div id="pcs-next-action-wrap"></div>
-      <!-- Information section -->
-      <div id="pcs-fields"></div>
-      <!-- History section -->
-      <div class="pcs-section" id="pcs-history-section">
-        <div class="pcs-section-label">History</div>
-        <div class="pcs-activity-body" id="pcs-activity-body"></div>
+      <!-- Pipeline progress -->
+      <div class="pcs-body-section" id="pcs-progress-wrap"></div>
+      <!-- Action controls -->
+      <div class="pcs-body-section" id="pcs-next-action-wrap"></div>
+      <!-- Tool card (Design/LinkedIn) -->
+      <div class="pcs-body-section" id="pcs-action-btn-wrap"></div>
+      <!-- Information grid + Notes -->
+      <div class="pcs-body-section" id="pcs-fields"></div>
+      <!-- Activity (collapsed by default) -->
+      <div class="pcs-body-section pcs-activity-section" id="pcs-history-section">
+        <button class="pcs-activity-toggle" id="pcs-activity-toggle" onclick="togglePCSActivity()">
+          <span>Activity</span>
+          <svg class="pcs-activity-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
+        <div class="pcs-activity-body" id="pcs-activity-body" style="display:none"></div>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -3012,101 +3012,117 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 
 /* ═══════════════════════════════════════════════
-   PCS — Post Control Screen (premium bottom sheet)
+   PCS — Post Control Screen (Apple-style modal sheet)
 ═══════════════════════════════════════════════ */
 
+/* ── Overlay ── */
 #pcs-overlay {
   position: fixed;
   inset: 0;
   z-index: 800;
   display: none;
-  background: rgba(0,0,0,0.5);
-  align-items: flex-end;
+  background: rgba(0,0,0,0.35);
+  align-items: center;
   justify-content: center;
 }
 #pcs-overlay.open { display: flex; }
 
+/* ── Modal card ── */
 #pcs-screen {
   display: flex;
   flex-direction: column;
-  height: 72vh;
   width: 100%;
-  max-width: 640px;
-  background: var(--bg);
-  border-radius: 20px 20px 0 0;
-  box-shadow: 0 -12px 40px rgba(0,0,0,0.3);
+  max-width: 480px;
+  max-height: 90vh;
+  background: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 24px 80px rgba(0,0,0,0.18), 0 8px 24px rgba(0,0,0,0.10);
   overflow: hidden;
   will-change: transform;
-  transform: translateY(100%);
-  transition: transform 0.28s cubic-bezier(0.32, 0.72, 0, 1);
-  overscroll-behavior: contain;
+  transform: translateY(40px) scale(0.97);
+  opacity: 0;
+  transition: transform 0.28s cubic-bezier(0.32, 0.72, 0, 1),
+              opacity 0.22s ease;
 }
 #pcs-overlay.open #pcs-screen {
-  transform: translateY(0);
+  transform: translateY(0) scale(1);
+  opacity: 1;
 }
 
-/* Header */
+/* Mobile: bottom sheet on small screens */
+@media (max-width: 540px) {
+  #pcs-overlay { align-items: flex-end; }
+  #pcs-screen {
+    max-width: 100%;
+    max-height: 88vh;
+    border-radius: 20px 20px 0 0;
+    transform: translateY(100%);
+    opacity: 1;
+  }
+  #pcs-overlay.open #pcs-screen {
+    transform: translateY(0);
+  }
+}
+
+/* ── Header ── */
 .pcs-header {
-  position: sticky;
-  padding: 12px 52px;
+  position: relative;
+  padding: 20px 20px 12px;
   text-align: center;
   flex-shrink: 0;
-  top: 0;
-  z-index: 10;
-  background: var(--bg);
-  border-bottom: 1px solid rgba(0,0,0,0.06);
+  border-bottom: 1px solid #e5e7eb;
 }
-.pcs-back {
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text2);
-  border-radius: 10px;
-}
-.pcs-back:active { background: var(--surface2); }
 
-.pcs-menu {
+.pcs-close-btn,
+.pcs-delete-btn {
   position: absolute;
-  right: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 36px;
-  height: 36px;
+  top: 16px;
+  width: 32px;
+  height: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 18px;
-  color: var(--text2);
-  border-radius: 10px;
+  border-radius: 50%;
+  background: #f3f4f6;
+  color: #6b7280;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s ease;
 }
-.pcs-menu:active { background: var(--surface2); }
+.pcs-close-btn { left: 16px; }
+.pcs-delete-btn { right: 16px; }
+.pcs-close-btn:hover,
+.pcs-delete-btn:hover { background: #e5e7eb; }
+.pcs-close-btn:active,
+.pcs-delete-btn:active { background: #d1d5db; }
 
 .pcs-header-center {
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding: 0 44px;
   min-width: 0;
 }
+
+/* Title */
 .pcs-title {
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 700;
-  color: var(--text);
-  filter: brightness(1.15);
-  line-height: 1.25;
+  color: #111111;
+  line-height: 1.3;
   letter-spacing: -0.3px;
   text-align: center;
-  max-width: 80%;
+  max-width: 100%;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
-  margin-bottom: 3px;
+  margin-bottom: 8px;
+  filter: none;
 }
+
+/* Subtitle / Metadata */
 .pcs-subtitle {
   display: flex;
   align-items: center;
@@ -3114,94 +3130,129 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   gap: 0;
   flex-wrap: wrap;
   font-size: 12px;
-  color: var(--text3);
+  color: #6b7280;
 }
 .pcs-subtitle span { white-space: nowrap; }
 .pcs-subtitle-stage { font-weight: 600; letter-spacing: 0.01em; }
 .pcs-subtitle-sep {
   margin: 0 5px;
-  opacity: 0.4;
+  color: #d1d5db;
 }
 
-/* Scroll area */
+/* ── Scroll area ── */
 .pcs-scroll {
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-  padding: 16px 16px 40px;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
+  padding: 0 20px 32px;
   min-height: 0;
 }
 
-/* ── Stage progress ── */
+/* Body sections — unified left-aligned spacing */
+.pcs-body-section {
+  margin-top: 16px;
+}
+.pcs-body-section:first-child {
+  margin-top: 16px;
+}
+.pcs-body-section:empty {
+  display: none;
+}
+
+/* ── Pipeline progress ── */
 .pcs-progress {
   display: flex;
-  align-items: center;
-  padding: 4px 0 2px;
-  margin-top: 24px;
-  margin-bottom: 28px;
+  align-items: flex-start;
+  padding: 0;
+  margin: 0;
 }
 .prog-step {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   flex-shrink: 0;
+  cursor: pointer;
 }
 .prog-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--border);
-  transition: background 0.2s;
-}
-.prog-dot.done    { background: var(--c-green); }
-.prog-dot.active  {
   width: 10px;
   height: 10px;
-  background: var(--bg);
-  border: 2.5px solid var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-dim);
+  border-radius: 50%;
+  background: #d1d5db;
+  transition: all 0.2s ease;
+}
+.prog-dot.done {
+  background: #10b981;
+}
+.prog-dot.active {
+  width: 12px;
+  height: 12px;
+  background: #ffffff;
+  border: 2.5px solid #2563eb;
+  box-shadow: 0 0 0 3px rgba(37,99,235,0.15);
 }
 .prog-label {
-  font-size: 9px;
+  font-size: 10px;
   font-weight: 600;
-  color: var(--text3);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  color: #6b7280;
+  letter-spacing: 0.02em;
   white-space: nowrap;
 }
-.prog-step:has(.prog-dot.active) .prog-label { color: var(--accent); }
-.prog-step:has(.prog-dot.done) .prog-label   { color: var(--c-green); }
+.prog-step:has(.prog-dot.active) .prog-label { color: #2563eb; }
+.prog-step:has(.prog-dot.done) .prog-label   { color: #10b981; }
 .prog-line {
   flex: 1;
-  height: 1px;
-  background: var(--border);
-  margin-bottom: 14px;
-  min-width: 6px;
+  height: 2px;
+  background: #e5e7eb;
+  margin-top: 5px;
+  min-width: 8px;
 }
 
-/* ── Design block ── */
+/* ── Action controls ── */
+.pcs-next-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 40px;
+  padding: 0 20px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #111111;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.pcs-next-action-btn:hover {
+  background: #e5e7eb;
+}
+.pcs-next-action-btn:active {
+  background: #d1d5db;
+}
+.pcs-next-action-info {
+  font-size: 13px;
+  color: #6b7280;
+  padding: 4px 0;
+}
+
+/* ── Tool card (Design / LinkedIn) ── */
 .pcs-design-block {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 12px 14px;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin-bottom: 16px;
 }
-.pcs-design-empty { opacity: 0.8; }
+.pcs-design-empty { opacity: 0.85; }
 .pcs-design-info {
   display: flex;
   align-items: center;
   gap: 10px;
 }
-/* Design icon — text-based, no fake SVG */
 .design-icon-wrap {
   width: 32px;
   height: 32px;
@@ -3213,9 +3264,9 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-weight: 800;
   flex-shrink: 0;
 }
-.design-icon-canva   { background: #7D2AE8; color: #fff; }
+.design-icon-canva    { background: #7D2AE8; color: #fff; }
 .design-icon-linkedin { background: #0A66C2; color: #fff; }
-.design-icon-empty   { background: var(--surface); border: 1.5px dashed var(--border); color: var(--text3); }
+.design-icon-empty    { background: #f3f4f6; border: 1.5px dashed #d1d5db; color: #6b7280; }
 .pcs-design-text {
   flex: 1;
   min-width: 0;
@@ -3225,20 +3276,21 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--text3);
+  color: #6b7280;
 }
 .pcs-design-status {
   font-size: 14px;
   font-weight: 500;
-  color: var(--text);
+  color: #111111;
   margin-top: 1px;
 }
-.pcs-design-status.muted { color: var(--text3); }
+.pcs-design-status.muted { color: #6b7280; }
 .pcs-design-actions {
   display: flex;
   gap: 8px;
   align-items: stretch;
 }
+
 /* Inline URL attach row */
 .pcs-attach-row {
   display: flex;
@@ -3248,25 +3300,27 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .pcs-attach-input {
   flex: 1;
   height: 36px;
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
   border-radius: 8px;
   padding: 0 10px;
   font-size: 13px;
-  color: var(--text);
+  color: #111111;
   font-family: inherit;
   min-width: 0;
 }
-.pcs-attach-input:focus { outline: none; border-color: var(--accent); }
+.pcs-attach-input:focus { outline: none; border-color: #2563eb; }
 .pcs-attach-save {
   height: 36px;
   padding: 0 14px;
-  background: var(--accent);
-  color: var(--bg);
+  background: #2563eb;
+  color: #ffffff;
   border-radius: 8px;
   font-size: 13px;
   font-weight: 600;
   flex-shrink: 0;
+  border: none;
+  cursor: pointer;
 }
 .pcs-attach-save:active { opacity: 0.85; }
 .pcs-primary {
@@ -3274,102 +3328,76 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 44px;
-  background: var(--accent);
-  color: var(--bg);
+  height: 40px;
+  background: #f3f4f6;
+  color: #111111;
   font-size: 14px;
   font-weight: 600;
   border-radius: 10px;
   text-decoration: none;
-  transition: transform 0.08s ease, opacity 0.12s ease;
+  border: 1px solid #e5e7eb;
+  transition: background 0.12s ease;
 }
-.pcs-primary:active { transform: scale(0.97); opacity: 0.88; text-decoration: none; }
+.pcs-primary:hover { background: #e5e7eb; }
+.pcs-primary:active { background: #d1d5db; text-decoration: none; }
 .pcs-design-replace {
   padding: 0 14px;
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
   border-radius: 10px;
   font-size: 13px;
   font-weight: 500;
-  color: var(--text2);
+  color: #6b7280;
   white-space: nowrap;
-  align-self: stretch;
+  cursor: pointer;
 }
-.pcs-design-replace:active { background: var(--surface3); }
+.pcs-design-replace:hover { background: #e5e7eb; }
+.pcs-design-replace:active { background: #d1d5db; }
 
-/* ── Next action button ── */
-.pcs-next-action-btn {
-  width: 100%;
-  height: 52px;
-  background: var(--surface2);
-  border: 2px solid var(--accent);
-  border-radius: 12px;
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
-  text-align: center;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.18);
-  margin-bottom: 16px;
-  transition: transform 0.08s ease, background 0.12s, box-shadow 0.12s, border-color 0.12s;
-}
-.pcs-next-action-btn:hover {
-  border-color: var(--accent);
-  background: var(--surface2);
-}
-.pcs-next-action-btn:active {
-  transform: scale(0.98);
-  background: var(--surface3);
-  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-}
-.pcs-next-action-info {
-  font-size: 13px;
-  color: var(--text3);
-  text-align: center;
-  padding: 10px 0;
-}
-
-/* ── Section containers ── */
+/* ── Section containers (Info, Notes) ── */
 .pcs-section {
-  background: var(--surface2);
-  margin-bottom: 16px;
-  border-radius: 14px;
-  padding: 14px 16px;
+  margin-bottom: 0;
+  margin-top: 20px;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
+  background: transparent;
+  border-radius: 0;
 }
+.pcs-section:first-child { margin-top: 0; }
 .pcs-section-label {
-  font-size: 11px;
-  font-weight: 700;
+  font-size: 12px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--text3);
+  letter-spacing: 0.06em;
+  color: #6b7280;
 }
 
 /* ── Information grid ── */
 .pcs-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 14px 20px;
+  gap: 16px 20px;
 }
 .pcs-field {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 4px;
 }
 .pcs-field-label {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text3);
-  margin-bottom: 2px;
+  letter-spacing: 0.04em;
+  color: #6b7280;
+  margin-bottom: 0;
 }
 .pcs-field-val {
   border: none;
   background: transparent;
-  color: var(--text);
-  font-size: 14px;
+  color: #111111;
+  font-size: 15px;
   font-weight: 600;
   font-family: inherit;
   padding: 0;
@@ -3379,134 +3407,153 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   -webkit-appearance: none;
   cursor: pointer;
 }
-.pcs-field-val:focus { outline: none; color: var(--accent); }
-.pcs-field-val:disabled { opacity: 0.55; cursor: default; }
+.pcs-field-val:focus { outline: none; color: #2563eb; }
+.pcs-field-val:disabled { opacity: 0.45; cursor: default; }
 .pcs-field-val-ro {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
-  color: var(--text);
+  color: #111111;
 }
 
-
-/* Date field — icon + value inline */
+/* Date field */
 .pcs-date-field {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 .pcs-date-value {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 500;
-  color: var(--text);
+  color: #111111;
 }
 .pcs-date-icon {
   font-size: 14px;
-  opacity: 0.6;
+  opacity: 0.5;
   flex-shrink: 0;
   line-height: 1;
-}
-
-/* Section card spacing — prevent sections from visually merging */
-.pcs-section + .pcs-section,
-#pcs-history-section {
-  margin-top: 20px;
 }
 
 /* ── Notes ── */
 .pcs-notes-input {
   border: none;
   background: transparent;
-  color: var(--text);
-  font-size: 14px;
+  color: #111111;
+  font-size: 15px;
   font-family: inherit;
   line-height: 1.55;
-  min-height: 60px;
+  min-height: 56px;
   resize: none;
   width: 100%;
   padding: 0;
 }
 .pcs-notes-input:focus { outline: none; }
-.pcs-notes-input::placeholder { color: var(--text3); }
+.pcs-notes-input::placeholder { color: #9ca3af; }
 .pcs-notes-ro {
-  font-size: 14px;
-  color: var(--text2);
+  font-size: 15px;
+  color: #374151;
   line-height: 1.55;
 }
 
-/* ── History ── */
-#pcs-history-section {
-  background: var(--surface2);
-  border-radius: 14px;
-  padding: 14px 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+/* ── Activity section (collapsed by default) ── */
+.pcs-activity-section {
+  border-top: 1px solid #e5e7eb;
+  padding-top: 12px;
+  margin-top: 20px;
 }
+.pcs-activity-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: #6b7280;
+  padding: 0;
+  font-family: inherit;
+  transition: color 0.12s ease;
+}
+.pcs-activity-toggle:hover { color: #111111; }
+.pcs-activity-chevron {
+  transition: transform 0.2s ease;
+}
+.pcs-activity-section.expanded .pcs-activity-chevron {
+  transform: rotate(90deg);
+}
+
 .pcs-activity-body {
   display: flex;
   flex-direction: column;
   gap: 0;
+  margin-top: 10px;
 }
 .pcs-activity-row {
   display: flex;
   align-items: baseline;
-  gap: 4px;
-  padding: 6px 0;
-  border-bottom: 1px solid var(--border);
-  font-size: 12px;
+  gap: 6px;
+  padding: 5px 0;
+  border-bottom: 1px solid #f3f4f6;
+  font-size: 11px;
 }
 .pcs-activity-row:last-child { border-bottom: none; }
-.pcs-activity-who { font-weight: 600; color: var(--text2); flex-shrink: 0; }
-.pcs-activity-what { flex: 1; color: var(--text3); }
-.pcs-activity-when { font-size: 11px; color: var(--text3); flex-shrink: 0; white-space: nowrap; }
+.pcs-activity-who { font-weight: 600; color: #374151; flex-shrink: 0; }
+.pcs-activity-what { flex: 1; color: #6b7280; }
+.pcs-activity-when { font-size: 11px; color: #9ca3af; flex-shrink: 0; white-space: nowrap; }
 .pcs-activity-loading,
-.pcs-activity-empty { font-size: 12px; color: var(--text3); padding: 4px 0; }
+.pcs-activity-empty { font-size: 12px; color: #6b7280; padding: 4px 0; }
 
-/* Delete confirm */
+/* ── Delete confirm ── */
 .pcs-confirm-overlay {
   position: fixed;
   inset: 0;
   z-index: 1200;
-  background: rgba(0,0,0,0.5);
+  background: rgba(0,0,0,0.35);
   display: flex;
-  align-items: flex-end;
-  padding: 16px;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
 }
 .pcs-confirm-sheet {
-  background: var(--surface);
+  background: #ffffff;
   border-radius: 16px;
   padding: 24px 20px 20px;
   width: 100%;
+  max-width: 360px;
+  box-shadow: 0 16px 48px rgba(0,0,0,0.15);
 }
 .pcs-confirm-msg {
   font-size: 15px;
   font-weight: 600;
-  color: var(--text);
+  color: #111111;
   margin-bottom: 20px;
   line-height: 1.4;
 }
 .pcs-confirm-btns { display: flex; gap: 10px; }
 .pcs-confirm-cancel {
   flex: 1; height: 44px; border-radius: 10px;
-  border: 1px solid var(--border); color: var(--text2);
-  font-size: 15px; font-weight: 600; background: var(--surface2);
+  border: 1px solid #e5e7eb; color: #6b7280;
+  font-size: 15px; font-weight: 600; background: #f3f4f6;
+  cursor: pointer;
 }
+.pcs-confirm-cancel:hover { background: #e5e7eb; }
 .pcs-confirm-delete {
   flex: 1; height: 44px; border-radius: 10px;
-  background: var(--c-red, #ef4444); color: #fff;
+  background: #ef4444; color: #fff;
   font-size: 15px; font-weight: 700;
+  border: none; cursor: pointer;
 }
+.pcs-confirm-delete:hover { background: #dc2626; }
 
 /* End screen */
 .pcs-end-screen {
   flex: 1; display: flex; flex-direction: column;
   align-items: center; justify-content: center;
-  gap: 12px; color: var(--text3); font-size: 15px;
+  gap: 12px; color: #6b7280; font-size: 15px;
 }
 .pcs-end-icon { font-size: 40px; }
 
 /* Legacy compat */
 .pcs-footer { display: none; }
-
-/* Next action wrap margin */
-#pcs-next-action-wrap { margin-top: 4px; }
+.pcs-back { display: none; }
+.pcs-menu { display: none; }


### PR DESCRIPTION
- Centered modal card on desktop, bottom sheet on mobile (<540px)
- Header: X close button (left) + trash delete button (right) + centered title/metadata
- Title: 20px, max 2 lines with ellipsis, 8px gap to metadata
- Pipeline: visible labels under dots, color-coded (completed=#10b981, current=#2563eb, future=#d1d5db)
- Action controls: compact 40px buttons with #f3f4f6 background
- Tool card: lighter #f9fafb background, separated from actions
- Information grid: 2-column, 12px field labels, 15px values
- Notes: visible by default, inline editable
- Activity: collapsed by default with chevron toggle
- White (#ffffff) card background, rgba(0,0,0,0.35) overlay
- Consistent 16px/20px section spacing throughout
- No swipe/touch/drag listeners introduced
- Only UI files modified: index.html, styles.css, 10-ui.js

https://claude.ai/code/session_01BsyBRGRusrNzduExyRkbQj