### PR TITLE
Redesign Library month headers: title case with inline post count and…

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -811,14 +811,14 @@ function renderLibraryRows(posts) {
   const groups = {};
   posts.forEach(p => {
     const d = p.targetDate ? new Date(p.targetDate) : null;
-    const key = d && !isNaN(d) ? d.toLocaleDateString('en-GB', { month: 'short', year: 'numeric' }).toUpperCase() : 'NO DATE';
+    const key = d && !isNaN(d) ? d.toLocaleDateString('en-GB', { month: 'short', year: 'numeric' }) : 'No Date';
     if (!groups[key]) groups[key] = [];
     groups[key].push(p);
   });
 
   let html = '';
   for (const [month, group] of Object.entries(groups)) {
-    html += `<div class="pcs-month-group"><div class="pcs-library-month"><span class="pcs-month-label">${esc(month)}</span><span class="pcs-month-count">${group.length}</span></div><div class="row-list">${group.map(p => buildPostCard(p, 'library')).join('')}</div></div>`;
+    html += `<div class="pcs-month-group"><div class="pcs-library-month">${esc(month)} &middot; ${group.length} post${group.length === 1 ? '' : 's'}</div><div class="row-list">${group.map(p => buildPostCard(p, 'library')).join('')}</div></div>`;
   }
   listView.innerHTML = html;
 }

--- a/styles.css
+++ b/styles.css
@@ -2686,17 +2686,15 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 .pcs-library-month {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  font-size: 11px;
+  justify-content: flex-start;
+  font-size: 12px;
   letter-spacing: 0.08em;
-  opacity: 0.6;
-  margin-top: 18px;
-  margin-bottom: 8px;
-}
-
-.pcs-month-count {
-  opacity: 0.5;
+  opacity: 0.65;
+  margin-top: var(--pcs-space-5);
+  margin-bottom: var(--pcs-space-3);
+  padding-bottom: var(--pcs-space-2);
+  border-bottom: 1px solid rgba(255,255,255,0.06);
 }
 
 .row-tile {


### PR DESCRIPTION
… divider

- Header format changed to "Mar 2026 · 6 posts" (title case, inline count)
- Removed separate span elements, simplified to single text node
- Added border-bottom divider for visual section separation
- Updated CSS to use PCS spacing tokens and flex-start layout
- Cross-browser safe: no absolute positioning or browser-specific CSS

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL