### PR TITLE
feat(pcs-library): shared grid spine for date + header alignment

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -819,7 +819,7 @@ function renderLibraryRows(posts) {
 
   let html = '';
   for (const [month, group] of Object.entries(groups)) {
-    html += `<div class="pcs-month-group"><div class="pcs-library-month">${esc(month)} &middot; ${group.length} post${group.length === 1 ? '' : 's'}</div><div class="row-list">${group.map(p => buildPostCard(p, 'library')).join('')}</div></div>`;
+    html += `<div class="pcs-month-group"><div class="pcs-library-month"><span class="pcs-month-label">${esc(month)}</span><span class="pcs-month-count">${group.length} post${group.length === 1 ? '' : 's'}</span></div><div class="row-list">${group.map(p => buildPostCard(p, 'library')).join('')}</div></div>`;
   }
   listView.innerHTML = html;
 }

--- a/styles.css
+++ b/styles.css
@@ -2827,20 +2827,29 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 
 .pcs-library-month {
-  display: flex;
+  display: grid;
+  grid-template-columns: 64px 1fr auto;
   align-items: center;
-  justify-content: flex-start;
   font-size: 12px;
   letter-spacing: 0.08em;
   opacity: 0.65;
   margin-top: var(--pcs-space-5);
   margin-bottom: var(--pcs-space-3);
-  padding-bottom: var(--pcs-space-2);
+  padding: 0 16px var(--pcs-space-2);
   border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.pcs-month-label {
+  grid-column: 1;
+  justify-self: start;
+}
+.pcs-month-count {
+  grid-column: 3;
+  justify-self: end;
 }
 
 .row-tile {
-  display: flex;
+  display: grid;
+  grid-template-columns: 64px 1fr auto;
   align-items: center;
   gap: 10px;
   padding: 10px 16px;
@@ -2855,18 +2864,19 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .row-tile:active { background: var(--surface2); }
 
 .row-date {
+  grid-column: 1;
   font-family: var(--font-mono, monospace);
   font-size: 11px;
   font-weight: 700;
   color: var(--text3);
-  min-width: 40px;
-  text-align: center;
-  flex-shrink: 0;
+  width: 64px;
+  min-width: 64px;
+  text-align: left;
 }
 .row-date.today { color: var(--accent); }
 
 .row-body {
-  flex: 1;
+  grid-column: 2;
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -2891,21 +2901,16 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 
 .row-dot {
+  grid-column: 3;
+  justify-self: end;
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  flex-shrink: 0;
 }
 
 /* Action slot — reserved for future stage-progression button */
 .row-action {
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  /* empty for now — button will be injected here */
+  display: none;
 }
 
 /* ═══════════════════════════════════════════════


### PR DESCRIPTION
Create deterministic alignment between month headers and post cards using a shared 3-column grid: 64px | 1fr | auto.

CSS changes:
  .pcs-library-month: flex → grid (64px 1fr auto)
    + padding includes 16px horizontal to match card padding .pcs-month-label: grid-column 1, justify-self start .pcs-month-count: grid-column 3, justify-self end .row-tile: flex → grid (64px 1fr auto) .row-date: locked 64px column, text-align left (was center) .row-body: explicit grid-column 2 .row-dot: grid-column 3, justify-self end .row-action: display none (empty reserved slot, prevents 4th col)

JS change (07-post-load.js):
  Split month header into two spans:
    <span class="pcs-month-label">Mar 2026</span> <span class="pcs-month-count">24 posts</span>

Result: month labels and card dates share left spine, post count and status dots share right spine.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL