### PR TITLE
Fix color system for light/dark mode, reduce modal to 70vh

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -84,6 +84,28 @@
   --pcs-row-gap: var(--pcs-space-3);
   --pcs-section-gap: var(--pcs-space-5);
   --pcs-bar-height: 6px;
+
+  /* Semantic text colors — light mode defaults */
+  --text-primary: #111111;
+  --text-secondary: #6b7280;
+  --text-tertiary: #9ca3af;
+  --surface-bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --text-primary: rgba(255,255,255,0.92);
+    --text-secondary: rgba(255,255,255,0.6);
+    --text-tertiary: rgba(255,255,255,0.4);
+    --surface-bg: #0b0f1a;
+  }
+}
+
+[data-theme="dark"] {
+  --text-primary: rgba(255,255,255,0.92);
+  --text-secondary: rgba(255,255,255,0.6);
+  --text-tertiary: rgba(255,255,255,0.4);
+  --surface-bg: #0b0f1a;
 }
 
 [data-theme="dark"] {
@@ -3195,8 +3217,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   gap: var(--pcs-space-5);
   width: var(--pcs-modal-width);
   max-width: var(--pcs-modal-width);
-  height: 100dvh;
-  max-height: 90vh;
+  height: auto;
+  max-height: 70vh;
   background: var(--surface);
   border: 1px solid rgba(255,255,255,0.06);
   border-radius: 20px;
@@ -3321,8 +3343,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   gap: var(--pcs-inline-separator-gap);
   flex-wrap: wrap;
   font-size: 13px;
-  color: var(--text);
-  opacity: 0.7;
+  line-height: 1.4;
+  color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -3680,20 +3702,20 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-size: 13px;
   line-height: 1.3;
   font-weight: 500;
-  color: rgba(255,255,255,0.5);
+  color: var(--text-secondary);
 }
 
 .pcs-value {
   font-size: 16px;
   line-height: 1.4;
   font-weight: 500;
-  color: rgba(255,255,255,0.92);
+  color: var(--text-primary);
 }
 
 .pcs-subtitle {
   font-size: 13px;
   line-height: 1.4;
-  color: rgba(255,255,255,0.6);
+  color: var(--text-secondary);
 }
 
 .pcs-field-label {
@@ -3701,13 +3723,13 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   line-height: 1.3;
   font-weight: 500;
   letter-spacing: 0.02em;
-  color: rgba(255,255,255,0.5);
+  color: var(--text-secondary);
   margin-bottom: 0;
 }
 .pcs-field-val {
   border: none;
   background: transparent;
-  color: rgba(255,255,255,0.92);
+  color: var(--text-primary);
   font-size: 16px;
   line-height: 1.4;
   font-weight: 500;
@@ -3731,7 +3753,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-size: 16px;
   line-height: 1.4;
   font-weight: 500;
-  color: rgba(255,255,255,0.92);
+  color: var(--text-primary);
   width: 100%;
   min-width: 0;
   max-width: 100%;
@@ -3791,7 +3813,7 @@ div.pcs-date-tap {
   font-size: 16px;
   line-height: 1.4;
   font-weight: 500;
-  color: rgba(255,255,255,0.92);
+  color: var(--text-primary);
 }
 label.pcs-date-tap {
   display: flex;
@@ -3804,7 +3826,7 @@ label.pcs-date-tap {
   font-size: 16px;
   line-height: 1.4;
   font-weight: 500;
-  color: rgba(255,255,255,0.92);
+  color: var(--text-primary);
 }
 .pcs-date-tap .pcs-date-input-native {
   position: absolute;


### PR DESCRIPTION
PART 1 — Color system:
- Add semantic tokens: --text-primary, --text-secondary, --text-tertiary, --surface-bg
- Light mode defaults (#111111, #6b7280, #9ca3af, #ffffff)
- Dark mode overrides via @media prefers-color-scheme and [data-theme="dark"]
- Replace all hardcoded rgba(255,255,255,...) text colors with var() tokens
- Remove opacity stacking on .pcs-subtitle

PART 2 — Modal height:
- #pcs-screen: height 100dvh→auto, max-height 90vh→70vh (thumb zone)
- .pcs-scroll already has overflow-y:auto + -webkit-overflow-scrolling

No JS, DOM, or grid layout changes.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL