### PR TITLE
feat(pcs): implement deterministic vertical spacing system

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -46,13 +46,13 @@
   --pcs-space-1: 4px;
   --pcs-space-2: 8px;
   --pcs-space-3: 12px;
-  --pcs-space-4: 12px;
-  --pcs-space-5: 24px;
+  --pcs-space-4: 10px;
+  --pcs-space-5: 20px;
 
   /* Header system */
   --pcs-header-icon-zone: 32px;
   --pcs-header-gap: 24px;
-  --pcs-header-padding: 52px;
+  --pcs-header-padding: 44px;
 
   /* Icons */
   --pcs-icon-size: 20px;
@@ -71,10 +71,10 @@
 
   /* Notes */
   --pcs-notes-radius: 12px;
-  --pcs-notes-padding: 16px;
+  --pcs-notes-padding: 14px;
 
   /* Safe area */
-  --pcs-safe-bottom: 24px;
+  --pcs-safe-bottom: 20px;
 
   /* Inline separator */
   --pcs-inline-separator-gap: 6px;
@@ -3326,7 +3326,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   align-items: flex-start;
   padding: 0;
   min-width: 0;
-  gap: 8px;
+  gap: 6px;
 }
 
 /* Title — most visually prominent element */
@@ -3394,7 +3394,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-  padding: 0 var(--pcs-content-padding) var(--pcs-content-padding);
+  padding: 0 var(--pcs-content-padding) 20px;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -3405,7 +3405,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   position: sticky;
   bottom: 0;
   display: block;
-  height: 16px;
+  height: 12px;
   background: linear-gradient(to bottom, transparent, var(--surface));
   pointer-events: none;
   flex-shrink: 0;
@@ -3491,7 +3491,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .pcs-divider {
   border: none;
   border-top: 1px solid var(--border);
-  margin: var(--pcs-space-4) 0;
+  margin: 8px 0;
   opacity: 0.16;
 }
 
@@ -3716,7 +3716,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--pcs-space-2);
+  gap: 6px;
   background: transparent;
   border-radius: 0;
 }


### PR DESCRIPTION
Apply proportional spacing reduction across 3 buckets to ensure Activity section fits within modal viewport on standard devices.

Token changes:
  --pcs-space-4: 12px → 10px (section gaps)
  --pcs-space-5: 24px → 20px (fields gap)
  --pcs-header-padding: 52px → 44px (header top)
  --pcs-notes-padding: 16px → 14px (notes box)
  --pcs-safe-bottom: 24px → 20px

Hardcoded overrides:
  .pcs-header-center gap: 8px → 6px
  .pcs-divider margin: var(--pcs-space-4) → 8px
  .pcs-section gap: var(--pcs-space-2) → 6px
  .pcs-scroll padding-bottom: var(--content-padding) → 20px
  .pcs-scroll::after height: 16px → 12px

Total savings: ~42px. No DOM, layout, or typography changes.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL