### PR TITLE
Revert value shell container + density refinement

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -725,24 +725,24 @@ function _buildInfoGrid(post, canEdit, id) {
   const { hex } = stageStyle(post.stage);
 
   const sel = (field, opts, val, dbField, displayMap) =>
-    `<div class="pcs-value-shell"><select class="pcs-field-val" ${canEdit ? `onchange="updatePost('${esc(id)}','${dbField||field}',this.value)"` : 'disabled'}>
+    `<select class="pcs-field-val" ${canEdit ? `onchange="updatePost('${esc(id)}','${dbField||field}',this.value)"` : 'disabled'}>
        ${opts.map(o => `<option value="${esc(o)}" ${o === val ? 'selected' : ''}>${esc(displayMap ? (displayMap[o] || o) : o)}</option>`).join('')}
-     </select></div>`;
+     </select>`;
 
-  const ro = val => `<div class="pcs-value-shell"><span class="pcs-field-val-ro">${esc(val || '—')}</span></div>`;
+  const ro = val => `<span class="pcs-field-val-ro">${esc(val || '—')}</span>`;
 
   // Stage selector uses unified changeStage() with confirmation
   const stageSel = canEdit
-    ? `<div class="pcs-value-shell"><select class="pcs-field-val" onchange="changeStage(this.value)">
+    ? `<select class="pcs-field-val" onchange="changeStage(this.value)">
          ${STAGES_DB.map(o => `<option value="${esc(o)}" ${o === (post.stage||'') ? 'selected' : ''}>${esc(STAGE_DISPLAY ? (STAGE_DISPLAY[o] || o) : o)}</option>`).join('')}
-       </select></div>`
-    : `<div class="pcs-value-shell"><span class="pcs-field-val-ro" style="color:${hex}">${esc(stageStyle(post.stage).label || post.stage || '—')}</span></div>`;
+       </select>`
+    : `<span class="pcs-field-val-ro" style="color:${hex}">${esc(stageStyle(post.stage).label || post.stage || '—')}</span>`;
 
   // Date field — full click area with 44px minimum tap target
   const dateInput = canEdit
-    ? `<div class="pcs-value-shell"><label class="pcs-date-tap"><input type="date" class="pcs-field-val pcs-date-input-native" value="${esc(dateValue)}"
-             onchange="updatePost('${esc(id)}','targetDate',this.value)"></label></div>`
-    : `<div class="pcs-value-shell"><span class="pcs-date-text">${esc(formatDate(dateValue) || '—')}</span><svg class="pcs-date-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></div>`;
+    ? `<label class="pcs-date-tap"><input type="date" class="pcs-field-val pcs-date-input-native" value="${esc(dateValue)}"
+             onchange="updatePost('${esc(id)}','targetDate',this.value)"></label>`
+    : `<div class="pcs-date-tap"><span class="pcs-date-text">${esc(formatDate(dateValue) || '—')}</span><svg class="pcs-date-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></div>`;
 
   const cell = (label, content) =>
     `<div class="pcs-field">

--- a/styles.css
+++ b/styles.css
@@ -3671,7 +3671,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .pcs-field {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
   min-width: 0;
   width: 100%;
 }
@@ -3680,7 +3680,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-weight: 500;
   letter-spacing: 0.02em;
   color: var(--text);
-  opacity: 0.6;
+  opacity: 0.55;
   margin-bottom: 0;
 }
 .pcs-field-val {
@@ -3715,39 +3715,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-.pcs-value-shell {
-  background: var(--surface);
-  border-radius: 8px;
-  padding: 10px 12px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  min-width: 0;
-  max-width: 100%;
-  box-sizing: border-box;
-}
-.pcs-value-shell .pcs-field-val,
-.pcs-value-shell .pcs-field-val-ro {
-  padding: 0;
-}
-.pcs-value-shell .pcs-date-text {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 15px;
-  font-weight: 500;
-  color: var(--text);
-}
-.pcs-value-shell .pcs-date-icon {
-  flex-shrink: 0;
-  margin-left: auto;
-  opacity: 0.6;
-  width: var(--pcs-space-4);
-  height: var(--pcs-space-4);
 }
 .pcs-field select {
   width: 100%;


### PR DESCRIPTION
The previous pass introduced .pcs-value-shell wrappers and density adjustments that caused unintended layout shifts. This reverts to the pre-shell DOM structure where values sit directly inside .pcs-field, restores .pcs-field gap to 4px, .pcs-field-label opacity to 0.55, and removes all .pcs-value-shell CSS rules.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL