### PR TITLE
Guard null owner with 'Admin' fallback in PCS subtitle and hero card

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -478,7 +478,7 @@ function renderNextPost() {
   const stage     = post.stage || '';
   const stageLC   = stage.toLowerCase().trim();
   const { hex, label: stageLabel } = stageStyle(stage);
-  const owner     = post.owner || '-';
+  const owner     = post.owner || 'Admin';
   const pillar    = post.contentPillar || '';
   const comments  = post.comments || '';
   const postLink  = post.postLink || '';

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -385,7 +385,7 @@ function _renderPCS(postId) {
   // 3. Build subtitle parts — always Pillar · Owner · Date
   const subtitleParts = [
     `<span>${esc(pillarLabel || '—')}</span>`,
-    `<span>${esc(post.owner  || '—')}</span>`,
+    `<span>${esc(post.owner  || 'Admin')}</span>`,
     `<span>${esc(dateDisplay || '—')}</span>`,
   ];
 


### PR DESCRIPTION
- 08-post-actions.js:388 — PCS modal subtitle: post.owner || '—' → 'Admin'
- 07-post-load.js:481 — hero card owner tag: post.owner || '-' → 'Admin'

Ensures subtitle always shows a valid owner name from the allowed set (Admin, Chitra, Pranav) even when post.owner is null/empty.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL