### PR TITLE
Rebuild PCS pipeline as deterministic stage-column indicator

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -542,24 +542,17 @@ function _buildStageProgress(stageLC) {
 
   const activeIdx = steps.findIndex(s => s.key === norm);
 
-  let html = '';
-  steps.forEach((s, i) => {
-    if (i > 0) {
-      const lineFuture = activeIdx === -1 || i > activeIdx;
-      html += `<div class="prog-line${lineFuture ? ' prog-line--future' : ''}"></div>`;
-    }
+  const html = steps.map((s, i) => {
     const isDone    = activeIdx !== -1 && i < activeIdx;
     const isCurrent = i === activeIdx;
-    const isFuture  = !isDone && !isCurrent;
-    const dotCls = isCurrent ? 'prog-dot active' : isDone ? 'prog-dot done' : 'prog-dot';
-    const stepCls = isFuture ? 'prog-step prog-step--future' : 'prog-step';
-    html += `<div class="${stepCls}">
+    const dotCls = isDone ? 'pipeline-dot completed' : isCurrent ? 'pipeline-dot active' : 'pipeline-dot pending';
+    return `<div class="pipeline-stage">
       <div class="${dotCls}"></div>
-      <div class="prog-label">${s.label}</div>
+      <div class="pipeline-label">${s.label}</div>
     </div>`;
-  });
+  }).join('');
 
-  return `<div class="pcs-progress">${html}</div>`;
+  return `<div class="pipeline-container">${html}</div>`;
 }
 
 function _buildInlineActions(canvaUrl, linkedinUrl, isPublished, canEdit, postId, stageLC) {

--- a/styles.css
+++ b/styles.css
@@ -3351,63 +3351,58 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 
 /* ── Pipeline progress row ── */
-.pcs-progress {
+/* ── Pipeline stage indicator ── */
+.pipeline-container {
   display: flex;
-  align-items: flex-start;
   justify-content: space-between;
+  align-items: flex-start;
   padding: 0 0 var(--pcs-space-2);
-  margin: 0;
 }
-.prog-step {
+.pipeline-stage {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--pcs-space-2);
-  flex-shrink: 0;
-  position: relative;
+  gap: 6px;
+  flex: 1;
 }
-/* Future steps: reduced opacity */
-.prog-step--future .prog-dot  { opacity: 0.3; }
-.prog-step--future .prog-label { opacity: 0.45; }
-.prog-dot {
-  width: var(--pcs-pipeline-dot);
-  height: var(--pcs-pipeline-dot);
+.pipeline-dot {
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
-  background: #d1d5db;
-  position: relative;
-  z-index: 1;
+  background: var(--border2);
+  opacity: 0.3;
 }
-.prog-dot.done {
+.pipeline-dot.completed {
   background: var(--c-green);
+  opacity: 1;
 }
-.prog-dot.active {
-  width: 12px;
-  height: 12px;
+.pipeline-dot.active {
   background: var(--surface);
   border: 2px solid var(--c-blue);
   box-shadow: 0 0 0 3px var(--c-blue-dim);
+  opacity: 1;
 }
-.prog-label {
-  font-size: 10px;
+.pipeline-dot.pending {
+  background: var(--border2);
+  opacity: 0.3;
+}
+.pipeline-label {
+  font-size: 12px;
   font-weight: 600;
   color: var(--text3);
   letter-spacing: 0.02em;
   white-space: nowrap;
   text-align: center;
+  opacity: 0.45;
 }
-.prog-step:has(.prog-dot.active) .prog-label { color: var(--c-blue); opacity: 1; font-weight: 700; }
-.prog-step:has(.prog-dot.done) .prog-label   { color: var(--c-green); opacity: 0.9; }
-.prog-line {
-  flex: 1;
-  height: var(--pcs-pipeline-line);
-  background: var(--border);
-  position: relative;
-  top: calc((12px - var(--pcs-pipeline-line)) / 2);
-  min-width: var(--pcs-space-2);
-  opacity: 0.5;
+.pipeline-stage:has(.pipeline-dot.active) .pipeline-label {
+  color: var(--c-blue);
+  opacity: 1;
+  font-weight: 700;
 }
-.prog-line--future {
-  opacity: 0.15;
+.pipeline-stage:has(.pipeline-dot.completed) .pipeline-label {
+  color: var(--c-green);
+  opacity: 0.9;
 }
 
 /* ── Design section layout ── */


### PR DESCRIPTION
Replace the two-row dot+line pipeline with a single-row column-per-stage layout (Linear-style):

JS (08-post-actions.js):
- Remove prog-line connector elements from _buildStageProgress
- Rename classes: prog-step → pipeline-stage, prog-dot → pipeline-dot, prog-label → pipeline-label, pcs-progress → pipeline-container
- Dot states: completed (green), active (accent ring), pending (muted)
- Stage order preserved: Production → Ready → Approval → Scheduled → Published
- Stage normalization logic unchanged

CSS (styles.css):
- Remove .pcs-progress, .prog-step, .prog-dot, .prog-label, .prog-line
- Add .pipeline-container (flex, space-between)
- Add .pipeline-stage (flex column, flex:1, gap:6px)
- Add .pipeline-dot (10×10px, three states via color tokens)
- Add .pipeline-label (12px, centered below dot)
- :has() selectors for active/completed label coloring

All dots align on same horizontal line. Labels sit directly below their dots. No wrapping — flex:1 distributes evenly.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL