### PR TITLE
Fix timezone-shift bug in parseDate() — construct Date in local time

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -9,8 +9,13 @@ function getPostById(postId) { return allPosts.find(p => getPostId(p) === postId
 
 function parseDate(raw) {
   if (!raw) return null;
-  const d = new Date(raw);
-  return isNaN(d) ? null : d;
+  const parts = String(raw).split('-');
+  if (parts.length !== 3) return null;
+  const y = Number(parts[0]);
+  const m = Number(parts[1]);
+  const d = Number(parts[2]);
+  if (!y || !m || !d) return null;
+  return new Date(y, m - 1, d);
 }
 
 function formatDate(raw) {


### PR DESCRIPTION
new Date("YYYY-MM-DD") parses as UTC midnight, causing toLocaleDateString() to shift the day back by one in negative-UTC timezones. Replaced with split-and-construct using new Date(y, m-1, d) which creates the Date in local time.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL