### PR TITLE
fix: stabilize PCS metadata grid columns across browsers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3619,6 +3619,16 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   width: 100%;
   min-width: 0;
   max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.pcs-field:nth-child(even) {
+  text-align: right;
+}
+.pcs-field:nth-child(even) .pcs-field-val,
+.pcs-field:nth-child(even) select {
+  text-align: right;
 }
 .pcs-field select {
   width: 100%;


### PR DESCRIPTION
Add overflow protection to .pcs-field-val-ro and right-align even-column values so the two-column grid renders consistently across Safari, Chrome iOS, Android Chrome, and Firefox.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL