### PR TITLE
Normalize metadata value baselines with unified line-height

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3721,6 +3721,14 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   min-width: 0;
   max-width: 100%;
 }
+.pcs-field-val,
+.pcs-field-val-ro,
+.pcs-date-text {
+  display: block;
+  line-height: 1.4;
+  margin: 0;
+  padding: 0;
+}
 
 /* Section 7: Date field — full clickable tap area */
 .pcs-date-tap {


### PR DESCRIPTION
Add a shared rule for .pcs-field-val, .pcs-field-val-ro, and .pcs-date-text that enforces display:block, line-height:1.4, margin:0, padding:0 — ensuring all value elements share identical baseline metrics regardless of element type (span, select, div).

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL