### PR TITLE
PCS modal: final cosmetic polish pass

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3037,9 +3037,9 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   max-width: 520px;
   max-height: 90vh;
   background: var(--surface);
-  border: 1px solid var(--border);
+  border: 1px solid rgba(255,255,255,0.06);
   border-radius: 20px;
-  box-shadow: 0 24px 80px rgba(0,0,0,0.18), 0 8px 24px rgba(0,0,0,0.10);
+  box-shadow: 0 10px 30px rgba(0,0,0,0.45), 0 2px 6px rgba(0,0,0,0.25);
   overflow: hidden;
   will-change: transform;
   transform: translateY(40px) scale(0.97);
@@ -3072,7 +3072,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 ═══════════════════════════════════════════════ */
 .pcs-header {
   position: relative;
-  padding: 72px 24px 0;  /* 48px button zone + 24px gap before title */
+  padding: 64px 24px 0;  /* 40px button zone + 24px gap before title */
   text-align: left;
   flex-shrink: 0;
   border-bottom: none;
@@ -3081,7 +3081,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .pcs-close-btn,
 .pcs-delete-btn {
   position: absolute;
-  top: 8px;             /* vertically centered in 48px header zone */
+  top: 16px;            /* 24px safe spacing from top */
   width: 32px;
   height: 32px;
   display: flex;
@@ -3111,10 +3111,10 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 /* Title — most visually prominent element */
 .pcs-title {
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 600;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.25;
   letter-spacing: -0.3px;
   text-align: left;
   max-width: 100%;
@@ -3133,10 +3133,10 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 .pcs-title-input {
   width: 100%;
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 600;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.25;
   letter-spacing: -0.3px;
   text-align: left;
   background: var(--surface2);
@@ -3158,7 +3158,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-size: 13px;
   color: var(--text);
   opacity: 0.7;
-  margin-top: 4px;
+  margin-top: 6px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -3202,7 +3202,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .pcs-progress {
   display: flex;
   align-items: flex-start;
-  justify-content: center;
+  justify-content: space-between;
   padding: 0 0 8px;
   margin: 0;
 }
@@ -3240,17 +3240,18 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   white-space: nowrap;
   text-align: center;
 }
-.prog-step:has(.prog-dot.active) .prog-label { color: var(--c-blue); opacity: 1; }
+.prog-step:has(.prog-dot.active) .prog-label { color: var(--c-blue); opacity: 1; font-weight: 700; }
 .prog-step:has(.prog-dot.done) .prog-label   { color: var(--c-green); opacity: 1; }
 .prog-line {
   flex: 1;
-  height: 2px;
+  height: 1.5px;
   background: var(--border);
   margin-top: 3px;       /* center with 8px dot */
   min-width: 8px;
+  opacity: 0.7;
 }
 .prog-line--future {
-  opacity: 0.2;
+  opacity: 0.15;
 }
 
 /* ── Action controls ── */
@@ -3361,10 +3362,11 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 /* Canva chip */
 .pcs-action-chip--canva {
-  background: rgba(125,42,232,0.10);
+  background: rgba(125,42,232,0.08);
   border-color: transparent;
   color: #7D2AE8;
   width: 80px;
+  opacity: 0.90;
 }
 [data-theme="dark"] .pcs-action-chip--canva { color: #b68aff; background: rgba(125,42,232,0.18); }
 .pcs-action-chip--canva:hover { filter: brightness(1.1); }
@@ -3391,16 +3393,17 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   background: none;
   border: none;
   color: var(--text);
-  opacity: 0.7;
+  opacity: 0.78;
   font-size: 13px;
   font-weight: 500;
   font-family: inherit;
   cursor: pointer;
   padding: 4px 0;
-  border-radius: 6px;
-  transition: opacity 120ms ease, background 120ms ease;
+  border-radius: 0;
+  text-decoration: none;
+  transition: opacity 120ms ease;
 }
-.pcs-action-text:hover { opacity: 0.8; background: var(--surface2); }
+.pcs-action-text:hover { opacity: 0.95; }
 .pcs-action-text:active { transform: scale(0.97); }
 
 /* Legacy action controls — matched to 36px chip height */
@@ -3549,7 +3552,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-weight: 500;
   letter-spacing: 0.03em;
   color: var(--text);
-  opacity: 0.6;
+  opacity: 0.65;
 }
 
 /* ── Information grid ── */
@@ -3568,7 +3571,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-weight: 500;
   letter-spacing: 0.03em;
   color: var(--text);
-  opacity: 0.6;
+  opacity: 0.65;
   margin-bottom: 0;
 }
 .pcs-field-val {
@@ -3596,8 +3599,9 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 /* Section 7: Date field — full clickable tap area */
 .pcs-date-tap {
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  gap: 6px;
   min-height: 44px;
   cursor: pointer;
 }
@@ -3614,8 +3618,9 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .pcs-notes-box {
   background: var(--surface2);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 12px;
   padding: 12px;
+  opacity: 0.95;
 }
 .pcs-notes-input {
   border: none;


### PR DESCRIPTION
UI-only micro refinements for elevated visual quality:
- Header safe spacing (top: 16px icons, 64px header padding)
- Title hierarchy (22px, semibold, line-height 1.25, 6px gap to metadata)
- Pipeline even distribution (space-between)
- Active stage label emphasis (font-weight 700)
- Connector lines refined (1.5px, reduced opacity)
- Canva chip reduced dominance (opacity 0.90)
- Replace design link styled as clean interactive text (opacity 0.78)
- Metadata labels contrast bump (0.60 → 0.65)
- Date field inline-flex grouping with 6px gap
- Notes container softened (border-radius 12px, opacity 0.95)
- Modal surface depth (stronger shadow, faint rgba border)

No business logic, routing, API, or state changes.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL