### PR TITLE
fix: add _dirty guard and server truth reconciliation to updatePost()

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -742,8 +742,12 @@ async function updatePost(postId, field, value) {
 
   // Optimistic update in memory — store old value for rollback
   const post = getPostById(postId);
-  const oldValue = post ? post[field] : undefined;
-  if (post) post[field] = value;
+  if (!post) return;
+  // Block duplicate writes — if a PATCH is already in-flight, bail
+  if (post._dirty) return;
+  const oldValue = post[field];
+  post[field] = value;
+  post._dirty = true;
 
   // Sync subtitle immediately after optimistic update
   _updateSubtitle(post);
@@ -765,15 +769,23 @@ async function updatePost(postId, field, value) {
   const wireValue = (dbField === 'stage') ? toDbStage(value) : (value || null);
 
   try {
-    await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
+    const rows = await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
       method: 'PATCH',
       body: JSON.stringify({ [dbField]: wireValue, updated_at: new Date().toISOString() }),
     });
+    // Apply server truth — preserves the exact memory reference
+    if (Array.isArray(rows) && rows[0]) {
+      const server = normalise(rows)[0];
+      if (server.stage) server.stage = toUiStage(server.stage);
+      Object.assign(post, server);
+    }
+    post._dirty = false;
     showToast('Saved', 'success');
     refreshSystemViews();
   } catch(e) {
     // Rollback optimistic update on failure
-    if (post) post[field] = oldValue;
+    post._dirty = false;
+    post[field] = oldValue;
     scheduleRender();
     showToast('Save failed', 'error');
   }


### PR DESCRIPTION
updatePost() was the only mutation path missing _dirty flag management and server truth reconciliation. quickStage() and _executeStageChange() both had this pattern, but updatePost() did not — causing poll merges to overwrite in-flight optimistic updates (especially owner changes).

Changes to 08-post-actions.js updatePost():
- Set post._dirty = true before PATCH (blocks poll overwrites)
- Apply server response via Object.assign after success
- Clear _dirty before refreshSystemViews()
- Clear _dirty before rollback on failure
- Early return if post not found or _dirty already set

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG