### PR TITLE
fix: pipeline stage strip clicks, card font sizes, and FAB button

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -1372,6 +1372,35 @@ function updatePipelineChipCounts() {
   }
 }
 
+// -- Pipeline stage chip click handler ----------
+function filterPipelineByChip(stage) {
+  var strip = document.getElementById('stage-strip');
+  if (!strip) return;
+  var chips = strip.querySelectorAll('.stage-chip');
+  chips.forEach(function(c) { c.classList.remove('active'); });
+  var clicked = strip.querySelector('.stage-chip[data-stage="' + stage + '"]');
+  if (clicked) clicked.classList.add('active');
+  if (stage === 'all') {
+    window.pcsPipelineFilter = null;
+  } else {
+    window.pcsPipelineFilter = [stage];
+  }
+  renderPipeline();
+}
+
+// Wire pipeline stage chip clicks
+document.addEventListener('DOMContentLoaded', function() {
+  var strip = document.getElementById('stage-strip');
+  if (strip) {
+    strip.addEventListener('click', function(e) {
+      var chip = e.target.closest('.stage-chip');
+      if (!chip) return;
+      var stage = chip.dataset.stage;
+      if (stage) filterPipelineByChip(stage);
+    });
+  }
+});
+
 // -- Task stage chip filter ---------------------
 let _taskFilter = null; // null = show all, string = bucket key
 

--- a/index.html
+++ b/index.html
@@ -679,7 +679,7 @@
 ══════════════════════════════════════════ -->
 <button class="fab" id="fab" onclick="toggleFabMenu()"><span class="fab-icon">+</span></button>
 
-<div class="fab-backdrop" id="fab-backdrop"></div>
+<div class="fab-backdrop" id="fab-backdrop" onclick="closeFabMenu()"></div>
 
 <div class="fab-menu" id="fab-menu">
   <div class="fab-option fab-post" id="fab-create-post">

--- a/styles.css
+++ b/styles.css
@@ -3240,6 +3240,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   border-bottom: 1px dotted var(--dotline);
   -webkit-overflow-scrolling: touch;
   flex-wrap: nowrap;
+  width: 100%;
 }
 .stage-strip::-webkit-scrollbar { display: none; }
 
@@ -3622,7 +3623,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 /* ═══════════════════════════════════════════════
    ACTION BAR (persistent, above bottom nav)
 ═══════════════════════════════════════════════ */
-.action-bar {
+.fab {
   position: fixed;
   bottom: 74px;
   right: max(20px, calc(50% - 175px));
@@ -3639,6 +3640,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   z-index: 200;
   transition: transform 0.22s cubic-bezier(0.34,1.56,0.64,1), background 0.2s;
 }
+.action-bar { display: none; }
 .fab:hover { background: #F0F0F0; }
 .fab.open { transform: rotate(45deg); background: #EFEFEF; }
 .fab:active { transform: scale(0.94); }
@@ -4612,7 +4614,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   padding: 0 20px 14px;
   border-bottom: 1px dotted var(--dotline);
 }
-.pc-title {
+.pc-title-block .pc-title {
   font-size: 26px;
   font-weight: 700;
   color: var(--text);
@@ -4620,8 +4622,8 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   line-height: 1.1;
   margin-bottom: 5px;
 }
-.pc-title.pcs-title--editable { cursor: text; }
-.pc-title.pcs-title--editable:hover { background: var(--surface2); border-radius: 8px; }
+.pc-title-block .pc-title.pcs-title--editable { cursor: text; }
+.pc-title-block .pc-title.pcs-title--editable:hover { background: var(--surface2); border-radius: 8px; }
 .pc-subtitle {
   font-family: var(--mono);
   font-size: 10px;


### PR DESCRIPTION
- Add width:100% to .stage-strip CSS and wire click handlers on pipeline stage chips to filter posts by stage
- Scope PCS .pc-title override (26px) to .pc-title-block so pipeline card titles correctly render at 14px
- Add .fab base CSS (position/size/z-index) so FAB button is visible and clickable; hide unused .action-bar element
- Add onclick="closeFabMenu()" to fab-backdrop in HTML

https://claude.ai/code/session_01W8j7nsSP9jygFzH6iVpWLG