### PR TITLE
Add batch approval pipeline for Ready group

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -3,6 +3,10 @@
 =============================================== */
 console.log("LOADED:", "07-post-load.js");
 
+// -- Batch selection state --
+var _batchMode = false;
+var _batchSelected = new Set();
+
 // Depends on: 01-config.js (STAGES_DB, STAGE_DISPLAY, PILLARS_DB, PILLAR_DISPLAY)
 
 // -- Unified link helpers  -  SINGLE SOURCE OF TRUTH for link display --
@@ -1332,7 +1336,7 @@ function buildPipelineCard(p, listKey) {
   var dotCls = 'status-dot';
   if (sk) dotCls += ' sd-' + sk;
 
-  return '<div class="' + cardCls + '" id="upc-' + esc(id) + '" data-post-id="' + esc(id) + '" data-list="' + esc(listKey||'') + '">' +
+  return '<div class="' + cardCls + '" id="upc-' + esc(id) + '" data-post-id="' + esc(id) + '" data-stage="' + esc(stage) + '" data-list="' + esc(listKey||'') + '">' +
     '<span class="' + dateCls + '">' + esc(dateDisplay) + '</span>' +
     '<span class="pc-body">' +
       '<span class="pc-title">' + esc(title) + '</span>' +
@@ -1534,6 +1538,83 @@ function toggleStageOverflow(btn, totalHidden) {
   }
 }
 
+// ===============================================
+// Batch selection mode for Ready group
+// ===============================================
+function toggleBatchMode() {
+  _batchMode = !_batchMode;
+  _batchSelected.clear();
+
+  var btn = document.getElementById('batch-select-btn');
+  var bar = document.getElementById('batch-bar');
+
+  if (btn) btn.classList.toggle('active', _batchMode);
+  if (bar) bar.style.display = _batchMode ? 'flex' : 'none';
+
+  document.querySelectorAll('.post-card[data-stage="ready"]').forEach(function(card) {
+    if (_batchMode) {
+      card.classList.add('batch-mode');
+      var cb = document.createElement('div');
+      cb.className = 'batch-checkbox';
+      cb.setAttribute('data-batch-cb', '1');
+      card.insertBefore(cb, card.firstChild);
+    } else {
+      card.classList.remove('batch-mode', 'batch-selected');
+      var existing = card.querySelector('[data-batch-cb]');
+      if (existing) existing.remove();
+    }
+  });
+
+  updateBatchCount();
+}
+
+function toggleBatchCard(postId, cardEl) {
+  if (!_batchMode) return;
+  if (_batchSelected.has(postId)) {
+    _batchSelected.delete(postId);
+    cardEl.classList.remove('batch-selected');
+  } else {
+    _batchSelected.add(postId);
+    cardEl.classList.add('batch-selected');
+  }
+  updateBatchCount();
+}
+
+function updateBatchCount() {
+  var countEl = document.getElementById('batch-count');
+  if (countEl) countEl.textContent = _batchSelected.size;
+}
+
+async function executeBatchAction(targetStage) {
+  if (_batchSelected.size === 0) return;
+
+  var ids = Array.from(_batchSelected);
+  var now = new Date().toISOString();
+  var dbStage = toDbStage(targetStage);
+  var actor = resolveActor();
+
+  try {
+    // PostgREST IN filter: post_id=in.(id1,id2,...)
+    var inList = ids.map(function(id) { return encodeURIComponent(id); }).join(',');
+    await apiFetch('/posts?post_id=in.(' + inList + ')', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        stage: dbStage,
+        status_changed_at: now,
+        updated_at: now,
+        updated_by: actor
+      }),
+    });
+
+    toggleBatchMode();
+    loadPosts();
+
+  } catch (err) {
+    console.error('Batch action error:', err);
+    showToast('Batch update failed - try again', 'error');
+  }
+}
+
 function renderPipeline() {
   try { _renderPipelineInner(); } catch(e) { console.error('[PCS] renderPipeline crash:', e); }
 }
@@ -1596,10 +1677,16 @@ function _renderPipelineInner() {
       }
       return card;
     }).join('');
+    var selectBtn = (stage === 'ready')
+      ? '<button class="batch-select-btn" id="batch-select-btn" onclick="toggleBatchMode()">Select</button>'
+      : '';
     return `
       <div class="group-hdr">
         <span class="group-label" data-stage="${esc(sk)}">${esc(label)}</span>
-        <span class="group-count">${posts.length}</span>
+        <div style="display:flex;align-items:center;gap:8px">
+          ${selectBtn}
+          <span class="group-count">${posts.length}</span>
+        </div>
       </div>
       <div class="row-list post-list">
         ${cards || '<div class="pstage-empty">' + (emptyMsg.default || 'Empty') + '</div>'}
@@ -2151,9 +2238,26 @@ function _closeDayDrawer() {
   var postId  = card.dataset.postId;
   var listKey = card.dataset.list || '';
   if (!postId) return;
+  // Batch mode intercept: clicking a ready card toggles selection
+  if (_batchMode && card.dataset.stage === 'ready') {
+    toggleBatchCard(postId, card);
+    return;
+  }
   // Parked overlay rows also need to close the parked sheet
   if (card.dataset.closeParked) {
     try { closeParked(); } catch (_) {}
   }
   openPCS(postId, listKey);
+});
+
+// -- Wire batch action bar buttons --
+document.addEventListener('DOMContentLoaded', function() {
+  var approvalBtn = document.getElementById('batch-approval-btn');
+  if (approvalBtn) approvalBtn.addEventListener('click', function() {
+    executeBatchAction('awaiting_approval');
+  });
+  var inputBtn = document.getElementById('batch-input-btn');
+  if (inputBtn) inputBtn.addEventListener('click', function() {
+    executeBatchAction('awaiting_brand_input');
+  });
 });

--- a/index.html
+++ b/index.html
@@ -170,6 +170,19 @@
     </div>
     <div class="dash-body">
       <div id="pipeline-container"></div>
+      <div class="batch-bar" id="batch-bar" style="display:none">
+        <div class="batch-bar-count">
+          <span id="batch-count">0</span> selected
+        </div>
+        <div class="batch-bar-actions">
+          <button class="batch-btn batch-btn-input" id="batch-input-btn">
+            Request Input
+          </button>
+          <button class="batch-btn batch-btn-approval" id="batch-approval-btn">
+            Send for Approval
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -4911,3 +4911,118 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   padding: 2px 8px;
   border: 1px dotted var(--muted2);
 }
+
+/* ===============================================
+   BATCH APPROVAL BAR
+=============================================== */
+.batch-bar {
+  position: fixed;
+  bottom: 74px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 32px);
+  max-width: 448px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 16px;
+  background: var(--surface2);
+  border: 1px dotted var(--dotline);
+  border-radius: 8px;
+  z-index: 150;
+  backdrop-filter: blur(12px);
+}
+
+.batch-bar-count {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--text2);
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.batch-bar-count span {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.batch-bar-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.batch-btn {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 8px 14px;
+  border: 1px dotted;
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+
+.batch-btn-input {
+  color: var(--purple);
+  border-color: rgba(155,135,245,0.4);
+}
+.batch-btn-input:hover { background: rgba(155,135,245,0.08); }
+
+.batch-btn-approval {
+  color: var(--green);
+  border-color: rgba(62,207,142,0.4);
+}
+.batch-btn-approval:hover { background: rgba(62,207,142,0.08); }
+
+.batch-select-btn {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px dotted rgba(255,255,255,0.2);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.batch-select-btn.active {
+  color: var(--text);
+  border-color: rgba(255,255,255,0.4);
+}
+
+.post-card.batch-mode { cursor: pointer; }
+.post-card.batch-selected {
+  border-color: rgba(62,207,142,0.4);
+  background: rgba(62,207,142,0.04);
+}
+
+.batch-checkbox {
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  border: 1px solid var(--muted);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+.post-card.batch-selected .batch-checkbox {
+  background: var(--green);
+  border-color: var(--green);
+}
+.batch-checkbox::after {
+  content: '';
+  width: 8px;
+  height: 5px;
+  border-left: 1.5px solid #000;
+  border-bottom: 1.5px solid #000;
+  transform: rotate(-45deg) translateY(-1px);
+  opacity: 0;
+}
+.post-card.batch-selected .batch-checkbox::after { opacity: 1; }


### PR DESCRIPTION
When in Pipeline view, the Ready group header shows a Select button. Tapping it enters selection mode with checkboxes on ready cards. A fixed bottom bar appears with "Request Input" and "Send for Approval" actions that batch-update all selected posts via a single API call.

- HTML: batch action bar inside pipeline panel
- CSS: batch bar, select button, card selection, checkbox styles
- JS: batch mode state, toggle, card selection, batch PATCH via PostgREST

https://claude.ai/code/session_013KinhLWQn4wkf4ZerumGNb