### PR TITLE
fix: ensure bottom navigation tabs persist across all roles

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -185,6 +185,8 @@ function logout() {
   stopRealtime();
   document.getElementById('dashboard-view')?.classList.remove('active');
   document.getElementById('client-view')?.classList.remove('active');
+  const bnav = document.getElementById('bottom-nav');
+  if (bnav) bnav.style.display = 'none';
   showLoginOverlay();
 }
 
@@ -202,6 +204,9 @@ function activateRole(role) {
   const overlay = document.getElementById('login-overlay');
   if (overlay) overlay.classList.add('hidden');
   updateActionButton();
+  // Show bottom nav for ALL roles (it lives outside both views now)
+  const bnav = document.getElementById('bottom-nav');
+  if (bnav) bnav.style.display = '';
   if (effectiveRole === 'Client') {
     document.getElementById('client-view')?.classList.add('active');
     loadPostsForClient();

--- a/10-ui.js
+++ b/10-ui.js
@@ -169,6 +169,12 @@ const _TAB_TITLES = {
 };
 
 function switchTab(btn) {
+  // Ensure dashboard-view is visible (tab panels live there)
+  const dv = document.getElementById('dashboard-view');
+  if (dv && !dv.classList.contains('active')) {
+    dv.classList.add('active');
+    document.getElementById('client-view')?.classList.remove('active');
+  }
   document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
   document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
   btn.classList.add('active');

--- a/index.html
+++ b/index.html
@@ -215,23 +215,6 @@
     </div>
   </div>
 
-  <!-- BOTTOM NAVIGATION -->
-  <nav class="bottom-nav" id="bottom-nav">
-    <button class="bnav-btn tab-btn active" data-tab="tasks" onclick="switchTab(this)">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-      <span>My Tasks</span>
-      <span class="bnav-badge" id="badge-tasks" style="display:none"></span>
-    </button>
-    <button class="bnav-btn tab-btn" data-tab="pipeline" onclick="switchTab(this)">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-      <span>Pipeline</span>
-    </button>
-    <button class="bnav-btn tab-btn" data-tab="library" onclick="switchTab(this)">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
-      <span>Library</span>
-    </button>
-  </nav>
-
   <!-- Hidden stat elements for JS compatibility -->
   <span class="stat-pill" style="display:none"><span class="stat-num" id="s-total"></span></span>
   <span class="stat-pill" style="display:none"><span class="stat-num" id="s-published"></span></span>
@@ -242,6 +225,23 @@
   <span class="stat-pill" style="display:none"><span class="stat-num" id="s-ready"></span><span id="pill-ready"></span></span>
   <!-- legacy stat pills removed -->
 </div>
+
+<!-- BOTTOM NAVIGATION (global — outside all views so it persists across roles) -->
+<nav class="bottom-nav" id="bottom-nav" style="display:none">
+  <button class="bnav-btn tab-btn active" data-tab="tasks" onclick="switchTab(this)">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+    <span>My Tasks</span>
+    <span class="bnav-badge" id="badge-tasks" style="display:none"></span>
+  </button>
+  <button class="bnav-btn tab-btn" data-tab="pipeline" onclick="switchTab(this)">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+    <span>Pipeline</span>
+  </button>
+  <button class="bnav-btn tab-btn" data-tab="library" onclick="switchTab(this)">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+    <span>Library</span>
+  </button>
+</nav>
 
 <!-- ══════════════════════════════════════════
      CLIENT VIEW


### PR DESCRIPTION
Root cause: <nav class="bottom-nav"> was nested inside #dashboard-view, which is display:none when Client view is active — hiding the tabs for Client role entirely.

Fix:
- Moved bottom-nav OUTSIDE #dashboard-view to be a global sibling element (between dashboard-view and client-view)
- activateRole() now shows bottom-nav for ALL roles
- logout() hides bottom-nav
- switchTab() activates dashboard-view if it's not visible (handles Client→dashboard tab navigation)
- bottom-nav starts hidden (display:none) until login

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG