### PR TITLE
Add consistent typography tokens and align field styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3675,19 +3675,41 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   min-width: 0;
   width: 100%;
 }
+/* ── Typography tokens ── */
+.pcs-label {
+  font-size: 13px;
+  line-height: 1.3;
+  font-weight: 500;
+  color: rgba(255,255,255,0.5);
+}
+
+.pcs-value {
+  font-size: 16px;
+  line-height: 1.4;
+  font-weight: 500;
+  color: rgba(255,255,255,0.92);
+}
+
+.pcs-subtitle {
+  font-size: 13px;
+  line-height: 1.4;
+  color: rgba(255,255,255,0.6);
+}
+
 .pcs-field-label {
-  font-size: 12px;
+  font-size: 13px;
+  line-height: 1.3;
   font-weight: 500;
   letter-spacing: 0.02em;
-  color: var(--text);
-  opacity: 0.55;
+  color: rgba(255,255,255,0.5);
   margin-bottom: 0;
 }
 .pcs-field-val {
   border: none;
   background: transparent;
-  color: var(--text);
-  font-size: 15px;
+  color: rgba(255,255,255,0.92);
+  font-size: 16px;
+  line-height: 1.4;
   font-weight: 500;
   font-family: inherit;
   padding: 0;
@@ -3706,9 +3728,10 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .pcs-field-val:disabled { opacity: 0.45; cursor: default; }
 .pcs-field-val-ro {
   display: block;
-  font-size: 15px;
+  font-size: 16px;
+  line-height: 1.4;
   font-weight: 500;
-  color: var(--text);
+  color: rgba(255,255,255,0.92);
   width: 100%;
   min-width: 0;
   max-width: 100%;
@@ -3754,14 +3777,21 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   height: var(--pcs-space-4);
 }
 
+.pcs-value-shell svg {
+  position: relative;
+  top: 1px;
+  opacity: 0.6;
+}
+
 /* Date tap — inside .pcs-value-shell */
 div.pcs-date-tap {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 15px;
+  font-size: 16px;
+  line-height: 1.4;
   font-weight: 500;
-  color: var(--text);
+  color: rgba(255,255,255,0.92);
 }
 label.pcs-date-tap {
   display: flex;
@@ -3771,9 +3801,10 @@ label.pcs-date-tap {
   width: 100%;
   min-height: 44px;
   cursor: pointer;
-  font-size: 15px;
+  font-size: 16px;
+  line-height: 1.4;
   font-weight: 500;
-  color: var(--text);
+  color: rgba(255,255,255,0.92);
 }
 .pcs-date-tap .pcs-date-input-native {
   position: absolute;


### PR DESCRIPTION
- Add .pcs-label, .pcs-value, .pcs-subtitle token classes
- Align .pcs-field-label to 13px/1.3 with rgba color
- Align .pcs-field-val, .pcs-field-val-ro, .pcs-date-tap to 16px/1.4
- Add SVG optical alignment (top: 1px) in .pcs-value-shell
- No layout or DOM changes

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL