### PR TITLE
Compress UI spacing: headers, stage strip, nav bar, pipeline cards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3238,8 +3238,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 .stage-strip {
   display: flex;
-  gap: 8px;
-  padding: 14px 16px;
+  gap: 6px;
+  padding: 10px 14px;
   overflow-x: auto;
   scrollbar-width: none;
   border-bottom: 1px dotted var(--dotline);
@@ -3312,7 +3312,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
    PIPELINE GROUP HEADER
 ═══════════════════════════════════════════════ */
 
-.group-hdr { display: flex; justify-content: space-between; align-items: center; padding: 10px 20px 6px; }
+.group-hdr { display: flex; justify-content: space-between; align-items: center; padding: 8px 20px 6px; }
 .group-label { font-family: var(--mono); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; font-weight: 600; }
 .group-label[data-stage="production"] { color: var(--amber); }
 .group-label[data-stage="ready"]      { color: var(--green); }
@@ -3329,7 +3329,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 9px 12px;
+  padding: 8px 12px;
   background: var(--surface);
   border: 1px solid rgba(255,255,255,0.07);
   border-radius: 6px;
@@ -3485,7 +3485,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 14px 20px 12px;
+  padding: 12px 20px 10px;
   border-bottom: 1px dotted var(--dotline);
   flex-shrink: 0;
   position: sticky;
@@ -3613,13 +3613,13 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   align-items: center;
   justify-content: center;
   gap: 5px;
-  padding: 12px 0 10px;
+  padding: 9px 0 8px;
   cursor: pointer;
   position: relative;
 }
 .nav-item:not(:last-child) { border-right: 1px dotted var(--dotline); }
 .nav-item .nav-icon { width: 20px; height: 20px; color: var(--muted); transition: color 0.15s; }
-.nav-item .nav-label { font-family: var(--mono); font-size: 8px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); transition: color 0.15s; }
+.nav-item .nav-label { font-family: var(--mono); font-size: 7px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); transition: color 0.15s; }
 .nav-item.active .nav-icon { color: var(--text); }
 .nav-item.active .nav-label { color: var(--text); }
 .nav-item.active { border-bottom: none; border-bottom-color: transparent; background: none; text-decoration: none; color: inherit; }


### PR DESCRIPTION
- Reduce .app-header padding (14px/12px → 12px/10px)
- Compress .stage-strip padding (14px 16px → 10px 14px) and gap (8px → 6px)
- Compress .group-hdr padding (10px → 8px top)
- Reduce .nav-item padding (12px/10px → 9px/8px)
- Reduce .nav-label font-size (8px → 7px) and letter-spacing (0.16em → 0.14em)
- Compress .post-card padding (9px → 8px top)
- Strip non-ASCII characters from all JS files

https://claude.ai/code/session_01FzzSTHNq2SDC5XofnL3Y28