### PR TITLE
Redesign PCS layout: 3-zone structure with theme-aware styling

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -450,40 +450,29 @@ function _renderPCS(postId) {
   // Title — dominant element
   if (elTitle) elTitle.textContent = title;
 
-  // Subtitle: only non-empty parts, stage gets colour, pillar as short label
+  // Metadata row: Owner · Pillar · Target Date — clean centered line
   if (elSubtitle) {
     const pillarLabel = post.contentPillar
       ? (PILLAR_SHORT[post.contentPillar] || PILLAR_DISPLAY[post.contentPillar] || post.contentPillar)
       : '';
+    const dateValue = isPublished
+      ? (post.published_date || post.publishedDate || post.targetDate || '')
+      : (post.targetDate || '');
+    const dateDisplay = formatDate(dateValue) || '';
     const parts = [
-      stageLabel    ? `<span class="pcs-subtitle-stage" style="color:${hex}">${esc(stageLabel)}</span>` : '',
       post.owner    ? `<span>${esc(post.owner)}</span>`    : '',
-      post.location ? `<span>${esc(post.location)}</span>` : '',
       pillarLabel   ? `<span>${esc(pillarLabel)}</span>`   : '',
+      dateDisplay   ? `<span>${esc(dateDisplay)}</span>`   : '',
     ].filter(Boolean);
-    elSubtitle.innerHTML = parts.join('<span class="pcs-subtitle-sep">·</span>');
+    elSubtitle.innerHTML = parts.join('<span class="pcs-subtitle-sep">\u00b7</span>');
   }
 
   // Stage progress
   if (elProgress) elProgress.innerHTML = _buildStageProgress(stageLC);
 
-  // Design block
-  if (elDesign) elDesign.innerHTML = _buildDesignBlock(postLink, isPublished, canEdit, id);
-
-  // Next Action button
-  if (elNext) {
-    const { label: naLabel, nextStage } = _pcsNextAction(stageLC);
-    if (naLabel && canEdit && nextStage) {
-      elNext.innerHTML =
-        `<button class="pcs-next-action-btn" onclick="pcsDoNextAction('${esc(id)}','${esc(nextStage)}')">
-           ${esc(naLabel)} →
-         </button>`;
-    } else if (naLabel) {
-      elNext.innerHTML = `<div class="pcs-next-action-info">${esc(naLabel)}</div>`;
-    } else {
-      elNext.innerHTML = '';
-    }
-  }
+  // Inline action row — replaces the old large next-action button + design block
+  if (elNext) elNext.innerHTML = '';  // clear legacy next-action slot
+  if (elDesign) elDesign.innerHTML = _buildInlineActions(postLink, isPublished, canEdit, id, stageLC);
 
   // Information + Notes sections
   if (elFields) elFields.innerHTML = _buildPCSGrid(post, canEdit, id);
@@ -527,59 +516,45 @@ function _buildStageProgress(stageLC) {
   return `<div class="pcs-progress">${dots}</div>`;
 }
 
-function _buildDesignBlock(postLink, isPublished, canEdit, postId) {
-  // State 2: published/LinkedIn link
+function _buildInlineActions(postLink, isPublished, canEdit, postId, stageLC) {
+  const chips = [];
+  const { label: naLabel, nextStage } = _pcsNextAction(stageLC);
+  const { hex } = stageStyle(stageLC);
+
+  // Stage chip — advance or informational
+  if (naLabel && canEdit && nextStage) {
+    chips.push(`<button class="pcs-action-chip pcs-action-chip--stage" onclick="pcsDoNextAction('${esc(postId)}','${esc(nextStage)}')">${esc(naLabel)}</button>`);
+  } else if (naLabel) {
+    chips.push(`<span class="pcs-action-chip pcs-action-chip--info">${esc(naLabel)}</span>`);
+  }
+
+  // Canva / LinkedIn chips
   if (isPublished && postLink) {
-    return `<div class="pcs-design-block">
-      <div class="pcs-design-info">
-        <div class="design-icon-wrap design-icon-linkedin">in</div>
-        <div class="pcs-design-text">
-          <div class="pcs-design-label">Post</div>
-          <div class="pcs-design-status">Published on LinkedIn</div>
-        </div>
-      </div>
-      <div class="pcs-design-actions">
-        <a href="${esc(postLink)}" target="_blank" rel="noopener" class="pcs-primary" onclick="closePCS()">View on LinkedIn ↗</a>
-      </div>
-    </div>`;
+    chips.push(`<a href="${esc(postLink)}" target="_blank" rel="noopener" class="pcs-action-chip pcs-action-chip--linkedin" onclick="closePCS()">LinkedIn ↗</a>`);
+  } else if (postLink) {
+    chips.push(`<a href="${esc(postLink)}" target="_blank" rel="noopener" class="pcs-action-chip pcs-action-chip--canva" onclick="closePCS()">Canva ↗</a>`);
+    if (canEdit) chips.push(`<button class="pcs-action-chip pcs-action-chip--secondary" onclick="pcsToggleAttach('${esc(postId)}')">Replace</button>`);
+  } else if (canEdit) {
+    chips.push(`<button class="pcs-action-chip pcs-action-chip--secondary" onclick="pcsToggleAttach('${esc(postId)}')">+ Design</button>`);
   }
 
-  // State 1: Canva link exists
-  if (postLink) {
-    return `<div class="pcs-design-block">
-      <div class="pcs-design-info">
-        <div class="design-icon-wrap design-icon-canva">C</div>
-        <div class="pcs-design-text">
-          <div class="pcs-design-label">Design</div>
-          <div class="pcs-design-status">Canva connected</div>
-        </div>
-      </div>
-      <div class="pcs-design-actions">
-        <a href="${esc(postLink)}" target="_blank" rel="noopener" class="pcs-primary" onclick="closePCS()">Open Canva ↗</a>
-        ${canEdit ? `<button class="pcs-design-replace" onclick="pcsToggleAttach('${esc(postId)}')">Replace</button>` : ''}
-      </div>
-      ${canEdit ? `<div class="pcs-attach-row" id="pcs-attach-row-${esc(postId)}" style="display:none">
-        <input type="url" class="pcs-attach-input" id="pcs-attach-input-${esc(postId)}" placeholder="Paste new Canva URL…">
+  // Attach URL row (hidden by default, toggled via pcsToggleAttach)
+  const attachRow = canEdit
+    ? `<div class="pcs-attach-row" id="pcs-attach-row-${esc(postId)}" style="display:none">
+        <input type="url" class="pcs-attach-input" id="pcs-attach-input-${esc(postId)}" placeholder="Paste Canva URL…">
         <button class="pcs-attach-save" onclick="pcsSaveAttach('${esc(postId)}')">Save</button>
-      </div>` : ''}
-    </div>`;
-  }
+      </div>`
+    : '';
 
-  // State 3: no link
-  if (!canEdit) return '';
-  return `<div class="pcs-design-block pcs-design-empty">
-    <div class="pcs-design-info">
-      <div class="design-icon-wrap design-icon-empty">+</div>
-      <div class="pcs-design-text">
-        <div class="pcs-design-label">Design</div>
-        <div class="pcs-design-status muted">No design attached</div>
-      </div>
-    </div>
-    <div class="pcs-attach-row" id="pcs-attach-row-${esc(postId)}">
-      <input type="url" class="pcs-attach-input" id="pcs-attach-input-${esc(postId)}" placeholder="Paste Canva URL…">
-      <button class="pcs-attach-save" onclick="pcsSaveAttach('${esc(postId)}')">Attach</button>
-    </div>
-  </div>`;
+  return `<div class="pcs-inline-actions">${chips.join('')}</div>${attachRow}`;
+}
+
+// Legacy alias — called by pcsSaveAttach to re-render the action area
+function _buildDesignBlock(postLink, isPublished, canEdit, postId) {
+  const stageLC = (_pcs.postId && allPosts.find(p => getPostId(p) === _pcs.postId))
+    ? (allPosts.find(p => getPostId(p) === _pcs.postId).stage || '').toLowerCase().trim()
+    : '';
+  return _buildInlineActions(postLink, isPublished, canEdit, postId, stageLC);
 }
 
 function pcsToggleAttach(postId) {
@@ -729,9 +704,9 @@ function _buildPCSGrid(post, canEdit, id) {
     : `<div class="pcs-date-field"><span class="pcs-date-value">${esc(formatDate(dateValue) || '—')}</span>${formatDate(dateValue) ? '<span class="pcs-date-icon">📅</span>' : ''}</div>`;
 
   const notesInput = canEdit
-    ? `<textarea class="pcs-notes-input" placeholder="Brief or caption…" rows="3"
-                 onblur="updatePost('${esc(id)}','comments',this.value)">${esc(post.comments || '')}</textarea>`
-    : (post.comments ? `<div class="pcs-notes-ro">${esc(post.comments)}</div>` : '');
+    ? `<div class="pcs-notes-box"><textarea class="pcs-notes-input" placeholder="Brief or caption…" rows="3"
+                 onblur="updatePost('${esc(id)}','comments',this.value)">${esc(post.comments || '')}</textarea></div>`
+    : (post.comments ? `<div class="pcs-notes-box"><div class="pcs-notes-ro">${esc(post.comments)}</div></div>` : '');
 
   const cell = (label, content) =>
     `<div class="pcs-field">

--- a/styles.css
+++ b/styles.css
@@ -3013,6 +3013,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 /* ═══════════════════════════════════════════════
    PCS — Post Control Screen (Apple-style modal sheet)
+   Redesigned: 3-zone layout with consistent spacing rhythm
+   8px micro · 16px section · 24px major
 ═══════════════════════════════════════════════ */
 
 /* ── Overlay ── */
@@ -3021,20 +3023,20 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   inset: 0;
   z-index: 800;
   display: none;
-  background: rgba(0,0,0,0.35);
+  background: rgba(0,0,0,0.4);
   align-items: center;
   justify-content: center;
 }
 #pcs-overlay.open { display: flex; }
 
-/* ── Modal card ── */
+/* ── Modal card — theme-aware ── */
 #pcs-screen {
   display: flex;
   flex-direction: column;
   width: 100%;
   max-width: 480px;
   max-height: 90vh;
-  background: #ffffff;
+  background: var(--surface);
   border-radius: 20px;
   box-shadow: 0 24px 80px rgba(0,0,0,0.18), 0 8px 24px rgba(0,0,0,0.10);
   overflow: hidden;
@@ -3064,51 +3066,53 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   }
 }
 
-/* ── Header ── */
+/* ═══════════════════════════════════════════════
+   ZONE 1 — HEADER (title + metadata + pipeline)
+═══════════════════════════════════════════════ */
 .pcs-header {
   position: relative;
-  padding: 20px 20px 12px;
+  padding: 24px 24px 0;
   text-align: center;
   flex-shrink: 0;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: none;
 }
 
 .pcs-close-btn,
 .pcs-delete-btn {
   position: absolute;
-  top: 16px;
+  top: 24px;
   width: 32px;
   height: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 50%;
-  background: #f3f4f6;
-  color: #6b7280;
+  background: var(--surface2);
+  color: var(--text2);
   border: none;
   cursor: pointer;
   transition: background 0.15s ease;
 }
-.pcs-close-btn { left: 16px; }
-.pcs-delete-btn { right: 16px; }
+.pcs-close-btn { left: 20px; }
+.pcs-delete-btn { right: 20px; }
 .pcs-close-btn:hover,
-.pcs-delete-btn:hover { background: #e5e7eb; }
+.pcs-delete-btn:hover { background: var(--surface3); }
 .pcs-close-btn:active,
-.pcs-delete-btn:active { background: #d1d5db; }
+.pcs-delete-btn:active { background: var(--border2); }
 
 .pcs-header-center {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 0 44px;
+  padding: 0 48px;
   min-width: 0;
 }
 
-/* Title */
+/* Title — most visually prominent element */
 .pcs-title {
   font-size: 20px;
   font-weight: 700;
-  color: #111111;
+  color: var(--text);
   line-height: 1.3;
   letter-spacing: -0.3px;
   text-align: center;
@@ -3118,25 +3122,29 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 8px;
+  margin-bottom: 0;
   filter: none;
 }
 
-/* Subtitle / Metadata */
+/* Metadata row — Owner · Pillar · Date */
 .pcs-subtitle {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 0;
-  flex-wrap: wrap;
-  font-size: 12px;
-  color: #6b7280;
+  flex-wrap: nowrap;
+  font-size: 13px;
+  color: var(--text2);
+  margin-top: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .pcs-subtitle span { white-space: nowrap; }
 .pcs-subtitle-stage { font-weight: 600; letter-spacing: 0.01em; }
 .pcs-subtitle-sep {
-  margin: 0 5px;
-  color: #d1d5db;
+  margin: 0 6px;
+  color: var(--text3);
 }
 
 /* ── Scroll area ── */
@@ -3145,11 +3153,11 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-  padding: 0 20px 32px;
+  padding: 0 24px 24px;
   min-height: 0;
 }
 
-/* Body sections — unified left-aligned spacing */
+/* Body sections — consistent spacing rhythm */
 .pcs-body-section {
   margin-top: 16px;
 }
@@ -3160,11 +3168,12 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   display: none;
 }
 
-/* ── Pipeline progress ── */
+/* ── Pipeline progress row ── */
 .pcs-progress {
   display: flex;
   align-items: flex-start;
-  padding: 0;
+  justify-content: center;
+  padding: 16px 0 24px;
   margin: 0;
 }
 .prog-step {
@@ -3172,148 +3181,169 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   flex-direction: column;
   align-items: center;
   gap: 6px;
-  flex-shrink: 0;
-  cursor: pointer;
+  flex: 1;
+  min-width: 0;
 }
 .prog-dot {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #d1d5db;
+  background: var(--border2);
   transition: all 0.2s ease;
 }
 .prog-dot.done {
-  background: #10b981;
+  background: var(--c-green);
 }
 .prog-dot.active {
   width: 12px;
   height: 12px;
-  background: #ffffff;
-  border: 2.5px solid #2563eb;
-  box-shadow: 0 0 0 3px rgba(37,99,235,0.15);
+  background: var(--surface);
+  border: 2.5px solid var(--c-blue);
+  box-shadow: 0 0 0 3px var(--c-blue-dim);
 }
 .prog-label {
   font-size: 10px;
   font-weight: 600;
-  color: #6b7280;
+  color: var(--text3);
   letter-spacing: 0.02em;
   white-space: nowrap;
+  text-align: center;
 }
-.prog-step:has(.prog-dot.active) .prog-label { color: #2563eb; }
-.prog-step:has(.prog-dot.done) .prog-label   { color: #10b981; }
+.prog-step:has(.prog-dot.active) .prog-label { color: var(--c-blue); }
+.prog-step:has(.prog-dot.done) .prog-label   { color: var(--c-green); }
 .prog-line {
   flex: 1;
   height: 2px;
-  background: #e5e7eb;
+  background: var(--border);
   margin-top: 5px;
   min-width: 8px;
 }
 
-/* ── Action controls ── */
+/* ═══════════════════════════════════════════════
+   ZONE 2 — INLINE ACTION ROW
+   Replaces the old large next-action button
+═══════════════════════════════════════════════ */
+.pcs-inline-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+
+.pcs-action-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 34px;
+  padding: 0 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  border: 1px solid var(--border2);
+  background: var(--surface2);
+  color: var(--text);
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.pcs-action-chip:hover { background: var(--surface3); }
+.pcs-action-chip:active { background: var(--border2); }
+
+/* Stage advance chip — subtle primary emphasis */
+.pcs-action-chip--stage {
+  background: var(--c-blue-dim);
+  border-color: transparent;
+  color: var(--c-blue);
+}
+.pcs-action-chip--stage:hover { background: var(--c-blue-dim); filter: brightness(1.1); }
+
+/* Informational chip (no action) */
+.pcs-action-chip--info {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text3);
+  cursor: default;
+  font-weight: 500;
+}
+.pcs-action-chip--info:hover { background: transparent; }
+
+/* Canva chip */
+.pcs-action-chip--canva {
+  background: rgba(125,42,232,0.10);
+  border-color: transparent;
+  color: #7D2AE8;
+}
+[data-theme="dark"] .pcs-action-chip--canva { color: #b68aff; background: rgba(125,42,232,0.18); }
+.pcs-action-chip--canva:hover { filter: brightness(1.1); }
+
+/* LinkedIn chip */
+.pcs-action-chip--linkedin {
+  background: rgba(10,102,194,0.10);
+  border-color: transparent;
+  color: #0A66C2;
+}
+[data-theme="dark"] .pcs-action-chip--linkedin { color: #5ba3e6; background: rgba(10,102,194,0.18); }
+.pcs-action-chip--linkedin:hover { filter: brightness(1.1); }
+
+/* Secondary chip (Replace, + Design) */
+.pcs-action-chip--secondary {
+  background: var(--surface2);
+  color: var(--text2);
+  font-weight: 500;
+}
+
+/* Legacy action controls — kept for compat */
 .pcs-next-action-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 40px;
-  padding: 0 20px;
-  background: #f3f4f6;
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
-  font-size: 14px;
+  height: 34px;
+  padding: 0 14px;
+  background: var(--c-blue-dim);
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
   font-weight: 600;
-  color: #111111;
+  color: var(--c-blue);
   cursor: pointer;
   transition: background 0.12s ease;
 }
-.pcs-next-action-btn:hover {
-  background: #e5e7eb;
-}
-.pcs-next-action-btn:active {
-  background: #d1d5db;
-}
+.pcs-next-action-btn:hover { filter: brightness(1.1); }
 .pcs-next-action-info {
   font-size: 13px;
-  color: #6b7280;
+  color: var(--text3);
   padding: 4px 0;
-}
-
-/* ── Tool card (Design / LinkedIn) ── */
-.pcs-design-block {
-  background: #f9fafb;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.pcs-design-empty { opacity: 0.85; }
-.pcs-design-info {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.design-icon-wrap {
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 14px;
-  font-weight: 800;
-  flex-shrink: 0;
-}
-.design-icon-canva    { background: #7D2AE8; color: #fff; }
-.design-icon-linkedin { background: #0A66C2; color: #fff; }
-.design-icon-empty    { background: #f3f4f6; border: 1.5px dashed #d1d5db; color: #6b7280; }
-.pcs-design-text {
-  flex: 1;
-  min-width: 0;
-}
-.pcs-design-label {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: #6b7280;
-}
-.pcs-design-status {
-  font-size: 14px;
-  font-weight: 500;
-  color: #111111;
-  margin-top: 1px;
-}
-.pcs-design-status.muted { color: #6b7280; }
-.pcs-design-actions {
-  display: flex;
-  gap: 8px;
-  align-items: stretch;
+  text-align: center;
 }
 
 /* Inline URL attach row */
 .pcs-attach-row {
   display: flex;
-  gap: 6px;
+  gap: 8px;
   align-items: center;
+  margin-top: 8px;
 }
 .pcs-attach-input {
   flex: 1;
-  height: 36px;
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
+  height: 34px;
+  background: var(--surface);
+  border: 1px solid var(--border2);
   border-radius: 8px;
   padding: 0 10px;
   font-size: 13px;
-  color: #111111;
+  color: var(--text);
   font-family: inherit;
   min-width: 0;
 }
-.pcs-attach-input:focus { outline: none; border-color: #2563eb; }
+.pcs-attach-input:focus { outline: none; border-color: var(--c-blue); }
 .pcs-attach-save {
-  height: 36px;
+  height: 34px;
   padding: 0 14px;
-  background: #2563eb;
+  background: var(--c-blue);
   color: #ffffff;
   border-radius: 8px;
   font-size: 13px;
@@ -3323,41 +3353,47 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   cursor: pointer;
 }
 .pcs-attach-save:active { opacity: 0.85; }
+
+/* Legacy design block classes — kept for pcsSaveAttach re-render compat */
+.pcs-design-block { display: none; }
 .pcs-primary {
-  flex: 1;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 40px;
-  background: #f3f4f6;
-  color: #111111;
-  font-size: 14px;
+  height: 34px;
+  padding: 0 14px;
+  background: var(--surface2);
+  color: var(--text);
+  font-size: 13px;
   font-weight: 600;
-  border-radius: 10px;
+  border-radius: 8px;
   text-decoration: none;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--border2);
   transition: background 0.12s ease;
 }
-.pcs-primary:hover { background: #e5e7eb; }
-.pcs-primary:active { background: #d1d5db; text-decoration: none; }
+.pcs-primary:hover { background: var(--surface3); }
+.pcs-primary:active { background: var(--border2); text-decoration: none; }
 .pcs-design-replace {
   padding: 0 14px;
-  background: #f3f4f6;
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
+  background: var(--surface2);
+  border: 1px solid var(--border2);
+  border-radius: 8px;
   font-size: 13px;
   font-weight: 500;
-  color: #6b7280;
+  color: var(--text2);
   white-space: nowrap;
   cursor: pointer;
 }
-.pcs-design-replace:hover { background: #e5e7eb; }
-.pcs-design-replace:active { background: #d1d5db; }
+.pcs-design-replace:hover { background: var(--surface3); }
 
-/* ── Section containers (Info, Notes) ── */
+/* ═══════════════════════════════════════════════
+   ZONE 3 — CONTENT (Info grid, Notes, Activity)
+═══════════════════════════════════════════════ */
+
+/* ── Section containers ── */
 .pcs-section {
   margin-bottom: 0;
-  margin-top: 20px;
+  margin-top: 16px;
   padding: 0;
   display: flex;
   flex-direction: column;
@@ -3367,18 +3403,18 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 .pcs-section:first-child { margin-top: 0; }
 .pcs-section-label {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #6b7280;
+  color: var(--text3);
 }
 
 /* ── Information grid ── */
 .pcs-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 16px 20px;
+  gap: 16px 24px;
 }
 .pcs-field {
   display: flex;
@@ -3386,17 +3422,17 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   gap: 4px;
 }
 .pcs-field-label {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: #6b7280;
+  color: var(--text3);
   margin-bottom: 0;
 }
 .pcs-field-val {
   border: none;
   background: transparent;
-  color: #111111;
+  color: var(--text);
   font-size: 15px;
   font-weight: 600;
   font-family: inherit;
@@ -3407,12 +3443,12 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   -webkit-appearance: none;
   cursor: pointer;
 }
-.pcs-field-val:focus { outline: none; color: #2563eb; }
+.pcs-field-val:focus { outline: none; color: var(--c-blue); }
 .pcs-field-val:disabled { opacity: 0.45; cursor: default; }
 .pcs-field-val-ro {
   font-size: 15px;
   font-weight: 600;
-  color: #111111;
+  color: var(--text);
 }
 
 /* Date field */
@@ -3424,7 +3460,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .pcs-date-value {
   font-size: 15px;
   font-weight: 500;
-  color: #111111;
+  color: var(--text);
 }
 .pcs-date-icon {
   font-size: 14px;
@@ -3433,11 +3469,16 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   line-height: 1;
 }
 
-/* ── Notes ── */
+/* ── Notes box — subtle container ── */
+.pcs-notes-box {
+  background: var(--surface2);
+  border-radius: 10px;
+  padding: 12px;
+}
 .pcs-notes-input {
   border: none;
   background: transparent;
-  color: #111111;
+  color: var(--text);
   font-size: 15px;
   font-family: inherit;
   line-height: 1.55;
@@ -3447,18 +3488,18 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   padding: 0;
 }
 .pcs-notes-input:focus { outline: none; }
-.pcs-notes-input::placeholder { color: #9ca3af; }
+.pcs-notes-input::placeholder { color: var(--text3); }
 .pcs-notes-ro {
   font-size: 15px;
-  color: #374151;
+  color: var(--text2);
   line-height: 1.55;
 }
 
 /* ── Activity section (collapsed by default) ── */
 .pcs-activity-section {
-  border-top: 1px solid #e5e7eb;
-  padding-top: 12px;
-  margin-top: 20px;
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+  margin-top: 24px;
 }
 .pcs-activity-toggle {
   display: flex;
@@ -3469,12 +3510,12 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   cursor: pointer;
   font-size: 13px;
   font-weight: 600;
-  color: #6b7280;
+  color: var(--text2);
   padding: 0;
   font-family: inherit;
   transition: color 0.12s ease;
 }
-.pcs-activity-toggle:hover { color: #111111; }
+.pcs-activity-toggle:hover { color: var(--text); }
 .pcs-activity-chevron {
   transition: transform 0.2s ease;
 }
@@ -3486,70 +3527,70 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   display: flex;
   flex-direction: column;
   gap: 0;
-  margin-top: 10px;
+  margin-top: 8px;
 }
 .pcs-activity-row {
   display: flex;
   align-items: baseline;
-  gap: 6px;
-  padding: 5px 0;
-  border-bottom: 1px solid #f3f4f6;
-  font-size: 11px;
+  gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
 }
 .pcs-activity-row:last-child { border-bottom: none; }
-.pcs-activity-who { font-weight: 600; color: #374151; flex-shrink: 0; }
-.pcs-activity-what { flex: 1; color: #6b7280; }
-.pcs-activity-when { font-size: 11px; color: #9ca3af; flex-shrink: 0; white-space: nowrap; }
+.pcs-activity-who { font-weight: 600; color: var(--text2); flex-shrink: 0; }
+.pcs-activity-what { flex: 1; color: var(--text3); }
+.pcs-activity-when { font-size: 11px; color: var(--text3); flex-shrink: 0; white-space: nowrap; }
 .pcs-activity-loading,
-.pcs-activity-empty { font-size: 12px; color: #6b7280; padding: 4px 0; }
+.pcs-activity-empty { font-size: 12px; color: var(--text3); padding: 4px 0; }
 
-/* ── Delete confirm ── */
+/* ── Delete confirm — theme-aware ── */
 .pcs-confirm-overlay {
   position: fixed;
   inset: 0;
   z-index: 1200;
-  background: rgba(0,0,0,0.35);
+  background: rgba(0,0,0,0.4);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
+  padding: 24px;
 }
 .pcs-confirm-sheet {
-  background: #ffffff;
+  background: var(--surface);
   border-radius: 16px;
-  padding: 24px 20px 20px;
+  padding: 24px;
   width: 100%;
   max-width: 360px;
-  box-shadow: 0 16px 48px rgba(0,0,0,0.15);
+  box-shadow: 0 16px 48px rgba(0,0,0,0.2);
 }
 .pcs-confirm-msg {
   font-size: 15px;
   font-weight: 600;
-  color: #111111;
+  color: var(--text);
   margin-bottom: 20px;
   line-height: 1.4;
 }
-.pcs-confirm-btns { display: flex; gap: 10px; }
+.pcs-confirm-btns { display: flex; gap: 8px; }
 .pcs-confirm-cancel {
   flex: 1; height: 44px; border-radius: 10px;
-  border: 1px solid #e5e7eb; color: #6b7280;
-  font-size: 15px; font-weight: 600; background: #f3f4f6;
+  border: 1px solid var(--border2); color: var(--text2);
+  font-size: 15px; font-weight: 600; background: var(--surface2);
   cursor: pointer;
 }
-.pcs-confirm-cancel:hover { background: #e5e7eb; }
+.pcs-confirm-cancel:hover { background: var(--surface3); }
 .pcs-confirm-delete {
   flex: 1; height: 44px; border-radius: 10px;
-  background: #ef4444; color: #fff;
+  background: var(--c-red); color: #fff;
   font-size: 15px; font-weight: 700;
   border: none; cursor: pointer;
 }
-.pcs-confirm-delete:hover { background: #dc2626; }
+.pcs-confirm-delete:hover { filter: brightness(1.1); }
 
 /* End screen */
 .pcs-end-screen {
   flex: 1; display: flex; flex-direction: column;
   align-items: center; justify-content: center;
-  gap: 12px; color: #6b7280; font-size: 15px;
+  gap: 12px; color: var(--text2); font-size: 15px;
 }
 .pcs-end-icon { font-size: 40px; }
 


### PR DESCRIPTION
Zone 1 (Header): 24px top padding, centered title with metadata row (Owner · Pillar · Date) replacing old stage-centric subtitle. Pipeline progress row centered with even flex spacing.

Zone 2 (Actions): Replace large next-action button with compact inline action chips (stage advance, Canva, LinkedIn, Replace). Secondary emphasis, centered row.

Zone 3 (Content): Notes wrapped in subtle .pcs-notes-box container with var(--surface2) background. Activity section with proper 24px major spacing separation.

Dark mode: All hardcoded colors replaced with CSS custom properties (--surface, --text, --border, etc). Modal card, confirm dialog, and all child elements now theme-aware.

Spacing rhythm: 8px micro, 16px section, 24px major applied consistently throughout.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL