### PR TITLE
feat: pipeline UI stage strip, restyled group headers, post cards, an…

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -1229,6 +1229,94 @@ function buildPostCard(p, listKey) {
 }
 
 
+// -- Pipeline card builder ----------------------
+function _pipelineStageKey(stage) {
+  var s = (stage || '').toLowerCase().trim();
+  if (s === 'in production') return 'production';
+  if (s === 'ready') return 'ready';
+  if (s === 'awaiting brand input') return 'input';
+  if (s === 'awaiting approval') return 'approval';
+  if (s === 'scheduled') return 'scheduled';
+  if (s === 'published') return 'published';
+  return '';
+}
+
+function buildPipelineCard(p, listKey) {
+  var id     = getPostId(p);
+  var title  = getTitle(p);
+  var stage  = p.stage || '';
+  var pillar = getPillarShort(p.contentPillar);
+  var sk     = _pipelineStageKey(stage);
+
+  var d = parseDate(p.targetDate);
+  var dateStr = formatDateShort(p.targetDate);
+  var today = new Date();
+  today.setHours(0,0,0,0);
+  var isToday = d && d.toDateString() === today.toDateString();
+  var isOverdue = d && !isToday && d < today;
+
+  var cardCls = 'post-card';
+  if (isOverdue) cardCls += ' overdue';
+  if (isToday) cardCls += ' due-today';
+
+  var dateCls = 'pc-date';
+  if (isOverdue) dateCls += ' overdue';
+  else if (isToday) dateCls += ' today';
+  else if (!d) dateCls += ' nodate';
+
+  var dateDisplay = dateStr || '-- --';
+
+  // Responsibility badge
+  var badgeCls = 'resp-badge';
+  var badgeText = '';
+  if (sk === 'production')  { badgeCls += ' p'; badgeText = 'P'; }
+  else if (sk === 'ready')  { badgeCls += ' ch'; badgeText = 'Ch'; }
+  else if (sk === 'input')  { badgeCls += ' cl-input'; badgeText = 'Cl'; }
+  else if (sk === 'approval') { badgeCls += ' cl-approval'; badgeText = 'Cl'; }
+  else if (sk === 'scheduled') { badgeCls += ' sched'; badgeText = 'Ch'; }
+  else if (sk === 'published') { badgeCls += ' pub'; badgeText = '\u2713'; }
+
+  // Status dot
+  var dotCls = 'status-dot';
+  if (sk) dotCls += ' sd-' + sk;
+
+  return '<div class="' + cardCls + '" id="upc-' + esc(id) + '" data-post-id="' + esc(id) + '" data-list="' + esc(listKey||'') + '">' +
+    '<span class="' + dateCls + '">' + esc(dateDisplay) + '</span>' +
+    '<span class="pc-body">' +
+      '<span class="pc-title">' + esc(title) + '</span>' +
+      (pillar ? '<span class="pc-meta">' + esc(pillar) + '</span>' : '') +
+    '</span>' +
+    '<span class="pc-right">' +
+      '<span class="' + badgeCls + '">' + badgeText + '</span>' +
+      '<span class="' + dotCls + '"></span>' +
+    '</span>' +
+  '</div>';
+}
+
+// -- Pipeline chip count updater ----------------
+function updatePipelineChipCounts() {
+  var container = document.getElementById('pipeline-container');
+  if (!container) return;
+  var stageMap = { production: 0, ready: 0, input: 0, approval: 0, scheduled: 0, published: 0 };
+  var total = 0;
+  var hdrs = container.querySelectorAll('.group-hdr');
+  for (var i = 0; i < hdrs.length; i++) {
+    var label = hdrs[i].querySelector('.group-label');
+    var count = hdrs[i].querySelector('.group-count');
+    if (!label || !count) continue;
+    var sk = label.getAttribute('data-stage') || '';
+    var n = parseInt(count.textContent, 10) || 0;
+    if (stageMap.hasOwnProperty(sk)) { stageMap[sk] = n; total += n; }
+  }
+  var allEl = document.getElementById('chip-count-all');
+  if (allEl) allEl.textContent = total || '0';
+  var keys = Object.keys(stageMap);
+  for (var k = 0; k < keys.length; k++) {
+    var el = document.getElementById('chip-count-' + keys[k]);
+    if (el) el.textContent = stageMap[keys[k]];
+  }
+}
+
 // -- Task stage chip filter ---------------------
 let _taskFilter = null; // null = show all, string = bucket key
 
@@ -1415,22 +1503,23 @@ function _renderPipelineInner() {
     const posts   = prioritySort(grouped[stage]);
     const listKey = `pipeline-${stage.toLowerCase().replace(/\s+/g,'-')}`;
     _postLists[listKey] = posts;
-    const { hex, label } = stageStyle(stage);
+    const { label } = stageStyle(stage);
+    const sk = _pipelineStageKey(stage);
     const cards = posts.map((p, i) => {
-      const card = buildPostCard(p, listKey);
+      const card = buildPipelineCard(p, listKey);
       if (isFirstCard && activeFilter) {
         isFirstCard = false;
-        return card.replace('class="row-tile"', 'class="row-tile pc-focus"');
+        return card.replace('class="post-card', 'class="post-card pc-focus');
       }
       return card;
     }).join('');
     return `
-      <div class="pstage-header">
-        <span class="pstage-name" style="color:${hex}">${esc(label)}</span>
-        <span class="pstage-badge">${posts.length}</span>
+      <div class="group-hdr">
+        <span class="group-label" data-stage="${esc(sk)}">${esc(label)}</span>
+        <span class="group-count">${posts.length}</span>
       </div>
       <div class="row-list">
-        ${cards || `<div class="pstage-empty">${emptyMsg.default || 'Empty'}</div>`}
+        ${cards || '<div class="pstage-empty">' + (emptyMsg.default || 'Empty') + '</div>'}
       </div>`;
   }).join('');
 
@@ -1438,16 +1527,19 @@ function _renderPipelineInner() {
   if (!container) return;
   container.innerHTML = html;
 
+  // -- Update chip counts from rendered group headers --
+  updatePipelineChipCounts();
+
   // -- GLOBAL EMPTY STATE (filtered view with no results) --
   if (activeFilter && stages.length === 0) {
-    container.innerHTML = `<div class="empty-state"><div class="empty-icon">\u2713</div><p>${emptyMsg.default || 'Nothing here \u2014 you\u2019re clear'}</p></div>`;
+    container.innerHTML = '<div class="empty-state"><div class="empty-icon">\u2713</div><p>' + (emptyMsg.default || 'Nothing here -- you are clear') + '</p></div>';
     return;
   }
 
   // -- AUTO-SCROLL to first focused card --
   if (activeFilter) {
-    requestAnimationFrame(() => {
-      const focus = container.querySelector('.pc-focus');
+    requestAnimationFrame(function() {
+      var focus = container.querySelector('.pc-focus');
       if (focus) {
         focus.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }

--- a/index.html
+++ b/index.html
@@ -142,6 +142,43 @@
 
   <!-- TAB: PIPELINE -->
   <div class="tab-panel" id="panel-pipeline">
+    <div class="stage-strip" id="pipeline-stage-strip">
+      <div class="stage-chip active" data-stage="all">
+        <div class="chip-dot"></div>
+        <div class="chip-label">All</div>
+        <div class="chip-count" id="chip-count-all">&mdash;</div>
+      </div>
+      <div class="stage-chip" data-stage="production">
+        <div class="chip-dot"></div>
+        <div class="chip-label">Production</div>
+        <div class="chip-count" id="chip-count-production">&mdash;</div>
+      </div>
+      <div class="stage-chip" data-stage="ready">
+        <div class="chip-dot"></div>
+        <div class="chip-label">Ready</div>
+        <div class="chip-count" id="chip-count-ready">&mdash;</div>
+      </div>
+      <div class="stage-chip" data-stage="input">
+        <div class="chip-dot"></div>
+        <div class="chip-label">Input</div>
+        <div class="chip-count" id="chip-count-input">&mdash;</div>
+      </div>
+      <div class="stage-chip" data-stage="approval">
+        <div class="chip-dot"></div>
+        <div class="chip-label">Approval</div>
+        <div class="chip-count" id="chip-count-approval">&mdash;</div>
+      </div>
+      <div class="stage-chip" data-stage="scheduled">
+        <div class="chip-dot"></div>
+        <div class="chip-label">Scheduled</div>
+        <div class="chip-count" id="chip-count-scheduled">&mdash;</div>
+      </div>
+      <div class="stage-chip" data-stage="published">
+        <div class="chip-dot"></div>
+        <div class="chip-label">Published</div>
+        <div class="chip-count" id="chip-count-published">&mdash;</div>
+      </div>
+    </div>
     <div class="dash-body">
       <div id="pipeline-container"></div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -119,6 +119,10 @@
   --green-bg: rgba(62,207,142,0.08);
   --amber:    #F6A623;
   --amber-bg: rgba(246,166,35,0.08);
+  --cyan:     #22D3EE;
+  --cyan-bg:  rgba(34,211,238,0.08);
+  --purple:   #9b87f5;
+  --purple-bg:rgba(155,135,245,0.08);
 
   /* Semantic tokens — dark-only design */
   --text-primary: #FFFFFF;
@@ -3191,6 +3195,118 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .row-action {
   display: none;
 }
+
+/* ═══════════════════════════════════════════════
+   PIPELINE STAGE STRIP
+═══════════════════════════════════════════════ */
+
+.stage-strip {
+  display: flex;
+  gap: 8px;
+  padding: 14px 20px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  border-bottom: 1px dotted var(--dotline);
+  -webkit-overflow-scrolling: touch;
+}
+.stage-strip::-webkit-scrollbar { display: none; }
+
+.stage-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 11px;
+  border: 1px dotted;
+  white-space: nowrap;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s;
+  font-family: var(--mono);
+  background: none;
+}
+.stage-chip.active { border-style: solid; }
+
+.stage-chip[data-stage="all"]        { color: #BBBBBB; border-color: rgba(255,255,255,0.2); }
+.stage-chip[data-stage="production"] { color: var(--amber); border-color: rgba(246,166,35,0.35); }
+.stage-chip[data-stage="production"].active { background: var(--amber-bg); }
+.stage-chip[data-stage="ready"]      { color: var(--green); border-color: rgba(62,207,142,0.35); }
+.stage-chip[data-stage="ready"].active { background: var(--green-bg); }
+.stage-chip[data-stage="input"]      { color: var(--purple); border-color: rgba(155,135,245,0.35); }
+.stage-chip[data-stage="input"].active { background: var(--purple-bg); }
+.stage-chip[data-stage="approval"]   { color: var(--red); border-color: rgba(255,75,75,0.35); }
+.stage-chip[data-stage="approval"].active { background: var(--red-bg); }
+.stage-chip[data-stage="scheduled"]  { color: var(--cyan); border-color: rgba(34,211,238,0.35); }
+.stage-chip[data-stage="scheduled"].active { background: var(--cyan-bg); }
+.stage-chip[data-stage="published"]  { color: var(--muted); border-color: var(--muted2); }
+
+.chip-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
+.chip-label { font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; font-weight: 500; }
+.chip-count { font-size: 9px; font-weight: 700; background: rgba(255,255,255,0.07); padding: 1px 5px; min-width: 18px; text-align: center; }
+
+/* ═══════════════════════════════════════════════
+   PIPELINE GROUP HEADER
+═══════════════════════════════════════════════ */
+
+.group-hdr { display: flex; justify-content: space-between; align-items: center; padding: 18px 20px 10px; }
+.group-label { font-family: var(--mono); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; font-weight: 600; }
+.group-label[data-stage="production"] { color: var(--amber); }
+.group-label[data-stage="ready"]      { color: var(--green); }
+.group-label[data-stage="input"]      { color: var(--purple); }
+.group-label[data-stage="approval"]   { color: var(--red); }
+.group-label[data-stage="scheduled"]  { color: var(--cyan); }
+.group-label[data-stage="published"]  { color: var(--muted); }
+.group-count { font-family: var(--mono); font-size: 10px; font-weight: 600; color: var(--text2); background: var(--surface2); border: 1px solid var(--muted2); padding: 2px 8px; }
+
+/* ═══════════════════════════════════════════════
+   PIPELINE POST CARD
+═══════════════════════════════════════════════ */
+
+.post-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  background: var(--surface);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 6px;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 2px;
+}
+.post-card.overdue::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; background: var(--red); }
+.post-card.due-today::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; background: var(--gold); }
+
+.pc-date { font-family: var(--mono); font-size: 10px; min-width: 40px; flex-shrink: 0; color: var(--muted); }
+.pc-date.overdue { color: var(--red); }
+.pc-date.today   { color: var(--gold); }
+.pc-date.nodate  { color: var(--muted2); }
+
+.pc-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.pc-title { font-size: 14px; font-weight: 500; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pc-meta { font-family: var(--mono); font-size: 9px; letter-spacing: 0.06em; color: var(--muted); text-transform: uppercase; }
+
+.pc-right { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+
+/* ═══════════════════════════════════════════════
+   RESPONSIBILITY BADGE + STATUS DOT
+═══════════════════════════════════════════════ */
+
+.resp-badge { width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: var(--mono); font-size: 8px; font-weight: 700; flex-shrink: 0; }
+.resp-badge.p          { background: var(--amber-bg); border: 1px solid rgba(246,166,35,0.35); color: var(--amber); }
+.resp-badge.ch         { background: var(--green-bg); border: 1px solid rgba(62,207,142,0.35); color: var(--green); }
+.resp-badge.cl-input   { background: var(--purple-bg); border: 1px solid rgba(155,135,245,0.35); color: var(--purple); }
+.resp-badge.cl-approval{ background: var(--red-bg); border: 1px solid rgba(255,75,75,0.35); color: var(--red); }
+.resp-badge.sched      { background: var(--cyan-bg); border: 1px solid rgba(34,211,238,0.35); color: var(--cyan); }
+.resp-badge.pub        { background: rgba(85,85,85,0.08); border: 1px solid var(--muted2); color: var(--muted); }
+
+.status-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+.status-dot.sd-ready      { background: var(--green); }
+.status-dot.sd-production { background: var(--amber); }
+.status-dot.sd-input      { background: var(--purple); }
+.status-dot.sd-approval   { background: var(--red); }
+.status-dot.sd-scheduled  { background: var(--cyan); }
+.status-dot.sd-published  { background: var(--muted); }
 
 /* ═══════════════════════════════════════════════
    UPC — Universal Post Card

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-// Load 01-config.js — execute as plain script
+// Load 01-config.js  execute as plain script
 const configSrc = readFileSync(resolve(__dirname, '..', '01-config.js'), 'utf8');
 
 function loadConfig() {
@@ -21,7 +21,7 @@ function loadConfig() {
 
 const config = loadConfig();
 
-// ─── stageStyle ─────────────────────────────────
+//  stageStyle 
 describe('stageStyle', () => {
   it('returns correct hex and label for known stage', () => {
     const s = config.stageStyle('in production');
@@ -49,7 +49,7 @@ describe('stageStyle', () => {
   });
 });
 
-// ─── Config integrity ───────────────────────────
+//  Config integrity 
 describe('config integrity', () => {
   it('STAGE_META keys match STAGES_DB entries (plus archive)', () => {
     const metaKeys = Object.keys(config.STAGE_META);
@@ -124,7 +124,7 @@ describe('config integrity', () => {
   });
 });
 
-// ─── Pillar helpers ─────────────────────────────
+//  Pillar helpers 
 describe('formatPillarDisplay', () => {
   it('returns Capital Case for known pillar', () => {
     expect(config.formatPillarDisplay('leadership')).toBe('Leadership');
@@ -165,7 +165,7 @@ describe('getPillarShort', () => {
   });
 });
 
-// ─── sanitizePillar ─────────────────────────────
+//  sanitizePillar 
 describe('sanitizePillar', () => {
   it('lowercases and trims input', () => {
     expect(config.sanitizePillar('Leadership')).toBe('leadership');
@@ -186,7 +186,7 @@ describe('sanitizePillar', () => {
   });
 });
 
-// ─── Pillar system lockdown ─────────────────────
+//  Pillar system lockdown 
 describe('pillar system lockdown', () => {
   it('PILLAR_DISPLAY keys exactly match PILLARS_DB', () => {
     expect(Object.keys(config.PILLAR_DISPLAY).sort()).toEqual([...config.PILLARS_DB].sort());

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -14,7 +14,7 @@ function loadUtils() {
 
 const { getTitle, getPostId, parseDate, formatDate, esc, timeAgo } = loadUtils();
 
-// ─── getTitle ───────────────────────────────────
+//  getTitle 
 describe('getTitle', () => {
   it('returns title when present', () => {
     expect(getTitle({ title: 'My Post' })).toBe('My Post');
@@ -33,7 +33,7 @@ describe('getTitle', () => {
   });
 });
 
-// ─── getPostId ──────────────────────────────────
+//  getPostId 
 describe('getPostId', () => {
   it('returns post_id when present', () => {
     expect(getPostId({ post_id: 'POST-1' })).toBe('POST-1');
@@ -48,7 +48,7 @@ describe('getPostId', () => {
   });
 });
 
-// ─── parseDate ──────────────────────────────────
+//  parseDate 
 describe('parseDate', () => {
   it('returns null for null/undefined/empty', () => {
     expect(parseDate(null)).toBeNull();
@@ -67,7 +67,7 @@ describe('parseDate', () => {
   });
 });
 
-// ─── formatDate ─────────────────────────────────
+//  formatDate 
 describe('formatDate', () => {
   it('returns null for null input', () => {
     expect(formatDate(null)).toBeNull();
@@ -86,7 +86,7 @@ describe('formatDate', () => {
   });
 });
 
-// ─── esc ────────────────────────────────────────
+//  esc 
 describe('esc', () => {
   it('escapes ampersand', () => {
     expect(esc('a&b')).toBe('a&amp;b');
@@ -116,7 +116,7 @@ describe('esc', () => {
   });
 });
 
-// ─── timeAgo ────────────────────────────────────
+//  timeAgo 
 describe('timeAgo', () => {
   beforeEach(() => {
     vi.useFakeTimers();


### PR DESCRIPTION
…d responsibility badges

- Add horizontally scrollable stage chip strip at top of pipeline view with colored dots, labels, and count badges populated from rendered group headers
- Restyle pipeline group headers with mono font, colored labels per stage, and bordered count badges
- New post card layout with flex display, overdue/due-today left border indicators, date column with color states, and ellipsis title/meta
- Replace plain status dot with responsibility badge circle (initials by stage) plus smaller status dot
- Add CSS variables: --cyan, --cyan-bg, --purple, --purple-bg
- Strip non-ASCII characters from all JS files

https://claude.ai/code/session_01XrWxYi3jPr27jx5TDRBqr9