### PR TITLE
fix: Create Request flow — fix broken element IDs + add activity logging

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -210,28 +210,46 @@ function scrollToNewRequest() {
 }
 
 async function submitClientRequest() {
-  const brief = document.getElementById('client-req-brief')?.value.trim();
-  if (!brief) { showToast('Please describe what you need', 'error'); return; }
-  const btn  = document.getElementById('client-req-submit');
-  const fileInput = document.getElementById('client-req-file');
-  const file = fileInput?.files[0] || null;
+  console.log('[REQUEST] Client submit clicked');
+  const brief = document.getElementById('req-topic')?.value.trim();
+  if (!brief) {
+    console.warn('[REQUEST] BLOCKED: missing brief');
+    showToast('Please describe what you need', 'error');
+    return;
+  }
+  const btn       = document.getElementById('req-submit-btn');
+  const fileInput = document.getElementById('req-file');
+  const file      = fileInput?.files[0] || null;
   if (btn) btn.disabled = true;
   try {
     const postId = 'REQ-' + Date.now();
     const email  = localStorage.getItem('gbl_email') || 'Client';
+    const payload = {
+      post_id:     postId,
+      title:       'Client Request \u2014 ' + new Date().getDate() + ' ' + MONTHS[new Date().getMonth()],
+      stage:       toDbStage('awaiting brand input'),
+      owner:       email,
+      comments:    brief,
+      created_at:  new Date().toISOString(),
+      updated_at:  new Date().toISOString(),
+    };
+    console.log('[REQUEST] PAYLOAD:', payload);
     await apiFetch('/posts', {
       method: 'POST',
-      body: JSON.stringify({ post_id: postId, title: `Client Request — ${new Date().getDate()} ${MONTHS[new Date().getMonth()]}`, stage: toDbStage('awaiting brand input'), owner: email, comments: brief, created_at: new Date().toISOString(), updated_at: new Date().toISOString() }),
+      body: JSON.stringify(payload),
     });
+    console.log('[REQUEST] API SUCCESS');
     if (file) await uploadPostAsset(file, postId);
-    await logActivity({ post_id: postId, actor_name: email, actor_role: 'Client', action: `New request: ${brief.substring(0,60)}` });
-    if (document.getElementById('client-req-brief')) document.getElementById('client-req-brief').value = '';
+    await logActivity({ post_id: postId, actor_name: email, actor_role: 'Client', action: 'New request: ' + brief.substring(0, 60) });
+    const topicEl = document.getElementById('req-topic');
+    if (topicEl) topicEl.value = '';
     if (fileInput) fileInput.value = '';
     if (btn) btn.disabled = false;
-    showToast('Request sent ✓ The team will be in touch.', 'success');
+    showToast('Request sent \u2713 The team will be in touch.', 'success');
     setTimeout(() => loadPostsForClient(), 800);
   } catch (err) {
-    showToast('Failed — try again', 'error');
+    console.error('[REQUEST] API FAILED:', err);
+    showToast('Failed \u2014 try again', 'error');
     if (btn) btn.disabled = false;
   }
 }

--- a/10-ui.js
+++ b/10-ui.js
@@ -563,32 +563,43 @@ function closeRequestSheet() {
 }
 
 async function submitRequestSheet() {
+  console.log('[REQUEST] Sheet submit clicked');
   const brief = document.getElementById('req-sheet-brief')?.value.trim();
-  if (!brief) { showToast('Please describe the request', 'error'); return; }
+  if (!brief) {
+    console.warn('[REQUEST] BLOCKED: missing brief');
+    showToast('Please describe the request', 'error');
+    return;
+  }
   const date  = document.getElementById('req-sheet-date')?.value  || null;
   const owner = document.getElementById('req-sheet-owner')?.value || null;
   const btn   = document.getElementById('req-sheet-submit');
-  if (btn) { btn.disabled = true; btn.textContent = 'Sending…'; }
+  if (btn) { btn.disabled = true; btn.textContent = 'Sending\u2026'; }
   try {
     const postId = 'REQ-' + Date.now();
+    const actor  = resolveActor();
+    const payload = {
+      post_id:     postId,
+      title:       brief.substring(0, 80),
+      stage:       toDbStage('awaiting brand input'),
+      owner:       owner || null,
+      comments:    brief,
+      target_date: date || null,
+      created_at:  new Date().toISOString(),
+      updated_at:  new Date().toISOString(),
+    };
+    console.log('[REQUEST] PAYLOAD:', payload);
     await apiFetch('/posts', {
       method: 'POST',
-      body: JSON.stringify({
-        post_id:    postId,
-        title:      brief.substring(0, 80),
-        stage:      'Awaiting Brand Input',
-        owner:      owner || null,
-        comments:   brief,
-        target_date: date || null,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      }),
+      body: JSON.stringify(payload),
     });
+    console.log('[REQUEST] API SUCCESS');
+    await logActivity({ post_id: postId, actor_name: actor, actor_role: actor, action: 'New request: ' + brief.substring(0, 60) });
     closeRequestSheet();
-    showToast('Request created ✓', 'success');
+    showToast('Request created \u2713', 'success');
     await loadPosts();
-  } catch {
-    showToast('Failed — try again', 'error');
+  } catch (err) {
+    console.error('[REQUEST] API FAILED:', err);
+    showToast('Failed \u2014 try again', 'error');
   } finally {
     if (btn) { btn.disabled = false; btn.textContent = 'Send Request'; }
   }


### PR DESCRIPTION
submitRequestSheet() (modal form):
- Added logActivity() call after successful insert
- Used toDbStage() for consistent stage value
- Added console debug logs at each step

submitClientRequest() (inline client form):
- Fixed element ID mismatches that caused silent failure: client-req-brief → req-topic client-req-submit → req-submit-btn client-req-file → req-file
- Added console debug logs at each step

Both flows now: validate → insert → log activity → toast → refresh

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG