### PR TITLE
feat: nav bar, FAB, and fab menu UI overhaul

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -543,16 +543,13 @@ function updateFabVisibility() {
 }
 
 function toggleFabMenu() {
-  const sheet = document.getElementById('fab-menu-sheet');
-  const backdrop = document.getElementById('fab-backdrop');
-  if (!sheet) return;
-  const open = sheet.classList.toggle('open');
-  backdrop.classList.toggle('open', open);
-  // Show/hide request button based on role
-  const reqBtn = document.getElementById('fab-request-btn');
-  if (reqBtn) reqBtn.style.display = '';
-  // Role-only FAB visibility
-  updateFabVisibility();
+  var fab = document.getElementById('fab');
+  var menu = document.getElementById('fab-menu');
+  var backdrop = document.getElementById('fab-backdrop');
+  if (!menu) return;
+  var isOpen = menu.classList.toggle('open');
+  if (fab) fab.classList.toggle('open', isOpen);
+  if (backdrop) backdrop.classList.toggle('open', isOpen);
 }
 
 function openAssignTaskFromFab() {
@@ -598,9 +595,39 @@ async function _fabAssignTask(postId, assignee, message) {
 }
 
 function closeFabMenu() {
-  document.getElementById('fab-menu-sheet')?.classList.remove('open');
-  document.getElementById('fab-backdrop')?.classList.remove('open');
+  var fab = document.getElementById('fab');
+  var menu = document.getElementById('fab-menu');
+  var backdrop = document.getElementById('fab-backdrop');
+  if (fab) fab.classList.remove('open');
+  if (menu) menu.classList.remove('open');
+  if (backdrop) backdrop.classList.remove('open');
 }
+
+// -- FAB menu wiring (runs once on DOMContentLoaded) --
+document.addEventListener('DOMContentLoaded', function() {
+  var backdrop = document.getElementById('fab-backdrop');
+  if (backdrop) backdrop.addEventListener('click', closeFabMenu);
+
+  var createPost = document.getElementById('fab-create-post');
+  if (createPost) createPost.addEventListener('click', function() {
+    closeFabMenu();
+    if (typeof openNewPostModal === 'function') openNewPostModal();
+    else console.log('[FAB] Create Post clicked');
+  });
+
+  var createReq = document.getElementById('fab-create-request');
+  if (createReq) createReq.addEventListener('click', function() {
+    closeFabMenu();
+    if (typeof openRequestSheet === 'function') openRequestSheet();
+    else console.log('[FAB] Create Request clicked');
+  });
+
+  var assignTask = document.getElementById('fab-assign-task');
+  if (assignTask) assignTask.addEventListener('click', function() {
+    closeFabMenu();
+    console.log('[FAB] Assign Task clicked');
+  });
+});
 
 // -- Task Detail Modal --------------------------
 function openTaskModal(taskId) {

--- a/index.html
+++ b/index.html
@@ -239,21 +239,21 @@
   <!-- legacy stat pills removed -->
 </div>
 
-<!-- BOTTOM NAVIGATION (global — outside all views so it persists across roles) -->
+<!-- BOTTOM NAVIGATION (global -- outside all views so it persists across roles) -->
 <nav class="bottom-nav" id="bottom-nav">
-  <button class="bnav-btn tab-btn active" data-tab="tasks" onclick="switchTab(this)">
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-    <span>My Tasks</span>
-    <span class="bnav-badge" id="badge-tasks" style="display:none"></span>
-  </button>
-  <button class="bnav-btn tab-btn" data-tab="pipeline" onclick="switchTab(this)">
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-    <span>Pipeline</span>
-  </button>
-  <button class="bnav-btn tab-btn" data-tab="library" onclick="switchTab(this)">
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
-    <span>Library</span>
-  </button>
+  <div class="nav-item tab-btn active" data-tab="tasks" onclick="switchTab(this)">
+    <svg class="nav-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+    <span class="nav-label">My Tasks</span>
+    <span class="nav-badge" id="badge-tasks" style="display:none"></span>
+  </div>
+  <div class="nav-item tab-btn" data-tab="pipeline" onclick="switchTab(this)">
+    <svg class="nav-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+    <span class="nav-label">Pipeline</span>
+  </div>
+  <div class="nav-item tab-btn" data-tab="library" onclick="switchTab(this)">
+    <svg class="nav-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+    <span class="nav-label">Library</span>
+  </div>
 </nav>
 
 <!-- ══════════════════════════════════════════
@@ -683,18 +683,35 @@
 <!-- ══════════════════════════════════════════
      FAB — body level so fixed positioning is never clipped
 ══════════════════════════════════════════ -->
-<button class="fab" id="fab" onclick="toggleFabMenu()">+</button>
-<div class="fab-backdrop" id="fab-backdrop" onclick="closeFabMenu()"></div>
-<div class="fab-menu-sheet" id="fab-menu-sheet">
-  <button class="fab-menu-item" id="fab-request-btn" onclick="openRequestSheet(); closeFabMenu()">
-    <span class="fab-menu-icon">📋</span> Create Request
-  </button>
-  <button class="fab-menu-item" onclick="openNewPostModal(); closeFabMenu()">
-    <span class="fab-menu-icon">✏</span> Create Post
-  </button>
-  <button class="fab-menu-item" id="fab-assign-task" onclick="event.stopPropagation(); closeFabMenu(); setTimeout(() => requestAnimationFrame(() => openAssignTaskFromFab()), 0)" style="display:none">
-    <span class="fab-menu-icon">📌</span> Assign Task
-  </button>
+<button class="fab" id="fab" onclick="toggleFabMenu()"><span class="fab-icon">+</span></button>
+
+<div class="fab-backdrop" id="fab-backdrop"></div>
+
+<div class="fab-menu" id="fab-menu">
+  <div class="fab-option fab-post" id="fab-create-post">
+    <div class="fab-option-label">Create Post</div>
+    <div class="fab-option-dot">
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" width="15" height="15">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z"/>
+      </svg>
+    </div>
+  </div>
+  <div class="fab-option fab-request" id="fab-create-request">
+    <div class="fab-option-label">Create Request</div>
+    <div class="fab-option-dot">
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" width="15" height="15">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z"/>
+      </svg>
+    </div>
+  </div>
+  <div class="fab-option fab-task" id="fab-assign-task">
+    <div class="fab-option-label">Assign Task</div>
+    <div class="fab-option-dot">
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" width="15" height="15">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z"/>
+      </svg>
+    </div>
+  </div>
 </div>
 
 <script>

--- a/styles.css
+++ b/styles.css
@@ -802,7 +802,7 @@ a:hover { text-decoration: underline; }
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  padding: 0 0 calc(64px + var(--sp-5));
+  padding: 0 0 140px;
   min-height: 0;
   position: relative;
 }
@@ -2477,7 +2477,7 @@ tr:hover td { background: var(--surface2); }
   overflow-y: auto;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
-  padding: 0 0 calc(64px + var(--sp-5));
+  padding: 0 0 140px;
   position: relative;
   min-height: 0;
 }
@@ -3521,59 +3521,38 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .bottom-nav {
   position: fixed;
   bottom: 0;
-  left: 0;
-  right: 0;
-  height: 64px;
-  z-index: 200;
-  background: var(--bg);
-  border-top: 1px solid var(--border);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 480px;
   display: flex;
   align-items: stretch;
+  background: rgba(8,8,8,0.97);
+  border-top: 1px dotted var(--dotline);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  z-index: 100;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
-.bnav-btn {
+.nav-item {
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 3px;
-  color: var(--text3);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
+  gap: 5px;
+  padding: 12px 0 10px;
+  cursor: pointer;
   position: relative;
-  transition: color 0.15s ease;
-  border-radius: 0;
-  border: none;
 }
-.bnav-btn:active { background: var(--surface2); }
-.bnav-btn.active {
-  color: var(--accent);
-}
-.bnav-btn svg {
-  opacity: 0.7;
-  transition: opacity 0.15s ease;
-}
-.bnav-btn.active svg { opacity: 1; }
+.nav-item:not(:last-child) { border-right: 1px dotted var(--dotline); }
+.nav-item .nav-icon { width: 20px; height: 20px; color: var(--muted); transition: color 0.15s; }
+.nav-item .nav-label { font-family: var(--mono); font-size: 8px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); transition: color 0.15s; }
+.nav-item.active .nav-icon { color: var(--text); }
+.nav-item.active .nav-label { color: var(--text); }
 
-.bnav-badge {
-  position: absolute;
-  top: 6px;
-  right: calc(50% - 18px);
-  min-width: 16px;
-  height: 16px;
-  background: var(--c-red);
-  color: #fff;
-  font-size: 10px;
-  font-weight: 700;
-  border-radius: var(--r-pill);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 3px;
-  font-family: var(--font-mono);
-}
+.nav-badge { position: absolute; top: 8px; right: calc(50% - 20px); background: var(--red); color: #fff; font-family: var(--mono); font-size: 7px; font-weight: 700; padding: 1px 4px; border-radius: 8px; min-width: 14px; text-align: center; border: 1.5px solid var(--bg); }
 
 /* ═══════════════════════════════════════════════
    FAB
@@ -3581,71 +3560,50 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 .fab {
   position: fixed;
-  bottom: 24px;
-  right: 16px;
-  width: 52px;
-  height: 52px;
+  bottom: 74px;
+  right: max(20px, calc(50% - 175px));
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
-  background: radial-gradient(circle at 35% 35%, var(--gold-hi), #7a5c10);
-  border: 1.5px solid var(--gold);
-  box-shadow: 0 0 24px rgba(200,168,75,0.22), 0 6px 18px rgba(0,0,0,0.7);
-  color: #fff;
-  font-size: 26px;
-  z-index: 100;
+  background: #FFFFFF;
+  border: none;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.1);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.2s ease, opacity 0.2s ease;
+  cursor: pointer;
+  z-index: 200;
+  transition: transform 0.22s cubic-bezier(0.34,1.56,0.64,1), background 0.2s;
 }
+.fab:hover { background: #F0F0F0; }
+.fab.open { transform: rotate(45deg); background: #EFEFEF; }
 .fab:active { transform: scale(0.94); }
 .fab.hidden {
   transform: translateY(16px) scale(0.9);
   opacity: 0;
   pointer-events: none;
 }
+.fab-icon { color: #080808; font-size: 22px; font-weight: 300; line-height: 1; user-select: none; }
 
 /* FAB menu */
-.fab-backdrop {
-  display: none;
-  position: fixed;
-  inset: 0;
-  z-index: 390;
-}
-.fab-backdrop.open { display: block; }
+.fab-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0); z-index: 198; pointer-events: none; transition: background 0.2s; }
+.fab-backdrop.open { background: rgba(0,0,0,0.55); pointer-events: all; }
 
-.fab-menu-sheet {
-  position: fixed;
-  right: 16px;
-  bottom: 152px;
-  z-index: 9999;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  box-shadow: 0 8px 32px rgba(0,0,0,0.2);
-  overflow: hidden;
-  min-width: 170px;
-  display: none;
-  flex-direction: column;
-}
-.fab-menu-sheet.open { display: flex; }
+.fab-menu { position: fixed; bottom: 134px; right: max(20px, calc(50% - 175px)); display: flex; flex-direction: column; gap: 10px; align-items: flex-end; z-index: 199; pointer-events: none; opacity: 0; transform: translateY(10px); transition: opacity 0.18s, transform 0.18s; }
+.fab-menu.open { pointer-events: all; opacity: 1; transform: translateY(0); }
+.fab-option { display: flex; align-items: center; gap: 10px; cursor: pointer; }
+.fab-option-label { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text2); background: rgba(20,20,20,0.95); border: 1px dotted var(--dotline); padding: 7px 14px; white-space: nowrap; backdrop-filter: blur(8px); transition: color 0.15s, border-color 0.15s; }
+.fab-option-dot { width: 38px; height: 38px; border-radius: 50%; border: 1px dotted; display: flex; align-items: center; justify-content: center; flex-shrink: 0; transition: background 0.15s; }
 
-.fab-menu-item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 14px 16px;
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text);
-  border-bottom: 1px solid var(--border);
-  text-align: left;
-  width: 100%;
-  pointer-events: auto;
-  cursor: pointer;
-}
-.fab-menu-item:last-child { border-bottom: none; }
-.fab-menu-item:active { background: var(--surface2); }
-.fab-menu-icon { font-size: 16px; flex-shrink: 0; }
+.fab-post .fab-option-dot    { color: var(--green);  border-color: rgba(62,207,142,0.45);  background: rgba(62,207,142,0.07); }
+.fab-request .fab-option-dot { color: var(--amber);  border-color: rgba(246,166,35,0.45);  background: rgba(246,166,35,0.07); }
+.fab-task .fab-option-dot    { color: var(--purple); border-color: rgba(155,135,245,0.45); background: rgba(155,135,245,0.07); }
+.fab-post:hover .fab-option-dot    { background: rgba(62,207,142,0.14); }
+.fab-request:hover .fab-option-dot { background: rgba(246,166,35,0.14); }
+.fab-task:hover .fab-option-dot    { background: rgba(155,135,245,0.14); }
+.fab-post:hover .fab-option-label    { color: var(--green);  border-color: rgba(62,207,142,0.3); }
+.fab-request:hover .fab-option-label { color: var(--amber);  border-color: rgba(246,166,35,0.3); }
+.fab-task:hover .fab-option-label    { color: var(--purple); border-color: rgba(155,135,245,0.3); }
 
 /* ═══════════════════════════════════════════════
    REQUEST SHEET


### PR DESCRIPTION
FIX 1: Action bar text input already removed (no-op)

FIX 2: Bottom nav restyled - 3 items (My Tasks, Pipeline, Library)
       with dotted borders, mono labels, centered max-width 480px,
       frosted glass background

FIX 3: FAB changed from gold gradient to white circle (#FFFFFF),
       positioned above nav at bottom: 74px, rotates 45deg when open

FIX 4: New fab-menu with three radiating options (Create Post,
       Create Request, Assign Task) using colored dot circles and
       mono labels with backdrop overlay

FIX 5: toggleFabMenu/closeFabMenu updated for new element IDs,
       backdrop click wired, menu item click handlers added

FIX 6: All scrollable content containers (.dash-body, #library-content)
       padding-bottom set to 140px for nav+FAB clearance

Non-ASCII stripped from all JS files.

https://claude.ai/code/session_01XrWxYi3jPr27jx5TDRBqr9