### PR TITLE
feat: Add search icon to Pipeline header (stub only)

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -184,6 +184,9 @@ function switchTab(btn) {
   // Update header title
   const titleEl = document.getElementById('app-header-title');
   if (titleEl) titleEl.textContent = _TAB_TITLES[tab] || tab;
+  // Show pipeline search icon only on Pipeline tab
+  const searchBtn = document.getElementById('pipeline-search-btn');
+  if (searchBtn) searchBtn.style.display = (tab === 'pipeline') ? 'flex' : 'none';
   // Reset task chip filter when leaving tasks tab
   if (tab !== 'tasks' && typeof _taskFilter !== 'undefined') {
     window._taskFilter = null;
@@ -191,6 +194,11 @@ function switchTab(btn) {
   // Re-render the newly active tab with current data
   safeRender();
   _fabAttachScroll();
+}
+
+function openPipelineSearch() {
+  console.log('Open Pipeline Search');
+  // Stub — search UI will be built in a future step
 }
 
 function switchClientTab(tab) {

--- a/index.html
+++ b/index.html
@@ -125,6 +125,10 @@
           </div>
         </div>
       </div>
+      <!-- Pipeline search (visible only on Pipeline tab) -->
+      <button class="pipeline-search-btn" id="pipeline-search-btn" onclick="openPipelineSearch()" title="Search" style="display:none">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      </button>
       <!-- Three-dot menu -->
       <div class="user-menu-wrap" id="user-menu-wrap">
         <button class="app-icon-btn" onclick="toggleUserMenu()" title="Menu">

--- a/styles.css
+++ b/styles.css
@@ -3369,6 +3369,25 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 .app-icon-btn:active { background: var(--surface2); }
 
+/* Pipeline search icon */
+.pipeline-search-btn {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: transparent;
+  border: none;
+  color: var(--text2);
+  opacity: 0.8;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-right: 4px;
+}
+.pipeline-search-btn:active { opacity: 1; }
+.pipeline-search-btn svg { width: 18px; height: 18px; }
+
 /* Notification red dot (replaces badge number) */
 .notif-dot {
   position: absolute;


### PR DESCRIPTION
Adds a magnifying glass icon to the left of the 3-dot menu in the shared header, visible only when the Pipeline tab is active.

- index.html: Search button with SVG icon (hidden by default)
- styles.css: .pipeline-search-btn (36px tap target, opacity 0.8)
- 10-ui.js: switchTab toggles visibility; openPipelineSearch() stub

No search UI yet — icon logs to console as placeholder.

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG