### PR TITLE
Normalize modal height across devices using dvh units

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3245,6 +3245,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   max-width: var(--pcs-modal-width);
   height: auto;
   max-height: 70vh;
+  max-height: min(70dvh, 680px);
+  padding-bottom: calc(var(--pcs-content-padding) + env(safe-area-inset-bottom));
   color: var(--text-primary);
   background: var(--surface);
   border: 1px solid var(--border);
@@ -3268,6 +3270,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   #pcs-screen {
     max-width: 100%;
     max-height: 88vh;
+    max-height: min(88dvh, 680px);
     border-radius: 20px 20px 0 0;
     transform: translateY(100%);
     opacity: 1;


### PR DESCRIPTION
Problem: Modal height inconsistent — iOS Chrome full height, iOS Safari ~60%, Android correct. Caused by vh units not accounting for dynamic browser chrome on iOS.

Fix:
- Add max-height: min(70dvh, 680px) as progressive enhancement over 70vh
- Same treatment for mobile bottom sheet (88vh → 88dvh fallback)
- Add safe-area padding for iOS notch/home-indicator
- Existing .pcs-scroll and #pcs-overlay properties already correct

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL