### PR TITLE
polish(pcs-library): final micro-refinement pass

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2839,14 +2839,14 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   border-bottom: 1px solid rgba(255,255,255,0.06);
 }
 .pcs-month-label {}
-.pcs-month-count {}
+.pcs-month-count { opacity: 0.84; }
 
 .row-tile {
   display: grid;
   grid-template-columns: 64px 1fr auto;
   align-items: center;
   gap: 10px;
-  padding: 10px 16px;
+  padding: 10px 16px 8px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-sm, 10px);
@@ -2863,7 +2863,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-size: 11px;
   font-weight: 700;
   color: var(--text3);
-  opacity: 0.92;
+  opacity: 0.89;
   width: 64px;
   min-width: 64px;
   text-align: left;


### PR DESCRIPTION
- .pcs-month-count: opacity 0.84 (hierarchy: label > count)
- .row-date: opacity 0.92 → 0.89 (calmer metadata weight)
- .row-tile: padding-bottom 10px → 8px (optical centering)

No layout, grid, or DOM changes. Opacity + 2px padding only.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL