### PR TITLE
Fix date icon baseline: use inline-flex centering instead of translat…

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3732,7 +3732,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 /* Section 7: Date field — full clickable tap area */
 .pcs-date-tap {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 6px;
   width: 100%;
@@ -3747,7 +3747,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   color: var(--text);
 }
 div.pcs-date-tap {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 6px;
   min-height: 0;
@@ -3774,9 +3774,7 @@ div.pcs-date-tap {
   padding-right: 0;
 }
 .pcs-date-icon {
-  position: static;
   flex-shrink: 0;
-  transform: translateY(-1px);
   opacity: 0.6;
   width: var(--pcs-space-4);
   height: var(--pcs-space-4);


### PR DESCRIPTION
…eY hack

Replace transform:translateY(-1px) with pure flex alignment to avoid sub-pixel rounding differences across WebKit and Blink. Switch .pcs-date-tap to display:inline-flex for consistent baseline behavior.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL