### PR TITLE
Stabilize PCS modal shell — add gap to #pcs-screen, normalize scroll …

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3192,6 +3192,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 #pcs-screen {
   display: flex;
   flex-direction: column;
+  gap: var(--pcs-space-5);
   width: var(--pcs-modal-width);
   max-width: var(--pcs-modal-width);
   height: 100dvh;
@@ -3338,7 +3339,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-  padding: 0 var(--pcs-content-padding) var(--pcs-safe-bottom);
+  padding: 0 var(--pcs-content-padding) var(--pcs-content-padding);
   min-height: 0;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
…padding

Pass 1 layout stabilization:

1. #pcs-screen — add gap:var(--pcs-space-5) to create deterministic 24px spacing between .pcs-header and .pcs-scroll (was 0px — header and content had no controlled separation).

2. .pcs-scroll — change bottom padding from var(--pcs-safe-bottom) to var(--pcs-content-padding) so scroll area padding matches left/right inset (24px).

All other containers (.pcs-design-stack, #pcs-fields, .pipeline-container) were already correct from prior passes.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL