### PR TITLE
refactor: remove Upcoming tab, merge scheduled posts into Pipeline

### DIFF
--- a/01-config.js
+++ b/01-config.js
@@ -171,7 +171,7 @@ const ROLE_STAGES = {
 };
 
 // All non-Client roles get full tab access
-const _FULL_TABS = ['tasks','pipeline','upcoming','library'];
+const _FULL_TABS = ['tasks','pipeline','library'];
 const ROLE_TABS = {
   'Admin':     _FULL_TABS,
   'Servicing': _FULL_TABS,
@@ -207,7 +207,7 @@ const STRIP_STAGES = [
   { label:'Requests',      stages:['awaiting brand input'], color: STAGE_META['awaiting brand input'].hex, tab:'tasks',    bucket:'requests' },
   { label:'Approval',      stages:['awaiting approval'],    color: STAGE_META['awaiting approval'].hex,    tab:'tasks',    bucket:'approval' },
   { label:'Ready',         stages:['ready'],                color: STAGE_META['ready'].hex,                tab:'tasks',    bucket:'ready', target:true },
-  { label:'Scheduled',     stages:['scheduled'],            color: STAGE_META['scheduled'].hex,            tab:'upcoming', bucket:null },
+  { label:'Scheduled',     stages:['scheduled'],            color: STAGE_META['scheduled'].hex,            tab:'pipeline', bucket:null },
   { label:'Published',     stages:['published'],            color: STAGE_META['published'].hex,            tab:'library',  bucket:null },
 ];
 

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -231,8 +231,6 @@ function renderAll() {
     run('taskStageChips',     renderTaskStageChips);
   } else if (activeTab === 'pipeline') {
     run('pipeline',           renderPipeline);
-  } else if (activeTab === 'upcoming') {
-    run('upcoming',           renderUpcoming);
   } else if (activeTab === 'library') {
     run('library',            renderLibrary);
     run('filterDropdowns',    populateFilterDropdowns);
@@ -269,7 +267,6 @@ function updateStats() {
   setText('s-ready',     `${readyToSend}/${READY_TO_SEND_TARGET}`);
   // Legacy stats removed
   updateBadge('badge-tasks',    getMyTasks().length);
-  updateBadge('badge-upcoming', getUpcoming().length);
 }
 
 function setText(id, val) {
@@ -1050,64 +1047,6 @@ function _renderPipelineInner() {
     });
   }
 }
-
-function getUpcoming() {
-  const today = new Date(); today.setHours(0,0,0,0);
-  return allPosts.filter(p => { const d = parseDate(p.targetDate); const s = (p.stage||'').toLowerCase(); return d && d >= today && !['published','archive','parked'].includes(s); }).sort((a,b) => parseDate(a.targetDate) - parseDate(b.targetDate));
-}
-
-function renderUpcoming() {
-  try { _renderUpcomingInner(); } catch(e) { console.error('[PCS] renderUpcoming crash:', e); }
-}
-function _renderUpcomingInner() {
-  // Consume date filter (set by runway click)
-  const activeFilter = window.pcsUpcomingFilter;
-  window.pcsUpcomingFilter = null;
-
-  const container = document.getElementById('upcoming-wrap');
-  if (!container) return;
-  let posts = getUpcoming();
-
-  // Apply date filter if present — show only posts matching that date
-  if (activeFilter && activeFilter.date) {
-    const filterDate = activeFilter.date;
-    filterDate.setHours(0, 0, 0, 0);
-    posts = posts.filter(p => {
-      const d = parseDate(p.targetDate);
-      return d && d.getTime() === filterDate.getTime();
-    });
-  }
-
-  _postLists['upcoming'] = posts;
-  const today = new Date(); today.setHours(0,0,0,0);
-  const w7    = new Date(today); w7.setDate(w7.getDate()+7);
-
-  if (!posts.length) {
-    container.innerHTML = `<div class="empty-state"><div class="empty-icon">[date]</div><p>No upcoming posts scheduled.</p></div>`;
-    return;
-  }
-
-  const groups = {};
-  posts.forEach(p => {
-    const d   = parseDate(p.targetDate);
-    const key = d ? `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}` : 'undated';
-    if (!groups[key]) groups[key] = { date: d, posts: [] };
-    groups[key].posts.push(p);
-  });
-
-  container.innerHTML = Object.keys(groups).sort().map(dateKey => {
-    const g       = groups[dateKey];
-    const d       = g.date;
-    const isToday = d && d.getTime() === today.getTime();
-    const isSoon  = d && d <= w7;
-    const label   = isToday ? 'Today' : d ? formatWeekdayDateShort(dateKey) : 'NO DATE';
-    const hdrCls  = isToday ? 'today-hdr' : isSoon ? 'soon' : '';
-    const cards   = g.posts.map(p => buildPostCard(p, 'upcoming')).join('');
-    return `<div class="schedule-group"><div class="schedule-date-header ${hdrCls}">${label}</div><div class="row-list" style="gap:10px;padding-top:6px">${cards}</div></div>`;
-  }).join('');
-}
-
-
 
 
 function populateFilterDropdowns() {

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -718,7 +718,6 @@ function refreshSystemViews() {
   try {
     if (activeTab === 'tasks')    renderTasks();
     else if (activeTab === 'pipeline') renderPipeline();
-    else if (activeTab === 'upcoming') renderUpcoming();
     else if (activeTab === 'library')  renderLibrary();
   } catch(e) { console.error('refreshSystemViews:', e); }
 }
@@ -726,7 +725,7 @@ function refreshSystemViews() {
 // Re-render all stage-dependent background views (dashboard + active tab)
 function _renderBackgroundViews() {
   try { renderDashboard(); } catch(e) { console.error('renderDashboard:', e); }
-  // refreshSystemViews renders the active tab (pipeline/tasks/upcoming/library).
+  // refreshSystemViews renders the active tab (pipeline/tasks/library).
   // Pipeline filter is preserved — refreshSystemViews calls renderPipeline which
   // reads window.pcsPipelineFilter directly. Single render, no duplicates.
   try { refreshSystemViews(); } catch(e) { console.error('refreshSystemViews:', e); }

--- a/10-ui.js
+++ b/10-ui.js
@@ -106,14 +106,14 @@ function goToTab(tabName) {
 /**
  * Standard navigation handler — sets filter BEFORE tab switch so the
  * target render function consumes it on the same frame.
- *   tab:    'pipeline' | 'upcoming'
- *   filter: string[] of stages  OR  { date: Date } for upcoming
+ *   tab:    'pipeline'
+ *   filter: string[] of stages
  */
 function navigateWithFilter(tab, filter) {
-  if (tab === 'pipeline') {
-    window.pcsPipelineFilter = filter;
-  } else if (tab === 'upcoming') {
-    window.pcsUpcomingFilter = filter;
+  if (tab === 'pipeline' || tab === 'upcoming') {
+    // 'upcoming' redirects to pipeline filtered to scheduled
+    window.pcsPipelineFilter = (tab === 'upcoming') ? ['scheduled'] : filter;
+    tab = 'pipeline';
   }
   goToTab(tab);
 }
@@ -152,7 +152,6 @@ function scrollToBucket(bucketKey) {
 const _TAB_TITLES = {
   tasks: 'My Tasks',
   pipeline: 'Pipeline',
-  upcoming: 'Upcoming',
   library: 'Library',
 };
 

--- a/index.html
+++ b/index.html
@@ -150,13 +150,6 @@
     </div>
   </div>
 
-  <!-- TAB: UPCOMING -->
-  <div class="tab-panel" id="panel-upcoming">
-    <div class="dash-body">
-      <div id="upcoming-wrap"></div>
-    </div>
-  </div>
-
   <!-- TAB: LIBRARY -->
   <div class="tab-panel" id="panel-library">
     <!-- Row 1: Search + view toggle -->
@@ -204,11 +197,6 @@
     <button class="bnav-btn tab-btn" data-tab="pipeline" onclick="switchTab(this)">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
       <span>Pipeline</span>
-    </button>
-    <button class="bnav-btn tab-btn" data-tab="upcoming" onclick="switchTab(this)">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-      <span>Upcoming</span>
-      <span class="bnav-badge" id="badge-upcoming" style="display:none"></span>
     </button>
     <button class="bnav-btn tab-btn" data-tab="library" onclick="switchTab(this)">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>

--- a/styles.css
+++ b/styles.css
@@ -790,12 +790,6 @@ a:hover { text-decoration: underline; }
   position: relative;
 }
 
-/* Upcoming panel needs padding since it has no sticky header */
-#panel-upcoming .dash-body {
-  padding-top: var(--sp-4);
-  padding-left: var(--sp-4);
-  padding-right: var(--sp-4);
-}
 
 
 


### PR DESCRIPTION
Upcoming tab removed — scheduled posts now appear as a stage group inside Pipeline (they already did; Upcoming was a redundant view).

Removals:
- index.html: panel-upcoming div, upcoming nav button + badge
- 01-config.js: 'upcoming' from _FULL_TABS; STRIP_STAGES scheduled tab changed from 'upcoming' to 'pipeline'
- 07-post-load.js: getUpcoming(), renderUpcoming(), _renderUpcomingInner(), badge-upcoming update, render dispatcher branch for 'upcoming'
- 08-post-actions.js: 'upcoming' branch in refreshSystemViews()
- 10-ui.js: 'upcoming' from _TAB_TITLES
- styles.css: #panel-upcoming rule

Preserved:
- navigateWithFilter('upcoming', ...) redirects to pipeline filtered to ['scheduled'] (backward compat)
- Pipeline already renders all PIPELINE_ORDER stages including 'scheduled' — no filter excludes it

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG