### PR TITLE
PCS modal: fix column drift, date escape, pipeline connector

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3269,10 +3269,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   gap: var(--pcs-space-2);
   flex-shrink: 0;
 }
-.pcs-progress > .prog-step,
-.pcs-progress > .prog-line {
-  align-self: flex-start;
-}
 /* Future steps: reduced opacity */
 .prog-step--future .prog-dot  { opacity: 0.3; }
 .prog-step--future .prog-label { opacity: 0.45; }
@@ -3307,7 +3303,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   height: var(--pcs-pipeline-line);
   background: var(--border);
   position: relative;
-  top: calc((var(--pcs-pipeline-dot) - var(--pcs-pipeline-line)) / 2);
+  top: calc((12px - var(--pcs-pipeline-line)) / 2);
   min-width: var(--pcs-space-2);
   opacity: 0.5;
 }
@@ -3623,9 +3619,11 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 /* Section 7: Date field — full clickable tap area */
 .pcs-date-tap {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: var(--pcs-space-2);
+  min-width: 0;
+  max-width: 100%;
   min-height: 44px;
   cursor: pointer;
 }


### PR DESCRIPTION
Three structural fixes based on diagnostic root cause analysis:

- .pcs-date-tap: change display:inline-flex → display:flex and add min-width:0 + max-width:100% so the date field respects its grid column boundary instead of sizing to intrinsic content width. This fixes both the right-column drift and the Target Date escape.

- .prog-line top offset: change from var(--pcs-pipeline-dot) (8px) to 12px so the connector line centers on the active dot (12×12px) rather than undershooting by ~2.75px.

- Remove redundant .pcs-progress > .prog-step/.prog-line align-self override that conflicted with the container's flex-start alignment.

No tokens modified. No JS files touched.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL