### PR TITLE
refactor: match industrial reference — structural + visual overhaul

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -737,6 +737,12 @@ function renderScoreboard() {
     var approvalPad = pad2(approvalDisplay.replace(/[^0-9]/g, '') || '0');
     var inputPad = pad2(inputDisplay.replace(/[^0-9]/g, '') || '0');
 
+    // Dynamic button labels
+    var pranavLabel = pranavVal < 0 ? 'CREATE MORE' : 'INITIATE DRAFT';
+    var chitraLabel = chitraVal > 0 ? 'DISPATCH NOW' : 'DISPATCH READY';
+    var approvalLabel = approval > 0 ? 'APPROVAL DUE' : 'APPROVAL';
+    var inputLabel = input > 0 ? 'INPUT DUE' : 'INPUT';
+
     // Chitra fraction: ready|total
     var chitraTotal = safe(data.chitra.total);
     var chitraFraction = chitraTotal > 0
@@ -754,50 +760,54 @@ function renderScoreboard() {
         '</div>' +
       '</div>' +
 
-      /* ── 2. Main Grid (two operator panels with gold divider) ── */
-      '<div class="sb-main-grid">' +
-        '<div class="sb-main-cell" data-action="open-production">' +
+      /* ── 2. Main section: header strip + grid ── */
+      '<div class="sb-main-section">' +
+        /* Metallic header strip with labels */
+        '<div class="sb-main-header">' +
           '<div class="sb-main-label">PRANAV</div>' +
-          '<div class="sb-main-num gold">' + pranavPad + '</div>' +
-          '<div class="sb-dots gold">\u25CF \u25CF \u25CF \u25CB</div>' +
-          '<div class="sb-main-sub gold">INITIATE DRAFT</div>' +
-        '</div>' +
-        '<div class="sb-divider"></div>' +
-        '<div class="sb-main-cell" data-action="open-ready">' +
           '<div class="sb-main-label">CHITRA</div>' +
-          '<div class="sb-main-num green">' + chitraFraction + '</div>' +
-          '<div class="sb-dots green">\u25CF \u25CF \u25CF \u25CB</div>' +
-          '<div class="sb-main-sub green">DISPATCH READY</div>' +
+        '</div>' +
+        /* Number panels with gold divider */
+        '<div class="sb-main-grid">' +
+          '<div class="sb-main-cell" data-action="open-production">' +
+            '<div class="sb-main-num gold">' + pranavPad + '</div>' +
+            '<div class="sb-main-sub gold">' + pranavLabel + '</div>' +
+          '</div>' +
+          '<div class="sb-divider"></div>' +
+          '<div class="sb-main-cell" data-action="open-ready">' +
+            '<div class="sb-main-num green">' + chitraFraction + '</div>' +
+            '<div class="sb-main-sub green">' + chitraLabel + '</div>' +
+          '</div>' +
         '</div>' +
       '</div>' +
 
-      /* ── 3. CLIENT section label bar with decorative rivets ── */
+      /* ── 3. CLIENT section label bar ── */
       '<div class="sb-section-label">' +
-        '<span class="sb-rivet-row">\u25CF \u25CF \u25CF \u25CF \u25CF \u25CF</span>' +
+        '<span class="sb-rivet-row"></span>' +
         '<span>CLIENT</span>' +
-        '<span class="sb-rivet-row">\u25CF \u25CF \u25CF \u25CF \u25CF \u25CF</span>' +
+        '<span class="sb-rivet-row"></span>' +
       '</div>' +
 
-      /* ── 4. Client Grid (two metric panels) ── */
+      /* ── 4. Client Grid (number → label → dots) ── */
       '<div class="sb-client-strip">' +
         '<div class="sb-client-cell" data-action="open-approval">' +
           '<div class="sb-client-num">' + approvalPad + '</div>' +
-          '<div class="sb-dots dim">\u25CF \u25CF \u25CF \u25CB</div>' +
-          '<div class="sb-client-label">APPROVAL</div>' +
+          '<div class="sb-client-label">' + approvalLabel + '</div>' +
+          '<div class="sb-dots dim">\u25CF \u25CF \u25CF</div>' +
         '</div>' +
         '<div class="sb-client-divider"></div>' +
         '<div class="sb-client-cell" data-action="open-input">' +
           '<div class="sb-client-num">' + inputPad + '</div>' +
-          '<div class="sb-dots dim">\u25CF \u25CF \u25CF \u25CB</div>' +
-          '<div class="sb-client-label">INPUT</div>' +
+          '<div class="sb-client-label">' + inputLabel + '</div>' +
+          '<div class="sb-dots dim">\u25CF \u25CF \u25CF</div>' +
         '</div>' +
       '</div>' +
 
-      /* ── 5. DO THIS NOW bar with bottom rivets ── */
+      /* ── 5. NEXT ACTION bar ── */
       '<div class="sb-task-bar"' + taskAttrs + '>' +
         '<div class="sb-task-content">' +
-          '<div class="sb-task-label">DO THIS NOW</div>' +
-          '<div class="sb-task-text">' + esc(taskText) + ' &nbsp;\u2026</div>' +
+          '<div class="sb-task-label">NEXT ACTION</div>' +
+          '<div class="sb-task-text">' + esc(taskText) + ' <span class="sb-task-dots">\u25CF \u25CF \u25CF</span></div>' +
         '</div>' +
         '<button class="sb-fab" onclick="event.stopPropagation();toggleFabMenu()">+</button>' +
       '</div>' +

--- a/styles.css
+++ b/styles.css
@@ -1073,19 +1073,21 @@ a:hover { text-decoration: underline; }
 
 /* ── Scoreboard Design Tokens ── */
 .pcs-scoreboard {
-  --color-bg: #0a0a0a;
+  --color-bg: #080808;
   --color-steel: #3a3a3a;
   --color-red-alert: #cc2200;
   --color-led-yellow: #f5c400;
   --color-led-green: #00e040;
   --color-led-white: #e8e8e8;
   --color-gold-accent: #c8a84b;
-  --color-panel-border: #555555;
+  --color-panel-border: #2a2a2a;
   --font-led: 'Share Tech Mono', monospace;
   --font-label: 'Rajdhani', sans-serif;
 }
 
-/* ── 0a. Outer Frame ── */
+/* ═══════════════════════════════════════════
+   0a. OUTER FRAME — thick industrial metal housing
+═══════════════════════════════════════════ */
 .pcs-scoreboard {
   position: relative;
   width: 100%;
@@ -1097,7 +1099,7 @@ a:hover { text-decoration: underline; }
   background:
     url('/assets/frame.svg') center / 100% 100% no-repeat;
   box-shadow:
-    0 10px 40px rgba(0,0,0,0.85),
+    0 12px 48px rgba(0,0,0,0.9),
     0 0 0 1px #000;
   font-family: var(--font-label);
   color: var(--color-led-white);
@@ -1115,17 +1117,18 @@ a:hover { text-decoration: underline; }
   z-index: 0;
   pointer-events: none;
 }
-/* Deep inner recess shadow */
+/* Deep inner recess — sharp, aggressive cavity shadow */
 .pcs-scoreboard::after {
   content: "";
   position: absolute;
   inset: clamp(24px, 5vw, 34px) clamp(18px, 4.5vw, 26px);
   border-radius: 5px;
   box-shadow:
-    inset 0 6px 16px rgba(0,0,0,0.98),
-    inset 0 -6px 16px rgba(0,0,0,0.98),
-    inset 5px 0 12px rgba(0,0,0,0.8),
-    inset -5px 0 12px rgba(0,0,0,0.8);
+    inset 0 8px 20px rgba(0,0,0,1),
+    inset 0 -8px 20px rgba(0,0,0,1),
+    inset 8px 0 16px rgba(0,0,0,0.9),
+    inset -8px 0 16px rgba(0,0,0,0.9),
+    inset 0 0 40px rgba(0,0,0,0.5);
   z-index: 0;
   pointer-events: none;
 }
@@ -1134,26 +1137,30 @@ a:hover { text-decoration: underline; }
   z-index: 1;
 }
 
-/* ── 0b. Inner Screen Cavity ── */
+/* ═══════════════════════════════════════════
+   0b. INNER SCREEN CAVITY — no gap, no padding
+   Sections butt up against each other, divided by
+   metallic strips (the "frame" between panels)
+═══════════════════════════════════════════ */
 .sb-inner {
-  border: 2px solid #222;
+  border: 2px solid #1a1a1a;
   border-radius: 4px;
   background: var(--color-bg);
   display: flex;
   flex-direction: column;
-  gap: clamp(4px, 1vw, 6px);
-  padding: clamp(4px, 1vw, 6px);
+  gap: 0;
+  padding: 0;
   overflow: hidden;
   box-shadow:
-    inset 0 3px 10px rgba(0,0,0,0.98),
-    inset 0 -3px 10px rgba(0,0,0,0.98),
-    inset 2px 0 6px rgba(0,0,0,0.6),
-    inset -2px 0 6px rgba(0,0,0,0.6);
+    inset 0 4px 14px rgba(0,0,0,1),
+    inset 0 -4px 14px rgba(0,0,0,1),
+    inset 4px 0 10px rgba(0,0,0,0.8),
+    inset -4px 0 10px rgba(0,0,0,0.8);
 }
 
 /* ═══════════════════════════════════════════
-   LED DOT-MATRIX TEXTURE (shared by all nums)
-   Overlays a pixel grid on text via repeating-linear-gradient
+   LED DOT-MATRIX TEXTURE
+   Stronger grid — 4px cells, higher contrast
 ═══════════════════════════════════════════ */
 .sb-critical-num,
 .sb-main-num,
@@ -1165,73 +1172,70 @@ a:hover { text-decoration: underline; }
 .sb-client-num::after {
   content: "";
   position: absolute;
-  inset: 0;
+  inset: -4px -8px;
   pointer-events: none;
   background:
     repeating-linear-gradient(
       0deg,
       transparent 0px,
-      transparent 2px,
-      rgba(0,0,0,0.25) 2px,
-      rgba(0,0,0,0.25) 3px
+      transparent 3px,
+      rgba(0,0,0,0.35) 3px,
+      rgba(0,0,0,0.35) 4px
     ),
     repeating-linear-gradient(
       90deg,
       transparent 0px,
-      transparent 2px,
-      rgba(0,0,0,0.2) 2px,
-      rgba(0,0,0,0.2) 3px
+      transparent 3px,
+      rgba(0,0,0,0.3) 3px,
+      rgba(0,0,0,0.3) 4px
     );
-  mix-blend-mode: multiply;
   border-radius: 2px;
 }
 
 /* ═══════════════════════════════════════════
-   1. CRITICAL BANNER — centered stacked, dashed red border
+   1. CRITICAL BANNER
+   Centered stacked, dashed red border, strong glow
 ═══════════════════════════════════════════ */
 .sb-critical-panel {
   flex-shrink: 0;
-  padding: clamp(12px, 3vw, 20px) clamp(16px, 4vw, 24px);
+  padding: clamp(16px, 4vw, 26px) clamp(20px, 5vw, 30px);
   background:
-    radial-gradient(ellipse at 50% 60%, rgba(204,34,0,0.3), transparent 65%),
-    #100000;
-  border: 1px solid #333;
-  border-radius: 4px;
-  box-shadow:
-    inset 0 0 30px rgba(0,0,0,0.95),
-    inset 0 3px 10px rgba(0,0,0,0.9);
+    radial-gradient(ellipse at 50% 55%, rgba(204,34,0,0.35), transparent 60%),
+    #0c0000;
+  border-bottom: 2px solid #222;
   display: flex;
   align-items: center;
   justify-content: center;
 }
-/* Dashed red border box inside critical panel */
+/* Dashed red border box — more visible */
 .sb-critical-box {
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: clamp(8px, 2vw, 14px) clamp(24px, 6vw, 40px);
-  border: 1px dashed var(--color-red-alert);
-  border-radius: 3px;
+  width: 65%;
+  padding: clamp(10px, 2.5vw, 16px) clamp(20px, 5vw, 32px);
+  border: 2px dashed rgba(204,34,0,0.7);
+  border-radius: 4px;
   box-shadow:
-    0 0 12px rgba(204,34,0,0.15),
-    inset 0 0 12px rgba(204,34,0,0.08);
+    0 0 18px rgba(204,34,0,0.12),
+    inset 0 0 18px rgba(204,34,0,0.06);
 }
 .sb-critical-label {
   font-family: var(--font-led);
-  font-size: clamp(14px, 3.5vw, 18px);
+  font-size: clamp(16px, 4vw, 20px);
   font-weight: 400;
-  letter-spacing: 0.15em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--color-red-alert);
   line-height: 1.2;
   text-shadow:
-    0 0 6px var(--color-red-alert),
-    0 0 14px rgba(204,34,0,0.4);
+    0 0 8px var(--color-red-alert),
+    0 0 20px rgba(204,34,0,0.5);
 }
 .sb-critical-num {
   font-family: var(--font-led);
-  font-size: clamp(44px, 12vw, 58px);
+  font-size: clamp(48px, 14vw, 66px);
   font-weight: 400;
   font-variant-numeric: tabular-nums;
   line-height: 1;
@@ -1239,88 +1243,113 @@ a:hover { text-decoration: underline; }
   letter-spacing: 3px;
   margin-top: 2px;
   text-shadow:
-    0 0 12px var(--color-red-alert),
-    0 0 30px rgba(204,34,0,0.6),
-    0 0 50px rgba(204,34,0,0.3);
+    0 0 14px var(--color-red-alert),
+    0 0 35px rgba(204,34,0,0.6),
+    0 0 60px rgba(204,34,0,0.25);
 }
 
 /* ═══════════════════════════════════════════
-   2. MAIN SCOREBOARD GRID
+   2. MAIN SECTION — metallic header + number grid
 ═══════════════════════════════════════════ */
+.sb-main-section {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Metallic header strip with PRANAV / CHITRA labels */
+.sb-main-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: clamp(6px, 1.5vw, 10px) clamp(14px, 3.5vw, 20px);
+  background: linear-gradient(180deg,
+    #1e1e1e 0%,
+    #2a2a2a 30%,
+    #333 50%,
+    #2a2a2a 70%,
+    #1e1e1e 100%
+  );
+  border-top: 1px solid #444;
+  border-bottom: 1px solid #444;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.06),
+    inset 0 -1px 0 rgba(0,0,0,0.5);
+}
+
+/* Operator name labels — in the metallic strip */
+.sb-main-label {
+  font-family: var(--font-label);
+  font-size: clamp(14px, 3.8vw, 18px);
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-led-white);
+  line-height: 1;
+}
+
+/* Number panels grid with gold divider */
 .sb-main-grid {
   display: grid;
   grid-template-columns: 1fr 5px 1fr;
 }
 
-/* GOLD GLOWING vertical divider */
+/* GOLD GLOWING vertical divider — extends full height */
 .sb-divider {
   width: 5px;
   background: linear-gradient(
     180deg,
-    rgba(200,168,75,0) 0%,
-    var(--color-gold-accent) 15%,
+    rgba(200,168,75,0.1) 0%,
+    var(--color-gold-accent) 10%,
     #f5d76e 50%,
-    var(--color-gold-accent) 85%,
-    rgba(200,168,75,0) 100%
+    var(--color-gold-accent) 90%,
+    rgba(200,168,75,0.1) 100%
   );
   box-shadow:
-    0 0 8px rgba(200,168,75,0.5),
-    0 0 16px rgba(200,168,75,0.25);
+    0 0 10px rgba(200,168,75,0.6),
+    0 0 20px rgba(200,168,75,0.3),
+    0 0 4px rgba(200,168,75,0.8);
 }
 
-/* Main operator panels */
+/* Main operator cells — deep black, strong recess */
 .sb-main-cell {
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: clamp(14px, 3.5vw, 22px) clamp(6px, 1.5vw, 10px);
+  padding: clamp(18px, 4.5vw, 28px) clamp(8px, 2vw, 14px) clamp(14px, 3.5vw, 20px);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
-  background: #0e0e0e;
+  background: #0a0a0a;
   box-shadow:
-    inset 0 3px 10px rgba(0,0,0,0.9),
-    inset 0 -3px 10px rgba(0,0,0,0.7);
-  border: 1px solid #333;
-  border-radius: 4px;
+    inset 0 4px 14px rgba(0,0,0,0.95),
+    inset 0 -2px 8px rgba(0,0,0,0.6);
 }
 .sb-main-cell:active { opacity: 0.8; }
 
-/* Operator name labels */
-.sb-main-label {
-  font-family: var(--font-label);
-  font-size: clamp(14px, 3.8vw, 18px);
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-led-white);
-  margin-bottom: clamp(6px, 1.5vw, 10px);
-  line-height: 1;
-}
-
-/* LED numbers — large, glowing */
+/* LED numbers — large, glowing, tight shadow */
 .sb-main-num {
   font-family: var(--font-led);
-  font-size: clamp(58px, 17vw, 80px);
+  font-size: clamp(60px, 18vw, 84px);
   font-weight: 400;
   line-height: 1;
   font-variant-numeric: tabular-nums;
   letter-spacing: 4px;
+  margin-bottom: clamp(10px, 2.5vw, 16px);
 }
 .sb-main-num.gold {
   color: var(--color-led-yellow);
   text-shadow:
-    0 0 10px var(--color-led-yellow),
-    0 0 30px rgba(245,196,0,0.5),
-    0 0 50px rgba(245,196,0,0.2);
+    0 0 8px var(--color-led-yellow),
+    0 0 24px rgba(245,196,0,0.45),
+    0 0 48px rgba(245,196,0,0.15);
 }
 .sb-main-num.green {
   color: var(--color-led-green);
   text-shadow:
-    0 0 10px var(--color-led-green),
-    0 0 30px rgba(0,224,64,0.5),
-    0 0 50px rgba(0,224,64,0.2);
+    0 0 8px var(--color-led-green),
+    0 0 24px rgba(0,224,64,0.45),
+    0 0 48px rgba(0,224,64,0.15);
 }
 
 /* Fraction: pipe separator + smaller total */
@@ -1336,89 +1365,84 @@ a:hover { text-decoration: underline; }
   margin: 0 1px;
 }
 
-/* Dot indicators (●●●○) */
-.sb-dots {
-  font-size: clamp(5px, 1.2vw, 7px);
-  letter-spacing: 3px;
-  margin-top: clamp(6px, 1.5vw, 10px);
-  margin-bottom: clamp(8px, 2vw, 12px);
-  color: #333;
-  line-height: 1;
-}
-.sb-dots.gold {
-  color: var(--color-led-yellow);
-  text-shadow: 0 0 4px rgba(245,196,0,0.6);
-}
-.sb-dots.green {
-  color: var(--color-led-green);
-  text-shadow: 0 0 4px rgba(0,224,64,0.6);
-}
-.sb-dots.dim { color: #444; }
-
-/* Action buttons — bordered, no fill, chamfered */
+/* Action buttons — bordered, no fill, thicker border */
 .sb-main-sub {
   font-family: var(--font-label);
-  font-size: clamp(10px, 2.6vw, 13px);
-  font-weight: 600;
+  font-size: clamp(11px, 2.8vw, 14px);
+  font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   background: transparent;
-  padding: clamp(4px, 1vw, 6px) clamp(10px, 2.5vw, 16px);
-  border-radius: 2px;
+  padding: clamp(5px, 1.2vw, 7px) clamp(12px, 3vw, 18px);
   line-height: 1;
 }
 .sb-main-sub.gold {
   color: var(--color-led-yellow);
-  border: 1.5px solid var(--color-led-yellow);
-  box-shadow: 0 0 10px rgba(245,196,0,0.3);
+  border: 2px solid var(--color-led-yellow);
+  box-shadow:
+    0 0 8px rgba(245,196,0,0.25),
+    inset 0 0 6px rgba(245,196,0,0.08);
 }
 .sb-main-sub.green {
   color: var(--color-led-green);
-  border: 1.5px solid var(--color-led-green);
-  box-shadow: 0 0 10px rgba(0,224,64,0.3);
+  border: 2px solid var(--color-led-green);
+  box-shadow:
+    0 0 8px rgba(0,224,64,0.25),
+    inset 0 0 6px rgba(0,224,64,0.08);
 }
 
 /* ═══════════════════════════════════════════
-   3. CLIENT Section Label — metallic strip with rivets
+   3. CLIENT SECTION LABEL — metallic strip with rivets
 ═══════════════════════════════════════════ */
 .sb-section-label {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(8px, 2vw, 14px);
+  gap: clamp(10px, 2.5vw, 16px);
   font-family: var(--font-label);
   font-size: clamp(12px, 3vw, 14px);
   font-weight: 700;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--color-led-white);
-  padding: clamp(5px, 1.2vw, 8px) 0;
-  background: linear-gradient(180deg, #282828 0%, #383838 40%, #3a3a3a 50%, #383838 60%, #282828 100%);
-  border-top: 1px solid #4a4a4a;
-  border-bottom: 1px solid #4a4a4a;
+  padding: clamp(6px, 1.5vw, 10px) 0;
+  background: linear-gradient(180deg,
+    #1e1e1e 0%,
+    #2a2a2a 30%,
+    #333 50%,
+    #2a2a2a 70%,
+    #1e1e1e 100%
+  );
+  border-top: 1px solid #444;
+  border-bottom: 1px solid #444;
   box-shadow:
-    inset 0 1px 0 rgba(255,255,255,0.08),
+    inset 0 1px 0 rgba(255,255,255,0.06),
     inset 0 -1px 0 rgba(0,0,0,0.5);
 }
-/* Decorative rivet dots flanking CLIENT text */
+/* Decorative rivet dots — tiny, subdued */
 .sb-rivet-row {
-  font-size: 4px;
-  letter-spacing: 3px;
-  color: #555;
-  opacity: 0.6;
+  display: inline-block;
+  width: 50px;
+  height: 3px;
+  background: repeating-linear-gradient(
+    90deg,
+    #555 0px, #555 3px,
+    transparent 3px, transparent 8px
+  );
+  opacity: 0.4;
+  border-radius: 1px;
 }
 
 /* ═══════════════════════════════════════════
-   4. CLIENT GRID
+   4. CLIENT GRID — number → label → dots (bottom)
 ═══════════════════════════════════════════ */
 .sb-client-strip {
   display: grid;
-  grid-template-columns: 1fr 3px 1fr;
+  grid-template-columns: 1fr 2px 1fr;
 }
 .sb-client-divider {
-  width: 3px;
-  background: linear-gradient(180deg, #1a1a1a, #444 50%, #1a1a1a);
-  box-shadow: inset 0 0 4px rgba(0,0,0,0.6);
+  width: 2px;
+  background: linear-gradient(180deg, #111, #3a3a3a 50%, #111);
 }
 .sb-client-cell {
   position: relative;
@@ -1426,59 +1450,73 @@ a:hover { text-decoration: underline; }
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: clamp(12px, 3vw, 18px) clamp(6px, 1.5vw, 10px);
+  padding: clamp(14px, 3.5vw, 22px) clamp(8px, 2vw, 12px) clamp(8px, 2vw, 12px);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
-  background: #0e0e0e;
+  background: #0a0a0a;
   box-shadow:
-    inset 0 3px 10px rgba(0,0,0,0.9),
-    inset 0 -3px 10px rgba(0,0,0,0.7);
-  border: 1px solid #333;
-  border-radius: 4px;
+    inset 0 4px 14px rgba(0,0,0,0.95),
+    inset 0 -2px 8px rgba(0,0,0,0.5);
+  border: 1px solid #1e1e1e;
 }
 .sb-client-cell:active { opacity: 0.7; }
 
 .sb-client-num {
   font-family: var(--font-led);
-  font-size: clamp(36px, 10vw, 50px);
+  font-size: clamp(38px, 11vw, 54px);
   font-weight: 400;
   line-height: 1;
   font-variant-numeric: tabular-nums;
   color: var(--color-led-white);
   letter-spacing: 3px;
   text-shadow:
-    0 0 8px rgba(232,232,232,0.35),
-    0 0 20px rgba(232,232,232,0.15);
+    0 0 6px rgba(232,232,232,0.3),
+    0 0 16px rgba(232,232,232,0.1);
 }
-/* Client labels — bordered button style (dimmer) */
+/* Client labels — plain text, NO border box */
 .sb-client-label {
   font-family: var(--font-label);
-  font-size: clamp(10px, 2.6vw, 13px);
-  font-weight: 600;
+  font-size: clamp(11px, 2.8vw, 14px);
+  font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: #888;
-  margin-top: clamp(4px, 1vw, 6px);
-  padding: clamp(3px, 0.8vw, 5px) clamp(10px, 2.5vw, 16px);
-  border: 1px solid #444;
-  border-radius: 2px;
+  margin-top: clamp(6px, 1.5vw, 10px);
   line-height: 1;
 }
 
+/* Dot indicators — shared */
+.sb-dots {
+  font-size: clamp(4px, 1vw, 6px);
+  letter-spacing: 4px;
+  margin-top: clamp(6px, 1.5vw, 10px);
+  color: #333;
+  line-height: 1;
+}
+.sb-dots.gold {
+  color: var(--color-led-yellow);
+  text-shadow: 0 0 4px rgba(245,196,0,0.5);
+}
+.sb-dots.green {
+  color: var(--color-led-green);
+  text-shadow: 0 0 4px rgba(0,224,64,0.5);
+}
+.sb-dots.dim { color: #333; }
+
 /* ═══════════════════════════════════════════
-   5. DO THIS NOW BAR
+   5. NEXT ACTION BAR
 ═══════════════════════════════════════════ */
 .sb-task-bar {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: clamp(10px, 2.5vw, 14px) clamp(12px, 3vw, 16px);
-  background: #0e0e0e;
-  border: 1px solid #333;
-  border-radius: 4px;
+  padding: clamp(12px, 3vw, 16px) clamp(14px, 3.5vw, 18px);
+  background: #0a0a0a;
+  border-top: 2px solid #222;
   box-shadow:
-    inset 0 3px 10px rgba(0,0,0,0.9),
-    inset 0 -2px 6px rgba(0,0,0,0.6);
+    inset 0 4px 14px rgba(0,0,0,0.95),
+    inset 0 -2px 6px rgba(0,0,0,0.5);
 }
 .sb-task-content {
   flex: 1;
@@ -1491,8 +1529,8 @@ a:hover { text-decoration: underline; }
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--color-gold-accent);
-  margin-bottom: 3px;
-  line-height: 1.1;
+  margin-bottom: 4px;
+  line-height: 1;
 }
 .sb-task-text {
   font-family: var(--font-label);
@@ -1503,6 +1541,14 @@ a:hover { text-decoration: underline; }
   overflow: hidden;
   text-overflow: ellipsis;
   opacity: 0.85;
+  line-height: 1.3;
+}
+/* Inline trailing dots */
+.sb-task-dots {
+  color: var(--color-gold-accent);
+  font-size: 0.6em;
+  letter-spacing: 3px;
+  opacity: 0.7;
 }
 .sb-task-bar[data-nav] {
   cursor: pointer;
@@ -1510,26 +1556,12 @@ a:hover { text-decoration: underline; }
 }
 .sb-task-bar[data-nav]:active { opacity: 0.8; }
 
-/* Decorative dot row at bottom of task bar */
-.sb-task-bar::after {
-  content: "\25CF  \25CF  \25CF  \25CF  \25CF  \25CF  \25CF  \25CF";
-  position: absolute;
-  bottom: 4px;
-  left: 12px;
-  font-size: 3px;
-  letter-spacing: 2px;
-  color: var(--color-gold-accent);
-  opacity: 0.5;
-  pointer-events: none;
-}
-.sb-task-bar { position: relative; }
-
-/* FAB — circular gold button with metallic sheen */
+/* FAB — circular gold button with deep metallic sheen */
 .sb-fab {
-  width: clamp(38px, 10vw, 46px);
-  height: clamp(38px, 10vw, 46px);
+  width: clamp(36px, 9vw, 44px);
+  height: clamp(36px, 9vw, 44px);
   background:
-    radial-gradient(circle at 40% 35%, #e0c060, #a8852f 60%, #7a6020 100%);
+    radial-gradient(circle at 40% 35%, #e0c060, #b8952f 55%, #7a6020 100%);
   border: 2px solid var(--color-gold-accent);
   border-radius: 50%;
   color: #2a1a00;


### PR DESCRIPTION
STRUCTURAL CHANGES (HTML):
- Extract PRANAV/CHITRA labels from inside cells into a separate metallic header strip (.sb-main-header) sitting between critical banner and number panels — matches reference where labels sit in the gray frame gutter, not inside black panels
- Wrap main section in .sb-main-section for proper grouping
- Reorder client cells: number → label → dots (was number → dots → label)
- Remove border box from client labels — plain text per reference
- Add dynamic button labels (CREATE MORE / DISPATCH NOW when active)
- Rename "DO THIS NOW" → "NEXT ACTION" per reference
- Add inline .sb-task-dots span for trailing gold dots

CSS OVERHAUL:
- Inner recess: 8px/20px shadows (was 6px/16px), added 40px ambient
- sb-inner: gap:0, padding:0 — panels butt against each other, separated by metallic strips not CSS gaps
- LED grid: 4px cells (was 3px), opacity 0.35/0.3 (was 0.25/0.2), inset extended -4px/-8px to cover glow bleed
- Critical banner: wider dashed box (65% width), 2px dash (was 1px), larger font sizes, stronger glow
- Gold divider: tighter gradient (10%-90%), added 3rd shadow layer for concentrated core glow
- Main cells: more padding, deeper shadows, darker #0a0a0a background
- Action buttons: 2px border (was 1.5px), bolder weight 700 (was 600), added inner glow shadow
- Metallic strips: unified gradient for header + CLIENT bar, matching brushed-metal look
- Rivet dots: replaced unicode circles with repeating-linear-gradient dashes — subtler, more mechanical
- Client labels: NO border box, plain text, dimmer color
- Task bar: border-top instead of full border, removed ::after decorative row, inline dots instead

https://claude.ai/code/session_01BuNgA8jRZCJhKzoXNzRqam