### PR TITLE
Remove redundant DOM wrappers from postcard read-only date field

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -742,7 +742,7 @@ function _buildInfoGrid(post, canEdit, id) {
   const dateInput = canEdit
     ? `<label class="pcs-date-tap"><input type="date" class="pcs-field-val pcs-date-input-native" value="${esc(dateValue)}"
              onchange="updatePost('${esc(id)}','targetDate',this.value)"></label>`
-    : `<div class="pcs-date-tap"><span class="pcs-date-value"><span class="pcs-date-text">${esc(formatDate(dateValue) || '—')}</span><svg class="pcs-date-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span></div>`;
+    : `<div class="pcs-date-tap">${esc(formatDate(dateValue) || '—')}<svg class="pcs-date-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></div>`;
 
   const cell = (label, content) =>
     `<div class="pcs-field">

--- a/styles.css
+++ b/styles.css
@@ -3602,8 +3602,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 
 /* ── Notes section — lighter feel ── */
-.pcs-notes-section {
-}
 
 /* Legacy design block classes — heights matched to 36px */
 .pcs-design-block { display: none; }
@@ -3718,13 +3716,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.pcs-field:nth-child(even) {
-  text-align: left;
-}
-.pcs-field:nth-child(even) .pcs-field-val,
-.pcs-field:nth-child(even) select {
-  text-align: left;
-}
 .pcs-field select {
   width: 100%;
   min-width: 0;
@@ -3740,26 +3731,18 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   max-width: 100%;
   min-height: 44px;
   cursor: pointer;
-}
-.pcs-date-tap .pcs-date-input-native {
-  min-height: 44px;
-  width: 100%;
-  min-width: 0;
-  max-width: 100%;
-}
-.pcs-date-value {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 6px;
-  min-width: 0;
-  max-width: 100%;
   overflow: hidden;
   white-space: nowrap;
   font-size: 15px;
   font-weight: 500;
   color: var(--text);
   line-height: 1;
+}
+.pcs-date-tap .pcs-date-input-native {
+  min-height: 44px;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
 }
 .pcs-date-icon {
   width: var(--pcs-space-4);


### PR DESCRIPTION
Flattened the read-only date field from 3 nested layers (.pcs-date-tap > .pcs-date-value > .pcs-date-text + icon) to 1 layer (.pcs-date-tap > text + icon).

08-post-actions.js:
  L745: removed .pcs-date-value and .pcs-date-text spans

styles.css:
  - Merged .pcs-date-value styles into .pcs-date-tap
  - Deleted .pcs-date-value rule (was duplicate flex)
  - Deleted empty .pcs-notes-section {} rule
  - Deleted 3 no-op .pcs-field:nth-child(even) rules

Editable date field unchanged.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL