### PR TITLE
fix: renderLibrary() now respects active view (insights/calendar/list)

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -794,7 +794,7 @@ function filterLibrary() {
 
 function renderLibrary() {
   populateFilterDropdowns();
-  renderLibraryRows(allPosts);
+  filterLibrary();
 }
 
 function renderLibraryRows(posts) {


### PR DESCRIPTION
renderLibrary() hardcoded renderLibraryRows(allPosts), ignoring _currentLibraryView. This meant the Insights container was never populated by the main render pipeline (renderAll), leaving it blank.

Replace with filterLibrary() which already dispatches correctly to list/calendar/insights based on _currentLibraryView.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL