### PR TITLE
fix: Remove all role-based post dimming logic

### DIFF
--- a/01-config.js
+++ b/01-config.js
@@ -79,13 +79,8 @@ const STAGES_DB = STAGE_ORDER;
 // Pipeline order (includes archive at end)
 const PIPELINE_ORDER = [...STAGE_ORDER, 'archive'];
 
-// Role-based primary stages for visual dimming (non-primary cards get dimmed)
-const ROLE_PRIMARY_STAGES = {
-  Admin:     ['in production', 'ready'],
-  Servicing: ['ready', 'awaiting brand input', 'awaiting approval'],
-  Creative:  ['ready', 'awaiting brand input', 'awaiting approval'],
-  Client:    ['awaiting approval', 'awaiting brand input'],
-};
+// REMOVED: Role-based dimming disabled — all posts fully visible to all roles
+// const ROLE_PRIMARY_STAGES = { ... };
 
 // Pipeline RENDER order — visual pipeline excludes parked/rejected (they live in Library only)
 const PIPELINE_RENDER_ORDER = [

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -838,10 +838,8 @@ function buildPostCard(p, listKey) {
   const dateStr = formatDateShort(p.targetDate);
   const isToday = d && d.toDateString() === new Date().toDateString();
 
-  // Role-based dimming: primary stages are bright, others are dimmed
-  const stageLC = stage.toLowerCase().trim();
-  const isPrimary = ROLE_PRIMARY_STAGES[effectiveRole]?.includes(stageLC);
-  const dimClass = isPrimary ? 'pc-primary' : 'pc-dim';
+  // All posts fully visible — no role-based dimming
+  const dimClass = 'pc-primary';
 
   return `
     <div class="row-tile ${dimClass}" id="upc-${esc(id)}" data-post-id="${esc(id)}" data-list="${esc(listKey||'')}">

--- a/styles.css
+++ b/styles.css
@@ -3153,9 +3153,9 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   scroll-margin-top: 16px;
 }
 
-/* Role-based dimming — primary stages bright, others dimmed */
+/* All posts fully visible — no role-based dimming */
 .row-tile.pc-primary { opacity: 1; }
-.row-tile.pc-dim     { opacity: 0.35; filter: grayscale(0.3); }
+.row-tile.pc-dim     { opacity: 1; filter: none; }
 
 .row-date {
   grid-column: 1;


### PR DESCRIPTION
All posts now fully visible to all roles — no opacity reduction, no grayscale filter, no visual de-emphasis based on stage ownership.

Changes:
- 07-post-load.js: Always apply pc-primary class (never pc-dim)
- styles.css: Neutralize .pc-dim to opacity:1/filter:none
- 01-config.js: Remove ROLE_PRIMARY_STAGES config

Button enabled/disabled states preserved. Only visual dimming removed.

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG