### PR TITLE
fix: sort Library list by newest date first

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -800,6 +800,7 @@ function renderLibrary() {
 function renderLibraryRows(posts) {
   const listView = document.getElementById('library-list-view');
   if (!listView) return;
+  posts = posts.slice().sort((a, b) => new Date(b.targetDate) - new Date(a.targetDate));
   _postLists['library'] = posts;
   if (!posts.length) {
     listView.innerHTML = `<div class="empty-state"><div class="empty-icon">[search]</div><p>No posts match your search.</p></div>`;


### PR DESCRIPTION
renderLibraryRows() now sorts posts in reverse chronological order (newest targetDate at top) before rendering. Uses .slice() to avoid mutating the source array.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL