### PR TITLE
debug: add setStage() interceptor to trace all stage mutations

### DIFF
--- a/01-config.js
+++ b/01-config.js
@@ -196,5 +196,19 @@ const STRIP_STAGES = [
 // Canonical owner list — used by dropdowns, validation, and grid
 const ALLOWED_OWNERS = ['Pranav', 'Chitra', 'Admin'];
 
+// ── Stage change interceptor — logs every .stage mutation ──
+function setStage(post, newStage, source) {
+  console.log('STAGE CHANGE →', {
+    id: post.id || post.post_id,
+    from: post.stage,
+    to: newStage,
+    source,
+    time: Date.now(),
+    stack: new Error().stack
+  });
+  post.stage = newStage;
+}
+window.setStage = setStage;
+
 const CREATIVE_URGENCY  = ['revisions needed','awaiting brand input','in production'];
 const NEXT_POST_URGENCY = ['revisions needed','awaiting brand input','in production','ready','awaiting approval'];

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -31,6 +31,10 @@ function mergePosts(fresh) {
     delete existing._dirty;
     delete existing._dirtyAt;
 
+    // Log stage change from poll merge BEFORE Object.assign overwrites it
+    if (existing.stage !== fp.stage) {
+      setStage(existing, fp.stage, 'poll_merge');
+    }
     Object.assign(existing, fp);
   });
 

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -7,7 +7,7 @@ async function quickStage(postId, newStage) {
   const post = getPostById(postId);
   if (!post) return;
   const oldStage = post.stage;
-  post.stage = newStage;
+  setStage(post, newStage, 'quickStage');
   post._dirty = true;
   post._dirtyAt = Date.now();
   console.log('[PCS] LOCAL UPDATE:', postId, newStage, Date.now());
@@ -26,7 +26,7 @@ async function quickStage(postId, newStage) {
   } catch (err) {
     delete post._dirty;
     // KEEP _dirtyAt — poll will clear it after 5s window expires
-    post.stage = oldStage;
+    setStage(post, oldStage, 'quickStage_rollback');
     scheduleRender();
     showToast('Update failed — try again', 'error');
   }
@@ -100,7 +100,7 @@ async function clientApprove(postId, btn) {
     await logActivity({ post_id: postId, actor_name: 'Client', actor_role: 'Client', action: 'Approved — moved to Scheduled' });
     const confirmEl = document.getElementById(`approved-confirm-${postId}`);
     if (confirmEl) confirmEl.classList.add('active');
-    post.stage = 'scheduled';
+    setStage(post, 'scheduled', 'clientApprove');
     post._dirtyAt = Date.now();
     setTimeout(() => loadPostsForClient(), 1200);
   } catch { if (btn) btn.disabled = false; showToast('Failed — try again', 'error'); }
@@ -512,7 +512,7 @@ function _executeStageChange(postId, newStage) {
   const post = getPostById(postId);
   if (!post) return;
   const previousStage = post.stage;
-  post.stage = newStage;
+  setStage(post, newStage, '_executeStageChange');
   post._dirty = true;
   post._dirtyAt = Date.now();
   console.log('[PCS] LOCAL UPDATE:', postId, newStage, Date.now());
@@ -535,7 +535,7 @@ function _executeStageChange(postId, newStage) {
       // Rollback local state
       delete post._dirty;
       // KEEP _dirtyAt — poll will clear it after 5s window expires
-      post.stage = previousStage;
+      setStage(post, previousStage, '_executeStageChange_rollback');
       _renderPCS(postId);
       _renderBackgroundViews();
       showToast('Update failed — rolled back', 'error');


### PR DESCRIPTION
Every post.stage write now routes through setStage(post, value, source) which logs: id, from, to, source function, timestamp, and stack trace.

Sites replaced:
- quickStage (write + rollback)
- clientApprove
- _executeStageChange (write + rollback)
- poll_merge (before Object.assign in mergePosts)

Only post.stage= remaining is inside setStage() itself (01-config.js).

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG