### PR TITLE
fix: client menu 3-dot button — correct element ID mismatch

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -90,12 +90,12 @@ function closeUserMenu() { document.getElementById('user-menu')?.classList.remov
 
 // -- Client menu -------------------------------
 function toggleClientMenu() {
-  const m = document.getElementById('client-user-menu');
+  const m = document.getElementById('client-menu');
   if (!m) return;
   const open = m.classList.toggle('open');
   if (open) setTimeout(() => document.addEventListener('click', closeClientMenu, { once: true }), 0);
 }
-function closeClientMenu() { document.getElementById('client-user-menu')?.classList.remove('open'); }
+function closeClientMenu() { document.getElementById('client-menu')?.classList.remove('open'); }
 
 // -- Global Admin Menu -------------------------
 function gamSwitchRole(role) {


### PR DESCRIPTION
toggleClientMenu() and closeClientMenu() referenced #client-user-menu but the HTML element is #client-menu. This caused the client 3-dot menu to silently fail (never opening).

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG