### PR TITLE
Add flex-shrink:0 to .pcs-inline-actions for fixed footer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3468,6 +3468,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   justify-content: center;
   gap: var(--pcs-space-3);
   flex-wrap: wrap;
+  flex-shrink: 0;
 }
 
 /* ── Divider ── */


### PR DESCRIPTION
Ensures action buttons stay pinned at the bottom of the PCS modal and don't collapse when .pcs-scroll content overflows.

All other sheet constraints (70vh max-height, flex column layout, scroll area, header pinning) were already in place.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL