### PR TITLE
fix: right-align Target Date value and use fixed 8px gap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3645,12 +3645,13 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .pcs-date-value {
   display: flex;
   align-items: center;
-  gap: var(--pcs-space-2);
+  justify-content: flex-end;
+  gap: 8px;
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+  text-overflow: ellipsis;
   font-size: 15px;
   font-weight: 500;
   color: var(--text);


### PR DESCRIPTION
Add justify-content:flex-end to .pcs-date-value and change gap from var(--pcs-space-2) to 8px to prevent right-column drift.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL