### PR TITLE
fix: force PCS + background re-render after DB success in _executeSta…

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -530,7 +530,13 @@ function _executeStageChange(postId, newStage) {
   })
     .then(() => { console.log('[PCS] DB WRITE SUCCESS:', postId, newStage, Date.now()); delete post._dirty; /* KEEP _dirtyAt for time-based poll protection */ })
     .then(() => logActivity({ post_id: postId, actor_name: localStorage.getItem('gbl_email') || currentRole, actor_role: currentRole, action: `Stage → ${newStage}` }))
-    .then(() => showUndoToast(`Moved to ${newStage}`, () => _executeStageChange(postId, previousStage)))
+    .then(() => {
+      // CRITICAL: force final UI sync after DB success
+      _renderPCS(postId);
+      _renderBackgroundViews();
+      console.log('[PCS] FINAL RENDER SYNC:', postId, post.stage, Date.now());
+      showUndoToast(`Moved to ${newStage}`, () => _executeStageChange(postId, previousStage));
+    })
     .catch(() => {
       // Rollback local state
       delete post._dirty;


### PR DESCRIPTION
…geChange

After DB write confirms, re-render PCS modal and background views to guarantee UI reflects the committed stage. Previously only the optimistic pre-DB render ran; any intermediate DOM overwrite left the modal stale despite correct local state.

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG