### PR TITLE
feat: replace dashboard with system control surface UI

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -606,17 +606,45 @@ function _renderDashboardInner() {
   const pranavRow = scRow('PRANAV', pranavCount, pranavTarget, pranavGap, 'short', pranavSorted, 'data-nav="pranav"');
   const chitraRow = scRow('CHITRA', chitraReady, chitraTotal || chitraReady, chitraGap, 'not sent', chitraSorted, 'data-nav="chitra"');
 
-  // ── RENDER (scorecard interface) ──
+  // ── RUNWAY DISPLAY TEXT ──
+  const runwayText = runwayDisplay === 1 ? '1 DAY CLEAR' : `${runwayDisplay} DAYS CLEAR`;
+
+  // ── CLIENT ACTION TEXT ──
+  const clientActionText = clientPending === 0 ? 'ALL CLEAR'
+    : clientPending === 1 ? '1 AWAITING REVIEW'
+    : `${clientPending} AWAITING REVIEW`;
+
+  // ── RENDER (system interface) ──
   el.innerHTML = `<div class="pc-root ${uiState}" data-pressure="${pressureLevel}">
-    <div class="pc-state ${stateClass}">${stateMsg}</div>
-    <div class="pc-runway ${runwayState}" data-nav="runway">${runwayDisplay}</div>
-    ${contextLine ? `<div class="pc-context pc-clickable" data-nav="runway">${contextLine}</div>` : ''}
-    <div class="sc-card">
-      ${clientRow}
-      ${pranavRow}
-      ${chitraRow}
+    <div class="pc-section" data-nav="runway">
+      <div class="pc-label">RUNWAY</div>
+      <div class="pc-headline">${runwayText}</div>
+      ${contextLine ? `<div class="pc-sub">${contextLine}</div>` : ''}
     </div>
-    <div class="pc-action" data-nav="action">${actionText} \u2192</div>
+
+    <div class="pc-divider"></div>
+
+    <div class="pc-section" data-nav="chitra">
+      <div class="pc-label">CHITRA</div>
+      <div class="pc-ratio">${chitraReady}<span class="pc-ratio-sep">:</span>${chitraTotal || chitraReady}</div>
+      <div class="pc-action-text">READY TO SEND</div>
+    </div>
+
+    <div class="pc-divider"></div>
+
+    <div class="pc-section" data-nav="pranav">
+      <div class="pc-label">PRANAV</div>
+      <div class="pc-ratio">${pranavCount}<span class="pc-ratio-sep">:</span>${pranavTarget}</div>
+      <div class="pc-action-text">READY TO MOVE</div>
+    </div>
+
+    <div class="pc-divider"></div>
+
+    <div class="pc-client-strip" data-nav="client">
+      <span class="pc-client-label">CLIENT</span>
+      <span class="pc-client-count">${clientPending}</span>
+      <span class="pc-client-action">${clientActionText}</span>
+    </div>
   </div>`;
 
   // ── CLICK DELEGATION ──

--- a/styles.css
+++ b/styles.css
@@ -804,245 +804,126 @@ a:hover { text-decoration: underline; }
 ═══════════════════════════════════════════════ */
 
 /* ═══════════════════════════════════════════════
-   DASHBOARD — Editorial Control Surface
+   DASHBOARD — System Control Surface
 ═══════════════════════════════════════════════ */
 .pcs-dash-surface { padding: 0; }
 
-/* ── Pressure Control Interface ── */
+/* ── Root container ── */
 .pc-root {
   display: flex;
   flex-direction: column;
-  padding: 30px var(--pcs-gap-4) var(--pcs-gap-4);
+  padding: 24px 20px;
   max-width: 520px;
-  position: relative;
-  transition: background 220ms ease, box-shadow 220ms ease;
+  background: #000000;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-/* ── 4-Level Pressure Intensity ── */
-/* LEVEL 0 — CALM */
-.pc-root[data-pressure="0"] {
-  background: transparent;
-}
-/* LEVEL 1 — LOW PRESSURE */
-.pc-root[data-pressure="1"] {
-  background:
-    radial-gradient(circle at 0% 0%, rgba(255,180,0,0.04), transparent 60%);
-}
-/* LEVEL 2 — HIGH PRESSURE */
-.pc-root[data-pressure="2"] {
-  background:
-    radial-gradient(circle at 0% 0%, rgba(255,120,0,0.08), transparent 55%),
-    radial-gradient(circle at 100% 100%, rgba(255,60,0,0.05), transparent 60%);
-}
-/* LEVEL 3 — PANIC */
-.pc-root[data-pressure="3"] {
-  background:
-    radial-gradient(circle at 0% 0%, rgba(255,60,60,0.14), transparent 50%),
-    radial-gradient(circle at 100% 100%, rgba(120,0,0,0.12), transparent 60%);
-  box-shadow: inset 0 0 60px rgba(255,0,0,0.12);
-  animation: panic-hit 280ms ease-out;
-}
-
-@keyframes panic-hit {
-  0%   { filter: brightness(1.25); }
-  100% { filter: brightness(1); }
-}
-
-/* SUBTLE PERSISTENT PRESSURE */
-.pc-root[data-pressure="3"] .sc-pending {
-  animation: pulse 1.4s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,100% { opacity: 1; }
-  50%     { opacity: 0.92; }
-}
-
-/* 1. State line */
-.pc-state {
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  padding: 0 0 18px;
-  text-transform: uppercase;
-}
-.pc-state.st-fail { color: var(--c-red, #ef4444); font-weight: 600; letter-spacing: 0.04em; }
-.pc-state.st-risk { color: var(--c-amber, #f59e0b); }
-.pc-state.st-safe { color: #5b8a6e; opacity: 0.7; }
-
-/* 2. Runway number — dominant anchor, clickable */
-.pc-runway {
+/* ── Section block (runway / chitra / pranav) ── */
+.pc-section {
   cursor: pointer;
-  font-size: 52px;
-  font-weight: 700;
-  color: var(--text);
-  line-height: 1;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -1px;
+  -webkit-tap-highlight-color: transparent;
 }
-.pc-runway.rw-runway-crit {
-  color: var(--c-red, #ef4444);
-  text-shadow: 0 0 18px rgba(255, 60, 60, 0.45);
-  transform: scale(1.05);
-  transform-origin: left bottom;
-}
-.pc-runway.rw-runway-warn {
-  color: var(--c-amber, #f59e0b);
-  text-shadow: 0 0 12px rgba(255, 180, 0, 0.25);
-}
+.pc-section:active { opacity: 0.7; }
 
-/* 3. Context line — tight to runway, always clickable */
-.pc-context {
-  font-size: 12.5px;
-  color: var(--text3);
-  opacity: 0.55;
-  margin-top: 4px;
-  padding-bottom: 22px;
-  cursor: pointer;
-  text-decoration: underline;
-  text-decoration-style: dotted;
-  text-underline-offset: 3px;
-}
-.pc-context:active {
-  opacity: 1;
-}
-
-/* 4. Scorecard — 3-role accountability */
-.sc-card {
-  padding: 16px 0 8px;
-  margin-top: 4px;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-/* Scorecard row — base */
-.sc-row {
-  position: relative;
-  display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 9px 14px 9px 16px;
-  line-height: 1.35;
-  transition: opacity 80ms ease;
-}
-
-/* Slight row misalignment — break table feel */
-.sc-row:nth-child(2) { padding-left: 18px; }
-.sc-row:nth-child(3) { padding-left: 14px; transform: translateY(1px); }
-
-/* Left edge — pressure slab */
-.sc-row::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 3px;
-  bottom: 3px;
-  width: 3px;
-  background: var(--text3);
-  opacity: 0.15;
-  border-radius: 1px;
-}
-
-/* Pending row — clickable, sharp */
-.sc-pending {
-  cursor: pointer;
-}
-.sc-pending::before {
-  width: 4px;
-  background: var(--c-amber, #f59e0b);
-  opacity: 0.7;
-}
-.sc-pending:active { opacity: 0.6; }
-@media (hover: hover) {
-  .sc-pending:hover { opacity: 0.7; }
-}
-
-/* Failure state pending rows — red edge */
-.pc-root.failure .sc-pending::before {
-  background: var(--c-red, #ef4444);
-  opacity: 0.85;
-  width: 5px;
-  box-shadow: 2px 0 8px rgba(255, 60, 60, 0.2);
-}
-
-/* Sorted row — calm, faded, not clickable */
-.sc-sorted {
-  opacity: 0.35;
-  cursor: default;
-}
-.sc-sorted::before {
-  background: #5b8a6e;
-  opacity: 0.25;
-}
-
-/* Scorecard typography */
-.sc-name {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text);
-}
-.sc-sorted .sc-name {
-  font-weight: 600;
-  color: var(--text3);
-}
-
-.sc-num {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.01em;
-}
-.sc-sep {
-  font-weight: 400;
-  color: var(--text3);
-  opacity: 0.4;
-}
-
-.sc-gap {
-  width: 100%;
+/* ── Section label (RUNWAY / CHITRA / PRANAV) ── */
+.pc-label {
   font-size: 11px;
   font-weight: 600;
-  color: var(--text3);
-  opacity: 0.55;
-  padding-left: 1px;
-  margin-top: -2px;
-}
-
-.sc-dot {
-  color: #5b8a6e;
-  font-size: 14px;
-  line-height: 1;
-}
-.sc-ok {
-  font-size: 11px;
-  font-weight: 600;
-  color: #5b8a6e;
+  letter-spacing: 1px;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  color: #ffffff;
+  opacity: 0.5;
+  margin-bottom: 6px;
 }
 
-/* 6. Action line */
-.pc-action {
+/* ── Runway headline ("7 DAYS CLEAR") ── */
+.pc-headline {
+  font-size: 28px;
+  font-weight: 600;
+  color: #ffffff;
+  line-height: 1;
+  letter-spacing: -0.3px;
+  font-feature-settings: "tnum";
+}
+
+/* ── Runway sub ("Breaks on Thursday") ── */
+.pc-sub {
   font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: var(--accent);
+  color: #ffffff;
+  opacity: 0.6;
+  margin-top: 4px;
+}
+
+/* ── Divider ── */
+.pc-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+  margin: 16px 0;
+}
+
+/* ── Ratio numbers (11:14 / 14:35) — dominant ── */
+.pc-ratio {
+  font-size: 64px;
+  font-weight: 700;
+  color: #ffffff;
+  line-height: 1;
+  letter-spacing: -1px;
+  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
+  margin-top: 6px;
+}
+
+.pc-ratio-sep {
+  opacity: 0.3;
+}
+
+/* ── Action text below ratio ── */
+.pc-action-text {
+  font-size: 13px;
+  color: #ffffff;
+  opacity: 0.75;
+  margin-top: 4px;
+}
+
+/* ── Client strip — inverted ── */
+.pc-client-strip {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #ffffff;
+  color: #000000;
+  padding: 0 16px;
+  height: 44px;
+  border-radius: 6px;
   cursor: pointer;
-  margin-top: 14px;
-  padding-top: 6px;
-  transition: opacity 120ms ease, transform 120ms ease, color 200ms ease;
+  -webkit-tap-highlight-color: transparent;
 }
-.pc-root.failure .pc-action { color: var(--c-red, #ef4444); }
-.pc-root.risk .pc-action { color: var(--c-amber, #f59e0b); }
-.pc-action:active { opacity: 0.6; transform: translateX(2px); }
-@media (hover: hover) {
-  .pc-action:hover { opacity: 0.8; transform: translateX(2px); }
+.pc-client-strip:active { opacity: 0.85; }
+
+.pc-client-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  opacity: 0.5;
 }
+
+.pc-client-count {
+  font-size: 18px;
+  font-weight: 700;
+  font-feature-settings: "tnum";
+}
+
+.pc-client-action {
+  font-size: 14px;
+  font-weight: 400;
+}
+
+/* ── Legacy scorecard classes (kept for JS compat — hidden in new UI) ── */
+.sc-card, .sc-row, .sc-name, .sc-num, .sc-sep, .sc-gap, .sc-dot, .sc-ok,
+.pc-state, .pc-context, .pc-action, .pc-runway { display: none; }
 
 
 /* ═══════════════════════════════════════════════


### PR DESCRIPTION
New mobile-first dashboard matching reference design:
- RUNWAY header: days clear + context line
- CHITRA block: ratio number (64px) + READY TO SEND
- PRANAV block: ratio number (64px) + READY TO MOVE
- CLIENT strip: inverted white bar with pending count

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG