### PR TITLE
fix: Wrap stage values with toDbStage() before API write

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -83,10 +83,14 @@ async function saveAdminEdit() {
   const btn = _ae('ae-save-btn');
   if (btn) btn.disabled = true;
   try {
+    const _payload = { title, owner: owner||null, content_pillar: sanitizePillar(pillar)||null, location: location||null, stage: toDbStage(stage)||null, target_date: date||null, comments: comments||null, post_link: postLink||null, updated_at: new Date().toISOString() };
+    console.log('[saveAdminEdit] FORM STAGE:', stage, '→ DB STAGE:', toDbStage(stage));
+    console.log('[saveAdminEdit] PAYLOAD BEFORE SEND:', _payload);
     await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
       method: 'PATCH',
-      body: JSON.stringify({ title, owner: owner||null, content_pillar: sanitizePillar(pillar)||null, location: location||null, stage: stage||null, target_date: date||null, comments: comments||null, post_link: postLink||null, updated_at: new Date().toISOString() }),
+      body: JSON.stringify(_payload),
     });
+    console.log('[saveAdminEdit] SAVE OK for', postId);
     await logActivity({ post_id: postId, actor_name: 'Admin', actor_role: 'Admin', action: 'Full edit saved' });
     closeAdminEdit();
     await loadPosts();

--- a/09-approval.js
+++ b/09-approval.js
@@ -100,7 +100,7 @@ async function submitApproval(type, postId, btn) {
     try {
       await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
         method: 'PATCH',
-        body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString() }),
+        body: JSON.stringify({ stage: toDbStage('scheduled'), updated_at: new Date().toISOString() }),
       });
       await logActivity({ post_id: postId, actor_name: 'Client', actor_role: 'Client', action: 'Approved — moved to Scheduled' });
       const c = document.getElementById('approval-confirmation');


### PR DESCRIPTION
saveAdminEdit() was sending UI-format stage (e.g. 'in production') directly to the DB instead of DB-format ('in_production'). Same issue in submitApproval() sending 'scheduled' without toDbStage().

This caused the DB to receive unrecognized stage values, resulting in all posts effectively saving as draft.

Added debug console.log in saveAdminEdit to trace stage conversion.

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG