### PR TITLE
fix: hard grid containment — use minmax(0,1fr) columns, drop text-ove…

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3570,9 +3570,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 /* ── Information grid ── */
 .pcs-grid {
   display: grid;
-  grid-template-columns:
-    minmax(0, var(--pcs-column-width))
-    minmax(0, var(--pcs-column-width));
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: var(--pcs-space-4) var(--pcs-column-gap);
   width: var(--pcs-content-width);
   max-width: var(--pcs-content-width);
@@ -3651,7 +3649,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   max-width: 100%;
   overflow: hidden;
   white-space: nowrap;
-  text-overflow: ellipsis;
   font-size: 15px;
   font-weight: 500;
   color: var(--text);


### PR DESCRIPTION
…rflow on date value

Replace token-based grid-template-columns with minmax(0,1fr) to enforce hard containment regardless of intrinsic child width. Remove text-overflow from .pcs-date-value per spec.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL