### PR TITLE
Fix date text layering: ensure visible span renders above hidden input

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3757,8 +3757,11 @@ div.pcs-date-tap {
   width: 100%;
   min-width: 0;
   max-width: 100%;
+  z-index: 1;
 }
 .pcs-date-text {
+  position: relative;
+  z-index: 2;
   display: block;
   min-width: 0;
   overflow: hidden;


### PR DESCRIPTION
On Android the hidden date input's locale-formatted text could bleed through beneath the visible formatted span. Adding z-index:2 to .pcs-date-text and z-index:1 to the input ensures correct stacking order across all platforms.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL