### PR TITLE
fix: FAB Assign Task click — stopPropagation + close-first + pointer-…

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -544,11 +544,14 @@ function toggleFabMenu() {
 }
 
 function openAssignTaskFromFab() {
+  console.log('[FAB] Assign Task clicked');
   const postId = window._pcs?.postId;
   if (!postId) {
+    console.warn('[FAB] No post open — blocked');
     showToast('Open a post first to assign a task', 'error');
     return;
   }
+  console.log('[FAB] Post context:', postId);
   const assignee = prompt('Assign to (e.g. Pranav, Chitra):');
   if (!assignee || !assignee.trim()) return;
   const message = prompt('Task description:');

--- a/index.html
+++ b/index.html
@@ -650,7 +650,7 @@
   <button class="fab-menu-item" onclick="openNewPostModal(); closeFabMenu()">
     <span class="fab-menu-icon">✏</span> Create Post
   </button>
-  <button class="fab-menu-item" id="fab-assign-task" onclick="openAssignTaskFromFab(); closeFabMenu()" style="display:none">
+  <button class="fab-menu-item" id="fab-assign-task" onclick="event.stopPropagation(); closeFabMenu(); openAssignTaskFromFab()" style="display:none">
     <span class="fab-menu-icon">📌</span> Assign Task
   </button>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -3522,6 +3522,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   border-bottom: 1px solid var(--border);
   text-align: left;
   width: 100%;
+  pointer-events: auto;
+  cursor: pointer;
 }
 .fab-menu-item:last-child { border-bottom: none; }
 .fab-menu-item:active { background: var(--surface2); }


### PR DESCRIPTION
…events

- Added event.stopPropagation() to prevent click bubbling to backdrop
- Reordered onclick: closeFabMenu() runs before openAssignTaskFromFab() so the prompt dialog isn't obscured by the menu sheet
- Added pointer-events: auto + cursor: pointer to .fab-menu-item CSS
- Added console debug logging at each step of the handler

https://claude.ai/code/session_019XM6Zfu4cYxzNU85DcyHxG