### PR TITLE
Eliminate all toLocaleDateString calls with deterministic formatters

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -384,7 +384,7 @@ function renderTaskBanner() {
   const myTasks  = allTasks.filter(t => !t.done && (t.assigned_to === roleName || (email && t.assigned_to.toLowerCase().includes(email.split('@')[0].toLowerCase()))));
   if (!myTasks.length) { section.innerHTML = ''; return; }
   const rows = myTasks.map(t => {
-    const due = t.due_date ? `Due ${parseDate(t.due_date)?.toLocaleDateString('en-GB',{day:'numeric',month:'short'}) || ''}` : '';
+    const due = t.due_date ? `Due ${formatDateShort(t.due_date)}` : '';
     return `<div class="task-banner-item" id="task-item-${t.id}"><div><div class="task-banner-msg">${esc(t.message)}</div>${due ? `<div class="task-banner-due">${due}</div>` : ''}</div><button class="btn-task-done" onclick="markTaskDone(${t.id})">Mark Done</button></div>`;
   }).join('');
   section.innerHTML = `<div class="task-banner"><div class="task-banner-label">Your Tasks (${myTasks.length})</div>${rows}</div>`;
@@ -397,7 +397,7 @@ function renderAdminTaskPanel() {
   const openTasks = allTasks.filter(t => !t.done);
   const doneTasks = allTasks.filter(t => t.done).slice(0, 5);
   const openRows = openTasks.map(t => {
-    const due = t.due_date ? ` . Due ${parseDate(t.due_date)?.toLocaleDateString('en-GB',{day:'numeric',month:'short'}) || ''}` : '';
+    const due = t.due_date ? ` . Due ${formatDateShort(t.due_date)}` : '';
     return `<div class="admin-task-item"><div class="admin-task-item-body"><div class="admin-task-item-msg">${esc(t.message)}</div><div class="admin-task-item-meta">${esc(t.assigned_to)}${due}</div></div><button class="btn-task-delete" onclick="deleteTask(${t.id})" title="Delete task">x</button></div>`;
   }).join('');
   const doneRows = doneTasks.map(t => `<div class="admin-task-item"><div class="admin-task-item-body admin-task-item-done"><div class="admin-task-item-msg">${esc(t.message)}</div><div class="admin-task-item-meta">${esc(t.assigned_to)}</div></div><button class="btn-task-delete" onclick="deleteTask(${t.id})" title="Delete task">x</button></div>`).join('');
@@ -518,7 +518,7 @@ function buildPostCard(p, listKey) {
   const { hex } = stageStyle(stage);
 
   const d = parseDate(p.targetDate);
-  const dateStr = d ? d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' }) : '';
+  const dateStr = formatDateShort(p.targetDate);
   const isToday = d && d.toDateString() === new Date().toDateString();
 
   return `
@@ -722,7 +722,7 @@ function renderUpcoming() {
     const d       = g.date;
     const isToday = d && d.getTime() === today.getTime();
     const isSoon  = d && d <= w7;
-    const label   = isToday ? 'Today' : d ? d.toLocaleDateString('en-GB',{weekday:'short',day:'numeric',month:'short'}).toUpperCase() : 'NO DATE';
+    const label   = isToday ? 'Today' : d ? formatWeekdayDateShort(dateKey) : 'NO DATE';
     const hdrCls  = isToday ? 'today-hdr' : isSoon ? 'soon' : '';
     const cards   = g.posts.map(p => buildPostCard(p, 'upcoming')).join('');
     return `<div class="schedule-group"><div class="schedule-date-header ${hdrCls}">${label}</div><div class="row-list" style="gap:10px;padding-top:6px">${cards}</div></div>`;
@@ -812,7 +812,7 @@ function renderLibraryRows(posts) {
   const groups = {};
   posts.forEach(p => {
     const d = parseDate(p.targetDate);
-    const key = d ? d.toLocaleDateString('en-GB', { month: 'short', year: 'numeric' }) : 'No Date';
+    const key = d ? formatMonthYear(p.targetDate) : 'No Date';
     if (!groups[key]) groups[key] = [];
     groups[key].push(p);
   });
@@ -1136,7 +1136,7 @@ function renderLibraryCalendar(posts) {
   const today      = new Date(); today.setHours(0,0,0,0);
   withDates.forEach(p => {
     const d   = parseDate(p.targetDate);
-    const key = d.toLocaleDateString('en-GB',{month:'long',year:'numeric'});
+    const key = formatMonthYearLong(p.targetDate);
     if (!months[key]) months[key] = [];
     months[key].push(p);
   });
@@ -1145,7 +1145,7 @@ function renderLibraryCalendar(posts) {
       const id  = getPostId(p);
       const d   = parseDate(p.targetDate);
       const isToday = d && d.toDateString() === today.toDateString();
-      const dayStr  = d ? d.toLocaleDateString('en-GB',{day:'numeric',month:'short'}) : '';
+      const dayStr  = formatDateShort(p.targetDate);
       const { hex } = stageStyle(p.stage);
       return `<div class="calendar-item" data-post-id="${esc(id)}" data-list="library">
         <span class="calendar-date-badge ${isToday?'today-badge':''}">${dayStr}</span>

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -166,7 +166,7 @@ async function submitClientRequest() {
     const email  = localStorage.getItem('gbl_email') || 'Client';
     await apiFetch('/posts', {
       method: 'POST',
-      body: JSON.stringify({ post_id: postId, title: `Client Request — ${new Date().toLocaleDateString('en-GB',{day:'numeric',month:'short'})}`, stage: 'awaiting brand input', owner: email, comments: brief, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }),
+      body: JSON.stringify({ post_id: postId, title: `Client Request — ${new Date().getDate()} ${MONTHS[new Date().getMonth()]}`, stage: 'awaiting brand input', owner: email, comments: brief, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }),
     });
     if (file) await uploadPostAsset(file, postId);
     await logActivity({ post_id: postId, actor_name: email, actor_role: 'Client', action: `New request: ${brief.substring(0,60)}` });

--- a/utils.js
+++ b/utils.js
@@ -22,6 +22,39 @@ const MONTHS = [
   'Jan','Feb','Mar','Apr','May','Jun',
   'Jul','Aug','Sep','Oct','Nov','Dec'
 ];
+const MONTHS_LONG = [
+  'January','February','March','April','May','June',
+  'July','August','September','October','November','December'
+];
+const DAYS_SHORT = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+
+// "D Mon" — no year
+function formatDateShort(raw) {
+  const d = parseDate(raw);
+  if (!d) return '';
+  return `${d.getDate()} ${MONTHS[d.getMonth()]}`;
+}
+
+// "Mon YYYY" — for group headers
+function formatMonthYear(raw) {
+  const d = parseDate(raw);
+  if (!d) return 'No Date';
+  return `${MONTHS[d.getMonth()]} ${d.getFullYear()}`;
+}
+
+// "Month YYYY" — for calendar headers
+function formatMonthYearLong(raw) {
+  const d = parseDate(raw);
+  if (!d) return 'No Date';
+  return `${MONTHS_LONG[d.getMonth()]} ${d.getFullYear()}`;
+}
+
+// "DAY D Mon" uppercased — for schedule date headers
+function formatWeekdayDateShort(raw) {
+  const d = parseDate(raw);
+  if (!d) return 'NO DATE';
+  return `${DAYS_SHORT[d.getDay()]} ${d.getDate()} ${MONTHS[d.getMonth()]}`.toUpperCase();
+}
 
 function formatDate(raw) {
   const d = parseDate(raw);


### PR DESCRIPTION
Add formatDateShort, formatMonthYear, formatMonthYearLong, and formatWeekdayDateShort helpers to utils.js. Replace all 8 toLocaleDateString calls across 07-post-load.js and 08-post-actions.js so every UI date path uses the static MONTHS/DAYS arrays instead of browser locale. Fixes mixed date format rendering in PCS modal.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL