### PR TITLE
PCS structural redesign: clean section hierarchy and interaction safety

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -498,6 +498,9 @@ function _renderPCS(postId) {
 // ── Section 1: Inline title editing ──────────────
 function _pcsTitleEdit(el, postId) {
   if (el.querySelector('input')) return; // already editing
+  // Close other interactive layers — only one at a time
+  _removePcsConfirm();
+  pcsCloseAttach(postId);
   const current = el.textContent;
   const input = document.createElement('input');
   input.type = 'text';
@@ -541,6 +544,8 @@ function changeStage(newStage) {
 
 function _showStageConfirm(postId, newStage) {
   _removePcsConfirm();
+  // Close any open attach editor — only one interactive layer at a time
+  if (_pcs.postId) pcsCloseAttach(_pcs.postId);
   const displayName = (typeof STAGE_DISPLAY !== 'undefined' && STAGE_DISPLAY[newStage]) || newStage;
   const overlay = document.createElement('div');
   overlay.className = 'pcs-confirm-overlay';
@@ -621,41 +626,34 @@ function _buildStageProgress(stageLC, canEdit, postId) {
 }
 
 function _buildInlineActions(postLink, isPublished, canEdit, postId, stageLC) {
-  const { label: naLabel, nextStage } = _pcsNextAction(stageLC);
-
-  // Row 1: Next Stage + Canva/LinkedIn
-  const row1 = [];
-  if (naLabel && canEdit && nextStage) {
-    row1.push(`<button class="pcs-action-chip pcs-action-chip--stage" onclick="changeStage('${esc(nextStage)}')">${esc(naLabel)}</button>`);
-  } else if (naLabel) {
-    row1.push(`<span class="pcs-action-chip pcs-action-chip--info">${esc(naLabel)}</span>`);
-  }
-
-  // Link chip — LinkedIn when published, Canva otherwise (Section 7)
+  // Design section — vertical stack: primary link button + replace text
+  // Pipeline is the sole stage control; no Next Stage chip here.
+  let primary = '';
   if (isPublished && postLink) {
-    row1.push(`<a href="${esc(postLink)}" target="_blank" rel="noopener" class="pcs-action-chip pcs-action-chip--linkedin" onclick="closePCS()">LinkedIn ↗</a>`);
+    primary = `<a href="${esc(postLink)}" target="_blank" rel="noopener" class="pcs-action-chip pcs-action-chip--linkedin" onclick="closePCS()">LinkedIn ↗</a>`;
   } else if (postLink) {
-    row1.push(`<a href="${esc(postLink)}" target="_blank" rel="noopener" class="pcs-action-chip pcs-action-chip--canva" onclick="closePCS()">Canva ↗</a>`);
+    primary = `<a href="${esc(postLink)}" target="_blank" rel="noopener" class="pcs-action-chip pcs-action-chip--canva" onclick="closePCS()">Canva ↗</a>`;
   } else if (canEdit) {
-    row1.push(`<button class="pcs-action-chip pcs-action-chip--secondary" onclick="pcsToggleAttach('${esc(postId)}')">+ Design</button>`);
+    primary = `<button class="pcs-action-chip pcs-action-chip--secondary" onclick="pcsToggleAttach('${esc(postId)}')">+ Design</button>`;
   }
 
-  // Row 2: Replace link (low-emphasis text action)
-  let row2 = '';
+  // Replace text — low emphasis, directly below primary
+  let replaceRow = '';
   if (canEdit && postLink) {
     const replaceLabel = isPublished ? 'Replace link' : 'Replace design';
-    row2 = `<div class="pcs-action-row2"><button class="pcs-action-text" onclick="pcsToggleAttach('${esc(postId)}')">${replaceLabel}</button></div>`;
+    replaceRow = `<button class="pcs-action-text" onclick="pcsToggleAttach('${esc(postId)}')">${replaceLabel}</button>`;
   }
 
-  // Attach URL row
+  // Attach URL editor — inline, aligned to primary button width
   const attachRow = canEdit
     ? `<div class="pcs-attach-row" id="pcs-attach-row-${esc(postId)}" style="display:none">
-        <input type="url" class="pcs-attach-input" id="pcs-attach-input-${esc(postId)}" placeholder="Paste URL…">
+        <input type="url" class="pcs-attach-input" id="pcs-attach-input-${esc(postId)}" placeholder="Paste design link...">
         <button class="pcs-attach-save" onclick="pcsSaveAttach('${esc(postId)}')">Save</button>
-      </div>`
+      </div>
+      <button class="pcs-attach-cancel" id="pcs-attach-cancel-${esc(postId)}" style="display:none" onclick="pcsCloseAttach('${esc(postId)}')">Cancel</button>`
     : '';
 
-  return `<div class="pcs-inline-actions">${row1.join('')}</div>${row2}${attachRow}`;
+  return `<div class="pcs-design-stack">${primary}${replaceRow}${attachRow}</div>`;
 }
 
 // Legacy alias — called by pcsSaveAttach to re-render the action area
@@ -668,19 +666,29 @@ function _buildDesignBlock(postLink, isPublished, canEdit, postId) {
 
 function pcsToggleAttach(postId) {
   const row = document.getElementById(`pcs-attach-row-${postId}`);
+  const cancel = document.getElementById(`pcs-attach-cancel-${postId}`);
   if (!row) return;
   const open = row.style.display === 'none';
   row.style.display = open ? 'flex' : 'none';
+  if (cancel) cancel.style.display = open ? '' : 'none';
   if (open) {
+    // Close any confirm overlay first — only one interactive layer at a time
+    _removePcsConfirm();
     const input = document.getElementById(`pcs-attach-input-${postId}`);
     if (input) {
       input.focus();
-      // Escape closes attach row (Section 6)
       input.onkeydown = function(e) {
-        if (e.key === 'Escape') { row.style.display = 'none'; }
+        if (e.key === 'Escape') { pcsCloseAttach(postId); }
       };
     }
   }
+}
+
+function pcsCloseAttach(postId) {
+  const row = document.getElementById(`pcs-attach-row-${postId}`);
+  const cancel = document.getElementById(`pcs-attach-cancel-${postId}`);
+  if (row) row.style.display = 'none';
+  if (cancel) cancel.style.display = 'none';
 }
 
 async function pcsSaveAttach(postId) {
@@ -845,8 +853,9 @@ function _buildPCSGrid(post, canEdit, id) {
        ${content}
      </div>`;
 
-  // Section 9: "Information" label removed — grid stands alone
+  // Information grid — preceded by visual divider
   return `
+    <div class="pcs-info-divider"></div>
     <div class="pcs-section">
       <div class="pcs-grid">
         ${cell('Stage',    stageSel)}
@@ -858,7 +867,7 @@ function _buildPCSGrid(post, canEdit, id) {
       </div>
     </div>
     ${(canEdit || post.comments) ? `
-    <div class="pcs-section">
+    <div class="pcs-section pcs-notes-section">
       <div class="pcs-section-label">Notes</div>
       ${notesInput || '<div class="pcs-activity-empty">No notes.</div>'}
     </div>` : ''}

--- a/styles.css
+++ b/styles.css
@@ -3189,6 +3189,10 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .pcs-body-section:empty {
   display: none;
 }
+/* Design section gets 24px major spacing above */
+#pcs-action-btn-wrap {
+  margin-top: 0;
+}
 
 /* ── Pipeline progress row ── */
 .pcs-progress {
@@ -3213,11 +3217,15 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .prog-step--clickable { cursor: pointer; }
 .prog-step--clickable:hover {
   background: var(--surface2);
+  transform: scale(1.08);
 }
 .prog-step--clickable:hover .prog-dot {
-  box-shadow: 0 0 0 4px var(--surface3);
+  box-shadow: 0 0 0 5px var(--surface3);
 }
-.prog-step--clickable:active { transform: scale(0.93); }
+.prog-step--clickable:hover + .prog-line {
+  background: var(--border2);
+}
+.prog-step--clickable:active { transform: scale(0.95); }
 .prog-dot {
   width: 10px;
   height: 10px;
@@ -3251,12 +3259,25 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   background: var(--border);
   margin-top: 9px;
   min-width: 8px;
+  transition: background 120ms ease;
+}
+/* Brighten connector before hovered step */
+.prog-line:has(+ .prog-step--clickable:hover) {
+  background: var(--border2);
 }
 
 /* ═══════════════════════════════════════════════
-   ZONE 2 — INLINE ACTION ROW
-   Replaces the old large next-action button
+   ZONE 2 — DESIGN SECTION
+   Vertical stack: primary button + replace text
 ═══════════════════════════════════════════════ */
+.pcs-design-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Legacy horizontal layout kept for compatibility */
 .pcs-inline-actions {
   display: flex;
   align-items: center;
@@ -3331,25 +3352,21 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-weight: 500;
 }
 
-/* Row 2: Low-emphasis text action (Replace design / Replace link) */
-.pcs-action-row2 {
-  display: flex;
-  justify-content: center;
-  margin-top: 8px;
-}
+/* Low-emphasis text action (Replace design / Replace link) */
 .pcs-action-text {
   background: none;
   border: none;
-  color: var(--text3);
-  font-size: 12px;
+  color: var(--text);
+  opacity: 0.55;
+  font-size: 13px;
   font-weight: 500;
   font-family: inherit;
   cursor: pointer;
   padding: 4px 8px;
   border-radius: 6px;
-  transition: color 120ms ease, background 120ms ease;
+  transition: opacity 120ms ease, background 120ms ease;
 }
-.pcs-action-text:hover { color: var(--text2); background: var(--surface2); }
+.pcs-action-text:hover { opacity: 0.8; background: var(--surface2); }
 .pcs-action-text:active { transform: scale(0.97); }
 
 /* Legacy action controls — matched to 36px chip height */
@@ -3413,6 +3430,33 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 .pcs-attach-save:hover { filter: brightness(1.1); }
 .pcs-attach-save:active { transform: scale(0.97); }
+/* Cancel text under attach row */
+.pcs-attach-cancel {
+  background: none;
+  border: none;
+  color: var(--text3);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 2px 8px;
+  margin-top: 2px;
+  transition: color 120ms ease;
+}
+.pcs-attach-cancel:hover { color: var(--text2); }
+
+/* ── Information section divider ── */
+.pcs-info-divider {
+  height: 1px;
+  background: var(--border);
+  opacity: 0.5;
+  margin: 24px 0 0;
+}
+
+/* ── Notes section — lighter feel ── */
+.pcs-notes-section {
+  margin-top: 16px;
+}
 
 /* Legacy design block classes — heights matched to 36px */
 .pcs-design-block { display: none; }
@@ -3536,7 +3580,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   background: var(--surface2);
   border: 1px solid var(--border);
   border-radius: 14px;
-  padding: 16px;
+  padding: 14px;
 }
 .pcs-notes-input {
   border: none;


### PR DESCRIPTION
Design section: Remove Next Stage chip — pipeline is now the sole stage control. Restructure to vertical stack with Canva/LinkedIn button on top and low-emphasis "Replace design" text (opacity 0.55) directly below with 6px gap. Add Cancel text under the attach editor.

Pipeline: Hover scales nodes to 1.08 with glow ring (5px surface3 shadow). Adjacent connector lines brighten on hover using both adjacent sibling and :has() selectors. 120ms transitions throughout.

Information section: Add 1px divider (opacity 0.5) before the grid with 24px margin above. Grid remains 2-column with Title Case labels.

Notes section: Separated from information with its own section class. Notes box uses 14px padding and 14px radius for lighter feel.

Interaction stacking: Only one interactive layer may be active at a time. Opening the stage confirm dialog closes any open attach editor. Opening the attach editor closes any confirm dialog. Starting title edit closes both. Implemented via _removePcsConfirm() and pcsCloseAttach() calls at each entry point.

Design section spacing: Body-section for design area uses margin-top 0 since it sits directly below the pipeline's 24px bottom padding.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL