### PR TITLE
Fix visual hierarchy: limit warnings, soften pipeline, clarify signals

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -399,8 +399,8 @@ function renderDashboard() {
     }
     // Next gap: first posting day with no content
     if (hard_runway > 0) {
-      const dn = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
-      nextGapDay = dn[check.getDay()] + ' ' + check.getDate() + '/' + (check.getMonth() + 1);
+      const dn = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+      nextGapDay = dn[check.getDay()];
     }
   }
   const soft_runway = Math.floor(approval * 0.7);
@@ -421,15 +421,15 @@ function renderDashboard() {
   // ── TODAY CHECK ──
   const todayHasPost = futureDays.has(dayKey(now));
 
-  // ── WARNINGS (max 3, ordered: today → runway → pipeline) ──
+  // ── WARNINGS (max 2: primary signal + secondary concern) ──
   const warnings = [];
-  if (!todayHasPost) warnings.push({ text: 'No post scheduled today', level: 'crit' });
-  if (hard_runway === 0 && warnings.length < 3) warnings.push({ text: 'No runway', level: 'crit' });
-  else if (hard_runway <= 2 && hard_runway > 0 && warnings.length < 3) warnings.push({ text: 'Low runway \u2014 act now', level: 'crit' });
-  if (approval === 0 && warnings.length < 3) warnings.push({ text: 'Approval empty', level: 'risk' });
-  if (production === 0 && warnings.length < 3) warnings.push({ text: 'Production empty', level: 'risk' });
-  const warningsHtml = warnings.map(w =>
-    `<span class="rw-warn rw-warn-${w.level}">${w.text}</span>`
+  if (!todayHasPost) warnings.push({ text: 'No post scheduled today' });
+  if (hard_runway === 0 && warnings.length < 2) warnings.push({ text: 'No runway' });
+  else if (hard_runway <= 2 && hard_runway > 0 && warnings.length < 2) warnings.push({ text: 'Low runway \u2014 act now' });
+  if (approval === 0 && warnings.length < 2) warnings.push({ text: 'Approval empty' });
+  // First warning = red (rw-warn-1), second = amber (rw-warn-2)
+  const warningsHtml = warnings.map((w, i) =>
+    `<span class="rw-warn rw-warn-${i === 0 ? '1' : '2'}">${w.text}</span>`
   ).join('');
 
   // ── RUNWAY STATE COLOR ──
@@ -458,7 +458,7 @@ function renderDashboard() {
     <div class="rw-month">${monthLabel}</div>
     <div class="rw-hero">
       <div class="rw-runway-hard ${runwayState}">${hard_runway}</div>
-      ${nextGapDay ? `<div class="rw-next-gap">Next gap: ${nextGapDay}</div>` : ''}
+      ${nextGapDay ? `<div class="rw-next-gap">Covered till ${nextGapDay}</div>` : ''}
       <div class="rw-runway-label">days of runway</div>
       ${soft_runway > 0 ? `<div class="rw-runway-soft">+${soft_runway} in approval</div>` : ''}
     </div>

--- a/styles.css
+++ b/styles.css
@@ -859,11 +859,11 @@ a:hover { text-decoration: underline; }
   margin-top: 4px;
 }
 
-/* Text pipeline (replaces graph) */
+/* Text pipeline */
 .rw-pipeline {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
 }
 .rw-pipe-row {
   display: flex;
@@ -874,16 +874,17 @@ a:hover { text-decoration: underline; }
 .rw-pipe-row.rw-pipe-zero { opacity: 0.35; }
 .rw-pipe-label {
   font-size: 13px;
-  color: var(--text2);
+  color: var(--text3);
+  opacity: 0.55;
 }
 .rw-pipe-count {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--text);
   font-variant-numeric: tabular-nums;
 }
 
-/* Warnings */
+/* Warnings (max 2: red primary, amber secondary) */
 .rw-warnings {
   display: flex;
   flex-direction: column;
@@ -891,19 +892,19 @@ a:hover { text-decoration: underline; }
 }
 .rw-warn {
   font-size: 13px;
-  color: var(--text3);
-  opacity: 0.85;
   padding: 3px 10px;
   border-left: 3px solid var(--pcs-border-soft);
+  color: var(--text3);
+  opacity: 0.7;
 }
-.rw-warn-crit {
+.rw-warn-1 {
   color: var(--c-red, #ef4444);
   opacity: 1;
   border-left-color: var(--c-red, #ef4444);
 }
-.rw-warn-risk {
+.rw-warn-2 {
   color: var(--c-amber, #f59e0b);
-  opacity: 0.9;
+  opacity: 0.75;
   border-left-color: var(--c-amber, #f59e0b);
 }
 
@@ -913,6 +914,7 @@ a:hover { text-decoration: underline; }
   font-weight: 600;
   color: var(--accent);
   cursor: pointer;
+  margin-top: 4px;
   transition: opacity 120ms ease;
 }
 .rw-action:active { opacity: 0.7; }


### PR DESCRIPTION
1. Warnings capped at 2 (was 3). "Production empty" removed. Priority: today missing (red) → low runway (amber)
2. "Next gap: Thu 19/3" → "Covered till Thursday" (human language)
3. Warning styling: first = red full opacity, second = amber 0.75 (distinct visual weight, not same treatment)
4. Pipeline: labels lighter (text3 @ 0.55), numbers stronger (14px), row gap increased 6px → 10px (less table feel)
5. Action: margin-top 4px separates from warnings visually

https://claude.ai/code/session_01QXDjF7CvU2kgDGDgJzo7eL