### PR TITLE
feat(pcs-calendar): rebuild as pillar grid month view

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -933,54 +933,104 @@ function switchLibraryView(btn) {
 }
 
 
+let _calMonth = new Date().getMonth();
+let _calYear  = new Date().getFullYear();
+
+function _calNav(delta) {
+  _calMonth += delta;
+  if (_calMonth > 11) { _calMonth = 0; _calYear++; }
+  if (_calMonth < 0)  { _calMonth = 11; _calYear--; }
+  filterLibrary();
+}
+
+function groupPostsByDay(posts, month, year) {
+  const map = {};
+  posts.forEach(p => {
+    const d = parseDate(p.targetDate);
+    if (!d || d.getMonth() !== month || d.getFullYear() !== year) return;
+    const s = (p.stage || '').toLowerCase().trim();
+    if (s !== 'published' && s !== 'scheduled') return;
+    const key = p.targetDate;
+    if (!map[key]) map[key] = [];
+    map[key].push(p);
+  });
+  return map;
+}
+
 function renderLibraryCalendar(posts) {
   const container = document.getElementById('library-calendar-view');
   if (!container) return;
   posts = posts || allPosts;
-  const withDates  = posts.filter(p => p.targetDate).sort((a,b) => (parseDate(a.targetDate) || 0) - (parseDate(b.targetDate) || 0));
-  const noDates    = posts.filter(p => !p.targetDate);
-  const months     = {};
-  const today      = new Date(); today.setHours(0,0,0,0);
-  withDates.forEach(p => {
-    const d   = parseDate(p.targetDate);
-    const key = formatMonthYearLong(p.targetDate);
-    if (!months[key]) months[key] = [];
-    months[key].push(p);
+
+  const dayMap = groupPostsByDay(posts, _calMonth, _calYear);
+  const monthLabel = MONTHS_LONG[_calMonth] + ' ' + _calYear;
+
+  // Grid: first day of month and total days
+  const firstDay = new Date(_calYear, _calMonth, 1).getDay(); // 0=Sun
+  const daysInMonth = new Date(_calYear, _calMonth + 1, 0).getDate();
+  const totalCells = firstDay + daysInMonth <= 35 ? 35 : 42;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  // Header
+  let html = `<div class="pcs-cal-header">
+    <span class="pcs-cal-title">${esc(monthLabel)}</span>
+    <span class="pcs-cal-nav">
+      <button class="pcs-cal-nav-btn" onclick="_calNav(-1)">&lsaquo;</button>
+      <button class="pcs-cal-nav-btn" onclick="_calNav(1)">&rsaquo;</button>
+    </span>
+  </div>`;
+
+  // Day-of-week labels
+  html += `<div class="pcs-cal-grid pcs-cal-dow">`;
+  ['Su','Mo','Tu','We','Th','Fr','Sa'].forEach(d => {
+    html += `<div class="pcs-cal-dow-label">${d}</div>`;
   });
-  let html = Object.entries(months).map(([month, posts]) => {
-    const items = posts.map(p => {
-      const id  = getPostId(p);
-      const d   = parseDate(p.targetDate);
-      const isToday = d && d.toDateString() === today.toDateString();
-      const dayStr  = formatDateShort(p.targetDate);
-      const { hex } = stageStyle(p.stage);
-      return `<div class="calendar-item" data-post-id="${esc(id)}" data-list="library">
-        <span class="calendar-date-badge ${isToday?'today-badge':''}">${dayStr}</span>
-        <span class="calendar-item-title">${esc(getTitle(p))}</span>
-        <span style="width:8px;height:8px;border-radius:50%;background:${hex};flex-shrink:0"></span>
-      </div>`;
-    }).join('');
-    return `<div class="calendar-month"><div class="calendar-month-head">${esc(month)}</div><div class="calendar-week-strip">${items}</div></div>`;
-  }).join('');
-  if (noDates.length) {
-    const items = noDates.map(p => {
-      const id = getPostId(p);
-      const { hex } = stageStyle(p.stage);
-      return `<div class="calendar-item" data-post-id="${esc(id)}" data-list="library">
-        <span class="calendar-date-badge" style="color:var(--text3)">-</span>
-        <span class="calendar-item-title">${esc(getTitle(p))}</span>
-        <span style="width:8px;height:8px;border-radius:50%;background:${hex};flex-shrink:0"></span>
-      </div>`;
-    }).join('');
-    html += `<div class="calendar-month"><div class="calendar-month-head">No Date Set</div><div class="calendar-week-strip">${items}</div></div>`;
+  html += `</div>`;
+
+  // Cells
+  html += `<div class="pcs-cal-grid">`;
+  for (let i = 0; i < totalCells; i++) {
+    const dayNum = i - firstDay + 1;
+    if (i < firstDay || dayNum > daysInMonth) {
+      html += `<div class="pcs-cal-cell pcs-cal-cell-empty"></div>`;
+      continue;
+    }
+
+    const dd = String(dayNum).padStart(2, '0');
+    const mm = String(_calMonth + 1).padStart(2, '0');
+    const key = `${_calYear}-${mm}-${dd}`;
+    const cellDate = new Date(_calYear, _calMonth, dayNum);
+    const isToday = cellDate.getTime() === today.getTime();
+    const dayPosts = dayMap[key] || [];
+
+    const first = dayPosts[0];
+    const pillar = first
+      ? ((PILLAR_DISPLAY && PILLAR_DISPLAY[(first.contentPillar || '').toLowerCase()]) || first.contentPillar || 'General')
+      : '';
+    const postId = first ? getPostId(first) : '';
+    const extra = dayPosts.length > 1 ? dayPosts.length - 1 : 0;
+
+    const clickAttr = postId ? ` data-post-id="${esc(postId)}" data-list="library"` : '';
+    const todayClass = isToday ? ' pcs-cal-today' : '';
+    const hasPost = dayPosts.length ? ' pcs-cal-has-post' : '';
+
+    html += `<div class="pcs-cal-cell${todayClass}${hasPost}"${clickAttr}>`;
+    html += `<div class="pcs-cal-date">${dayNum}</div>`;
+    if (pillar) html += `<div class="pcs-cal-pill">${esc(pillar)}</div>`;
+    if (extra)  html += `<div class="pcs-cal-more">+${extra}</div>`;
+    html += `</div>`;
   }
-  container.innerHTML = html || `<div class="empty-state"><div class="empty-icon">[date]</div><p>No posts with dates yet.</p></div>`;
+  html += `</div>`;
+
+  container.innerHTML = html;
 }
 
 // ═══════════════════════════════════════════════
 // Event delegation for card clicks
 // Single document-level listener — survives ALL innerHTML replacements.
-// Covers: .row-tile, .calendar-item, .upc-list-row (any element with data-post-id)
+// Covers: .row-tile, .pcs-cal-cell, .upc-list-row (any element with data-post-id)
 // ═══════════════════════════════════════════════
 (document.getElementById('dashboard-view') || document).addEventListener('click', function _cardClickDelegate(e) {
   var card = e.target.closest('[data-post-id]');

--- a/styles.css
+++ b/styles.css
@@ -2490,47 +2490,101 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .pillar-card-title { font-size: 13px; color: var(--text); flex: 1; min-width: 0; }
 .pillar-card-meta  { display: flex; align-items: center; gap: var(--sp-2); flex-shrink: 0; }
 
-/* Calendar view */
-.calendar-month {
-  margin-bottom: var(--sp-5);
-}
-.calendar-month-head {
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--text2);
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  padding: var(--sp-2) 0 var(--sp-1);
-  border-bottom: 1px solid var(--border);
-  margin-bottom: var(--sp-2);
-}
-.calendar-week-strip {
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-2);
-}
-.calendar-item {
+/* Calendar view — pillar grid */
+.pcs-cal-header {
   display: flex;
   align-items: center;
-  gap: var(--sp-3);
-  padding: var(--sp-2) var(--sp-3);
+  justify-content: space-between;
+  padding: 12px 16px 8px;
+}
+.pcs-cal-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+.pcs-cal-nav {
+  display: flex;
+  gap: 4px;
+}
+.pcs-cal-nav-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  color: var(--text2);
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+}
+.pcs-cal-nav-btn:active { background: var(--surface3); }
+
+.pcs-cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 1px;
+  padding: 0 16px;
+}
+
+.pcs-cal-dow {
+  gap: 0;
+  margin-bottom: 4px;
+}
+.pcs-cal-dow-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text3);
+  text-align: center;
+  padding: 4px 0;
+}
+
+.pcs-cal-cell {
+  min-height: 72px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-radius: 6px;
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: var(--r-sm);
+}
+.pcs-cal-cell-empty {
+  background: transparent;
+  border-color: transparent;
+}
+.pcs-cal-cell.pcs-cal-has-post {
   cursor: pointer;
-  transition: background var(--transition-fast);
 }
-.calendar-item:hover { background: var(--surface2); }
-.calendar-date-badge {
-  font-family: var(--font-mono);
-  font-size: 11px;
+.pcs-cal-cell.pcs-cal-has-post:active {
+  background: var(--surface2);
+}
+.pcs-cal-cell.pcs-cal-today .pcs-cal-date {
+  color: var(--accent);
   font-weight: 700;
-  color: var(--text3);
-  min-width: 38px;
-  text-align: center;
 }
-.calendar-date-badge.today-badge { color: var(--accent); }
-.calendar-item-title { font-size: 13px; color: var(--text); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.pcs-cal-date {
+  font-size: 11px;
+  opacity: 0.6;
+  font-variant-numeric: tabular-nums;
+}
+
+.pcs-cal-pill {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.3;
+}
+
+.pcs-cal-more {
+  font-size: 10px;
+  color: var(--text3);
+}
 
 /* ═══════════════════════════════════════════════
    V2 — CREATIVE TARGET TRACKER (fix 20)
@@ -2728,7 +2782,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 /* ═══════════════════════════════════════════════
    ROW TILE — universal compact list row
-   Matches calendar-item style for all views
 ═══════════════════════════════════════════════ */
 
 .row-list {


### PR DESCRIPTION
REMOVED (JS — renderLibraryCalendar):
  - Old grouped-by-month list layout
  - calendar-item, calendar-month, calendar-week-strip rendering
  - No-date fallback section

REMOVED (CSS):
  - .calendar-month, .calendar-month-head, .calendar-week-strip
  - .calendar-item, .calendar-item:hover
  - .calendar-date-badge, .calendar-date-badge.today-badge
  - .calendar-item-title

ADDED (JS):
  - _calMonth / _calYear state for month navigation
  - _calNav(delta) — prev/next month
  - groupPostsByDay(posts, month, year) — filters published + scheduled, groups by YYYY-MM-DD key
  - renderLibraryCalendar(posts) — proper 7-column Sunday-start grid 35 or 42 cells, pillar pill per day, +n overflow, today highlight, click opens first post via data-post-id delegation

ADDED (CSS):
  - .pcs-cal-header, .pcs-cal-title, .pcs-cal-nav, .pcs-cal-nav-btn
  - .pcs-cal-grid (7-col grid), .pcs-cal-dow, .pcs-cal-dow-label
  - .pcs-cal-cell, .pcs-cal-cell-empty, .pcs-cal-has-post, .pcs-cal-today
  - .pcs-cal-date, .pcs-cal-pill, .pcs-cal-more

NOT touched: list view, filters, PCS modal, data source

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL