### PR TITLE
Fix pipeline stage strip, BUILD NOW button, and strip non-ASCII

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -812,7 +812,7 @@ function renderScoreboard() {
     html += '<div class="person-right-title">' + pranavInSystem + ' of ' + pranavTarget + ' in system</div>';
     html += '</div>';
     html += '</div>';
-    html += '<button class="dash-action-btn dash-action-btn--amber" data-action="open-pranav" onclick="event.stopPropagation();if(typeof navigateWithFilter===\'function\')navigateWithFilter(\'pipeline\',[\'ready\',\'awaiting_approval\',\'awaiting_brand_input\',\'scheduled\'])">&rarr;&nbsp;&nbsp;&nbsp;BUILD NOW</button>';
+    html += '<button class="dash-action-btn dash-action-btn--amber" data-action="open-pranav" onclick="event.stopPropagation();if(typeof openNewPostModal===\'function\')openNewPostModal()">&rarr;&nbsp;&nbsp;&nbsp;BUILD NOW</button>';
     html += '</div>';
 
     /* -- CHITRA SECTION -- */
@@ -1361,8 +1361,8 @@ function updatePipelineChipCounts() {
   };
   // Map DB stage keys to chip element short keys
   var chipMap = {
-    all: 'all', in_production: 'production', ready: 'ready',
-    awaiting_approval: 'approval', awaiting_brand_input: 'input',
+    all: 'all', in_production: 'in_production', ready: 'ready',
+    awaiting_approval: 'awaiting_approval', awaiting_brand_input: 'awaiting_brand_input',
     scheduled: 'scheduled', published: 'published', parked: 'parked', rejected: 'rejected'
   };
   var keys = Object.keys(stageCounts);

--- a/index.html
+++ b/index.html
@@ -142,41 +142,42 @@
 
   <!-- TAB: PIPELINE -->
   <div class="tab-panel" id="panel-pipeline">
-    <div class="stage-strip" id="pipeline-stage-strip">
-      <div class="stage-chip active" data-stage="all">
-        <div class="chip-dot"></div>
+    <div class="stage-strip" id="stage-strip">
+      <div class="stage-chip active all" data-stage="all">
+        <div class="chip-count" id="chip-count-all">0</div>
         <div class="chip-label">All</div>
-        <div class="chip-count" id="chip-count-all">&mdash;</div>
       </div>
-      <div class="stage-chip" data-stage="production">
-        <div class="chip-dot"></div>
+      <div class="stage-chip in_production" data-stage="in_production">
+        <div class="chip-count" id="chip-count-in_production">0</div>
         <div class="chip-label">Production</div>
-        <div class="chip-count" id="chip-count-production">&mdash;</div>
       </div>
-      <div class="stage-chip" data-stage="ready">
-        <div class="chip-dot"></div>
+      <div class="stage-chip ready" data-stage="ready">
+        <div class="chip-count" id="chip-count-ready">0</div>
         <div class="chip-label">Ready</div>
-        <div class="chip-count" id="chip-count-ready">&mdash;</div>
       </div>
-      <div class="stage-chip" data-stage="input">
-        <div class="chip-dot"></div>
-        <div class="chip-label">Input</div>
-        <div class="chip-count" id="chip-count-input">&mdash;</div>
-      </div>
-      <div class="stage-chip" data-stage="approval">
-        <div class="chip-dot"></div>
+      <div class="stage-chip awaiting_approval" data-stage="awaiting_approval">
+        <div class="chip-count" id="chip-count-awaiting_approval">0</div>
         <div class="chip-label">Approval</div>
-        <div class="chip-count" id="chip-count-approval">&mdash;</div>
       </div>
-      <div class="stage-chip" data-stage="scheduled">
-        <div class="chip-dot"></div>
+      <div class="stage-chip awaiting_brand_input" data-stage="awaiting_brand_input">
+        <div class="chip-count" id="chip-count-awaiting_brand_input">0</div>
+        <div class="chip-label">Input</div>
+      </div>
+      <div class="stage-chip scheduled" data-stage="scheduled">
+        <div class="chip-count" id="chip-count-scheduled">0</div>
         <div class="chip-label">Scheduled</div>
-        <div class="chip-count" id="chip-count-scheduled">&mdash;</div>
       </div>
-      <div class="stage-chip" data-stage="published">
-        <div class="chip-dot"></div>
+      <div class="stage-chip published" data-stage="published">
+        <div class="chip-count" id="chip-count-published">0</div>
         <div class="chip-label">Published</div>
-        <div class="chip-count" id="chip-count-published">&mdash;</div>
+      </div>
+      <div class="stage-chip parked" data-stage="parked">
+        <div class="chip-count" id="chip-count-parked">0</div>
+        <div class="chip-label">Parked</div>
+      </div>
+      <div class="stage-chip rejected" data-stage="rejected">
+        <div class="chip-count" id="chip-count-rejected">0</div>
+        <div class="chip-label">Rejected</div>
       </div>
     </div>
     <div class="dash-body">

--- a/styles.css
+++ b/styles.css
@@ -3233,8 +3233,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 .stage-strip {
   display: flex;
-  gap: 6px;
-  padding: 12px 16px;
+  gap: 8px;
+  padding: 14px 16px;
   overflow-x: auto;
   scrollbar-width: none;
   border-bottom: 1px dotted var(--dotline);
@@ -3244,49 +3244,64 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .stage-strip::-webkit-scrollbar { display: none; }
 
 .stage-chip {
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  padding: 10px 14px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 4px;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 12px 14px;
+  background: var(--surface2);
+  border: 1.5px solid transparent;
+  border-radius: 8px;
   white-space: nowrap;
   cursor: pointer;
   flex-shrink: 0;
-  min-width: 72px;
-  transition: background 0.15s;
+  min-width: 80px;
+  gap: 8px;
+  transition: all 0.15s;
 }
-.stage-chip:hover { background: var(--surface2); }
-.stage-chip.active { border-style: solid; }
-.stage-chip.active.all { border-color: rgba(255,255,255,0.3); background: var(--surface2); }
-.stage-chip.active.in_production { border-color: var(--amber); background: var(--amber-bg); }
-.stage-chip.active.ready { border-color: var(--green); background: var(--green-bg); }
-.stage-chip.active.awaiting_approval { border-color: var(--red); background: var(--red-bg); }
-.stage-chip.active.awaiting_brand_input { border-color: var(--purple); background: var(--purple-bg); }
-.stage-chip.active.scheduled { border-color: var(--cyan); background: var(--cyan-bg); }
+.stage-chip:hover { background: #222; }
+
+.chip-count {
+  font-family: var(--mono);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text2);
+}
+.chip-label {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+/* Active states */
+.stage-chip.active { border-left-width: 3px; }
+.stage-chip.active.all { border-color: rgba(255,255,255,0.25); background: #1e1e1e; }
+.stage-chip.active.all .chip-count { color: var(--text); }
+.stage-chip.active.in_production { border-color: var(--amber); background: rgba(246,166,35,0.07); }
+.stage-chip.active.in_production .chip-count { color: var(--amber); }
+.stage-chip.active.in_production .chip-label { color: var(--amber); opacity: 0.7; }
+.stage-chip.active.ready { border-color: var(--green); background: rgba(62,207,142,0.07); }
+.stage-chip.active.ready .chip-count { color: var(--green); }
+.stage-chip.active.ready .chip-label { color: var(--green); opacity: 0.7; }
+.stage-chip.active.awaiting_approval { border-color: var(--red); background: rgba(255,75,75,0.07); }
+.stage-chip.active.awaiting_approval .chip-count { color: var(--red); }
+.stage-chip.active.awaiting_brand_input { border-color: var(--purple); background: rgba(155,135,245,0.07); }
+.stage-chip.active.awaiting_brand_input .chip-count { color: var(--purple); }
+.stage-chip.active.scheduled { border-color: var(--cyan); background: rgba(34,211,238,0.07); }
+.stage-chip.active.scheduled .chip-count { color: var(--cyan); }
 .stage-chip.active.published { border-color: var(--muted); }
-.stage-chip.active.parked { border-color: var(--muted); }
-.stage-chip.active.rejected { border-color: var(--red); }
+.stage-chip.active.published .chip-count { color: var(--text2); }
 
-.stage-chip[data-stage="all"]        { color: #BBBBBB; border-color: rgba(255,255,255,0.2); }
-.stage-chip[data-stage="production"] { color: var(--amber); border-color: rgba(246,166,35,0.35); }
-.stage-chip[data-stage="production"].active { background: var(--amber-bg); border-color: var(--amber); }
-.stage-chip[data-stage="ready"]      { color: var(--green); border-color: rgba(62,207,142,0.35); }
-.stage-chip[data-stage="ready"].active { background: var(--green-bg); border-color: var(--green); }
-.stage-chip[data-stage="input"]      { color: var(--purple); border-color: rgba(155,135,245,0.35); }
-.stage-chip[data-stage="input"].active { background: var(--purple-bg); border-color: var(--purple); }
-.stage-chip[data-stage="approval"]   { color: var(--red); border-color: rgba(255,75,75,0.35); }
-.stage-chip[data-stage="approval"].active { background: var(--red-bg); border-color: var(--red); }
-.stage-chip[data-stage="scheduled"]  { color: var(--cyan); border-color: rgba(34,211,238,0.35); }
-.stage-chip[data-stage="scheduled"].active { background: var(--cyan-bg); border-color: var(--cyan); }
-.stage-chip[data-stage="published"]  { color: var(--muted); border-color: var(--muted2); }
-
-.chip-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
-.chip-label { font-family: var(--mono); font-size: 8px; letter-spacing: 0.14em; text-transform: uppercase; font-weight: 500; }
-.chip-count { font-family: var(--mono); font-size: 16px; font-weight: 700; line-height: 1; }
+/* Inactive count colors dimmed */
+.stage-chip.in_production .chip-count { color: var(--amber); opacity: 0.5; }
+.stage-chip.ready .chip-count { color: var(--green); opacity: 0.5; }
+.stage-chip.awaiting_approval .chip-count { color: var(--red); opacity: 0.5; }
+.stage-chip.awaiting_brand_input .chip-count { color: var(--purple); opacity: 0.5; }
+.stage-chip.scheduled .chip-count { color: var(--cyan); opacity: 0.5; }
 
 /* ═══════════════════════════════════════════════
    PIPELINE GROUP HEADER


### PR DESCRIPTION
- FIX 1: Replace stage strip HTML with proper individual chips (all 9 stages with correct data-stage attributes and chip-count IDs). Replace CSS with new vertical chip layout (count on top, label below, left-border active). Update JS chipMap to use full stage names matching new element IDs.
- FIX 4: Change BUILD NOW button to call openNewPostModal() instead of navigateWithFilter().
- Strip non-ASCII from all JS files.

FIX 2 (card fonts), FIX 3 (FAB), FIX 5 (critical badge) already correct.

https://claude.ai/code/session_01R6ybwzKns4LHEMur6XvXx8