### PR TITLE
fix(pcs-calendar): use PILLAR_SHORT for cell labels

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -1006,8 +1006,9 @@ function renderLibraryCalendar(posts) {
     const dayPosts = dayMap[key] || [];
 
     const first = dayPosts[0];
+    const pillarKey = first ? (first.contentPillar || '').toLowerCase() : '';
     const pillar = first
-      ? ((PILLAR_DISPLAY && PILLAR_DISPLAY[(first.contentPillar || '').toLowerCase()]) || first.contentPillar || 'General')
+      ? (PILLAR_SHORT[pillarKey] || PILLAR_DISPLAY[pillarKey] || first.contentPillar || 'General')
       : '';
     const postId = first ? getPostId(first) : '';
     const extra = dayPosts.length > 1 ? dayPosts.length - 1 : 0;


### PR DESCRIPTION
Filter sync: already working — filterLibrary() passes the filtered dataset to renderLibraryCalendar(filtered) at line 792. No change needed.

Pillar text: PILLAR_DISPLAY → PILLAR_SHORT as primary lookup.
Fallback chain: PILLAR_SHORT → PILLAR_DISPLAY → raw → 'General'

Matches the same pattern used in postcard subtitles (08-post-actions.js:422).

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL