### PR TITLE
Fix vertical baseline offset of read-only date value in metadata grid

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3738,6 +3738,9 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-weight: 500;
   color: var(--text);
 }
+div.pcs-date-tap {
+  min-height: 0;
+}
 .pcs-date-tap .pcs-date-input-native {
   min-height: 44px;
   width: 100%;


### PR DESCRIPTION
div.pcs-date-tap { min-height: 0 } overrides the 44px tap-target constraint for the read-only <div> path only. The editable <label> path retains min-height: 44px. Date text now sits at natural height, aligning its baseline with adjacent .pcs-field-val-ro values.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL