### PR TITLE
feat: Wire search icon to full-screen overlay modal

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -197,8 +197,17 @@ function switchTab(btn) {
 }
 
 function openPipelineSearch() {
-  console.log('Open Pipeline Search');
-  // Stub — search UI will be built in a future step
+  const overlay = document.getElementById('pipeline-search-overlay');
+  if (overlay) {
+    overlay.style.display = 'flex';
+    const input = document.getElementById('pipeline-search-input');
+    if (input) { input.value = ''; input.focus(); }
+  }
+}
+
+function closePipelineSearch() {
+  const overlay = document.getElementById('pipeline-search-overlay');
+  if (overlay) overlay.style.display = 'none';
 }
 
 function switchClientTab(tab) {

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
       </div>
       <!-- Pipeline search (visible only on Pipeline tab) -->
       <button class="pipeline-search-btn" id="pipeline-search-btn" onclick="openPipelineSearch()" title="Search" style="display:none">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"></circle><line x1="16.65" y1="16.65" x2="21" y2="21"></line></svg>
       </button>
       <!-- Three-dot menu -->
       <div class="user-menu-wrap" id="user-menu-wrap">
@@ -702,6 +702,14 @@ window.allTasks        = window.allTasks    || [];
 <script src="03-auth.js?v=20260315" defer></script>
 <script src="05-api.js?v=20260315" defer></script>
 <script src="10-ui.js?v=20260315" defer></script>
+<!-- Pipeline search overlay -->
+<div id="pipeline-search-overlay" class="search-overlay" style="display:none;">
+  <div class="search-container">
+    <input type="text" placeholder="Search posts..." class="search-input" id="pipeline-search-input" autofocus />
+    <button class="search-close-btn" onclick="closePipelineSearch()">Close</button>
+  </div>
+</div>
+
 <script src="06-post-create.js?v=20260315" defer></script>
 <script src="07-post-load.js?v=20260315" defer></script>
 <script src="08-post-actions.js?v=20260315" defer></script>

--- a/styles.css
+++ b/styles.css
@@ -3379,14 +3379,58 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   border-radius: 50%;
   background: transparent;
   border: none;
-  color: var(--text2);
   opacity: 0.8;
-  cursor: pointer;
-  flex-shrink: 0;
-  margin-right: 4px;
+  position: relative;
+  z-index: 2;
 }
+.pipeline-search-btn svg { width: 18px; height: 18px; stroke: var(--text2); }
 .pipeline-search-btn:active { opacity: 1; }
-.pipeline-search-btn svg { width: 18px; height: 18px; }
+
+/* Pipeline search overlay */
+.search-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.9);
+  z-index: 9999;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 80px;
+}
+.search-container {
+  width: 90%;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.search-input {
+  width: 100%;
+  height: 48px;
+  padding: 0 16px;
+  font-size: 16px;
+  border-radius: 10px;
+  border: 1px solid var(--border, #444);
+  background: var(--surface1, #1a1a2e);
+  color: var(--text1, #fff);
+  outline: none;
+  box-sizing: border-box;
+}
+.search-input:focus { border-color: var(--c-blue, #5b8def); }
+.search-close-btn {
+  align-self: flex-end;
+  background: transparent;
+  border: 1px solid var(--border, #444);
+  color: var(--text2, #aaa);
+  padding: 8px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  cursor: pointer;
+}
+.search-close-btn:active { opacity: 0.7; }
 
 /* Notification red dot (replaces badge number) */
 .notif-dot {


### PR DESCRIPTION
- Update SVG to exact spec (r=7, stroke-width=2)
- Replace console.log stub with overlay open/close logic
- Add search overlay HTML (input + close button)
- Add overlay CSS (fixed fullscreen, z-index 9999)
- Update .pipeline-search-btn CSS to match spec (z-index, no cursor/margin)

No search filtering logic yet — entry point + container only.

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG