### PR TITLE
feat: add admin-only role preview switch

### DIFF
--- a/02-session.js
+++ b/02-session.js
@@ -6,6 +6,8 @@ console.log("LOADED:", "02-session.js");
 window.allPosts        = [];
 window.cachedPosts     = [];
 window.currentRole     = 'Admin';
+// Admin-only role preview — overrides UI visibility without touching auth
+window.effectiveRole   = (localStorage.getItem('pcs_role_preview') || 'Admin');
 window._renderTimer    = null;
 window._retryCount     = 0;
 window._retryTimer     = null;

--- a/03-auth.js
+++ b/03-auth.js
@@ -190,25 +190,59 @@ function logout() {
 
 function activateRole(role) {
   currentRole = role;
+  // Resolve effectiveRole: Admin can preview other roles via localStorage
+  if (role === 'Admin') {
+    const preview = localStorage.getItem('pcs_role_preview');
+    effectiveRole = (preview && preview !== 'Admin') ? preview : 'Admin';
+  } else {
+    // Non-admin: clear any stale preview, effectiveRole = real role
+    localStorage.removeItem('pcs_role_preview');
+    effectiveRole = role;
+  }
   const overlay = document.getElementById('login-overlay');
   if (overlay) overlay.classList.add('hidden');
   updateActionButton();
-  if (role === 'Client') {
+  if (effectiveRole === 'Client') {
     document.getElementById('client-view')?.classList.add('active');
     loadPostsForClient();
   } else {
     document.getElementById('dashboard-view')?.classList.add('active');
     const lbl = document.getElementById('topbar-role-label');
-    if (lbl) lbl.textContent = role;
+    if (lbl) lbl.textContent = effectiveRole;
     loadPosts();
     loadTasks();
     startRealtime();
     fetchUnreadCount();
   }
+  // Admin-only: inject role preview switcher into topbar
+  if (role === 'Admin') _injectRolePreview();
+}
+
+function _injectRolePreview() {
+  const header = document.querySelector('#dashboard-view .app-header-right, #client-view .app-header-right');
+  if (!header) return;
+  // Avoid duplicate injection
+  if (document.getElementById('role-preview')) return;
+  const wrap = document.createElement('div');
+  wrap.style.cssText = 'display:inline-flex;align-items:center;gap:6px;margin-right:8px;font-size:12px;color:var(--text3)';
+  wrap.innerHTML = `<label for="role-preview" style="opacity:0.7">View as</label>
+    <select id="role-preview" style="font-size:12px;padding:2px 6px;border-radius:6px;border:1px solid var(--border);background:var(--bg2);color:var(--text1);cursor:pointer">
+      <option value="Admin">Admin</option>
+      <option value="Pranav">Pranav</option>
+      <option value="Chitra">Chitra</option>
+      <option value="Client">Client</option>
+    </select>`;
+  header.prepend(wrap);
+  const sel = document.getElementById('role-preview');
+  sel.value = effectiveRole;
+  sel.onchange = function() {
+    localStorage.setItem('pcs_role_preview', this.value);
+    location.reload();
+  };
 }
 
 function applyRoleVisibility() {
-  const allowedTabs = ROLE_TABS[currentRole] || [];
+  const allowedTabs = ROLE_TABS[effectiveRole] || [];
   document.querySelectorAll('.tab-btn[data-tab]').forEach(btn => {
     btn.style.display = allowedTabs.includes(btn.dataset.tab) ? '' : 'none';
   });
@@ -224,11 +258,11 @@ function applyRoleVisibility() {
 function updateActionButton() {
   const btn = document.getElementById('btn-new-post');
   if (!btn) return;
-  btn.textContent = currentRole === 'Client' ? '+ New Request' : '+ New Post';
+  btn.textContent = effectiveRole === 'Client' ? '+ New Request' : '+ New Post';
 }
 
 function handleActionButton() {
-  if (currentRole === 'Client') {
+  if (effectiveRole === 'Client') {
     scrollToNewRequest();
   } else {
     openNewPostModal();

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -573,7 +573,7 @@ function renderPipelineStrip() {
 function renderProductionMeter() {
   const section = document.getElementById('prod-meter-section');
   if (!section) return;
-  if (currentRole !== 'Admin') { section.innerHTML = ''; return; }
+  if (effectiveRole !== 'Admin') { section.innerHTML = ''; return; }
   const readyCount = allPosts.filter(p=>(p.stage||'').toLowerCase().trim()==='ready').length;
   const gap  = Math.max(0, READY_TO_SEND_TARGET - readyCount);
   const pct  = Math.min(100, Math.round((readyCount / READY_TO_SEND_TARGET) * 100));
@@ -598,7 +598,7 @@ function renderProductionMeter() {
 function renderAdminInsight() {
   const section = document.getElementById('admin-insight-section');
   if (!section) return;
-  if (currentRole !== 'Admin') { section.innerHTML = ''; return; }
+  if (effectiveRole !== 'Admin') { section.innerHTML = ''; return; }
   const now = Date.now();
   const DAY = 86400000;
   function daysSince(post) {
@@ -683,9 +683,9 @@ function closeParked() {
 function renderTaskBanner() {
   const section = document.getElementById('task-banner-section');
   if (!section) return;
-  if (currentRole === 'Client') { section.innerHTML = ''; return; }
+  if (effectiveRole === 'Client') { section.innerHTML = ''; return; }
   const email    = localStorage.getItem('gbl_email') || '';
-  const roleName = currentRole;
+  const roleName = effectiveRole;
   const myTasks  = allTasks.filter(t => !t.done && (t.assigned_to === roleName || (email && t.assigned_to.toLowerCase().includes(email.split('@')[0].toLowerCase()))));
   if (!myTasks.length) { section.innerHTML = ''; return; }
   const rows = myTasks.map(t => {
@@ -698,7 +698,7 @@ function renderTaskBanner() {
 function renderAdminTaskPanel() {
   const section = document.getElementById('admin-task-section');
   if (!section) return;
-  if (currentRole !== 'Admin') { section.innerHTML = ''; return; }
+  if (effectiveRole !== 'Admin') { section.innerHTML = ''; return; }
   const openTasks = allTasks.filter(t => !t.done);
   const doneTasks = allTasks.filter(t => t.done).slice(0, 5);
   const openRows = openTasks.map(t => {
@@ -733,7 +733,7 @@ function staleClass(days) {
 }
 
 function getMyTasks() {
-  const allowed = ROLE_STAGES[currentRole];
+  const allowed = ROLE_STAGES[effectiveRole];
   if (!allowed) return allPosts;
   return allPosts.filter(p => allowed.includes((p.stage||'').toLowerCase().trim()));
 }
@@ -764,7 +764,7 @@ function getRelativeDate(rawDate) {
 function renderNextPost() {
   const section = document.getElementById('next-post-section');
   if (!section) return;
-  if (currentRole === 'Client') { section.innerHTML=''; return; }
+  if (effectiveRole === 'Client') { section.innerHTML=''; return; }
   const post = getNextPost();
   if (!post) {
     section.innerHTML = `<div class="hero-card"><div class="hero-label">Most Urgent Post</div><div class="empty-state" style="padding:var(--sp-5) 0 0"><div class="empty-icon">OK</div><p>All clear - nothing here right now.</p></div></div>`;
@@ -783,7 +783,7 @@ function renderNextPost() {
   const days      = daysInStage(post);
   const stLabel   = staleLabel(days, stage);
   const stCls     = staleClass(days);
-  const canUpdate = currentRole !== 'Client';
+  const canUpdate = effectiveRole !== 'Client';
   let primaryLabel = '', primaryAction = '', secondaryLabel = '', secondaryAction = '';
   if (stageLC === 'awaiting brand input') { primaryLabel='Start Production'; primaryAction=`quickStage('${esc(id)}','in production')`; secondaryLabel='Send for Approval'; secondaryAction=`quickStage('${esc(id)}','awaiting approval')`; }
   else if (stageLC === 'in production') { primaryLabel='Mark Ready'; primaryAction=`quickStage('${esc(id)}','ready')`; secondaryLabel='Send for Approval'; secondaryAction=`quickStage('${esc(id)}','awaiting approval')`; }
@@ -836,7 +836,7 @@ let _taskFilter = null; // null = show all, string = bucket key
 function renderTaskStageChips() {
   const el = document.getElementById('task-stage-chips');
   if (!el) return;
-  const buckets = ROLE_BUCKETS[currentRole];
+  const buckets = ROLE_BUCKETS[effectiveRole];
   if (!buckets || !buckets.length) { el.innerHTML = ''; return; }
 
   const chips = buckets.map(bucket => {
@@ -868,7 +868,7 @@ function filterTasksByChip(bucketKey) {
 function _renderFilteredTasks() {
   const container = document.getElementById('tasks-container');
   if (!container) return;
-  const buckets = ROLE_BUCKETS[currentRole];
+  const buckets = ROLE_BUCKETS[effectiveRole];
   if (!buckets) return;
 
   if (!_taskFilter) {
@@ -909,7 +909,7 @@ function _renderTasksInner() {
 
   const container = document.getElementById('tasks-container');
   if (!container) return;
-  const buckets = ROLE_BUCKETS[currentRole];
+  const buckets = ROLE_BUCKETS[effectiveRole];
   if (!buckets) {
     const posts = getMyTasks();
     _postLists['tasks'] = posts;
@@ -1258,7 +1258,7 @@ function renderClientApproved() {
 // -- Production Tracker ----------
 function renderCreativeTracker() {
   const section = document.getElementById('admin-insight-section');
-  if (!section || currentRole === 'Client') return;
+  if (!section || effectiveRole === 'Client') return;
   const now  = Date.now();
   const DAY  = 86400000;
   const weekAgo = now - 7 * DAY;

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -398,7 +398,7 @@ function _renderPCS(postId) {
   const isPublished = stageLC === 'published';
   const canvaUrl    = post.postLink || '';
   const linkedinUrl = post.linkedinUrl || '';
-  const canEdit     = currentRole !== 'Client';
+  const canEdit     = effectiveRole !== 'Client';
   const dateValue   = isPublished ? (post.publishedDate || post.targetDate || '') : (post.targetDate || '');
 
   // 3. Render into DOM
@@ -706,7 +706,7 @@ async function pcsSaveAttach(postId) {
     const isPublished = stageLC === 'published';
     const canvaUrl    = post.postLink || '';
     const linkedinUrl = post.linkedinUrl || '';
-    const canEdit = currentRole !== 'Client';
+    const canEdit = effectiveRole !== 'Client';
     const el = document.getElementById('pcs-action-btn-wrap');
     if (el) el.innerHTML = _buildInlineActions(canvaUrl, linkedinUrl, isPublished, canEdit, postId, stageLC);
   }


### PR DESCRIPTION
Adds a "View as" dropdown in the topbar (visible only when currentRole === 'Admin') that lets admins preview the UI as Pranav, Chitra, or Client without changing auth.

Implementation:
- 02-session.js: Add window.effectiveRole (reads localStorage)
- 03-auth.js: Inject <select id="role-preview"> in activateRole(), sync effectiveRole from pcs_role_preview, reload on change
- 07-post-load.js: Replace all currentRole visibility checks with effectiveRole (pipeline, tasks, buckets, meters, banners)
- 08-post-actions.js: Replace canEdit checks with effectiveRole

NOT changed:
- currentRole assignment in activateRole() (auth stays real)
- logActivity() calls still use currentRole (audit trail = real role)
- 03-auth.js auth flow, 04-router.js, 05-api.js untouched

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG