### PR TITLE
fix: Show post title instead of pillar in calendar view

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -1366,8 +1366,9 @@ function renderLibraryCalendar(posts) {
     const dayPosts = dayMap[key] || [];
 
     const first = dayPosts[0];
-    const pillar = first
-      ? getPillarShort(first.contentPillar)
+    const pillarFilterActive = !!(document.getElementById('filter-pillar')?.value);
+    const cellLabel = first
+      ? (pillarFilterActive ? getPillarShort(first.contentPillar) : getTitle(first))
       : '';
     const postId = first ? getPostId(first) : '';
     const extra = dayPosts.length > 1 ? dayPosts.length - 1 : 0;
@@ -1378,7 +1379,7 @@ function renderLibraryCalendar(posts) {
 
     html += `<div class="pcs-cal-cell${todayClass}${hasPost}"${clickAttr}>`;
     html += `<div class="pcs-cal-date">${dayNum}</div>`;
-    if (pillar) html += `<div class="pcs-cal-pill">${esc(pillar)}</div>`;
+    if (cellLabel) html += `<div class="pcs-cal-pill">${esc(cellLabel)}</div>`;
     if (extra)  html += `<div class="pcs-cal-more">+${extra}</div>`;
     html += `</div>`;
   }


### PR DESCRIPTION
Calendar cells now display the post title for quick scanning. Pillar only shown when the pillar filter dropdown is active. Truncation CSS already in place via .pcs-cal-pill.

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG