### PR TITLE
fix(pcs-calendar): eliminate horizontal scroll on all viewports

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2232,6 +2232,7 @@ tr:hover td { background: var(--surface2); }
 #library-content {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
   padding: var(--sp-3) 0 calc(64px + var(--sp-5));
   position: relative;
@@ -2523,9 +2524,13 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 .pcs-cal-grid {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
+  grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 1px;
   padding: 0 16px;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  overflow-x: hidden;
 }
 
 .pcs-cal-dow {
@@ -2542,6 +2547,9 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 .pcs-cal-cell {
   min-height: 72px;
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
   padding: 6px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
- .pcs-cal-grid: repeat(7, 1fr) → repeat(7, minmax(0, 1fr))
  + width: 100%, max-width: 100%, box-sizing: border-box
  + overflow-x: hidden
- .pcs-cal-cell: min-width: 0, width: 100%, box-sizing: border-box
- #library-content: overflow-x: hidden (container safety)

CSS-only fix. No JS or DOM changes.

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL