### PR TITLE
fix: prevent admin lock-in when previewing Client role

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -214,16 +214,25 @@ function activateRole(role) {
     startRealtime();
     fetchUnreadCount();
   }
-  // Admin-only: inject role preview switcher into topbar
-  if (role === 'Admin') _injectRolePreview();
+  // Admin-only: inject role preview switcher — always uses currentRole
+  if (currentRole === 'Admin') _injectRolePreview();
 }
 
+// Escape failsafe — callable from console if UI is ever unreachable
+window.resetRolePreview = function() {
+  localStorage.removeItem('pcs_role_preview');
+  location.reload();
+};
+
 function _injectRolePreview() {
-  const header = document.querySelector('#dashboard-view .app-header-right, #client-view .app-header-right');
-  if (!header) return;
   // Avoid duplicate injection
   if (document.getElementById('role-preview')) return;
+  // Find the active view's header — dashboard or client topbar
+  const header = document.querySelector('#dashboard-view .app-header-right')
+              || document.querySelector('#client-view .topbar');
+  if (!header) return;
   const wrap = document.createElement('div');
+  wrap.id = 'role-preview-wrap';
   wrap.style.cssText = 'display:inline-flex;align-items:center;gap:6px;margin-right:8px;font-size:12px;color:var(--text3)';
   wrap.innerHTML = `<label for="role-preview" style="opacity:0.7">View as</label>
     <select id="role-preview" style="font-size:12px;padding:2px 6px;border-radius:6px;border:1px solid var(--border);background:var(--bg2);color:var(--text1);cursor:pointer">
@@ -232,7 +241,13 @@ function _injectRolePreview() {
       <option value="Chitra">Chitra</option>
       <option value="Client">Client</option>
     </select>`;
-  header.prepend(wrap);
+  // For client topbar, insert before the spacer; for dashboard, prepend
+  const spacer = header.querySelector('.topbar-spacer');
+  if (spacer) {
+    spacer.after(wrap);
+  } else {
+    header.prepend(wrap);
+  }
   const sel = document.getElementById('role-preview');
   sel.value = effectiveRole;
   sel.onchange = function() {


### PR DESCRIPTION
Bug: switching to Client via role preview hid the dropdown because the client-view has a .topbar (not .app-header-right), so the querySelector missed it entirely.

Fixes:
- _injectRolePreview() now queries both #dashboard-view .app-header-right and #client-view .topbar
- Guard uses currentRole === 'Admin' (was already correct)
- Inserts after .topbar-spacer in client view for correct layout
- Added window.resetRolePreview() console escape failsafe

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG