### PR TITLE
fix(pcs-library): precision alignment of month header to date spine

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2822,30 +2822,24 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .row-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   padding: 8px 16px var(--sp-4);
 }
 
 .pcs-library-month {
-  display: grid;
-  grid-template-columns: 64px 1fr auto;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
   font-size: 12px;
   letter-spacing: 0.08em;
   opacity: 0.65;
   margin-top: var(--pcs-space-5);
-  margin-bottom: var(--pcs-space-3);
-  padding: 0 16px var(--pcs-space-2);
+  margin-bottom: 8px;
+  padding: 0 32px var(--pcs-space-2) 32px;
   border-bottom: 1px solid rgba(255,255,255,0.06);
 }
-.pcs-month-label {
-  grid-column: 1;
-  justify-self: start;
-}
-.pcs-month-count {
-  grid-column: 3;
-  justify-self: end;
-}
+.pcs-month-label {}
+.pcs-month-count {}
 
 .row-tile {
   display: grid;
@@ -2869,9 +2863,11 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-size: 11px;
   font-weight: 700;
   color: var(--text3);
+  opacity: 0.92;
   width: 64px;
   min-width: 64px;
   text-align: left;
+  font-variant-numeric: tabular-nums;
 }
 .row-date.today { color: var(--accent); }
 


### PR DESCRIPTION
Root cause: .pcs-library-month had 16px left padding, but .row-date sits inside .row-list (16px padding) + .row-tile (16px padding) = 32px total offset. This 16px drift made the month label float left of dates.

Fix:
- Header: grid → flex with space-between, padding 32px horizontal to match the nested card offset exactly
- Header margin-bottom: var(--pcs-space-3) → 8px (reduce by 4px)
- Card gap: 8px → 6px (tighter archive density)
- .row-date: add font-variant-numeric: tabular-nums (prevent jitter)
- .row-date: add opacity: 0.92 (subtle metadata deprioritization)

Result: single vertical spine for month label + all dates, tighter density, stable numeric widths.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL