### PR TITLE
fix: match scoreboard to reference image — deep visual accuracy pass

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -737,60 +737,63 @@ function renderScoreboard() {
     var approvalPad = pad2(approvalDisplay.replace(/[^0-9]/g, '') || '0');
     var inputPad = pad2(inputDisplay.replace(/[^0-9]/g, '') || '0');
 
-    // Chitra shows fraction: ready / total
+    // Chitra fraction: ready|total
     var chitraTotal = safe(data.chitra.total);
     var chitraFraction = chitraTotal > 0
-      ? pad2(safe(data.chitra.ready)) + '<span class="sb-fraction">/' + chitraTotal + '</span>'
+      ? pad2(safe(data.chitra.ready)) + '<span class="sb-fraction"><span class="sb-pipe">|</span>' + chitraTotal + '</span>'
       : chitraPad;
 
     return '<section class="pcs-scoreboard">' +
       '<div class="sb-inner">' +
 
-      /* ── 1. Critical Banner (horizontal: number LEFT, text RIGHT) ── */
+      /* ── 1. Critical Banner (centered stacked, dashed red border) ── */
       '<div class="sb-critical-panel">' +
-        '<div class="sb-critical-num">' + scheduled + '</div>' +
-        '<div class="sb-critical-text">' +
-          '<div class="sb-critical-label">CRITICAL:' + scheduled + '</div>' +
-          '<div class="sb-critical-sub">POSTS SCHEDULED</div>' +
+        '<div class="sb-critical-box">' +
+          '<div class="sb-critical-label">CRITICAL</div>' +
+          '<div class="sb-critical-num">' + scheduled + '</div>' +
         '</div>' +
       '</div>' +
 
-      /* ── 2. Main Grid (two operator panels) ── */
+      /* ── 2. Main Grid (two operator panels with gold divider) ── */
       '<div class="sb-main-grid">' +
         '<div class="sb-main-cell" data-action="open-production">' +
           '<div class="sb-main-label">PRANAV</div>' +
           '<div class="sb-main-num gold">' + pranavPad + '</div>' +
-          '<div class="sb-dots gold">\u25CF\u25CF\u25CF\u25CB</div>' +
+          '<div class="sb-dots gold">\u25CF \u25CF \u25CF \u25CB</div>' +
           '<div class="sb-main-sub gold">INITIATE DRAFT</div>' +
         '</div>' +
         '<div class="sb-divider"></div>' +
         '<div class="sb-main-cell" data-action="open-ready">' +
           '<div class="sb-main-label">CHITRA</div>' +
           '<div class="sb-main-num green">' + chitraFraction + '</div>' +
-          '<div class="sb-dots green">\u25CF\u25CF\u25CF\u25CB</div>' +
+          '<div class="sb-dots green">\u25CF \u25CF \u25CF \u25CB</div>' +
           '<div class="sb-main-sub green">DISPATCH READY</div>' +
         '</div>' +
       '</div>' +
 
-      /* ── 3. CLIENT section label bar ── */
-      '<div class="sb-section-label">CLIENT</div>' +
+      /* ── 3. CLIENT section label bar with decorative rivets ── */
+      '<div class="sb-section-label">' +
+        '<span class="sb-rivet-row">\u25CF \u25CF \u25CF \u25CF \u25CF \u25CF</span>' +
+        '<span>CLIENT</span>' +
+        '<span class="sb-rivet-row">\u25CF \u25CF \u25CF \u25CF \u25CF \u25CF</span>' +
+      '</div>' +
 
       /* ── 4. Client Grid (two metric panels) ── */
       '<div class="sb-client-strip">' +
         '<div class="sb-client-cell" data-action="open-approval">' +
           '<div class="sb-client-num">' + approvalPad + '</div>' +
-          '<div class="sb-dots dim">\u25CF\u25CF\u25CF\u25CB</div>' +
+          '<div class="sb-dots dim">\u25CF \u25CF \u25CF \u25CB</div>' +
           '<div class="sb-client-label">APPROVAL</div>' +
         '</div>' +
         '<div class="sb-client-divider"></div>' +
         '<div class="sb-client-cell" data-action="open-input">' +
           '<div class="sb-client-num">' + inputPad + '</div>' +
-          '<div class="sb-dots dim">\u25CF\u25CF\u25CF\u25CB</div>' +
+          '<div class="sb-dots dim">\u25CF \u25CF \u25CF \u25CB</div>' +
           '<div class="sb-client-label">INPUT</div>' +
         '</div>' +
       '</div>' +
 
-      /* ── 5. DO THIS NOW bar ── */
+      /* ── 5. DO THIS NOW bar with bottom rivets ── */
       '<div class="sb-task-bar"' + taskAttrs + '>' +
         '<div class="sb-task-content">' +
           '<div class="sb-task-label">DO THIS NOW</div>' +

--- a/styles.css
+++ b/styles.css
@@ -1091,18 +1091,19 @@ a:hover { text-decoration: underline; }
   width: 100%;
   max-width: 420px;
   margin: 0 auto;
-  padding: clamp(28px, 5vw, 36px) clamp(18px, 4.5vw, 26px) clamp(22px, 4vw, 30px);
+  padding: clamp(30px, 6vw, 40px) clamp(20px, 5vw, 28px) clamp(24px, 4.5vw, 32px);
   border: none;
   border-radius: 16px;
   background:
     url('/assets/frame.svg') center / 100% 100% no-repeat;
   box-shadow:
-    0 8px 32px rgba(0,0,0,0.75),
+    0 10px 40px rgba(0,0,0,0.85),
     0 0 0 1px #000;
   font-family: var(--font-label);
   color: var(--color-led-white);
   -webkit-font-smoothing: antialiased;
 }
+/* Outer highlight bevel */
 .pcs-scoreboard::before {
   content: "";
   position: absolute;
@@ -1114,16 +1115,17 @@ a:hover { text-decoration: underline; }
   z-index: 0;
   pointer-events: none;
 }
+/* Deep inner recess shadow */
 .pcs-scoreboard::after {
   content: "";
   position: absolute;
-  inset: clamp(22px, 4.5vw, 30px) clamp(16px, 4vw, 24px);
+  inset: clamp(24px, 5vw, 34px) clamp(18px, 4.5vw, 26px);
   border-radius: 5px;
   box-shadow:
-    inset 0 4px 12px rgba(0,0,0,0.95),
-    inset 0 -4px 12px rgba(0,0,0,0.95),
-    inset 3px 0 8px rgba(0,0,0,0.7),
-    inset -3px 0 8px rgba(0,0,0,0.7);
+    inset 0 6px 16px rgba(0,0,0,0.98),
+    inset 0 -6px 16px rgba(0,0,0,0.98),
+    inset 5px 0 12px rgba(0,0,0,0.8),
+    inset -5px 0 12px rgba(0,0,0,0.8);
   z-index: 0;
   pointer-events: none;
 }
@@ -1132,201 +1134,290 @@ a:hover { text-decoration: underline; }
   z-index: 1;
 }
 
-/* ── 0b. Inner Screen ── */
+/* ── 0b. Inner Screen Cavity ── */
 .sb-inner {
-  border: 1px solid #1a1a1a;
+  border: 2px solid #222;
   border-radius: 4px;
   background: var(--color-bg);
   display: flex;
   flex-direction: column;
+  gap: clamp(4px, 1vw, 6px);
+  padding: clamp(4px, 1vw, 6px);
   overflow: hidden;
   box-shadow:
-    inset 0 2px 8px rgba(0,0,0,0.95),
-    inset 0 -2px 8px rgba(0,0,0,0.95);
+    inset 0 3px 10px rgba(0,0,0,0.98),
+    inset 0 -3px 10px rgba(0,0,0,0.98),
+    inset 2px 0 6px rgba(0,0,0,0.6),
+    inset -2px 0 6px rgba(0,0,0,0.6);
 }
 
-/* ── 1. Critical Banner (horizontal: number LEFT, text RIGHT) ── */
+/* ═══════════════════════════════════════════
+   LED DOT-MATRIX TEXTURE (shared by all nums)
+   Overlays a pixel grid on text via repeating-linear-gradient
+═══════════════════════════════════════════ */
+.sb-critical-num,
+.sb-main-num,
+.sb-client-num {
+  position: relative;
+}
+.sb-critical-num::after,
+.sb-main-num::after,
+.sb-client-num::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      transparent 0px,
+      transparent 2px,
+      rgba(0,0,0,0.25) 2px,
+      rgba(0,0,0,0.25) 3px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      transparent 0px,
+      transparent 2px,
+      rgba(0,0,0,0.2) 2px,
+      rgba(0,0,0,0.2) 3px
+    );
+  mix-blend-mode: multiply;
+  border-radius: 2px;
+}
+
+/* ═══════════════════════════════════════════
+   1. CRITICAL BANNER — centered stacked, dashed red border
+═══════════════════════════════════════════ */
 .sb-critical-panel {
   flex-shrink: 0;
-  padding: clamp(10px, 2.5vw, 16px) clamp(12px, 3vw, 18px);
+  padding: clamp(12px, 3vw, 20px) clamp(16px, 4vw, 24px);
   background:
-    radial-gradient(ellipse at 30% 50%, rgba(204,34,0,0.3), transparent 70%),
-    #1a0000;
-  border: 1px solid var(--color-panel-border);
-  border-bottom: 2px solid var(--color-red-alert);
+    radial-gradient(ellipse at 50% 60%, rgba(204,34,0,0.3), transparent 65%),
+    #100000;
+  border: 1px solid #333;
   border-radius: 4px;
   box-shadow:
-    inset 0 0 20px rgba(0,0,0,0.9),
-    inset 0 2px 8px rgba(0,0,0,0.8);
+    inset 0 0 30px rgba(0,0,0,0.95),
+    inset 0 3px 10px rgba(0,0,0,0.9);
   display: flex;
-  flex-direction: row;
   align-items: center;
-  gap: clamp(8px, 2vw, 14px);
+  justify-content: center;
+}
+/* Dashed red border box inside critical panel */
+.sb-critical-box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: clamp(8px, 2vw, 14px) clamp(24px, 6vw, 40px);
+  border: 1px dashed var(--color-red-alert);
+  border-radius: 3px;
+  box-shadow:
+    0 0 12px rgba(204,34,0,0.15),
+    inset 0 0 12px rgba(204,34,0,0.08);
+}
+.sb-critical-label {
+  font-family: var(--font-led);
+  font-size: clamp(14px, 3.5vw, 18px);
+  font-weight: 400;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-red-alert);
+  line-height: 1.2;
+  text-shadow:
+    0 0 6px var(--color-red-alert),
+    0 0 14px rgba(204,34,0,0.4);
 }
 .sb-critical-num {
   font-family: var(--font-led);
-  font-size: clamp(42px, 11vw, 54px);
+  font-size: clamp(44px, 12vw, 58px);
   font-weight: 400;
   font-variant-numeric: tabular-nums;
   line-height: 1;
   color: var(--color-red-alert);
-  letter-spacing: 2px;
+  letter-spacing: 3px;
+  margin-top: 2px;
   text-shadow:
-    0 0 10px var(--color-red-alert),
-    0 0 24px rgba(204,34,0,0.6);
-  flex-shrink: 0;
-}
-.sb-critical-text {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.sb-critical-label {
-  font-family: var(--font-label);
-  font-size: clamp(13px, 3.5vw, 16px);
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-red-alert);
-  line-height: 1.1;
-}
-.sb-critical-sub {
-  font-family: var(--font-label);
-  font-size: clamp(11px, 2.8vw, 13px);
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(204,34,0,0.7);
-  line-height: 1.1;
+    0 0 12px var(--color-red-alert),
+    0 0 30px rgba(204,34,0,0.6),
+    0 0 50px rgba(204,34,0,0.3);
 }
 
-/* ── 2. Main Scoreboard Grid ── */
+/* ═══════════════════════════════════════════
+   2. MAIN SCOREBOARD GRID
+═══════════════════════════════════════════ */
 .sb-main-grid {
   display: grid;
-  grid-template-columns: 1fr 4px 1fr;
+  grid-template-columns: 1fr 5px 1fr;
 }
+
+/* GOLD GLOWING vertical divider */
 .sb-divider {
-  width: 4px;
+  width: 5px;
   background: linear-gradient(
     180deg,
-    #1a1a1a 0%,
-    var(--color-steel) 15%,
-    #666 50%,
-    var(--color-steel) 85%,
-    #1a1a1a 100%
+    rgba(200,168,75,0) 0%,
+    var(--color-gold-accent) 15%,
+    #f5d76e 50%,
+    var(--color-gold-accent) 85%,
+    rgba(200,168,75,0) 100%
   );
-  box-shadow: inset 0 0 6px rgba(0,0,0,0.8);
+  box-shadow:
+    0 0 8px rgba(200,168,75,0.5),
+    0 0 16px rgba(200,168,75,0.25);
 }
+
+/* Main operator panels */
 .sb-main-cell {
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: clamp(14px, 3.5vw, 20px) 6px;
+  padding: clamp(14px, 3.5vw, 22px) clamp(6px, 1.5vw, 10px);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
-  background: #111;
-  box-shadow: inset 0 2px 8px rgba(0,0,0,0.8);
-  border: 1px solid var(--color-panel-border);
+  background: #0e0e0e;
+  box-shadow:
+    inset 0 3px 10px rgba(0,0,0,0.9),
+    inset 0 -3px 10px rgba(0,0,0,0.7);
+  border: 1px solid #333;
   border-radius: 4px;
 }
 .sb-main-cell:active { opacity: 0.8; }
 
+/* Operator name labels */
 .sb-main-label {
   font-family: var(--font-label);
-  font-size: clamp(13px, 3.5vw, 16px);
+  font-size: clamp(14px, 3.8vw, 18px);
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--color-led-white);
-  margin-bottom: clamp(4px, 1vw, 8px);
-  line-height: 1.1;
+  margin-bottom: clamp(6px, 1.5vw, 10px);
+  line-height: 1;
 }
+
+/* LED numbers — large, glowing */
 .sb-main-num {
   font-family: var(--font-led);
-  font-size: clamp(56px, 16vw, 76px);
+  font-size: clamp(58px, 17vw, 80px);
   font-weight: 400;
   line-height: 1;
   font-variant-numeric: tabular-nums;
   letter-spacing: 4px;
-  text-shadow:
-    0 0 10px currentColor,
-    0 0 28px currentColor;
 }
-.sb-main-num.gold { color: var(--color-led-yellow); }
-.sb-main-num.green { color: var(--color-led-green); }
+.sb-main-num.gold {
+  color: var(--color-led-yellow);
+  text-shadow:
+    0 0 10px var(--color-led-yellow),
+    0 0 30px rgba(245,196,0,0.5),
+    0 0 50px rgba(245,196,0,0.2);
+}
+.sb-main-num.green {
+  color: var(--color-led-green);
+  text-shadow:
+    0 0 10px var(--color-led-green),
+    0 0 30px rgba(0,224,64,0.5),
+    0 0 50px rgba(0,224,64,0.2);
+}
 
-/* Fraction display (e.g. /14) */
+/* Fraction: pipe separator + smaller total */
 .sb-fraction {
-  font-size: 0.45em;
+  font-size: 0.5em;
   letter-spacing: 1px;
   opacity: 0.85;
-  vertical-align: super;
+  vertical-align: top;
+  margin-left: -2px;
+}
+.sb-pipe {
+  opacity: 0.6;
+  margin: 0 1px;
 }
 
-/* Dot indicators */
+/* Dot indicators (●●●○) */
 .sb-dots {
-  font-size: clamp(6px, 1.5vw, 8px);
-  letter-spacing: 4px;
-  margin-top: clamp(4px, 1vw, 8px);
-  margin-bottom: clamp(4px, 1vw, 8px);
+  font-size: clamp(5px, 1.2vw, 7px);
+  letter-spacing: 3px;
+  margin-top: clamp(6px, 1.5vw, 10px);
+  margin-bottom: clamp(8px, 2vw, 12px);
   color: #333;
+  line-height: 1;
 }
-.sb-dots.gold { color: var(--color-led-yellow); text-shadow: 0 0 4px var(--color-led-yellow); }
-.sb-dots.green { color: var(--color-led-green); text-shadow: 0 0 4px var(--color-led-green); }
+.sb-dots.gold {
+  color: var(--color-led-yellow);
+  text-shadow: 0 0 4px rgba(245,196,0,0.6);
+}
+.sb-dots.green {
+  color: var(--color-led-green);
+  text-shadow: 0 0 4px rgba(0,224,64,0.6);
+}
 .sb-dots.dim { color: #444; }
 
-/* Action buttons (INITIATE DRAFT, DISPATCH READY) */
+/* Action buttons — bordered, no fill, chamfered */
 .sb-main-sub {
   font-family: var(--font-label);
-  font-size: clamp(10px, 2.5vw, 12px);
+  font-size: clamp(10px, 2.6vw, 13px);
   font-weight: 600;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
   background: transparent;
-  padding: clamp(3px, 0.8vw, 5px) clamp(8px, 2vw, 14px);
+  padding: clamp(4px, 1vw, 6px) clamp(10px, 2.5vw, 16px);
   border-radius: 2px;
+  line-height: 1;
 }
 .sb-main-sub.gold {
   color: var(--color-led-yellow);
-  border: 1px solid var(--color-led-yellow);
-  box-shadow: 0 0 8px rgba(245,196,0,0.4);
-  clip-path: polygon(6px 0%, calc(100% - 6px) 0%, 100% 6px, 100% calc(100% - 6px), calc(100% - 6px) 100%, 6px 100%, 0% calc(100% - 6px), 0% 6px);
+  border: 1.5px solid var(--color-led-yellow);
+  box-shadow: 0 0 10px rgba(245,196,0,0.3);
 }
 .sb-main-sub.green {
   color: var(--color-led-green);
-  border: 1px solid var(--color-led-green);
-  box-shadow: 0 0 8px rgba(0,224,64,0.4);
-  clip-path: polygon(6px 0%, calc(100% - 6px) 0%, 100% 6px, 100% calc(100% - 6px), calc(100% - 6px) 100%, 6px 100%, 0% calc(100% - 6px), 0% 6px);
+  border: 1.5px solid var(--color-led-green);
+  box-shadow: 0 0 10px rgba(0,224,64,0.3);
 }
 
-/* ── 3. CLIENT Section Label ── */
+/* ═══════════════════════════════════════════
+   3. CLIENT Section Label — metallic strip with rivets
+═══════════════════════════════════════════ */
 .sb-section-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(8px, 2vw, 14px);
   font-family: var(--font-label);
-  font-size: clamp(11px, 2.8vw, 13px);
+  font-size: clamp(12px, 3vw, 14px);
   font-weight: 700;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  text-align: center;
   color: var(--color-led-white);
-  padding: clamp(4px, 1vw, 6px) 0;
-  background: linear-gradient(180deg, #222 0%, #333 50%, #222 100%);
-  border-top: 1px solid var(--color-panel-border);
-  border-bottom: 1px solid var(--color-panel-border);
+  padding: clamp(5px, 1.2vw, 8px) 0;
+  background: linear-gradient(180deg, #282828 0%, #383838 40%, #3a3a3a 50%, #383838 60%, #282828 100%);
+  border-top: 1px solid #4a4a4a;
+  border-bottom: 1px solid #4a4a4a;
   box-shadow:
-    inset 0 1px 0 rgba(255,255,255,0.06),
-    inset 0 -1px 0 rgba(0,0,0,0.4);
+    inset 0 1px 0 rgba(255,255,255,0.08),
+    inset 0 -1px 0 rgba(0,0,0,0.5);
+}
+/* Decorative rivet dots flanking CLIENT text */
+.sb-rivet-row {
+  font-size: 4px;
+  letter-spacing: 3px;
+  color: #555;
+  opacity: 0.6;
 }
 
-/* ── 4. Client Grid ── */
+/* ═══════════════════════════════════════════
+   4. CLIENT GRID
+═══════════════════════════════════════════ */
 .sb-client-strip {
   display: grid;
-  grid-template-columns: 1fr 2px 1fr;
+  grid-template-columns: 1fr 3px 1fr;
 }
 .sb-client-divider {
-  width: 2px;
-  background: linear-gradient(180deg, #222, var(--color-steel) 50%, #222);
+  width: 3px;
+  background: linear-gradient(180deg, #1a1a1a, #444 50%, #1a1a1a);
   box-shadow: inset 0 0 4px rgba(0,0,0,0.6);
 }
 .sb-client-cell {
@@ -1335,50 +1426,59 @@ a:hover { text-decoration: underline; }
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: clamp(10px, 2.5vw, 16px) 6px;
+  padding: clamp(12px, 3vw, 18px) clamp(6px, 1.5vw, 10px);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
-  background: #111;
-  box-shadow: inset 0 2px 8px rgba(0,0,0,0.8);
-  border: 1px solid var(--color-panel-border);
+  background: #0e0e0e;
+  box-shadow:
+    inset 0 3px 10px rgba(0,0,0,0.9),
+    inset 0 -3px 10px rgba(0,0,0,0.7);
+  border: 1px solid #333;
   border-radius: 4px;
 }
 .sb-client-cell:active { opacity: 0.7; }
 
 .sb-client-num {
   font-family: var(--font-led);
-  font-size: clamp(34px, 10vw, 46px);
+  font-size: clamp(36px, 10vw, 50px);
   font-weight: 400;
   line-height: 1;
   font-variant-numeric: tabular-nums;
   color: var(--color-led-white);
   letter-spacing: 3px;
-  text-shadow: 0 0 6px rgba(232,232,232,0.4);
+  text-shadow:
+    0 0 8px rgba(232,232,232,0.35),
+    0 0 20px rgba(232,232,232,0.15);
 }
+/* Client labels — bordered button style (dimmer) */
 .sb-client-label {
   font-family: var(--font-label);
-  font-size: clamp(10px, 2.5vw, 12px);
+  font-size: clamp(10px, 2.6vw, 13px);
   font-weight: 600;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #999;
+  color: #888;
   margin-top: clamp(4px, 1vw, 6px);
-  padding: clamp(2px, 0.5vw, 4px) clamp(8px, 2vw, 12px);
-  border: 1px solid var(--color-panel-border);
+  padding: clamp(3px, 0.8vw, 5px) clamp(10px, 2.5vw, 16px);
+  border: 1px solid #444;
   border-radius: 2px;
-  line-height: 1.1;
+  line-height: 1;
 }
 
-/* ── 5. DO THIS NOW Bar ── */
+/* ═══════════════════════════════════════════
+   5. DO THIS NOW BAR
+═══════════════════════════════════════════ */
 .sb-task-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: clamp(10px, 2.5vw, 14px) clamp(10px, 2.5vw, 14px);
-  background: #111;
-  border: 1px solid var(--color-panel-border);
+  padding: clamp(10px, 2.5vw, 14px) clamp(12px, 3vw, 16px);
+  background: #0e0e0e;
+  border: 1px solid #333;
   border-radius: 4px;
-  box-shadow: inset 0 2px 8px rgba(0,0,0,0.8);
+  box-shadow:
+    inset 0 3px 10px rgba(0,0,0,0.9),
+    inset 0 -2px 6px rgba(0,0,0,0.6);
 }
 .sb-task-content {
   flex: 1;
@@ -1386,7 +1486,7 @@ a:hover { text-decoration: underline; }
 }
 .sb-task-label {
   font-family: var(--font-label);
-  font-size: clamp(12px, 3vw, 14px);
+  font-size: clamp(13px, 3.2vw, 15px);
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -1402,6 +1502,7 @@ a:hover { text-decoration: underline; }
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  opacity: 0.85;
 }
 .sb-task-bar[data-nav] {
   cursor: pointer;
@@ -1409,18 +1510,33 @@ a:hover { text-decoration: underline; }
 }
 .sb-task-bar[data-nav]:active { opacity: 0.8; }
 
-/* FAB circular gold button */
+/* Decorative dot row at bottom of task bar */
+.sb-task-bar::after {
+  content: "\25CF  \25CF  \25CF  \25CF  \25CF  \25CF  \25CF  \25CF";
+  position: absolute;
+  bottom: 4px;
+  left: 12px;
+  font-size: 3px;
+  letter-spacing: 2px;
+  color: var(--color-gold-accent);
+  opacity: 0.5;
+  pointer-events: none;
+}
+.sb-task-bar { position: relative; }
+
+/* FAB — circular gold button with metallic sheen */
 .sb-fab {
-  width: 44px;
-  height: 44px;
-  background: linear-gradient(180deg, #d4a84b, #a8852f);
+  width: clamp(38px, 10vw, 46px);
+  height: clamp(38px, 10vw, 46px);
+  background:
+    radial-gradient(circle at 40% 35%, #e0c060, #a8852f 60%, #7a6020 100%);
   border: 2px solid var(--color-gold-accent);
   border-radius: 50%;
-  color: #000;
+  color: #2a1a00;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 22px;
+  font-size: clamp(18px, 5vw, 24px);
   font-weight: 700;
   cursor: pointer;
   flex-shrink: 0;
@@ -1429,13 +1545,16 @@ a:hover { text-decoration: underline; }
   -webkit-tap-highlight-color: transparent;
   outline: none;
   box-shadow:
-    inset 0 2px 4px rgba(255,255,255,0.3),
-    inset 0 -3px 6px rgba(0,0,0,0.6),
-    0 2px 8px rgba(0,0,0,0.7);
+    inset 0 2px 4px rgba(255,255,255,0.35),
+    inset 0 -3px 8px rgba(0,0,0,0.7),
+    0 3px 10px rgba(0,0,0,0.8),
+    0 0 12px rgba(200,168,75,0.2);
 }
 .sb-fab:active { opacity: 0.8; }
 
-/* ── Responsive: narrow screens ── */
+/* ═══════════════════════════════════════════
+   RESPONSIVE
+═══════════════════════════════════════════ */
 @media (max-width: 399px) {
   .sb-client-strip {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Studied reference JPEG in detail. Fixed every visual mismatch:

CRITICAL BANNER:
- Changed from horizontal (num LEFT, text RIGHT) → centered stacked
- "CRITICAL" label on top, large number below — both centered
- Added sb-critical-box with DASHED RED BORDER (1px dashed #cc2200)
- Subtle red glow inside the dashed box
- Label uses Share Tech Mono (was Rajdhani) to match LED dot-matrix look

LED DOT-MATRIX TEXTURE:
- Added ::after pseudo-element on ALL number displays
- Uses repeating-linear-gradient to create a pixel grid overlay
- Horizontal lines every 3px + vertical lines every 3px
- mix-blend-mode: multiply creates the screen-door LED effect

MAIN DIVIDER:
- Changed from gray metallic → BRIGHT GOLD/YELLOW glowing strip
- color: gold-accent → bright yellow center → gold edges
- Added box-shadow glow: 0 0 8px + 0 0 16px gold

PANEL BACKGROUNDS:
- Darkened from #111 → #0e0e0e (closer to true black)
- Increased inset shadow depth (3px 10px vs 2px 8px)
- Border color toned down from #555 → #333 (matches reference)

FRACTION DISPLAY:
- Changed separator from / → | (pipe) matching reference "03|14"
- Added sb-pipe span with reduced opacity

CLIENT SECTION LABEL:
- Added decorative rivet dots (sb-rivet-row) flanking "CLIENT" text
- Metallic gradient refined: #282828 → #3a3a3a → #282828
- Uses flexbox with gap to position rivets

TASK BAR:
- Added decorative dot row via ::after pseudo-element at bottom edge
- Gold-colored dots matching reference
- Refined FAB button: radial-gradient for 3D metallic sheen

INNER SCREEN:
- Added gap between panels (clamp 4-6px) for physical separation
- Added padding to sb-inner so panels don't touch frame edges
- Deepened inset shadows for more recessed look

RESPONSIVE:
- All values use clamp() — no fixed px

https://claude.ai/code/session_01BuNgA8jRZCJhKzoXNzRqam