### PR TITLE
Fix target date baseline misalignment across browsers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3839,7 +3839,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 /* Date tap — inside .pcs-value-shell */
 div.pcs-date-tap {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 6px;
   font-size: 16px;
   line-height: 1.4;
@@ -3848,7 +3848,7 @@ div.pcs-date-tap {
 }
 label.pcs-date-tap {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 6px;
   position: relative;
   width: 100%;


### PR DESCRIPTION
Root cause: .pcs-date-tap (both div and label variants) used align-items:center, breaking baseline propagation from parent .pcs-value-shell. Text sat at container center instead of on the shared text baseline with adjacent column fields.

Fix: align-items:center → align-items:baseline on both div.pcs-date-tap and label.pcs-date-tap. No layout, spacing, or tap-target changes — min-height:44px and icon offset preserved.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL