### PR TITLE
fix: Remove floating admin menu, unify header with single 3-dot menu

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -214,8 +214,8 @@ function activateRole(role) {
     startRealtime();
     fetchUnreadCount();
   }
-  // Admin-only: show global admin control menu — always uses currentRole
-  if (currentRole === 'Admin') _showGlobalAdminMenu();
+  // Build the ⋮ menu contents (role-switch shown only for Admin)
+  _buildUserMenu();
 }
 
 // Escape failsafe — callable from console if UI is ever unreachable
@@ -224,17 +224,28 @@ window.resetRolePreview = function() {
   location.reload();
 };
 
-function _showGlobalAdminMenu() {
-  const menu = document.getElementById('global-admin-menu');
+function _buildUserMenu() {
+  const menu = document.getElementById('user-menu');
   if (!menu) return;
-  menu.style.display = '';
-  // Highlight the active role button
-  menu.querySelectorAll('.gam-role-btn').forEach(btn => {
-    btn.classList.toggle('active', btn.dataset.role === effectiveRole);
-  });
-  // Hide per-view 3-dot menus (global menu supersedes them)
-  document.getElementById('user-menu-wrap')?.style.setProperty('display', 'none');
-  document.getElementById('client-menu-wrap')?.style.setProperty('display', 'none');
+  let html = '';
+  // Role-switch section (Admin only)
+  if (currentRole === 'Admin') {
+    const roles = ['Admin', 'Pranav', 'Chitra', 'Client'];
+    html += '<div class="um-section-label">View</div>';
+    html += '<div class="um-role-options">';
+    roles.forEach(r => {
+      const active = r === effectiveRole ? ' active' : '';
+      html += `<button class="um-role-btn${active}" onclick="gamSwitchRole('${r}')">${r}</button>`;
+    });
+    html += '</div><div class="um-divider"></div>';
+  }
+  // Preferences
+  html += '<div class="um-section-label">Preferences</div>';
+  html += '<button class="user-menu-item" onclick="toggleTheme(); closeUserMenu()"><span id="theme-icon">\u2600</span> Dark / Light</button>';
+  html += '<button class="user-menu-item" id="btn-refresh" onclick="loadPosts(); closeUserMenu()">\u21BA Refresh</button>';
+  html += '<div class="um-divider"></div>';
+  html += '<button class="user-menu-item danger" onclick="logout()">\u21A9 Sign Out</button>';
+  menu.innerHTML = html;
 }
 
 function applyRoleVisibility() {

--- a/10-ui.js
+++ b/10-ui.js
@@ -98,13 +98,6 @@ function toggleClientMenu() {
 function closeClientMenu() { document.getElementById('client-user-menu')?.classList.remove('open'); }
 
 // -- Global Admin Menu -------------------------
-function toggleGlobalAdminMenu() {
-  const m = document.getElementById('gam-dropdown');
-  if (!m) return;
-  const open = m.classList.toggle('open');
-  if (open) setTimeout(() => document.addEventListener('click', closeGlobalAdminMenu, { once: true }), 0);
-}
-function closeGlobalAdminMenu() { document.getElementById('gam-dropdown')?.classList.remove('open'); }
 function gamSwitchRole(role) {
   localStorage.setItem('pcs_role_preview', role);
   location.reload();

--- a/index.html
+++ b/index.html
@@ -72,31 +72,6 @@
 <!-- ══════════════════════════════════════════
      GLOBAL ADMIN CONTROL MENU (visible in all views)
 ══════════════════════════════════════════ -->
-<div id="global-admin-menu" class="gam-wrap" style="display:none">
-  <button class="gam-trigger" onclick="toggleGlobalAdminMenu()" title="Admin Controls">
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><circle cx="12" cy="5" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="19" r="1.5" fill="currentColor" stroke="none"/></svg>
-  </button>
-  <div class="gam-dropdown" id="gam-dropdown">
-    <div class="gam-section-label">Switch View</div>
-    <div class="gam-role-options" id="gam-role-options">
-      <button class="gam-role-btn" data-role="Admin" onclick="gamSwitchRole('Admin')">Admin</button>
-      <button class="gam-role-btn" data-role="Pranav" onclick="gamSwitchRole('Pranav')">Pranav</button>
-      <button class="gam-role-btn" data-role="Chitra" onclick="gamSwitchRole('Chitra')">Chitra</button>
-      <button class="gam-role-btn" data-role="Client" onclick="gamSwitchRole('Client')">Client</button>
-    </div>
-    <div class="gam-divider"></div>
-    <button class="gam-item" onclick="toggleTheme(); closeGlobalAdminMenu()">
-      ☀ Dark / Light
-    </button>
-    <button class="gam-item" onclick="loadPosts(); closeGlobalAdminMenu()">
-      ↺ Refresh
-    </button>
-    <button class="gam-item danger" onclick="logout()">
-      ↩ Sign Out
-    </button>
-  </div>
-</div>
-
 <!-- ══════════════════════════════════════════
      MAIN DASHBOARD  (Admin / Servicing / Creative)
 ══════════════════════════════════════════ -->
@@ -134,17 +109,7 @@
         <button class="app-icon-btn" onclick="toggleUserMenu()" title="Menu">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><circle cx="12" cy="5" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="19" r="1.5" fill="currentColor" stroke="none"/></svg>
         </button>
-        <div class="user-menu" id="user-menu">
-          <button class="user-menu-item" onclick="toggleTheme(); closeUserMenu()">
-            <span id="theme-icon">☀</span> Dark / Light
-          </button>
-          <button class="user-menu-item" id="btn-refresh" onclick="loadPosts(); this.closest('.user-menu').classList.remove('open'); closeUserMenu()">
-            ↺ Refresh
-          </button>
-          <button class="user-menu-item danger" onclick="logout()">
-            ↩ Sign Out
-          </button>
-        </div>
+        <div class="user-menu" id="user-menu"></div>
       </div>
     </div>
   </header>

--- a/styles.css
+++ b/styles.css
@@ -623,7 +623,7 @@ a:hover { text-decoration: underline; }
   position: absolute;
   top: calc(100% + 8px);
   right: 0;
-  min-width: 160px;
+  min-width: 180px;
   background: var(--surface);
   border: 1px solid var(--border2);
   border-radius: var(--r-md);
@@ -651,42 +651,8 @@ a:hover { text-decoration: underline; }
 /* ═══════════════════════════════════════════════
    GLOBAL ADMIN MENU (fixed, all views)
 ═══════════════════════════════════════════════ */
-.gam-wrap {
-  position: fixed;
-  top: 10px;
-  right: 12px;
-  z-index: 9999;
-}
-.gam-trigger {
-  width: 34px;
-  height: 34px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--surface);
-  border: 1.5px solid var(--border2);
-  box-shadow: var(--shadow-lift);
-  color: var(--text);
-  cursor: pointer;
-  transition: background var(--transition-fast);
-}
-.gam-trigger:hover { background: var(--surface2); }
-.gam-dropdown {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  min-width: 180px;
-  background: var(--surface);
-  border: 1px solid var(--border2);
-  border-radius: var(--r-md);
-  box-shadow: var(--shadow-lift);
-  overflow: hidden;
-  padding: var(--sp-1) 0;
-}
-.gam-dropdown.open { display: block; }
-.gam-section-label {
+/* User-menu inline role-switch (replaces floating GAM) */
+.um-section-label {
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
@@ -694,13 +660,13 @@ a:hover { text-decoration: underline; }
   color: var(--text3);
   padding: 8px 14px 4px;
 }
-.gam-role-options {
+.um-role-options {
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
   padding: 4px 12px 8px;
 }
-.gam-role-btn {
+.um-role-btn {
   font-size: 12px;
   padding: 4px 10px;
   border-radius: 999px;
@@ -710,31 +676,17 @@ a:hover { text-decoration: underline; }
   cursor: pointer;
   transition: all var(--transition-fast);
 }
-.gam-role-btn:hover { background: var(--surface2); }
-.gam-role-btn.active {
+.um-role-btn:hover { background: var(--surface2); }
+.um-role-btn.active {
   background: var(--c-blue);
   color: #fff;
   border-color: var(--c-blue);
 }
-.gam-divider {
+.um-divider {
   height: 1px;
   background: var(--border);
   margin: var(--sp-1) 0;
 }
-.gam-item {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-3);
-  padding: 10px 14px;
-  font-size: 13px;
-  color: var(--text);
-  width: 100%;
-  text-align: left;
-  cursor: pointer;
-  transition: background var(--transition-fast);
-}
-.gam-item:hover { background: var(--surface2); }
-.gam-item.danger { color: var(--c-red); }
 
 /* ═══════════════════════════════════════════════
    PIPELINE STRIP


### PR DESCRIPTION
- Removed #global-admin-menu (.gam-wrap) fixed-position overlay
- Moved role switch, theme toggle, refresh, logout into the ⋮ user-menu
- Role switch section only renders when currentRole === 'Admin'
- _buildUserMenu() dynamically populates menu contents on login
- Removed _showGlobalAdminMenu() which was hiding user-menu-wrap
- Header now has stable flex layout: [title] ... [search] [bell] [⋮]
- Search icon visible on Pipeline tab regardless of role
- No floating/fixed UI outside header

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG