### PR TITLE
feat: add "Assign Task" option to FAB menu for Admin only

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -538,6 +538,41 @@ function toggleFabMenu() {
   // Show/hide request button based on role
   const reqBtn = document.getElementById('fab-request-btn');
   if (reqBtn) reqBtn.style.display = '';
+  // Show "Assign Task" only for Admin
+  const assignBtn = document.getElementById('fab-assign-task');
+  if (assignBtn) assignBtn.style.display = (window.effectiveRole === 'Admin') ? '' : 'none';
+}
+
+function openAssignTaskFromFab() {
+  const postId = window._pcs?.postId;
+  if (!postId) {
+    showToast('Open a post first to assign a task', 'error');
+    return;
+  }
+  const assignee = prompt('Assign to (e.g. Pranav, Chitra):');
+  if (!assignee || !assignee.trim()) return;
+  const message = prompt('Task description:');
+  if (!message || !message.trim()) return;
+  _fabAssignTask(postId, assignee.trim(), message.trim());
+}
+
+async function _fabAssignTask(postId, assignee, message) {
+  try {
+    await apiFetch('/tasks', {
+      method: 'POST',
+      body: JSON.stringify({
+        assigned_to: assignee,
+        message: message,
+        post_id: postId,
+      }),
+    });
+    showToast('Task assigned OK', 'success');
+    await logActivity({ post_id: postId, actor_name: resolveActor(), actor_role: window.effectiveRole || 'Admin', action: 'Assigned task to ' + assignee });
+    if (typeof loadTasks === 'function') loadTasks();
+  } catch (err) {
+    console.error('[AssignTask] FAILED:', err);
+    showToast('Failed to assign task', 'error');
+  }
 }
 
 function closeFabMenu() {

--- a/index.html
+++ b/index.html
@@ -650,6 +650,9 @@
   <button class="fab-menu-item" onclick="openNewPostModal(); closeFabMenu()">
     <span class="fab-menu-icon">✏</span> Create Post
   </button>
+  <button class="fab-menu-item" id="fab-assign-task" onclick="openAssignTaskFromFab(); closeFabMenu()" style="display:none">
+    <span class="fab-menu-icon">📌</span> Assign Task
+  </button>
 </div>
 
 <script>


### PR DESCRIPTION
- Added Assign Task button to FAB menu (hidden by default)
- toggleFabMenu() shows it only when effectiveRole === 'Admin'
- Context-aware: requires a post to be open (checks _pcs.postId)
- Creates task via /tasks API with post_id linkage
- Logs activity after successful assignment

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG