### PR TITLE
fix: null-guard all DOM access and wrap render functions with try/catch

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -51,16 +51,18 @@ function backToEmail() {
 }
 
 window.sendMagicLink = async function sendMagicLink() {
-  const email = (document.getElementById('login-email-input').value || '').trim().toLowerCase();
+  const email = (document.getElementById('login-email-input')?.value || '').trim().toLowerCase();
   if (!email || !email.includes('@')) {
-    document.getElementById('login-error').textContent = 'Please enter a valid email.';
+    const errEl = document.getElementById('login-error');
+    if (errEl) errEl.textContent = 'Please enter a valid email.';
     return;
   }
   const btn = document.querySelector('#login-email-step .btn-modal-primary');
   if (!btn) return;
   btn.disabled = true;
   btn.textContent = 'Sending...';
-  document.getElementById('login-error').textContent = '';
+  const errClr = document.getElementById('login-error');
+  if (errClr) errClr.textContent = '';
   try {
     const res = await fetch(`${SUPABASE_URL}/auth/v1/otp`, {
       method: 'POST',
@@ -72,7 +74,7 @@ window.sendMagicLink = async function sendMagicLink() {
       throw new Error(err.error_description || err.msg || 'Could not send code');
     }
     localStorage.setItem('gbl_pending_email', email);
-    document.getElementById('login-email-step').classList.remove('active');
+    document.getElementById('login-email-step')?.classList.remove('active');
     const codeStep = document.getElementById('login-code-step');
     if (codeStep) {
       codeStep.classList.add('active');
@@ -81,7 +83,8 @@ window.sendMagicLink = async function sendMagicLink() {
       setTimeout(() => document.getElementById('login-code-input')?.focus(), 100);
     }
   } catch (err) {
-    document.getElementById('login-error').textContent = err.message || 'Could not send code. Try again.';
+    const errMsg = document.getElementById('login-error');
+    if (errMsg) errMsg.textContent = err.message || 'Could not send code. Try again.';
     btn.disabled = false;
     btn.textContent = 'Send Code ->';
   }

--- a/06-post-create.js
+++ b/06-post-create.js
@@ -45,14 +45,15 @@ return false;
 
 if (!d.title && !d.comments) return false;
 
-document.getElementById('npm-title').value    = d.title    || '';
-document.getElementById('npm-pillar').value   = d.pillar   || '';
-document.getElementById('npm-location').value = d.location || '';
-document.getElementById('npm-owner').value    = d.owner    || '';
-document.getElementById('npm-stage').value    = d.stage    || 'in production';
-document.getElementById('npm-date').value     = d.date     || '';
-document.getElementById('npm-comments').value = d.comments || '';
-document.getElementById('npm-postlink').value = d.postLink || '';
+const _npm = id => document.getElementById(id);
+if (_npm('npm-title'))    _npm('npm-title').value    = d.title    || '';
+if (_npm('npm-pillar'))   _npm('npm-pillar').value   = d.pillar   || '';
+if (_npm('npm-location')) _npm('npm-location').value = d.location || '';
+if (_npm('npm-owner'))    _npm('npm-owner').value    = d.owner    || '';
+if (_npm('npm-stage'))    _npm('npm-stage').value    = d.stage    || 'in production';
+if (_npm('npm-date'))     _npm('npm-date').value     = d.date     || '';
+if (_npm('npm-comments')) _npm('npm-comments').value = d.comments || '';
+if (_npm('npm-postlink')) _npm('npm-postlink').value = d.postLink || '';
 
 showDraftStatus('Draft restored');
 return true;
@@ -120,18 +121,20 @@ const el = document.getElementById(id);
 if (el) el.value = '';
 });
 
-document.getElementById('npm-pillar').value   = '';
-document.getElementById('npm-location').value = '';
-document.getElementById('npm-owner').value    = '';
-document.getElementById('npm-stage').value    = 'in production';
-document.getElementById('npm-date').value     = '';
+const _np = id => document.getElementById(id);
+if (_np('npm-pillar'))   _np('npm-pillar').value   = '';
+if (_np('npm-location')) _np('npm-location').value = '';
+if (_np('npm-owner'))    _np('npm-owner').value    = '';
+if (_np('npm-stage'))    _np('npm-stage').value    = 'in production';
+if (_np('npm-date'))     _np('npm-date').value     = '';
 }
 
-document.getElementById('npm-submit-btn').disabled = false;
-document.getElementById('npm-saving').classList.remove('active');
+const npmSubmit = document.getElementById('npm-submit-btn');
+if (npmSubmit) npmSubmit.disabled = false;
+document.getElementById('npm-saving')?.classList.remove('active');
 
 window._modalOpen = true;
-document.getElementById('new-post-overlay').classList.add('open');
+document.getElementById('new-post-overlay')?.classList.add('open');
 document.body.style.overflow = 'hidden';
 
 startDraftAutosave();
@@ -146,7 +149,7 @@ if (e && e.target !== document.getElementById('new-post-overlay')) return;
 saveDraft();
 stopDraftAutosave();
 
-document.getElementById('new-post-overlay').classList.remove('open');
+document.getElementById('new-post-overlay')?.classList.remove('open');
 document.body.style.overflow = '';
 window._modalOpen = false;
 _drainDeferredRender();
@@ -154,32 +157,33 @@ _drainDeferredRender();
 
 async function submitNewPost() {
 
-const title    = document.getElementById('npm-title').value.trim();
-const owner    = document.getElementById('npm-owner').value;
-const pillar   = document.getElementById('npm-pillar').value;
-const location = document.getElementById('npm-location').value;
-const stage    = document.getElementById('npm-stage').value;
-const date     = document.getElementById('npm-date').value;
-const comments = document.getElementById('npm-comments').value.trim();
-const postLink = document.getElementById('npm-postlink').value.trim();
+const _s = id => document.getElementById(id);
+const title    = (_s('npm-title')?.value || '').trim();
+const owner    = _s('npm-owner')?.value || '';
+const pillar   = _s('npm-pillar')?.value || '';
+const location = _s('npm-location')?.value || '';
+const stage    = _s('npm-stage')?.value || '';
+const date     = _s('npm-date')?.value || '';
+const comments = (_s('npm-comments')?.value || '').trim();
+const postLink = (_s('npm-postlink')?.value || '').trim();
 
 if (!title) {
 showToast('Post title is required', 'error');
-document.getElementById('npm-title').focus();
+_s('npm-title')?.focus();
 return;
 }
 
 if (!owner) {
 showToast('Owner is required', 'error');
-document.getElementById('npm-owner').focus();
+_s('npm-owner')?.focus();
 return;
 }
 
-const submitBtn = document.getElementById('npm-submit-btn');
-const savingMsg = document.getElementById('npm-saving');
+const submitBtn = _s('npm-submit-btn');
+const savingMsg = _s('npm-saving');
 
-submitBtn.disabled = true;
-savingMsg.classList.add('active');
+if (submitBtn) submitBtn.disabled = true;
+if (savingMsg) savingMsg.classList.add('active');
 
 try {
 
@@ -201,7 +205,7 @@ post_link: postLink || null
 clearDraft();
 stopDraftAutosave();
 
-document.getElementById('new-post-overlay').classList.remove('open');
+document.getElementById('new-post-overlay')?.classList.remove('open');
 document.body.style.overflow = '';
 window._modalOpen = false;
 
@@ -217,7 +221,7 @@ saveDraft();
 
 showToast('Failed to create - draft saved', 'error');
 
-submitBtn.disabled = false;
-savingMsg.classList.remove('active');
+if (submitBtn) submitBtn.disabled = false;
+if (savingMsg) savingMsg.classList.remove('active');
 }
 }

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -71,7 +71,8 @@ async function loadPosts() {
       showErrorBanner('Could not reach server. Showing cached data.',
         `Last updated: ${new Date().toLocaleTimeString()}`);
     } else {
-      document.getElementById('tasks-container').innerHTML =
+      const tc = document.getElementById('tasks-container');
+      if (tc) tc.innerHTML =
         `<div class="empty-state">
           <div class="empty-icon">[!]</div>
           <p><strong>Could not load posts.</strong><br>Check your connection.</p>
@@ -98,7 +99,8 @@ async function loadPostsForClient() {
       renderClientView();
       showErrorBanner('Showing cached data - connection issue.');
     } else {
-      document.getElementById('client-approved-tbody').innerHTML =
+      const catb = document.getElementById('client-approved-tbody');
+      if (catb) catb.innerHTML =
         `<tr><td colspan="3"><div class="empty-state"><div class="empty-icon">[!]</div>
         <p>Could not load. Check your connection.</p></div></td></tr>`;
     }
@@ -353,6 +355,9 @@ function computeDelayMeta(posts) {
 }
 
 function renderDashboard() {
+  try { _renderDashboardInner(); } catch(e) { console.error('[PCS] renderDashboard crash:', e); }
+}
+function _renderDashboardInner() {
   const el = document.getElementById('pcs-dashboard');
   if (!el) return;
 
@@ -770,6 +775,7 @@ function renderAdminInsight() {
 function openParked() {
   const posts = window._parkedPosts || [];
   const list  = document.getElementById('parked-sheet-list');
+  if (!list) return;
   list.innerHTML = posts.map(p => {
     const id    = getPostId(p);
     const title = getTitle(p);
@@ -784,12 +790,12 @@ function openParked() {
       <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:20px;background:${hex}22;color:${hex};flex-shrink:0">${esc(stage)}</span>
     </div>`;
   }).join('') || '<div style="color:var(--text3);padding:var(--sp-4) 0;font-size:14px">No parked posts.</div>';
-  document.getElementById('parked-overlay').classList.add('open');
+  document.getElementById('parked-overlay')?.classList.add('open');
   document.body.style.overflow = 'hidden';
 }
 
 function closeParked() {
-  document.getElementById('parked-overlay').classList.remove('open');
+  document.getElementById('parked-overlay')?.classList.remove('open');
   document.body.style.overflow = '';
 }
 
@@ -1021,6 +1027,9 @@ function _renderFilteredTasks() {
 }
 
 function renderTasks() {
+  try { _renderTasksInner(); } catch(e) { console.error('[PCS] renderTasks crash:', e); }
+}
+function _renderTasksInner() {
   renderTaskStageChips();
 
   // If a chip filter is active, let _renderFilteredTasks handle it
@@ -1083,6 +1092,9 @@ function toggleStageOverflow(btn, totalHidden) {
 }
 
 function renderPipeline() {
+  try { _renderPipelineInner(); } catch(e) { console.error('[PCS] renderPipeline crash:', e); }
+}
+function _renderPipelineInner() {
   // Consume pressure-click filter (set by dashboard click handler)
   const activeFilter = window.pcsPipelineFilter;
   window.pcsPipelineFilter = null;
@@ -1147,6 +1159,7 @@ function renderPipeline() {
   }).join('');
 
   const container = document.getElementById('pipeline-container');
+  if (!container) return;
   container.innerHTML = html;
 
   // ── GLOBAL EMPTY STATE (filtered view with no results) ──
@@ -1172,6 +1185,9 @@ function getUpcoming() {
 }
 
 function renderUpcoming() {
+  try { _renderUpcomingInner(); } catch(e) { console.error('[PCS] renderUpcoming crash:', e); }
+}
+function _renderUpcomingInner() {
   // Consume date filter (set by runway click)
   const activeFilter = window.pcsUpcomingFilter;
   window.pcsUpcomingFilter = null;
@@ -1283,8 +1299,10 @@ function filterLibrary() {
 }
 
 function renderLibrary() {
-  populateFilterDropdowns();
-  filterLibrary();
+  try {
+    populateFilterDropdowns();
+    filterLibrary();
+  } catch(e) { console.error('[PCS] renderLibrary crash:', e); }
 }
 
 function renderLibraryRows(posts) {
@@ -1314,6 +1332,9 @@ function renderLibraryRows(posts) {
 }
 
 function renderClientView() {
+  try { _renderClientViewInner(); } catch(e) { console.error('[PCS] renderClientView crash:', e); }
+}
+function _renderClientViewInner() {
   const inputPosts = allPosts.filter(p => (p.stage||'').toLowerCase().trim() === 'awaiting brand input');
   const inputCount = document.getElementById('client-input-count');
   if (inputCount) inputCount.textContent = inputPosts.length;
@@ -1415,8 +1436,10 @@ function switchLibraryView(btn) {
   btn.classList.add('active');
   _currentLibraryView = btn.dataset.view;
 
-  document.getElementById('library-list-view').style.display      = _currentLibraryView === 'list'     ? '' : 'none';
-  document.getElementById('library-calendar-view').style.display  = _currentLibraryView === 'calendar' ? '' : 'none';
+  const llv = document.getElementById('library-list-view');
+  const lcv = document.getElementById('library-calendar-view');
+  if (llv) llv.style.display = _currentLibraryView === 'list'     ? '' : 'none';
+  if (lcv) lcv.style.display = _currentLibraryView === 'calendar' ? '' : 'none';
 
   filterLibrary();
 }

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -36,41 +36,45 @@ function openAdminEdit(postId) {
   const post = getPostById(postId);
   if (!post) return;
   window._modalOpen = true;
-  document.getElementById('ae-postid').textContent   = postId;
-  document.getElementById('ae-title').value          = getTitle(post);
-  document.getElementById('ae-owner').value          = getResponsibleOwner(post) || '—';
-  document.getElementById('ae-pillar').value         = post.contentPillar || '';
-  document.getElementById('ae-location').value       = post.location || '';
-  document.getElementById('ae-date').value           = post.targetDate || '';
-  document.getElementById('ae-comments').value       = post.comments || '';
-  document.getElementById('ae-postlink').value       = post.postLink || '';
-  const sel = document.getElementById('ae-stage');
-  sel.innerHTML = PIPELINE_ORDER.map(s => `<option value="${s}" ${post.stage===s?'selected':''}>${s}</option>`).join('');
-  document.getElementById('ae-save-btn').dataset.postId = postId;
-  document.getElementById('admin-edit-overlay').classList.add('open');
+  const _ae = id => document.getElementById(id);
+  const aePostid = _ae('ae-postid');    if (aePostid) aePostid.textContent = postId;
+  const aeTitle  = _ae('ae-title');     if (aeTitle) aeTitle.value = getTitle(post);
+  const aeOwner  = _ae('ae-owner');     if (aeOwner) aeOwner.value = getResponsibleOwner(post) || '—';
+  const aePillar = _ae('ae-pillar');    if (aePillar) aePillar.value = post.contentPillar || '';
+  const aeLoc    = _ae('ae-location');  if (aeLoc) aeLoc.value = post.location || '';
+  const aeDate   = _ae('ae-date');      if (aeDate) aeDate.value = post.targetDate || '';
+  const aeComm   = _ae('ae-comments');  if (aeComm) aeComm.value = post.comments || '';
+  const aeLink   = _ae('ae-postlink');  if (aeLink) aeLink.value = post.postLink || '';
+  const sel = _ae('ae-stage');
+  if (sel) sel.innerHTML = PIPELINE_ORDER.map(s => `<option value="${s}" ${post.stage===s?'selected':''}>${s}</option>`).join('');
+  const aeBtn = _ae('ae-save-btn');     if (aeBtn) aeBtn.dataset.postId = postId;
+  const aeOverlay = _ae('admin-edit-overlay');
+  if (aeOverlay) aeOverlay.classList.add('open');
   document.body.style.overflow = 'hidden';
 }
 
 function closeAdminEdit() {
-  document.getElementById('admin-edit-overlay').classList.remove('open');
+  document.getElementById('admin-edit-overlay')?.classList.remove('open');
   document.body.style.overflow = '';
   window._modalOpen = false;
   _drainDeferredRender();
 }
 
 async function saveAdminEdit() {
-  const postId   = document.getElementById('ae-save-btn').dataset.postId;
-  const title    = document.getElementById('ae-title').value.trim();
-  const owner    = document.getElementById('ae-owner').value;
-  const pillar   = document.getElementById('ae-pillar').value;
-  const location = document.getElementById('ae-location').value;
-  const stage    = document.getElementById('ae-stage').value;
-  const date     = document.getElementById('ae-date').value;
-  const comments = document.getElementById('ae-comments').value.trim();
-  const postLink = document.getElementById('ae-postlink').value.trim();
+  const _ae = id => document.getElementById(id);
+  const postId   = _ae('ae-save-btn')?.dataset?.postId;
+  if (!postId) return;
+  const title    = (_ae('ae-title')?.value || '').trim();
+  const owner    = _ae('ae-owner')?.value || '';
+  const pillar   = _ae('ae-pillar')?.value || '';
+  const location = _ae('ae-location')?.value || '';
+  const stage    = _ae('ae-stage')?.value || '';
+  const date     = _ae('ae-date')?.value || '';
+  const comments = (_ae('ae-comments')?.value || '').trim();
+  const postLink = (_ae('ae-postlink')?.value || '').trim();
   if (!title) { showToast('Title is required', 'error'); return; }
-  const btn = document.getElementById('ae-save-btn');
-  btn.disabled = true;
+  const btn = _ae('ae-save-btn');
+  if (btn) btn.disabled = true;
   try {
     await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
       method: 'PATCH',
@@ -82,7 +86,7 @@ async function saveAdminEdit() {
     showToast('Post saved ✓', 'success');
   } catch (err) {
     showToast('Save failed — try again', 'error');
-    btn.disabled = false;
+    if (btn) btn.disabled = false;
   }
 }
 

--- a/10-ui.js
+++ b/10-ui.js
@@ -7,7 +7,8 @@ console.log("LOADED:", "10-ui.js");
 function showErrorBanner(msg, sub) {
   const b = document.getElementById('error-banner');
   if (!b) return;
-  b.querySelector('.error-banner-msg').textContent = msg;
+  const m = b.querySelector('.error-banner-msg');
+  if (m) m.textContent = msg;
   const s = b.querySelector('.error-banner-sub');
   if (s) s.textContent = sub || '';
   b.classList.remove('hidden');
@@ -45,7 +46,8 @@ function showUndoToast(msg, undoFn) {
   _undoFn = undoFn;
   const t = document.getElementById('undo-toast');
   if (!t) return;
-  t.querySelector('.undo-toast-msg').textContent = msg;
+  const um = t.querySelector('.undo-toast-msg');
+  if (um) um.textContent = msg;
   t.classList.add('active');
   _undoTimer = setTimeout(() => t.classList.remove('active'), 5000);
 }
@@ -299,6 +301,7 @@ async function openTimeline(postId, title) {
   const _tt = document.getElementById('timeline-title');
   if (_tt) _tt.textContent = title || postId;
   const list = document.getElementById('timeline-list');
+  if (!list) return;
   list.innerHTML = '<div style="color:var(--text3);padding:12px 0">Loading…</div>';
   overlay.classList.add('open');
   document.body.style.overflow = 'hidden';


### PR DESCRIPTION
Prevents TypeError crashes from null elements breaking the entire render pipeline. Changes across 5 files:

07-post-load.js:
- Wrap renderDashboard, renderPipeline, renderUpcoming, renderTasks, renderLibrary, renderClientView with try/catch crash isolation
- Null-guard tasks-container, client-approved-tbody, pipeline-container, parked-overlay, library view switches

08-post-actions.js:
- Null-guard all DOM reads in openAdminEdit (8 fields)
- Null-guard all DOM reads in saveAdminEdit (9 fields)
- Optional chain in closeAdminEdit

10-ui.js:
- Null-guard querySelector chains in showErrorBanner, showUndoToast
- Null-guard timeline-list in openTimeline

03-auth.js:
- Null-guard login-error, login-email-input, login-email-step

06-post-create.js:
- Null-guard all npm-* form fields in loadDraft, openNewPostModal, submitNewPost, closeNewPostModal

A single null element can no longer crash the render chain.

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG