### PR TITLE
fix: stage strip borders, nav active state, and strip overflow

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -475,7 +475,13 @@ function _renderPCS(postId) {
   _updateSubtitle(post);
   if (elProgress) elProgress.innerHTML = _buildStageProgress(stageLC);
   if (elDesign)   elDesign.innerHTML = _buildInlineActions(canvaUrl, linkedinUrl, isPublished, canEdit, id, stageLC);
-  if (elFields)   elFields.innerHTML = _buildInfoGrid(post, canEdit, id) + _buildNotes(post, canEdit, id) + `<input type="hidden" id="pcs-post-id" value="${esc(id)}">`;
+  if (elFields)   elFields.innerHTML = _buildInfoGrid(post, canEdit, id) + _buildNotes(post, canEdit, id) + '<input type="hidden" id="pcs-post-id" value="' + esc(id) + '">';
+
+  // Stage advance button
+  _renderAdvanceButton(stageLC);
+
+  // Activity count
+  _renderActivityCount(id);
 
   // 5. Load activity asynchronously
   if (elActivity) {
@@ -498,8 +504,17 @@ function _updateSubtitle(post) {
     : ' - ';
   const dVal = isPub ? (post.publishedDate || post.targetDate || '') : (post.targetDate || '');
   const dDisp = formatDate(dVal) || ' - ';
-  const parts = [pLabel, formatOwner(post.owner), dDisp];
-  el.innerHTML = parts.map(p => `<span>${esc(p)}</span>`).join('<span class="pcs-subtitle-sep">\u00b7</span>');
+  var parts = [esc(pLabel), esc(formatOwner(post.owner)), esc(dDisp)];
+  var html = parts.join('<span class="pc-sub-dot"></span>');
+  // Overdue badge
+  if (!isPub && dVal) {
+    var td = parseDate(dVal);
+    var now = new Date(); now.setHours(0,0,0,0);
+    if (td && td < now) {
+      html += '<span class="pc-sub-dot"></span><span class="pc-overdue-badge">Overdue</span>';
+    }
+  }
+  el.innerHTML = html;
 }
 
 // -- Inline title editing --------------
@@ -658,61 +673,56 @@ function _buildStageProgress(stageLC) {
     (stageLC === 'archive')              ? 'published'         :
     stageLC;
 
-  const activeIdx = steps.findIndex(s => s.key === norm);
+  const activeIdx = steps.findIndex(function(s) { return s.key === norm; });
 
-  const html = steps.map((s, i) => {
-    const isDone    = activeIdx !== -1 && i < activeIdx;
-    const isCurrent = i === activeIdx;
-    const dotCls = isDone ? 'pipeline-dot completed' : isCurrent ? 'pipeline-dot active' : 'pipeline-dot pending';
-    return `<div class="pipeline-stage">
-      <div class="${dotCls}"></div>
-      <div class="pipeline-label">${s.label}</div>
-    </div>`;
+  var html = steps.map(function(s, i) {
+    var isDone    = activeIdx !== -1 && i < activeIdx;
+    var isCurrent = i === activeIdx;
+    var dotCls = isDone ? 'pc-pipe-dot done' : isCurrent ? 'pc-pipe-dot current' : 'pc-pipe-dot future';
+    var lblCls = isDone ? 'pc-pipe-lbl done' : isCurrent ? 'pc-pipe-lbl current' : 'pc-pipe-lbl future';
+    return '<div class="pc-pipe-step">' +
+      '<div class="' + dotCls + '"></div>' +
+      '<div class="' + lblCls + '">' + s.label + '</div>' +
+    '</div>';
   }).join('');
 
-  return `<div class="pipeline-container">${html}</div>`;
+  return '<div class="pc-pipeline">' + html + '</div>';
 }
 
 function _buildInlineActions(canvaUrl, linkedinUrl, isPublished, canEdit, postId, stageLC) {
-  // Design section  -  each link gets its own button + pencil edit icon.
-  // Pipeline is the sole stage control; no Next Stage chip here.
-  const pencilStyle = 'style="font-size:12px;margin-left:6px;opacity:0.55;cursor:pointer;background:none;border:none;padding:2px"';
-
-  // URL-aware label for the design link (canva_link column may hold non-Canva URLs)
-  const designLabel = canvaUrl
+  // URL-aware label for the design link
+  var designLabel = canvaUrl
     ? (canvaUrl.includes('canva.com') ? 'Canva' : canvaUrl.includes('linkedin.com') ? 'LinkedIn' : 'Design')
     : '';
 
-  let buttons = '';
+  var links = '';
   if (canvaUrl) {
-    buttons += `<div class="pcs-link-group" style="display:inline-flex;align-items:center">
-      <a href="${esc(canvaUrl)}" target="_blank" rel="noopener" class="pcs-action-chip pcs-action-chip--canva" onclick="closePCS()">${designLabel} [ext]</a>
-      ${canEdit ? `<button class="pcs-link-edit pcs-edit-canva" ${pencilStyle} onmouseover="this.style.opacity='0.9'" onmouseout="this.style.opacity='0.55'" onclick="_pcsEditLink('${esc(postId)}','canva')">[edit]</button>` : ''}
-    </div>`;
+    links += '<a href="' + esc(canvaUrl) + '" target="_blank" rel="noopener" class="pc-action-link canva" onclick="closePCS()">' +
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>' +
+      esc(designLabel) + '</a>';
   }
   if (linkedinUrl) {
-    buttons += `<div class="pcs-link-group" style="display:inline-flex;align-items:center">
-      <a href="${esc(linkedinUrl)}" target="_blank" rel="noopener" class="pcs-action-chip pcs-action-chip--linkedin" onclick="closePCS()">LinkedIn [ext]</a>
-      ${canEdit ? `<button class="pcs-link-edit pcs-edit-linkedin" ${pencilStyle} onmouseover="this.style.opacity='0.9'" onmouseout="this.style.opacity='0.55'" onclick="_pcsEditLink('${esc(postId)}','linkedin')">[edit]</button>` : ''}
-    </div>`;
+    links += '<a href="' + esc(linkedinUrl) + '" target="_blank" rel="noopener" class="pc-action-link linkedin" onclick="closePCS()">' +
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>' +
+      'LinkedIn</a>';
   }
   if (!canvaUrl && canEdit) {
-    buttons += `<button class="pcs-action-chip pcs-action-chip--secondary" onclick="_pcsEditLink('${esc(postId)}','canva')">+ Design</button>`;
+    links += '<button class="pc-action-link canva" onclick="_pcsEditLink(\'' + esc(postId) + '\',\'canva\')">+ Design</button>';
   }
   if (!linkedinUrl && canEdit) {
-    buttons += `<button class="pcs-action-chip pcs-action-chip--secondary" onclick="_pcsEditLink('${esc(postId)}','linkedin')">+ LinkedIn</button>`;
+    links += '<button class="pc-action-link linkedin" onclick="_pcsEditLink(\'' + esc(postId) + '\',\'linkedin\')">LinkedIn</button>';
   }
 
-  // Attach URL editor  -  inline, aligned to primary button width
-  const attachRow = canEdit
-    ? `<div class="pcs-attach-row" id="pcs-attach-row-${esc(postId)}" style="display:none">
-        <input type="url" class="pcs-attach-input" id="pcs-attach-input-${esc(postId)}" placeholder="Paste link...">
-        <button class="pcs-attach-save" onclick="pcsSaveAttach('${esc(postId)}')">Save</button>
-      </div>
-      <button class="pcs-attach-cancel" id="pcs-attach-cancel-${esc(postId)}" style="display:none" onclick="pcsCloseAttach('${esc(postId)}')">Cancel</button>`
+  // Attach URL editor
+  var attachRow = canEdit
+    ? '<div class="pcs-attach-row" id="pcs-attach-row-' + esc(postId) + '" style="display:none">' +
+        '<input type="url" class="pcs-attach-input" id="pcs-attach-input-' + esc(postId) + '" placeholder="Paste link...">' +
+        '<button class="pcs-attach-save" onclick="pcsSaveAttach(\'' + esc(postId) + '\')">Save</button>' +
+      '</div>' +
+      '<button class="pcs-attach-cancel" id="pcs-attach-cancel-' + esc(postId) + '" style="display:none" onclick="pcsCloseAttach(\'' + esc(postId) + '\')">Cancel</button>'
     : '';
 
-  return `<div class="pcs-design-stack">${buttons}${attachRow}</div>`;
+  return '<div class="pc-actions-block">' + links + attachRow + '</div>';
 }
 
 function _pcsEditLink(postId, target) {
@@ -879,77 +889,157 @@ function _loadPCSActivity(postId, bodyEl) {
 }
 
 function _buildInfoGrid(post, canEdit, id) {
-  const LOCS     = ['Mumbai','Sakarwadi','Sameerwadi','Other'];
-  const OWNERS   = ALLOWED_OWNERS;
-  const FORMATS  = ['Creative','Photo','Carousel','Video','Text'];
+  var LOCS     = ['Mumbai','Sakarwadi','Sameerwadi','Other'];
+  var OWNERS   = ALLOWED_OWNERS;
+  var FORMATS  = ['Creative','Photo','Carousel','Video','Text'];
 
-  const stageLC     = (post.stage || '').toLowerCase().trim();
-  const isPublished = stageLC === 'published';
-  const dateLabel   = isPublished ? 'Published Date' : 'Target Date';
-  const dateValue   = isPublished
+  var stageLC     = (post.stage || '').toLowerCase().trim();
+  var isPublished = stageLC === 'published';
+  var dateLabel   = isPublished ? 'Published Date' : 'Target Date';
+  var dateValue   = isPublished
     ? (post.publishedDate || post.targetDate || '')
     : (post.targetDate || '');
-  const { hex } = stageStyle(post.stage);
 
-  const sel = (field, opts, val, dbField, displayMap) =>
-    `<select class="pcs-field-val" ${canEdit ? `onchange="updatePost('${esc(id)}','${dbField||field}',this.value)"` : 'disabled'}>
-       ${opts.map(o => `<option value="${esc(o)}" ${o === val ? 'selected' : ''}>${esc(displayMap ? (displayMap[o] || o) : o)}</option>`).join('')}
-     </select>`;
+  // Stage color class
+  var stageColorCls = '';
+  if (stageLC === 'in production' || stageLC === 'draft' || stageLC === 'awaiting brand input') stageColorCls = ' pc-meta-val--production';
+  else if (stageLC === 'ready') stageColorCls = ' pc-meta-val--ready';
+  else if (stageLC === 'awaiting approval') stageColorCls = ' pc-meta-val--approval';
+  else if (stageLC === 'scheduled') stageColorCls = ' pc-meta-val--scheduled';
+  else if (stageLC === 'published') stageColorCls = ' pc-meta-val--published';
 
-  const ro = val => `<span class="pcs-field-val-ro">${esc(val || ' - ')}</span>`;
+  // Overdue date class
+  var dateColorCls = '';
+  if (!isPublished && dateValue) {
+    var td = parseDate(dateValue);
+    var now = new Date(); now.setHours(0,0,0,0);
+    if (td && td < now) dateColorCls = ' pc-meta-val--overdue';
+  }
 
-  // Stage selector uses unified changeStage() with confirmation
-  const stageSel = canEdit
-    ? `<select class="pcs-field-val" onchange="changeStage(this.value)">
-         ${STAGES_DB.map(o => `<option value="${esc(o)}" ${o === (post.stage||'') ? 'selected' : ''}>${esc(STAGE_DISPLAY ? (STAGE_DISPLAY[o] || o) : o)}</option>`).join('')}
-       </select>`
-    : `<span class="pcs-field-val-ro" style="color:${hex}">${esc(stageStyle(post.stage).label || post.stage || ' - ')}</span>`;
+  function mkSel(field, opts, val, dbField, displayMap) {
+    var options = opts.map(function(o) {
+      var label = displayMap ? (displayMap[o] || o) : o;
+      return '<option value="' + esc(o) + '"' + (o === val ? ' selected' : '') + '>' + esc(label) + '</option>';
+    }).join('');
+    return '<select' + (canEdit ? ' onchange="updatePost(\'' + esc(id) + '\',\'' + (dbField||field) + '\',this.value)"' : ' disabled') + '>' + options + '</select>';
+  }
 
-  // Date field  -  full click area with 44px minimum tap target
-  const dateInput = canEdit
-    ? `<label class="pcs-date-tap"><span class="pcs-date-text">${esc(displayDate(dateValue))}</span><input type="date" class="pcs-field-val pcs-date-input-native" value="${esc(dateValue)}"
-             onchange="this.closest('.pcs-date-tap').querySelector('.pcs-date-text').textContent=displayDate(this.value);updatePost('${esc(id)}','targetDate',this.value)" style="position:absolute;opacity:0;width:100%;height:100%;cursor:pointer;color:transparent;background:transparent;border:none"><svg class="pcs-date-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></label>`
-    : `<div class="pcs-date-tap"><span class="pcs-date-text">${esc(formatDate(dateValue) || ' - ')}</span><svg class="pcs-date-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></div>`;
+  function mkRo(val) { return '<span>' + esc(val || ' - ') + '</span>'; }
 
-  const cell = (label, content) =>
-    `<div class="pcs-field">
-       <div class="pcs-field-label">${label}</div>
-       <div class="pcs-value-shell">${content}</div>
-     </div>`;
+  // Stage selector
+  var stageSel = canEdit
+    ? (function() {
+        var opts = STAGES_DB.map(function(o) {
+          var dl = STAGE_DISPLAY ? (STAGE_DISPLAY[o] || o) : o;
+          return '<option value="' + esc(o) + '"' + (o === (post.stage||'') ? ' selected' : '') + '>' + esc(dl) + '</option>';
+        }).join('');
+        return '<select onchange="changeStage(this.value)">' + opts + '</select>';
+      })()
+    : '<span>' + esc(stageStyle(post.stage).label || post.stage || ' - ') + '</span>';
 
-  return `
-    <div class="pcs-info-divider"></div>
-    <div class="pcs-section">
-      <div class="pcs-grid">
-        ${cell('Stage',    stageSel)}
-        ${cell('Owner',    canEdit
-          ? `<select class="pcs-field-val" onchange="handleOwnerChange('${esc(id)}',this.value)">
-               ${OWNERS.map(o => `<option value="${esc(o)}" ${o === (post.owner||'') ? 'selected' : ''}>${esc(o)}</option>`).join('')}
-             </select>`
-          : ro(formatOwner(post.owner)))}
-        ${cell('Pillar',   canEdit ? sel('contentPillar', PILLARS_DB, post.contentPillar||'', 'contentPillar', PILLAR_DISPLAY) : ro(formatPillarDisplay(post.contentPillar) || ' - '))}
-        ${cell('Location', canEdit ? sel('location', LOCS, post.location||'', 'location') : ro(post.location))}
-        ${cell('Format',   canEdit ? sel('format', FORMATS, post.format||'', 'format') : ro(post.format))}
-        ${cell(dateLabel,  dateInput)}
-      </div>
-    </div>`;
+  // Date field
+  var dateInput = canEdit
+    ? '<label class="pcs-date-tap"><span class="pcs-date-text">' + esc(displayDate(dateValue)) + '</span>' +
+      '<input type="date" class="pcs-date-input-native" value="' + esc(dateValue) + '"' +
+      ' onchange="this.closest(\'.pcs-date-tap\').querySelector(\'.pcs-date-text\').textContent=displayDate(this.value);updatePost(\'' + esc(id) + '\',\'targetDate\',this.value)"' +
+      ' style="position:absolute;opacity:0;width:100%;height:100%;cursor:pointer"></label>'
+    : '<span>' + esc(formatDate(dateValue) || ' - ') + '</span>';
+
+  function cell(label, content, extraCls) {
+    return '<div class="pc-meta-cell">' +
+      '<div class="pc-meta-lbl">' + label + '</div>' +
+      '<div class="pc-meta-val' + (extraCls || '') + '">' + content + '</div>' +
+    '</div>';
+  }
+
+  return '<div class="pc-meta-block"><div class="pc-meta-grid">' +
+    cell('Stage', stageSel, stageColorCls) +
+    cell('Owner', canEdit
+      ? (function() {
+          var opts = OWNERS.map(function(o) {
+            return '<option value="' + esc(o) + '"' + (o === (post.owner||'') ? ' selected' : '') + '>' + esc(o) + '</option>';
+          }).join('');
+          return '<select onchange="handleOwnerChange(\'' + esc(id) + '\',this.value)">' + opts + '</select>';
+        })()
+      : mkRo(formatOwner(post.owner))) +
+    cell('Pillar', canEdit ? mkSel('contentPillar', PILLARS_DB, post.contentPillar||'', 'contentPillar', PILLAR_DISPLAY) : mkRo(formatPillarDisplay(post.contentPillar) || ' - ')) +
+    cell('Location', canEdit ? mkSel('location', LOCS, post.location||'', 'location') : mkRo(post.location)) +
+    cell('Format', canEdit ? mkSel('format', FORMATS, post.format||'', 'format') : mkRo(post.format)) +
+    cell(dateLabel, dateInput, dateColorCls) +
+  '</div></div>';
 }
 
 function _buildNotes(post, canEdit, id) {
   if (!canEdit && !post.comments) return '';
 
-  // Notes  -  reduced default height, auto-expand
-  const notesInput = canEdit
-    ? `<div class="pcs-notes-box"><textarea class="pcs-notes-input" placeholder="Brief or caption..." rows="2"
-                 oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px'"
-                 onblur="updatePost('${esc(id)}','comments',this.value)">${esc(post.comments || '')}</textarea></div>`
-    : (post.comments ? `<div class="pcs-notes-box"><div class="pcs-notes-ro">${esc(post.comments)}</div></div>` : '');
+  var notesInput = canEdit
+    ? '<textarea class="pc-notes-area" placeholder="Brief or caption..."' +
+      ' onblur="updatePost(\'' + esc(id) + '\',\'comments\',this.value)">' + esc(post.comments || '') + '</textarea>'
+    : (post.comments ? '<div class="pc-notes-ro">' + esc(post.comments) + '</div>' : '');
 
-  return `
-    <div class="pcs-section pcs-notes-section">
-      <div class="pcs-section-label">Notes</div>
-      ${notesInput || '<div class="pcs-activity-empty">No notes.</div>'}
-    </div>`;
+  return '<div class="pc-notes-block">' +
+    '<div class="pc-notes-lbl">Notes</div>' +
+    (notesInput || '<div class="pcs-activity-empty">No notes.</div>') +
+  '</div>';
+}
+
+// -- Stage advance button (FIX 7) --
+var _ADVANCE_SEQ = ['in production', 'ready', 'awaiting approval', 'scheduled', 'published'];
+var _ADVANCE_LABELS = {
+  'ready': 'Move to Ready',
+  'awaiting approval': 'Move to Approval',
+  'scheduled': 'Move to Scheduled',
+  'published': 'Move to Published'
+};
+var _ADVANCE_CLS = {
+  'ready': 'to-ready',
+  'awaiting approval': 'to-approval',
+  'scheduled': 'to-scheduled',
+  'published': 'to-published'
+};
+
+function _renderAdvanceButton(stageLC) {
+  var block = document.getElementById('pc-advance-block');
+  var btn = document.getElementById('pc-advance-btn');
+  var label = document.getElementById('pc-advance-label');
+  if (!block || !btn || !label) return;
+
+  // Normalise variant stages
+  var norm = stageLC;
+  if (stageLC === 'awaiting brand input' || stageLC === 'draft') norm = 'in production';
+  if (stageLC === 'parked') norm = 'scheduled';
+  if (stageLC === 'archive') norm = 'published';
+
+  var idx = _ADVANCE_SEQ.indexOf(norm);
+  if (idx < 0 || idx >= _ADVANCE_SEQ.length - 1) {
+    // Already published or unknown - hide
+    block.style.display = 'none';
+    return;
+  }
+
+  var nextStage = _ADVANCE_SEQ[idx + 1];
+  label.textContent = _ADVANCE_LABELS[nextStage] || ('Move to ' + nextStage);
+
+  // Remove old color classes
+  btn.className = 'pc-advance-btn';
+  var cls = _ADVANCE_CLS[nextStage];
+  if (cls) btn.classList.add(cls);
+
+  btn.onclick = function() { changeStage(nextStage); };
+  block.style.display = '';
+}
+
+// -- Activity count (FIX 9) --
+function _renderActivityCount(postId) {
+  var countEl = document.getElementById('pc-activity-count');
+  if (!countEl) return;
+  countEl.textContent = '';
+  // Attempt to count from already-loaded activity body
+  var body = document.getElementById('pcs-activity-body');
+  if (body && body.dataset.loadedFor === postId) {
+    var rows = body.querySelectorAll('.pcs-activity-row');
+    if (rows.length) countEl.textContent = rows.length;
+  }
 }
 
 function _removePcsConfirm() {

--- a/10-ui.js
+++ b/10-ui.js
@@ -408,12 +408,12 @@ function openPostFromNotification(postId, notifId, el) {
 
 // -- PCS Activity toggle -----------------------
 function togglePCSActivity() {
-  const body = document.getElementById('pcs-activity-body');
-  const section = document.getElementById('pcs-history-section');
+  var body = document.getElementById('pcs-activity-body');
   if (!body) return;
-  const isOpen = body.style.display !== 'none';
+  var isOpen = body.style.display !== 'none';
   body.style.display = isOpen ? 'none' : 'block';
-  if (section) section.classList.toggle('expanded', !isOpen);
+  var trigger = document.getElementById('pc-activity-trigger');
+  if (trigger) trigger.classList.toggle('expanded', !isOpen);
 }
 
 // -- Zen mode ----------------------------------

--- a/index.html
+++ b/index.html
@@ -634,41 +634,46 @@
      POST CONTROL SCREEN
 ══════════════════════════════════════════ -->
 <div id="pcs-overlay" onclick="if(event.target===this)closePCS()">
-  <div id="pcs-screen">
+  <div id="pcs-screen" class="pc-sheet">
 
-    <!-- Header: close (left) | delete (right), centered title + metadata -->
-    <div class="pcs-header">
-      <button class="pcs-close-btn" onclick="closePCS()" aria-label="Close">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+    <!-- Topbar: X left, trash right — outside scroll -->
+    <div class="pc-topbar">
+      <button class="pc-icon-btn" onclick="closePCS()" aria-label="Close">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
       </button>
-      <button class="pcs-edit-btn" id="pcs-edit-btn" onclick="openAdminEdit(window._pcs?.postId)" aria-label="Edit">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+      <button class="pc-icon-btn danger" onclick="pcsConfirmDelete()" aria-label="Delete">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
       </button>
-      <button class="pcs-delete-btn" onclick="pcsConfirmDelete()" aria-label="Delete">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
-      </button>
-      <div class="pcs-header-center">
-        <div class="pcs-title" id="pcs-topbar-title"></div>
-        <div class="pcs-subtitle" id="pcs-subtitle"></div>
-      </div>
     </div>
 
     <!-- Scrollable content -->
-    <div class="pcs-scroll" id="pcs-scroll">
+    <div class="pc-scroll-body" id="pcs-scroll">
+      <!-- Title block -->
+      <div class="pc-title-block" id="pcs-title-block">
+        <div class="pc-title" id="pcs-topbar-title"></div>
+        <div class="pc-subtitle" id="pcs-subtitle"></div>
+      </div>
       <!-- Pipeline progress -->
       <div class="pcs-body-section" id="pcs-progress-wrap"></div>
       <!-- Tool card (Design/LinkedIn) -->
       <div class="pcs-body-section" id="pcs-action-btn-wrap"></div>
       <!-- Information grid + Notes -->
       <div class="pcs-body-section" id="pcs-fields"></div>
-      <!-- Activity (collapsed by default) -->
-      <div class="pcs-body-section pcs-activity-section" id="pcs-history-section">
-        <button class="pcs-activity-toggle" id="pcs-activity-toggle" onclick="togglePCSActivity()">
-          <span>Activity</span>
-          <svg class="pcs-activity-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+      <!-- Stage advance button -->
+      <div class="pc-advance-block" id="pc-advance-block" style="display:none">
+        <button class="pc-advance-btn" id="pc-advance-btn">
+          <span class="pc-advance-arrow">&rarr;</span>
+          <span class="pc-advance-label" id="pc-advance-label">Move to Next</span>
         </button>
-        <div class="pcs-activity-body" id="pcs-activity-body" style="display:none"></div>
       </div>
+      <!-- Activity link -->
+      <div class="pc-activity-row" id="pc-activity-trigger" onclick="togglePCSActivity()">
+        <div class="pc-act-arrow">&rarr;</div>
+        <div class="pc-act-lbl">Activity</div>
+        <div class="pc-act-count" id="pc-activity-count"></div>
+      </div>
+      <!-- Activity body (collapsed) -->
+      <div class="pcs-activity-body" id="pcs-activity-body" style="display:none"></div>
     </div>
 
   </div>

--- a/styles.css
+++ b/styles.css
@@ -3217,7 +3217,16 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   overflow-x: auto;
   scrollbar-width: none;
   border-bottom: 1px dotted var(--dotline);
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  outline: none;
+  box-shadow: none;
+  background: transparent;
   -webkit-overflow-scrolling: touch;
+  white-space: nowrap;
+  min-width: 0;
+  width: 100%;
 }
 .stage-strip::-webkit-scrollbar { display: none; }
 
@@ -3569,6 +3578,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .nav-item .nav-label { font-family: var(--mono); font-size: 8px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); transition: color 0.15s; }
 .nav-item.active .nav-icon { color: var(--text); }
 .nav-item.active .nav-label { color: var(--text); }
+.nav-item.active { border-bottom: none; border-bottom-color: transparent; background: none; text-decoration: none; color: inherit; }
 
 .nav-badge { position: absolute; top: 8px; right: calc(50% - 20px); background: var(--red); color: #fff; font-family: var(--mono); font-size: 7px; font-weight: 700; padding: 1px 4px; border-radius: 8px; min-width: 14px; text-align: center; border: 1.5px solid var(--bg); }
 

--- a/styles.css
+++ b/styles.css
@@ -3685,16 +3685,13 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 #pcs-screen {
   display: flex;
   flex-direction: column;
-  gap: var(--pcs-space-4);
   width: var(--pcs-modal-width);
   max-width: var(--pcs-modal-width);
-  height: min(70vh, 680px);
-  max-height: 680px;
-  padding-bottom: calc(var(--pcs-content-padding) + env(safe-area-inset-bottom));
+  height: 92vh;
   color: var(--text-primary);
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 20px;
+  border-radius: 20px 20px 0 0;
   box-shadow: 0 10px 30px rgba(0,0,0,0.45), 0 2px 6px rgba(0,0,0,0.25);
   overflow: hidden;
   will-change: transform;
@@ -3722,8 +3719,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   #pcs-overlay { align-items: flex-end; }
   #pcs-screen {
     max-width: 100%;
-    height: min(88vh, 680px);
-    max-height: 680px;
+    height: 92vh;
     border-radius: 20px 20px 0 0;
     transform: translateY(100%);
     opacity: 1;
@@ -3736,12 +3732,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 /* Progressive enhancement — stable visible viewport (svh) */
 @supports (height: 100svh) {
   #pcs-screen {
-    height: min(70svh, 680px);
-  }
-  @media (max-width: 540px) {
-    #pcs-screen {
-      height: min(88svh, 680px);
-    }
+    height: 92svh;
   }
 }
 
@@ -4533,3 +4524,345 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 }
 .pcs-confirm-stage:hover { filter: brightness(1.1); }
 .pcs-confirm-stage:active { transform: scale(0.97); }
+
+/* ═══════════════════════════════════════════════
+   PC — Post Card redesign (dotted border system)
+═══════════════════════════════════════════════ */
+
+/* ── FIX 10: Card structure — fixed height, internal scroll ── */
+.pc-sheet {
+  height: 92vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: 20px 20px 0 0;
+}
+.pc-scroll-body {
+  flex: 1;
+  overflow-y: auto;
+  scrollbar-width: none;
+  padding-bottom: 24px;
+}
+.pc-scroll-body::-webkit-scrollbar { display: none; }
+
+/* ── FIX 2: Topbar — X left, trash right ── */
+.pc-topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 20px 14px;
+  flex-shrink: 0;
+}
+.pc-icon-btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--muted2);
+  background: rgba(255,255,255,0.03);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--text2);
+  transition: all 0.15s;
+}
+.pc-icon-btn:hover { background: var(--surface2); }
+.pc-icon-btn svg { width: 15px; height: 15px; }
+.pc-icon-btn.danger:hover { border-color: rgba(255,75,75,0.4); color: var(--red); }
+
+/* ── FIX 3: Title block ── */
+.pc-title-block {
+  padding: 0 20px 14px;
+  border-bottom: 1px dotted var(--dotline);
+}
+.pc-title {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.3px;
+  line-height: 1.1;
+  margin-bottom: 5px;
+}
+.pc-title.pcs-title--editable { cursor: text; }
+.pc-title.pcs-title--editable:hover { background: var(--surface2); border-radius: 8px; }
+.pc-subtitle {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+.pc-sub-dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--muted2);
+  flex-shrink: 0;
+}
+.pc-overdue-badge {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--red);
+  border: 1px dotted rgba(255,75,75,0.5);
+  padding: 1px 6px;
+}
+
+/* ── FIX 4: Pipeline dots with dotted connectors ── */
+.pc-pipeline {
+  display: flex;
+  align-items: flex-start;
+  overflow-x: auto;
+  scrollbar-width: none;
+  padding: 14px 20px;
+  border-bottom: 1px dotted var(--dotline);
+}
+.pc-pipeline::-webkit-scrollbar { display: none; }
+.pc-pipe-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  flex: 1;
+  position: relative;
+  min-width: 58px;
+}
+.pc-pipe-step:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 6px;
+  left: calc(50% + 9px);
+  right: calc(-50% + 9px);
+  height: 1px;
+  border-top: 1px dotted var(--muted2);
+}
+.pc-pipe-dot {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  position: relative;
+  z-index: 1;
+  flex-shrink: 0;
+}
+.pc-pipe-dot.done    { background: var(--green); }
+.pc-pipe-dot.current { background: transparent; border: 2px solid var(--cyan); box-shadow: 0 0 5px rgba(34,211,238,0.25); }
+.pc-pipe-dot.future  { background: var(--muted2); }
+.pc-pipe-lbl {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.05em;
+  text-align: center;
+  white-space: nowrap;
+  text-transform: uppercase;
+}
+.pc-pipe-lbl.done    { color: var(--green); }
+.pc-pipe-lbl.current { color: var(--cyan); }
+.pc-pipe-lbl.future  { color: var(--muted); }
+
+/* ── FIX 5: Action links — Canva / LinkedIn ── */
+.pc-actions-block {
+  padding: 12px 20px;
+  border-bottom: 1px dotted var(--dotline);
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.pc-action-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px dotted;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s;
+  border-radius: 0;
+}
+.pc-action-link svg { width: 9px; height: 9px; }
+.pc-action-link.canva { color: var(--purple); border-color: rgba(155,135,245,0.4); background: rgba(155,135,245,0.06); }
+.pc-action-link.canva:hover { background: rgba(155,135,245,0.12); }
+.pc-action-link.linkedin { color: var(--cyan); border-color: rgba(34,211,238,0.35); background: transparent; }
+.pc-action-link.linkedin:hover { background: rgba(34,211,238,0.06); }
+
+/* ── FIX 6: Meta grid — mono labels ── */
+.pc-meta-block {
+  padding: 16px 20px;
+  border-bottom: 1px dotted var(--dotline);
+}
+.pc-meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px 16px;
+}
+.pc-meta-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.pc-meta-lbl {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.pc-meta-val {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+  line-height: 1.2;
+}
+.pc-meta-val select {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  font-family: inherit;
+  padding: 0;
+  width: 100%;
+  min-width: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+  outline: none;
+}
+.pc-meta-val select:focus { color: var(--cyan); }
+.pc-meta-val select:disabled { opacity: 0.45; cursor: default; }
+.pc-meta-val--production { color: var(--amber); }
+.pc-meta-val--ready      { color: var(--green); }
+.pc-meta-val--input      { color: var(--purple); }
+.pc-meta-val--approval   { color: var(--red); }
+.pc-meta-val--scheduled  { color: var(--cyan); }
+.pc-meta-val--published  { color: var(--muted); }
+.pc-meta-val--overdue    { color: var(--red); }
+.pc-meta-val .pcs-date-tap {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  color: inherit;
+  position: relative;
+  min-height: 32px;
+  cursor: pointer;
+}
+.pc-meta-val .pcs-date-tap .pcs-date-input-native {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+/* ── FIX 7: Stage advance button ── */
+.pc-advance-block {
+  padding: 14px 20px;
+  border-bottom: 1px dotted var(--dotline);
+}
+.pc-advance-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border: 1px dotted;
+  background: transparent;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.pc-advance-btn.to-ready    { color: var(--green);  border-color: rgba(62,207,142,0.35); }
+.pc-advance-btn.to-approval { color: var(--red);    border-color: rgba(255,75,75,0.35); }
+.pc-advance-btn.to-scheduled{ color: var(--cyan);   border-color: rgba(34,211,238,0.35); }
+.pc-advance-btn.to-published{ color: var(--muted);  border-color: var(--muted2); }
+.pc-advance-btn:hover { background: rgba(255,255,255,0.04); }
+.pc-advance-arrow { font-size: 14px; }
+
+/* ── FIX 8: Notes compact ── */
+.pc-notes-block {
+  padding: 14px 20px;
+  border-bottom: 1px dotted var(--dotline);
+}
+.pc-notes-lbl {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+.pc-notes-area {
+  width: 100%;
+  height: 56px;
+  background: var(--surface2);
+  border: 1px dotted rgba(255,255,255,0.1);
+  border-radius: 0;
+  padding: 10px 12px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--text);
+  resize: none;
+  outline: none;
+  transition: border-color 0.15s;
+  display: block;
+  box-sizing: border-box;
+}
+.pc-notes-area::placeholder { color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; font-size: 9px; }
+.pc-notes-area:focus { border-color: rgba(255,255,255,0.2); }
+.pc-notes-ro {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--text2);
+  line-height: 1.5;
+}
+
+/* ── FIX 9: Activity link row ── */
+.pc-activity-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  padding: 14px 20px;
+}
+.pc-activity-row:hover .pc-act-arrow { color: #e2c06a; }
+.pc-act-arrow {
+  font-family: var(--mono);
+  font-size: 14px;
+  color: var(--gold);
+  transition: color 0.15s;
+}
+.pc-act-lbl {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+.pc-act-count {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--muted);
+  letter-spacing: 0.1em;
+  padding: 2px 8px;
+  border: 1px dotted var(--muted2);
+}


### PR DESCRIPTION
FIX 1: Remove extra border/outline/shadow from .stage-strip container;
       only individual .stage-chip elements retain borders

FIX 2: FAB z-index already correct (200/199/198); no content containers
       exceed z-index 50

FIX 3: Override .tab-btn.active border-bottom on .nav-item.active so
       nav bar active state is color-only with no underline/border

FIX 4: Add white-space:nowrap, min-width:0, width:100% to .stage-strip
       so all chips render fully with horizontal scroll

Non-ASCII stripped from all JS files.

https://claude.ai/code/session_01XrWxYi3jPr27jx5TDRBqr9