### PR TITLE
Replace locale-dependent formatDate with deterministic formatter

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -18,10 +18,18 @@ function parseDate(raw) {
   return new Date(y, m - 1, d);
 }
 
+const MONTHS = [
+  'Jan','Feb','Mar','Apr','May','Jun',
+  'Jul','Aug','Sep','Oct','Nov','Dec'
+];
+
 function formatDate(raw) {
   const d = parseDate(raw);
   if (!d) return null;
-  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+  const day   = d.getDate();
+  const month = MONTHS[d.getMonth()];
+  const year  = d.getFullYear();
+  return `${day} ${month} ${year}`;
 }
 
 function displayDate(raw) {


### PR DESCRIPTION
Use a static MONTHS array and manual string construction instead of toLocaleDateString(), which some browsers ignore the locale parameter for. Output is now always "D Mon YYYY" regardless of browser/OS locale.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL