### PR TITLE
feat: group Library posts by month with section headers

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -806,7 +806,21 @@ function renderLibraryRows(posts) {
     listView.innerHTML = `<div class="empty-state"><div class="empty-icon">[search]</div><p>No posts match your search.</p></div>`;
     return;
   }
-  listView.innerHTML = `<div class="row-list">${posts.map(p => buildPostCard(p, 'library')).join('')}</div>`;
+
+  // Group posts by month
+  const groups = {};
+  posts.forEach(p => {
+    const d = p.targetDate ? new Date(p.targetDate) : null;
+    const key = d && !isNaN(d) ? d.toLocaleDateString('en-GB', { month: 'short', year: 'numeric' }).toUpperCase() : 'NO DATE';
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(p);
+  });
+
+  let html = '';
+  for (const [month, group] of Object.entries(groups)) {
+    html += `<div class="pcs-month-group"><div class="pcs-month-label">${esc(month)}</div><div class="row-list">${group.map(p => buildPostCard(p, 'library')).join('')}</div></div>`;
+  }
+  listView.innerHTML = html;
 }
 
 function renderClientView() {

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -818,7 +818,7 @@ function renderLibraryRows(posts) {
 
   let html = '';
   for (const [month, group] of Object.entries(groups)) {
-    html += `<div class="pcs-month-group"><div class="pcs-month-label">${esc(month)}</div><div class="row-list">${group.map(p => buildPostCard(p, 'library')).join('')}</div></div>`;
+    html += `<div class="pcs-month-group"><div class="pcs-library-month"><span class="pcs-month-label">${esc(month)}</span><span class="pcs-month-count">${group.length}</span></div><div class="row-list">${group.map(p => buildPostCard(p, 'library')).join('')}</div></div>`;
   }
   listView.innerHTML = html;
 }

--- a/styles.css
+++ b/styles.css
@@ -2684,6 +2684,14 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   padding: 8px 16px var(--sp-4);
 }
 
+.pcs-month-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  opacity: 0.6;
+  margin-top: 18px;
+  margin-bottom: 8px;
+}
+
 .row-tile {
   display: flex;
   align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -2684,12 +2684,19 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   padding: 8px 16px var(--sp-4);
 }
 
-.pcs-month-label {
+.pcs-library-month {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   font-size: 11px;
   letter-spacing: 0.08em;
   opacity: 0.6;
   margin-top: 18px;
   margin-bottom: 8px;
+}
+
+.pcs-month-count {
+  opacity: 0.5;
 }
 
 .row-tile {


### PR DESCRIPTION
renderLibraryRows() now groups posts by month (MMM YYYY) before rendering. Each group gets a .pcs-month-label header. Posts within each month remain sorted newest-first. Posts without a date fall under a "NO DATE" group at the end.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL