### PR TITLE
Fix date field left-alignment in postcard metadata grid

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3724,9 +3724,11 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 /* Section 7: Date field — full clickable tap area */
 .pcs-date-tap {
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 6px;
+  width: 100%;
   min-width: 0;
   max-width: 100%;
   min-height: 44px;


### PR DESCRIPTION
Changed .pcs-date-tap from inline-flex to flex and added width: 100% + justify-content: flex-start so the date value fills the grid cell and aligns with other metadata values.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL