### PR TITLE
Remove published, parked, rejected from pipeline view and stage strip

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -1348,22 +1348,21 @@ function buildPipelineCard(p, listKey) {
 // -- Pipeline chip count updater ----------------
 function updatePipelineChipCounts() {
   var posts = Array.isArray(window.allPosts) ? window.allPosts : [];
+  var pipelinePosts = posts.filter(function(p) {
+    return !['published', 'parked', 'rejected'].includes(p.stage);
+  });
   var stageCounts = {
-    all:                  posts.length,
-    in_production:        posts.filter(function(p) { return p.stage === 'in_production'; }).length,
-    ready:                posts.filter(function(p) { return p.stage === 'ready'; }).length,
-    awaiting_approval:    posts.filter(function(p) { return p.stage === 'awaiting_approval'; }).length,
-    awaiting_brand_input: posts.filter(function(p) { return p.stage === 'awaiting_brand_input'; }).length,
-    scheduled:            posts.filter(function(p) { return p.stage === 'scheduled'; }).length,
-    published:            posts.filter(function(p) { return p.stage === 'published'; }).length,
-    parked:               posts.filter(function(p) { return p.stage === 'parked'; }).length,
-    rejected:             posts.filter(function(p) { return p.stage === 'rejected'; }).length,
+    all:                  pipelinePosts.length,
+    in_production:        pipelinePosts.filter(function(p) { return p.stage === 'in_production'; }).length,
+    ready:                pipelinePosts.filter(function(p) { return p.stage === 'ready'; }).length,
+    awaiting_approval:    pipelinePosts.filter(function(p) { return p.stage === 'awaiting_approval'; }).length,
+    awaiting_brand_input: pipelinePosts.filter(function(p) { return p.stage === 'awaiting_brand_input'; }).length,
+    scheduled:            pipelinePosts.filter(function(p) { return p.stage === 'scheduled'; }).length,
   };
-  // Map DB stage keys to chip element short keys
   var chipMap = {
     all: 'all', in_production: 'in_production', ready: 'ready',
     awaiting_approval: 'awaiting_approval', awaiting_brand_input: 'awaiting_brand_input',
-    scheduled: 'scheduled', published: 'published', parked: 'parked', rejected: 'rejected'
+    scheduled: 'scheduled'
   };
   var keys = Object.keys(stageCounts);
   for (var k = 0; k < keys.length; k++) {

--- a/index.html
+++ b/index.html
@@ -167,18 +167,6 @@
         <div class="chip-count" id="chip-count-scheduled">0</div>
         <div class="chip-label">Scheduled</div>
       </div>
-      <div class="stage-chip published" data-stage="published">
-        <div class="chip-count" id="chip-count-published">0</div>
-        <div class="chip-label">Published</div>
-      </div>
-      <div class="stage-chip parked" data-stage="parked">
-        <div class="chip-count" id="chip-count-parked">0</div>
-        <div class="chip-label">Parked</div>
-      </div>
-      <div class="stage-chip rejected" data-stage="rejected">
-        <div class="chip-count" id="chip-count-rejected">0</div>
-        <div class="chip-label">Rejected</div>
-      </div>
     </div>
     <div class="dash-body">
       <div id="pipeline-container"></div>

--- a/styles.css
+++ b/styles.css
@@ -3293,8 +3293,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .stage-chip.active.awaiting_brand_input .chip-count { color: var(--purple); }
 .stage-chip.active.scheduled { border-color: var(--cyan); background: rgba(34,211,238,0.07); }
 .stage-chip.active.scheduled .chip-count { color: var(--cyan); }
-.stage-chip.active.published { border-color: var(--muted); }
-.stage-chip.active.published .chip-count { color: var(--text2); }
 
 /* Inactive count colors dimmed */
 .stage-chip.in_production .chip-count { color: var(--amber); opacity: 0.5; }
@@ -3314,7 +3312,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .group-label[data-stage="input"]      { color: var(--purple); }
 .group-label[data-stage="approval"]   { color: var(--red); }
 .group-label[data-stage="scheduled"]  { color: var(--cyan); }
-.group-label[data-stage="published"]  { color: var(--muted); }
 .group-count { font-family: var(--mono); font-size: 10px; font-weight: 600; color: var(--text2); background: var(--surface2); border: 1px solid var(--muted2); padding: 2px 8px; }
 
 /* ═══════════════════════════════════════════════
@@ -3358,7 +3355,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .resp-badge.cl-input   { background: var(--purple-bg); border: 1px solid rgba(155,135,245,0.35); color: var(--purple); }
 .resp-badge.cl-approval{ background: var(--red-bg); border: 1px solid rgba(255,75,75,0.35); color: var(--red); }
 .resp-badge.sched      { background: var(--cyan-bg); border: 1px solid rgba(34,211,238,0.35); color: var(--cyan); }
-.resp-badge.pub        { background: rgba(85,85,85,0.08); border: 1px solid var(--muted2); color: var(--muted); }
 
 .status-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
 .status-dot.sd-ready      { background: var(--green); }


### PR DESCRIPTION
- Filter pipeline chip counts to exclude published/parked/rejected stages
- Remove published/parked/rejected chip divs from stage strip in index.html
- Remove corresponding CSS rules (.stage-chip.active.published, .resp-badge.pub, .group-label published)
- Strip non-ASCII from all JS files
- Library view remains unchanged, still shows all stages

https://claude.ai/code/session_01Ufuyey3JMPTHfRhHqR5q4d