### PR TITLE
feat: library UI overhaul - unified search block, time-based list, ca…

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -1627,29 +1627,103 @@ function renderLibrary() {
   } catch(e) { console.error('[PCS] renderLibrary crash:', e); }
 }
 
+function _libStageDotColor(stage) {
+  var sk = _pipelineStageKey(stage);
+  if (sk === 'production') return 'var(--amber)';
+  if (sk === 'ready')      return 'var(--green)';
+  if (sk === 'input')      return 'var(--purple)';
+  if (sk === 'approval')   return 'var(--red)';
+  if (sk === 'scheduled')  return 'var(--cyan)';
+  if (sk === 'published')  return 'var(--muted)';
+  return 'var(--muted)';
+}
+
+function _buildLibCard(p) {
+  var id    = getPostId(p);
+  var title = getTitle(p);
+  var pillar = getPillarShort(p.contentPillar);
+  var owner  = formatOwner(p.owner || '');
+  var stage  = p.stage || '';
+
+  var d = parseDate(p.targetDate);
+  var dateStr = formatDateShort(p.targetDate);
+  var today = new Date(); today.setHours(0,0,0,0);
+  var isToday = d && d.toDateString() === today.toDateString();
+  var isOverdue = d && !isToday && d < today;
+
+  var cardCls = 'lib-card';
+  if (isOverdue) cardCls += ' overdue';
+  if (isToday) cardCls += ' today';
+
+  var dateCls = 'lib-date';
+  if (isOverdue) dateCls += ' overdue';
+  else if (isToday) dateCls += ' today';
+
+  var dateDisplay = dateStr || '-- --';
+
+  var metaParts = [];
+  if (pillar) metaParts.push(esc(pillar));
+  if (owner && owner !== ' - ') metaParts.push(esc(owner));
+  var metaHtml = metaParts.join('<span class="lib-meta-dot"></span>');
+
+  var dotColor = _libStageDotColor(stage);
+
+  return '<div class="' + cardCls + '" data-post-id="' + esc(id) + '" data-list="library">' +
+    '<span class="' + dateCls + '">' + esc(dateDisplay) + '</span>' +
+    '<div class="lib-body">' +
+      '<div class="lib-title">' + esc(title) + '</div>' +
+      (metaHtml ? '<div class="lib-meta">' + metaHtml + '</div>' : '') +
+    '</div>' +
+    '<span class="lib-stage-dot" style="background:' + dotColor + '"></span>' +
+  '</div>';
+}
+
 function renderLibraryRows(posts) {
-  const listView = document.getElementById('library-list-view');
+  var listView = document.getElementById('library-list-view');
   if (!listView) return;
-  posts = posts.slice().sort((a, b) => (parseDate(b.targetDate) || 0) - (parseDate(a.targetDate) || 0));
+  posts = posts.slice().sort(function(a, b) { return (parseDate(a.targetDate) || new Date(9999,0)) - (parseDate(b.targetDate) || new Date(9999,0)); });
   _postLists['library'] = posts;
   if (!posts.length) {
-    listView.innerHTML = `<div class="empty-state"><div class="empty-icon">[search]</div><p>No posts match your search.</p></div>`;
+    listView.innerHTML = '<div class="empty-state"><div class="empty-icon">[search]</div><p>No posts match your search.</p></div>';
     return;
   }
 
-  // Group posts by month
-  const groups = {};
-  posts.forEach(p => {
-    const d = parseDate(p.targetDate);
-    const key = d ? formatMonthYear(p.targetDate) : 'No Date';
-    if (!groups[key]) groups[key] = [];
-    groups[key].push(p);
+  var today = new Date(); today.setHours(0,0,0,0);
+  var day7 = new Date(today); day7.setDate(day7.getDate() + 7);
+  var day14 = new Date(today); day14.setDate(day14.getDate() + 14);
+  var thisMonthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0); thisMonthEnd.setHours(23,59,59,999);
+  var nextMonthEnd = new Date(today.getFullYear(), today.getMonth() + 2, 0); nextMonthEnd.setHours(23,59,59,999);
+
+  var groups = { overdue: [], thisWeek: [], nextWeek: [], laterMonth: [], nextMonth: [], later: [], noDate: [] };
+  posts.forEach(function(p) {
+    var d = parseDate(p.targetDate);
+    if (!d) { groups.noDate.push(p); return; }
+    if (d < today) { groups.overdue.push(p); return; }
+    if (d < day7) { groups.thisWeek.push(p); return; }
+    if (d < day14) { groups.nextWeek.push(p); return; }
+    if (d <= thisMonthEnd) { groups.laterMonth.push(p); return; }
+    if (d <= nextMonthEnd) { groups.nextMonth.push(p); return; }
+    groups.later.push(p);
   });
 
-  let html = '';
-  for (const [month, group] of Object.entries(groups)) {
-    html += `<div class="pcs-month-group"><div class="pcs-library-month"><span class="pcs-month-label">${esc(month)}</span><span class="pcs-month-count">${group.length} post${group.length === 1 ? '' : 's'}</span></div><div class="row-list">${group.map(p => buildPostCard(p, 'library')).join('')}</div></div>`;
-  }
+  var order = [
+    { key: 'overdue', label: 'Overdue', dot: 'var(--red)', countCls: ' style="color:var(--red)"' },
+    { key: 'thisWeek', label: 'This Week', dot: '', countCls: '' },
+    { key: 'nextWeek', label: 'Next Week', dot: '', countCls: '' },
+    { key: 'laterMonth', label: 'Later This Month', dot: '', countCls: '' },
+    { key: 'nextMonth', label: 'Next Month', dot: '', countCls: '' },
+    { key: 'later', label: 'Later', dot: '', countCls: '' },
+    { key: 'noDate', label: 'No Date', dot: '', countCls: '' }
+  ];
+
+  var html = '';
+  order.forEach(function(g) {
+    var arr = groups[g.key];
+    if (!arr.length) return;
+    var dotHtml = g.dot ? '<span class="time-label-dot" style="background:' + g.dot + '"></span>' : '';
+    html += '<div class="time-label"><span class="time-label-text">' + dotHtml + g.label + '</span><span class="time-label-count"' + g.countCls + '>' + arr.length + '</span></div>';
+    html += arr.map(function(p) { return _buildLibCard(p); }).join('');
+  });
   listView.innerHTML = html;
 }
 
@@ -1758,7 +1832,7 @@ function renderCreativeTracker() {
 let _currentLibraryView = 'list';
 
 function switchLibraryView(btn) {
-  document.querySelectorAll('.lib-view-btn').forEach(b => b.classList.remove('active'));
+  document.querySelectorAll('.vt-btn').forEach(b => b.classList.remove('active'));
   btn.classList.add('active');
   _currentLibraryView = btn.dataset.view;
 
@@ -1791,88 +1865,192 @@ function normalizePillar(pillar) {
 }
 
 function groupPostsByDay(posts, month, year) {
-  const map = {};
-  posts.forEach(p => {
-    const d = parseDate(p.targetDate);
+  var map = {};
+  posts.forEach(function(p) {
+    var d = parseDate(p.targetDate);
     if (!d || d.getMonth() !== month || d.getFullYear() !== year) return;
-    const s = (p.stage || '').toLowerCase().trim();
-    if (s !== 'published' && s !== 'scheduled') return;
-    const key = p.targetDate;
+    var key = p.targetDate;
     if (!map[key]) map[key] = [];
     map[key].push(p);
   });
   return map;
 }
 
+var _calDayMap = {}; // stored for drawer access
+
 function renderLibraryCalendar(posts) {
-  const container = document.getElementById('library-calendar-view');
+  var container = document.getElementById('library-calendar-view');
   if (!container) return;
   posts = posts || allPosts;
 
-  const dayMap = groupPostsByDay(posts, _calMonth, _calYear);
-  const monthLabel = MONTHS_LONG[_calMonth] + ' ' + _calYear;
+  var dayMap = groupPostsByDay(posts, _calMonth, _calYear);
+  _calDayMap = dayMap;
+  var monthLabel = MONTHS[_calMonth] + ' ' + _calYear;
 
-  // Grid: first day of month and total days
-  const firstDay = new Date(_calYear, _calMonth, 1).getDay(); // 0=Sun
-  const daysInMonth = new Date(_calYear, _calMonth + 1, 0).getDate();
-  const totalCells = firstDay + daysInMonth <= 35 ? 35 : 42;
+  var firstDay = new Date(_calYear, _calMonth, 1).getDay();
+  var numDays = new Date(_calYear, _calMonth + 1, 0).getDate();
+  var totalCells = firstDay + numDays <= 35 ? 35 : 42;
 
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  var today = new Date(); today.setHours(0,0,0,0);
 
-  // Header
-  let html = `<div class="pcs-cal-header">
-    <span class="pcs-cal-title">${esc(monthLabel)}</span>
-    <span class="pcs-cal-nav">
-      <button class="pcs-cal-nav-btn" onclick="_calNav(-1)">&lsaquo;</button>
-      <button class="pcs-cal-nav-btn" onclick="_calNav(1)">&rsaquo;</button>
-    </span>
-  </div>`;
-
-  // Day-of-week labels
-  html += `<div class="pcs-cal-grid pcs-cal-dow">`;
-  ['Su','Mo','Tu','We','Th','Fr','Sa'].forEach(d => {
-    html += `<div class="pcs-cal-dow-label">${d}</div>`;
+  // Count stats for month bar
+  var statSched = 0, statReady = 0, statLate = 0;
+  Object.keys(dayMap).forEach(function(k) {
+    dayMap[k].forEach(function(p) {
+      var s = (p.stage || '').toLowerCase().trim();
+      if (s === 'scheduled') statSched++;
+      else if (s === 'ready') statReady++;
+      var pd = parseDate(p.targetDate);
+      if (pd && pd < today) statLate++;
+    });
   });
-  html += `</div>`;
 
-  // Cells
-  html += `<div class="pcs-cal-grid">`;
-  for (let i = 0; i < totalCells; i++) {
-    const dayNum = i - firstDay + 1;
-    if (i < firstDay || dayNum > daysInMonth) {
-      html += `<div class="pcs-cal-cell pcs-cal-cell-empty"></div>`;
+  // Month bar
+  var html = '<div class="month-bar">' +
+    '<div class="month-nav">' +
+      '<button class="month-arrow" id="cal-prev" onclick="_calNav(-1)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg></button>' +
+      '<div class="month-title" id="cal-month-title">' + esc(monthLabel) + '</div>' +
+      '<button class="month-arrow" id="cal-next" onclick="_calNav(1)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 6 15 12 9 18"/></svg></button>' +
+    '</div>' +
+    '<div class="month-stats" id="month-stats">' +
+      '<div class="mstat-pill sched" title="Scheduled"><div class="mstat-dot"></div><span id="stat-sched">' + statSched + '</span></div>' +
+      '<div class="mstat-pill ready" title="Ready"><div class="mstat-dot"></div><span id="stat-ready">' + statReady + '</span></div>' +
+      '<div class="mstat-pill late" title="Overdue"><div class="mstat-dot"></div><span id="stat-late">' + statLate + '</span></div>' +
+    '</div>' +
+  '</div>';
+
+  // DOW header
+  html += '<div class="pcs-cal-grid pcs-cal-dow">';
+  ['Su','Mo','Tu','We','Th','Fr','Sa'].forEach(function(d) {
+    html += '<div class="pcs-cal-dow-label">' + d + '</div>';
+  });
+  html += '</div>';
+
+  // Cells with dots
+  html += '<div class="pcs-cal-grid" id="cal-grid">';
+  for (var i = 0; i < totalCells; i++) {
+    var dayNum = i - firstDay + 1;
+    if (i < firstDay || dayNum > numDays) {
+      html += '<div class="cal-cell-empty"></div>';
       continue;
     }
 
-    const dd = String(dayNum).padStart(2, '0');
-    const mm = String(_calMonth + 1).padStart(2, '0');
-    const key = `${_calYear}-${mm}-${dd}`;
-    const cellDate = new Date(_calYear, _calMonth, dayNum);
-    const isToday = cellDate.getTime() === today.getTime();
-    const dayPosts = dayMap[key] || [];
+    var dd = String(dayNum).padStart(2, '0');
+    var mm = String(_calMonth + 1).padStart(2, '0');
+    var key = _calYear + '-' + mm + '-' + dd;
+    var cellDate = new Date(_calYear, _calMonth, dayNum);
+    var isToday = cellDate.getTime() === today.getTime();
+    var dayPosts = dayMap[key] || [];
 
-    const first = dayPosts[0];
-    const pillarFilterActive = !!(document.getElementById('filter-pillar')?.value);
-    const cellLabel = first
-      ? (pillarFilterActive ? getPillarShort(first.contentPillar) : getTitle(first))
-      : '';
-    const postId = first ? getPostId(first) : '';
-    const extra = dayPosts.length > 1 ? dayPosts.length - 1 : 0;
+    var cellCls = 'cal-cell';
+    if (isToday) cellCls += ' today';
 
-    const clickAttr = postId ? ` data-post-id="${esc(postId)}" data-list="library"` : '';
-    const todayClass = isToday ? ' pcs-cal-today' : '';
-    const hasPost = dayPosts.length ? ' pcs-cal-has-post' : '';
+    html += '<div class="' + cellCls + '" data-cal-date="' + key + '">';
+    html += '<div class="cc-num">' + dayNum + '</div>';
 
-    html += `<div class="pcs-cal-cell${todayClass}${hasPost}"${clickAttr}>`;
-    html += `<div class="pcs-cal-date">${dayNum}</div>`;
-    if (cellLabel) html += `<div class="pcs-cal-pill">${esc(cellLabel)}</div>`;
-    if (extra)  html += `<div class="pcs-cal-more">+${extra}</div>`;
-    html += `</div>`;
+    if (dayPosts.length) {
+      html += '<div class="cc-dots">';
+      var maxDots = Math.min(dayPosts.length, 6);
+      for (var j = 0; j < maxDots; j++) {
+        var dotColor = _libStageDotColor(dayPosts[j].stage);
+        html += '<span class="cc-dot" style="background:' + dotColor + '"></span>';
+      }
+      html += '</div>';
+      if (dayPosts.length > 6) {
+        html += '<div class="cc-overflow">+' + (dayPosts.length - 6) + '</div>';
+      }
+    }
+
+    html += '</div>';
   }
-  html += `</div>`;
+  html += '</div>';
+
+  // Day drawer
+  html += '<div class="day-drawer" id="day-drawer">' +
+    '<div class="drawer-hdr">' +
+      '<div class="drawer-date" id="drawer-date">Select a day</div>' +
+      '<div class="drawer-close" id="drawer-close">x close</div>' +
+    '</div>' +
+    '<div id="drawer-posts"></div>' +
+  '</div>';
 
   container.innerHTML = html;
+
+  // Wire up cell clicks for drawer
+  var grid = document.getElementById('cal-grid');
+  if (grid) {
+    grid.addEventListener('click', function(e) {
+      var cell = e.target.closest('.cal-cell');
+      if (!cell) return;
+      var dateKey = cell.getAttribute('data-cal-date');
+      if (!dateKey) return;
+      _openDayDrawer(dateKey, cell);
+    });
+  }
+
+  // Wire up drawer close
+  var closeBtn = document.getElementById('drawer-close');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', function() { _closeDayDrawer(); });
+  }
+}
+
+function _stagePillClass(stage) {
+  var sk = _pipelineStageKey(stage);
+  if (sk === 'production') return 's-prod';
+  if (sk === 'ready')      return 's-ready';
+  if (sk === 'input')      return 's-input';
+  if (sk === 'approval')   return 's-appr';
+  if (sk === 'scheduled')  return 's-sched';
+  return '';
+}
+
+function _openDayDrawer(dateKey, cell) {
+  // Deselect previous
+  var prev = document.querySelector('.cal-cell.selected');
+  if (prev) prev.classList.remove('selected');
+  cell.classList.add('selected');
+
+  var drawer = document.getElementById('day-drawer');
+  var dateEl = document.getElementById('drawer-date');
+  var postsEl = document.getElementById('drawer-posts');
+  if (!drawer || !postsEl) return;
+
+  var d = parseDate(dateKey);
+  if (dateEl) dateEl.textContent = d ? (d.getDate() + ' ' + MONTHS[d.getMonth()] + ' ' + d.getFullYear()) : dateKey;
+
+  var posts = _calDayMap[dateKey] || [];
+  if (!posts.length) {
+    postsEl.innerHTML = '<div class="drawer-empty">No posts on this day</div>';
+  } else {
+    postsEl.innerHTML = posts.map(function(p) {
+      var id = getPostId(p);
+      var dotColor = _libStageDotColor(p.stage);
+      var owner = formatOwner(p.owner || '');
+      var pillar = getPillarShort(p.contentPillar);
+      var stLabel = stageStyle(p.stage).label;
+      var stCls = _stagePillClass(p.stage);
+      var html = '<div class="drawer-post" data-post-id="' + esc(id) + '" data-list="library">' +
+        '<span class="drawer-stage-dot" style="background:' + dotColor + '"></span>' +
+        '<div>' +
+          '<div class="drawer-post-title">' + esc(getTitle(p)) + '</div>' +
+          '<div class="drawer-post-meta">';
+      if (owner && owner !== ' - ') html += '<span class="meta-pill owner">' + esc(owner) + '</span>';
+      if (pillar) html += '<span class="meta-pill pillar">' + esc(pillar) + '</span>';
+      if (stLabel) html += '<span class="meta-pill ' + stCls + '">' + esc(stLabel) + '</span>';
+      html += '</div></div></div>';
+      return html;
+    }).join('');
+  }
+
+  drawer.classList.add('open');
+}
+
+function _closeDayDrawer() {
+  var drawer = document.getElementById('day-drawer');
+  if (drawer) drawer.classList.remove('open');
+  var prev = document.querySelector('.cal-cell.selected');
+  if (prev) prev.classList.remove('selected');
 }
 
 // ===============================================

--- a/index.html
+++ b/index.html
@@ -186,35 +186,42 @@
 
   <!-- TAB: LIBRARY -->
   <div class="tab-panel" id="panel-library">
-    <!-- Row 1: Search + view toggle -->
-    <div class="lib-search-bar">
-      <input type="text" id="search-input" class="lib-search-input" placeholder="Search posts…" oninput="filterLibrary()">
-      <div class="lib-view-toggle">
-        <button class="lib-view-btn active" data-view="list"     onclick="switchLibraryView(this)">List</button>
-        <button class="lib-view-btn"        data-view="calendar" onclick="switchLibraryView(this)">Cal</button>
+    <!-- Unified search + filter block -->
+    <div class="search-block">
+      <!-- Row 1: search + view toggle -->
+      <div class="search-row">
+        <div class="search-box" onclick="document.getElementById('search-input').focus()">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <input type="text" id="search-input" class="search-input-real" placeholder="Search posts..." oninput="filterLibrary()">
+        </div>
+        <div class="search-divider"></div>
+        <div class="view-toggle">
+          <button class="vt-btn active" id="btn-list" data-view="list" onclick="switchLibraryView(this)">List</button>
+          <button class="vt-btn" id="btn-cal" data-view="calendar" onclick="switchLibraryView(this)">Cal</button>
+        </div>
+      </div>
+      <!-- Row 2: filters -->
+      <div class="filter-row">
+        <select id="filter-stage" class="filter-chip" onchange="filterLibrary()">
+          <option value="">Stage</option>
+        </select>
+        <select id="filter-owner" class="filter-chip" onchange="filterLibrary()">
+          <option value="">Owner</option>
+        </select>
+        <select id="filter-pillar" class="filter-chip" onchange="filterLibrary()">
+          <option value="">Pillar</option>
+        </select>
+        <select id="filter-date" class="filter-chip" onchange="filterLibrary()">
+          <option value="">Date</option>
+          <option value="past">Past</option>
+          <option value="today">Today</option>
+          <option value="week">This week</option>
+          <option value="future">Future</option>
+          <option value="none">No date</option>
+        </select>
       </div>
     </div>
-    <!-- Row 2: Filter chips -->
-    <div class="lib-filter-row" id="lib-filter-row">
-      <select id="filter-stage" class="lib-filter-chip" onchange="filterLibrary()">
-        <option value="">Stage</option>
-      </select>
-      <select id="filter-owner" class="lib-filter-chip" onchange="filterLibrary()">
-        <option value="">Owner</option>
-      </select>
-      <select id="filter-pillar" class="lib-filter-chip" onchange="filterLibrary()">
-        <option value="">Pillar</option>
-      </select>
-      <select id="filter-date" class="lib-filter-chip" onchange="filterLibrary()">
-        <option value="">Date</option>
-        <option value="past">Past</option>
-        <option value="today">Today</option>
-        <option value="week">This week</option>
-        <option value="future">Future</option>
-        <option value="none">No date</option>
-      </select>
-    </div>
-    <!-- Row 3: Content -->
+    <!-- Content -->
     <div class="dash-body" id="library-content">
       <div id="library-list-view"></div>
       <div id="library-calendar-view" style="display:none"></div>

--- a/styles.css
+++ b/styles.css
@@ -113,6 +113,7 @@
   --muted2:   #222222;
   --gold:     #C8A84B;
   --gold-hi:  #E2C06A;
+  --gold-bg:  rgba(200,168,75,0.10);
   --red:      #FF4B4B;
   --red-bg:   rgba(255,75,75,0.08);
   --green:    #3ECF8E;
@@ -2444,104 +2445,31 @@ tr:hover td { background: var(--surface2); }
   overflow: hidden; /* keep tab-panel clipping, content area scrolls internally */
 }
 
-/* Row 1: Search + view toggle */
-.lib-search-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 16px 8px;
-  background: var(--bg);
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
+/* ── Unified Search + Filter Block ── */
+.search-block { border-bottom: 1px dotted var(--dotline); background: var(--bg); position: relative; }
+.search-row { display: flex; align-items: center; border-bottom: 1px dotted var(--dotline); }
+.search-box { flex: 1; display: flex; align-items: center; gap: 8px; padding: 12px 16px; color: var(--muted); cursor: text; }
+.search-input-real { background: none; border: none; outline: none; font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; color: var(--text); flex: 1; min-width: 0; }
+.search-input-real::placeholder { font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; color: var(--muted); text-transform: uppercase; }
+.search-divider { width: 1px; height: 36px; background: var(--dotline); flex-shrink: 0; }
+.view-toggle { display: flex; flex-shrink: 0; }
+.vt-btn { padding: 12px 16px; font-family: var(--mono); font-size: 9px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); cursor: pointer; background: transparent; border: none; border-left: 1px dotted var(--dotline); transition: all 0.15s; }
+.vt-btn.active { color: var(--text); background: var(--surface); }
+.filter-row { display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; }
+.filter-chip {
+  display: flex; align-items: center; justify-content: center; gap: 4px;
+  padding: 10px 4px; font-family: var(--mono); font-size: 9px; letter-spacing: 0.08em;
+  color: var(--muted); text-transform: uppercase; cursor: pointer;
+  border: none; border-right: 1px dotted var(--dotline); transition: all 0.15s;
+  white-space: nowrap; background: transparent; min-width: 0; width: 100%;
+  box-sizing: border-box; appearance: none; -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 24 24' fill='none' stroke='%23555555' stroke-width='2.5'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 6px center; padding-right: 18px;
+  text-overflow: ellipsis; overflow: hidden;
 }
-.lib-search-input {
-  flex: 1;
-  height: 36px;
-  background: var(--surface2);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 0 12px;
-  font-size: 14px;
-  color: var(--text);
-  font-family: inherit;
-  min-width: 0;
-}
-.lib-search-input:focus { outline: none; border-color: var(--accent); }
-
-/* View toggle */
-.lib-view-toggle {
-  display: flex;
-  gap: 1px;
-  background: var(--surface2);
-  border-radius: 8px;
-  padding: 2px;
-  flex-shrink: 0;
-}
-.lib-view-btn {
-  padding: 4px 9px;
-  border-radius: 6px;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text3);
-  transition: background 0.12s, color 0.12s;
-  white-space: nowrap;
-}
-.lib-view-btn.active {
-  background: var(--surface);
-  color: var(--text);
-  box-shadow: 0 1px 3px rgba(0,0,0,0.12);
-}
-.lib-view-btn:active { transform: none; }
-
-/* Horizontally scrolling filter chip row */
-.lib-filter-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
-  gap: 6px;
-  padding: 8px 16px;
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
-  background: var(--bg);
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
-  overflow: hidden;
-}
-
-.lib-filter-chip {
-  height: 38px;
-  padding: 0 8px;
-  background: var(--surface2);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text2);
-  font-family: inherit;
-  width: 100%;
-  min-width: 0;
-  max-width: 100%;
-  box-sizing: border-box;
-  appearance: none;
-  -webkit-appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%238892aa' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 8px center;
-  padding-right: 24px;
-  cursor: pointer;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.lib-filter-chip:focus { outline: none; border-color: var(--accent); }
-.lib-filter-chip:active { background: var(--surface3); }
-
-/* Active state */
-.lib-filter-chip.chip-active {
-  background: var(--accent-dim);
-  border-color: var(--accent);
-  color: var(--accent);
-}
+.filter-chip:last-child { border-right: none; }
+.filter-chip:focus { outline: none; }
+.filter-chip.chip-active { color: var(--gold); background: rgba(200,168,75,0.10); }
 
 /* Library content scroll area */
 #library-content {
@@ -2549,10 +2477,74 @@ tr:hover td { background: var(--surface2); }
   overflow-y: auto;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
-  padding: var(--sp-3) 0 calc(64px + var(--sp-5));
+  padding: 0 0 calc(64px + var(--sp-5));
   position: relative;
   min-height: 0;
 }
+
+/* ── Library List: time-based groups ── */
+.time-label { display: flex; justify-content: space-between; align-items: center; padding: 14px 20px 8px; }
+.time-label-text { font-family: var(--mono); font-size: 9px; letter-spacing: 0.22em; color: var(--muted); text-transform: uppercase; display: flex; align-items: center; gap: 6px; }
+.time-label-count { font-family: var(--mono); font-size: 9px; color: var(--muted); }
+.time-label-dot { width: 5px; height: 5px; border-radius: 50%; flex-shrink: 0; }
+
+.lib-card { display: flex; align-items: center; gap: 12px; padding: 12px 20px; border-bottom: 1px dotted var(--muted2); cursor: pointer; position: relative; transition: background 0.15s; }
+.lib-card:hover { background: var(--surface); }
+.lib-card.overdue::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; background: var(--red); }
+.lib-card.today::before   { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; background: var(--gold); }
+.lib-date { font-family: var(--mono); font-size: 10px; color: var(--muted); min-width: 42px; flex-shrink: 0; letter-spacing: 0.04em; }
+.lib-date.overdue { color: var(--red); }
+.lib-date.today   { color: var(--gold); }
+.lib-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.lib-title { font-size: 14px; font-weight: 500; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin-bottom: 3px; }
+.lib-meta { font-family: var(--mono); font-size: 9px; letter-spacing: 0.06em; color: var(--muted); text-transform: uppercase; display: flex; align-items: center; gap: 5px; }
+.lib-meta-dot { width: 3px; height: 3px; border-radius: 50%; background: var(--muted2); }
+.lib-stage-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+
+/* ── Calendar: month bar ── */
+.month-bar { display: flex; align-items: center; justify-content: space-between; padding: 14px 20px; border-bottom: 1px dotted var(--dotline); gap: 12px; }
+.month-nav { display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
+.month-title { font-family: var(--mono); font-size: 12px; font-weight: 600; letter-spacing: 0.06em; color: var(--text); white-space: nowrap; }
+.month-arrow { width: 26px; height: 26px; border: 1px dotted rgba(255,255,255,0.15); display: flex; align-items: center; justify-content: center; cursor: pointer; color: var(--muted); flex-shrink: 0; background: none; }
+.month-arrow svg { width: 11px; height: 11px; }
+.month-stats { display: flex; gap: 6px; align-items: center; flex-shrink: 0; }
+.mstat-pill { display: flex; align-items: center; gap: 5px; padding: 4px 8px; border: 1px dotted; font-family: var(--mono); font-size: 10px; font-weight: 600; white-space: nowrap; }
+.mstat-pill.sched { color: var(--cyan); border-color: rgba(34,211,238,0.3); background: var(--cyan-bg); }
+.mstat-pill.ready { color: var(--green); border-color: rgba(62,207,142,0.3); background: var(--green-bg); }
+.mstat-pill.late  { color: var(--red); border-color: rgba(255,75,75,0.3); background: var(--red-bg); }
+.mstat-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
+
+/* ── Calendar: cell dots ── */
+.cal-cell { background: var(--surface); border: 1px solid var(--muted2); border-radius: 3px; padding: 5px 4px 4px; cursor: pointer; display: flex; flex-direction: column; min-height: 52px; transition: background 0.15s; }
+.cal-cell.today { border-color: var(--gold); }
+.cal-cell.today .cc-num { color: var(--gold); font-weight: 700; }
+.cal-cell.selected { background: var(--surface2); border-color: rgba(255,255,255,0.18); }
+.cal-cell-empty { background: transparent; border-color: transparent; min-height: 52px; }
+.cc-num { font-family: var(--mono); font-size: 10px; color: var(--text2); margin-bottom: 4px; line-height: 1; }
+.cc-dots { display: flex; flex-wrap: wrap; gap: 2px; flex: 1; align-content: flex-start; }
+.cc-dot { width: 5px; height: 5px; border-radius: 50%; flex-shrink: 0; }
+.cc-overflow { font-family: var(--mono); font-size: 7px; color: var(--muted); margin-top: 2px; }
+
+/* ── Calendar: day drawer ── */
+.day-drawer { border-top: 1px dotted var(--dotline); background: var(--surface); display: none; flex-direction: column; }
+.day-drawer.open { display: flex; }
+.drawer-hdr { display: flex; justify-content: space-between; align-items: center; padding: 13px 20px; border-bottom: 1px dotted var(--dotline); }
+.drawer-date { font-family: var(--mono); font-size: 10px; letter-spacing: 0.2em; color: var(--gold); text-transform: uppercase; }
+.drawer-close { font-family: var(--mono); font-size: 9px; color: var(--muted); cursor: pointer; letter-spacing: 0.1em; text-transform: uppercase; }
+.drawer-post { display: flex; align-items: flex-start; gap: 12px; padding: 13px 20px; border-bottom: 1px dotted var(--muted2); cursor: pointer; }
+.drawer-post:last-child { border-bottom: none; }
+.drawer-stage-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; margin-top: 4px; }
+.drawer-post-title { font-size: 14px; font-weight: 500; color: var(--text); margin-bottom: 6px; line-height: 1.3; }
+.drawer-post-meta { display: flex; flex-wrap: wrap; gap: 5px; }
+.meta-pill { font-family: var(--mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 7px; border: 1px dotted; white-space: nowrap; }
+.meta-pill.owner  { color: var(--green); border-color: rgba(62,207,142,0.3); }
+.meta-pill.pillar { color: var(--muted); border-color: var(--muted2); }
+.meta-pill.s-ready  { color: var(--green); border-color: rgba(62,207,142,0.3); }
+.meta-pill.s-sched  { color: var(--cyan); border-color: rgba(34,211,238,0.3); }
+.meta-pill.s-appr   { color: var(--red); border-color: rgba(255,75,75,0.3); }
+.meta-pill.s-prod   { color: var(--amber); border-color: rgba(246,166,35,0.3); }
+.meta-pill.s-input  { color: var(--purple); border-color: rgba(155,135,245,0.3); }
+.drawer-empty { padding: 20px; font-family: var(--mono); font-size: 10px; color: var(--muted); letter-spacing: 0.1em; text-transform: uppercase; text-align: center; }
 
 /* Board view */
 .board-nav {


### PR DESCRIPTION
…lendar dots and drawer

FIX 1: Replace search bar and filter row with unified .search-block
       containing attached search-row + filter-row with mono styling

FIX 2: Library list view now groups by time-relative buckets (Overdue,
       This Week, Next Week, Later This Month, Next Month, Later, No Date)
       with new .lib-card layout showing date, title, pillar/owner meta,
       and colored stage dot

FIX 3: Calendar month bar with compact nav arrows and stat pills
       showing scheduled/ready/overdue counts

FIX 4: Calendar cells show colored micro-dots per post (max 6 + overflow)
       instead of truncated text labels

FIX 5: Day drawer opens below calendar on cell tap showing full post
       details with stage dot, title, owner/pillar/stage pills

FIX 6: Add --gold-bg CSS variable; strip non-ASCII from all JS files

https://claude.ai/code/session_01XrWxYi3jPr27jx5TDRBqr9