### PR TITLE
fix: prevent grid rebuild race and add rollback to updatePost

### DIFF
--- a/05-api.js
+++ b/05-api.js
@@ -72,6 +72,7 @@ function normalise(rows) {
     location:      r.location       || '',
     targetDate:    r.target_date    || '',
     postLink:      r.post_link      || '',
+    linkedinUrl:   r.linkedin_url   || '',
     publishedDate: r.published_date || '',
     comments:      r.comments       || '',
     format:        r.format         || '',

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -517,7 +517,10 @@ function _refreshPCSAfterStageChange(postId) {
 
   if (elProgress) elProgress.innerHTML = _buildStageProgress(stageLC);
   if (elDesign)   elDesign.innerHTML   = _buildInlineActions(canvaUrl, linkedinUrl, isPublished, canEdit, id, stageLC);
-  if (elFields)   elFields.innerHTML   = _buildInfoGrid(post, canEdit, id) + _buildNotes(post, canEdit, id) + `<input type="hidden" id="pcs-post-id" value="${esc(id)}">`;
+  // Note: elFields is intentionally NOT rebuilt here.
+  // Rebuilding the grid via innerHTML destroys <select> and <input>
+  // elements while other async saves (pillar, owner, etc.) may still
+  // be in flight, causing those changes to silently revert.
 }
 
 function _buildStageProgress(stageLC) {
@@ -662,8 +665,9 @@ function refreshSystemViews() {
 }
 
 async function updatePost(postId, field, value) {
-  // Optimistic update in memory
+  // Optimistic update in memory — store old value for rollback
   const post = getPostById(postId);
+  const oldValue = post ? post[field] : undefined;
   if (post) post[field] = value;
 
   const dbField = {
@@ -687,6 +691,9 @@ async function updatePost(postId, field, value) {
     showToast('Saved', 'success');
     refreshSystemViews();
   } catch(e) {
+    // Rollback optimistic update on failure
+    if (post) post[field] = oldValue;
+    scheduleRender();
     showToast('Save failed', 'error');
   }
 }


### PR DESCRIPTION
_refreshPCSAfterStageChange no longer rebuilds the metadata grid, so in-flight pillar/owner/format saves are not destroyed by an innerHTML replace. updatePost now rolls back the optimistic update on API failure (mirroring quickStage). normalise() now maps linkedin_url so the field survives a full data reload.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL