### PR TITLE
fix: exclude published/parked/rejected from overdue logic

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -416,7 +416,7 @@ function updateStats() {
     const d = parseDate(p.targetDate);
     if (d) {
       if (d > today && d <= weekEnd) dueWeek++;
-      if (d < today && stage !== 'published') overdue++;
+      if (d < today && !['published','parked','rejected'].includes(stage)) overdue++;
     }
   });
   setText('s-total',     allPosts.length);
@@ -1706,7 +1706,7 @@ function _buildLibCard(p) {
   var dateStr = formatDateShort(p.targetDate);
   var today = new Date(); today.setHours(0,0,0,0);
   var isToday = d && d.toDateString() === today.toDateString();
-  var isOverdue = d && !isToday && d < today;
+  var isOverdue = d && !isToday && d < today && !['published','parked','rejected'].includes(stage);
 
   var cardCls = 'lib-card';
   if (isOverdue) cardCls += ' overdue';


### PR DESCRIPTION
Posts in published, parked, or rejected stages are no longer marked as overdue in the stats counter or styled with overdue CSS in library cards.

https://claude.ai/code/session_01NrStC9hz2BQ3aB8zVUAWED