### PR TITLE
Fix modal overflow on iOS Chrome with strict height constraint

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3243,7 +3243,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   gap: var(--pcs-space-4);
   width: var(--pcs-modal-width);
   max-width: var(--pcs-modal-width);
-  height: auto;
+  height: 70vh;
+  height: min(70dvh, 680px);
   max-height: 70vh;
   max-height: min(70dvh, 680px);
   padding-bottom: calc(var(--pcs-content-padding) + env(safe-area-inset-bottom));
@@ -3269,6 +3270,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   #pcs-overlay { align-items: flex-end; }
   #pcs-screen {
     max-width: 100%;
+    height: 88vh;
+    height: min(88dvh, 680px);
     max-height: 88vh;
     max-height: min(88dvh, 680px);
     border-radius: 20px 20px 0 0;


### PR DESCRIPTION
iOS Chrome flex child (.pcs-scroll) expanded beyond parent (#pcs-screen) because height:auto allowed the container to grow unbounded before max-height could constrain it.

Fix: Replace height:auto with explicit height matching max-height (70dvh/680px desktop, 88dvh/680px mobile). Combined with existing overflow:hidden, this creates a hard containment boundary. No DOM, spacing, or layout changes.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL