### PR TITLE
Rebrand GBL to Hinglish and redesign login screen

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -73,7 +73,7 @@ window.sendMagicLink = async function sendMagicLink() {
       const err = await res.json().catch(() => ({}));
       throw new Error(err.error_description || err.msg || 'Could not send code');
     }
-    localStorage.setItem('gbl_pending_email', email);
+    localStorage.setItem('hinglish_pending_email', email);
     document.getElementById('login-email-step')?.classList.remove('active');
     const codeStep = document.getElementById('login-code-step');
     if (codeStep) {
@@ -91,7 +91,7 @@ window.sendMagicLink = async function sendMagicLink() {
 };
 
 window.verifyOTPCode = async function verifyOTPCode() {
-  const email = localStorage.getItem('gbl_pending_email') || '';
+  const email = localStorage.getItem('hinglish_pending_email') || '';
   const code  = (document.getElementById('login-code-input')?.value || '').trim();
   if (!code || code.length < 6) {
     const el = document.getElementById('login-code-error');
@@ -120,7 +120,7 @@ window.verifyOTPCode = async function verifyOTPCode() {
     if (!accessToken) throw new Error('No token returned');
     localStorage.setItem('sb_access_token', accessToken);
     if (refreshToken) localStorage.setItem('sb_refresh_token', refreshToken);
-    localStorage.removeItem('gbl_pending_email');
+    localStorage.removeItem('hinglish_pending_email');
     await resolveRoleFromToken(accessToken, email);
   } catch (err) {
     if (errEl) errEl.textContent = err.message || 'Incorrect code - try again.';
@@ -142,8 +142,8 @@ async function resolveRoleFromToken(accessToken, email) {
       if (el) el.textContent = `No role found for ${email}. Ask your admin.`;
       return;
     }
-    localStorage.setItem('gbl_role', role);
-    localStorage.setItem('gbl_email', email);
+    localStorage.setItem('hinglish_role', role);
+    localStorage.setItem('hinglish_email', email);
     const overlay = document.getElementById('login-overlay');
     if (overlay) overlay.classList.add('hidden');
     activateRole(role);
@@ -176,12 +176,12 @@ async function handleMagicLinkToken(accessToken, _retried) {
 }
 
 function logout() {
-  localStorage.removeItem('gbl_role');
-  localStorage.removeItem('gbl_email');
-  localStorage.removeItem('gbl_token');
+  localStorage.removeItem('hinglish_role');
+  localStorage.removeItem('hinglish_email');
+  localStorage.removeItem('hinglish_token');
   localStorage.removeItem('sb_access_token');
   localStorage.removeItem('sb_refresh_token');
-  localStorage.removeItem('gbl_pending_email');
+  localStorage.removeItem('hinglish_pending_email');
   stopRealtime();
   document.getElementById('dashboard-view')?.classList.remove('active');
   document.getElementById('client-view')?.classList.remove('active');

--- a/04-router.js
+++ b/04-router.js
@@ -14,7 +14,7 @@ async function _startRouter() {
 
   if (approveShort) { showApprovalView(approveShort); return; }
   if (action === 'viewApproval' && ref) {
-    showApprovalView(ref.replace(/-gbl$/i, '')); return;
+    showApprovalView(ref.replace(/-hinglish$/i, '')); return;
   }
 
   const hash = window.location.hash;
@@ -30,7 +30,7 @@ async function _startRouter() {
   }
 
   const savedToken   = localStorage.getItem('sb_access_token');
-  const savedRole    = localStorage.getItem('gbl_role');
+  const savedRole    = localStorage.getItem('hinglish_role');
   const refreshToken = localStorage.getItem('sb_refresh_token');
 
   if (savedRole && (savedToken || refreshToken)) {

--- a/06-post-create.js
+++ b/06-post-create.js
@@ -3,7 +3,7 @@
 =============================================== */
 console.log("LOADED:", "06-post-create.js");
 
-const DRAFT_KEY = 'gbl_new_post_draft';
+const DRAFT_KEY = 'hinglish_new_post_draft';
 let _draftTimer = null;
 let _draftDebounce = null;
 

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -486,7 +486,7 @@ function getTopTask() {
   }
 
   const role = _ttNorm(window.effectiveRole || '');
-  const email = localStorage.getItem('gbl_email') || '';
+  const email = localStorage.getItem('hinglish_email') || '';
   const emailPrefix = email ? email.split('@')[0].toLowerCase() : '';
 
   // 1. ASSIGNED TASKS (highest priority for all roles)
@@ -1131,7 +1131,7 @@ function renderTaskBanner() {
   const section = document.getElementById('task-banner-section');
   if (!section) return;
   if (effectiveRole === 'Client') { section.innerHTML = ''; return; }
-  const email    = localStorage.getItem('gbl_email') || '';
+  const email    = localStorage.getItem('hinglish_email') || '';
   const roleName = effectiveRole;
   const myTasks  = allTasks.filter(t => !t.done && (t.assigned_to === roleName || (email && t.assigned_to.toLowerCase().includes(email.split('@')[0].toLowerCase()))));
   if (!myTasks.length) { section.innerHTML = ''; return; }

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -223,7 +223,7 @@ async function submitClientRequest() {
   if (btn) btn.disabled = true;
   try {
     const postId = 'REQ-' + Date.now();
-    const email  = localStorage.getItem('gbl_email') || 'Client';
+    const email  = localStorage.getItem('hinglish_email') || 'Client';
     const payload = {
       post_id:     postId,
       title:       'Client Request - ' + new Date().getDate() + ' ' + MONTHS[new Date().getMonth()],

--- a/09-approval.js
+++ b/09-approval.js
@@ -51,7 +51,7 @@ async function showApprovalView(postId) {
     view.innerHTML = `
       <div class="approval-wrap">
         <div class="approval-header">
-          <div class="approval-logo">GBL Content</div>
+          <div class="approval-logo">Hinglish</div>
           <div class="approval-subtitle">Post Review & Approval</div>
         </div>
         <div class="approval-card">

--- a/10-ui.js
+++ b/10-ui.js
@@ -72,10 +72,10 @@ function showToast(msg, type = 'success') {
 function toggleTheme() {
   const next = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
   document.documentElement.dataset.theme = next;
-  localStorage.setItem('gbl_theme', next);
+  localStorage.setItem('hinglish_theme', next);
 }
 (function applyTheme() {
-  const saved = localStorage.getItem('gbl_theme') || 'light';
+  const saved = localStorage.getItem('hinglish_theme') || 'light';
   document.documentElement.dataset.theme = saved;
 })();
 

--- a/SYSTEM_MAP.md
+++ b/SYSTEM_MAP.md
@@ -1,4 +1,4 @@
-# System Map — GBL Content Ops
+# System Map — Hinglish Ops
 
 Architecture reference for the entire codebase. Vanilla JavaScript, no framework, no bundler, Supabase backend.
 
@@ -36,7 +36,7 @@ Every file depends on the ones above it. All share a single global scope (no mod
 User enters email
   → sendMagicLink()
     → POST /auth/v1/otp { email, create_user: false }
-    → stores email in localStorage('gbl_pending_email')
+    → stores email in localStorage('hinglish_pending_email')
     → shows code input step
 
 User enters 6-digit OTP
@@ -47,7 +47,7 @@ User enters 6-digit OTP
 
 resolveRoleFromToken(token, email)
   → GET /rest/v1/user_roles?email=eq.{email}&select=role&limit=1
-  → stores role in localStorage('gbl_role'), email in localStorage('gbl_email')
+  → stores role in localStorage('hinglish_role'), email in localStorage('hinglish_email')
   → calls activateRole(role)
 ```
 
@@ -71,11 +71,11 @@ Called from:
 |-----|--------|---------|
 | `sb_access_token` | `verifyOTPCode`, `refreshSession` | Supabase JWT |
 | `sb_refresh_token` | `verifyOTPCode`, `refreshSession` | Refresh token for silent renewal |
-| `gbl_role` | `resolveRoleFromToken` | User role (Admin/Servicing/Creative/Client) |
-| `gbl_email` | `resolveRoleFromToken` | User email |
-| `gbl_pending_email` | `sendMagicLink` | Temp: email awaiting OTP verification |
-| `gbl_theme` | `toggleTheme` | dark/light preference |
-| `gbl_new_post_draft` | `saveDraft` | Draft post JSON (expires after 24h) |
+| `hinglish_role` | `resolveRoleFromToken` | User role (Admin/Servicing/Creative/Client) |
+| `hinglish_email` | `resolveRoleFromToken` | User email |
+| `hinglish_pending_email` | `sendMagicLink` | Temp: email awaiting OTP verification |
+| `hinglish_theme` | `toggleTheme` | dark/light preference |
+| `hinglish_new_post_draft` | `saveDraft` | Draft post JSON (expires after 24h) |
 | `snooze_{postId}` | `confirmSnooze` | Snooze expiry timestamp |
 
 ### Role Activation
@@ -114,7 +114,7 @@ _startRouter()
   │    → showApprovalView(postId)                    [public, no auth]
   │
   ├─ ?action=viewApproval&ref={postId} query param?
-  │    → showApprovalView(postId, strip -gbl suffix) [public, no auth]
+  │    → showApprovalView(postId, strip -hinglish suffix) [public, no auth]
   │
   ├─ Hash contains access_token? (magic link callback)
   │    → store refresh_token

--- a/TEST_COVERAGE_ANALYSIS.md
+++ b/TEST_COVERAGE_ANALYSIS.md
@@ -120,7 +120,7 @@ The router determines which view loads. A bug here = blank screen.
 |---|---|
 | `/p/POST-123` path | Calls `showApprovalView('POST-123')` |
 | `?approve=POST-123` param | Calls `showApprovalView('POST-123')` |
-| `?action=viewApproval&ref=POST-123-gbl` | Strips `-gbl` suffix, calls approval view |
+| `?action=viewApproval&ref=POST-123-hinglish` | Strips `-hinglish` suffix, calls approval view |
 | Hash contains `access_token` | Stores refresh token, calls `handleMagicLinkToken` |
 | Saved role + valid token | Calls `activateRole` |
 | No saved session | Shows login overlay |

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<title>GBL · Content Ops</title>
+<title>Hinglish Ops</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
  <link rel="stylesheet" href="styles.css?v=20260315">
@@ -16,39 +16,62 @@
 ══════════════════════════════════════════ -->
 <div id="login-overlay" class="hidden">
   <div class="login-card">
-    <div class="login-logo">GBL <span>Ops</span></div>
-    <div class="login-tagline">Content Command Console</div>
+
+    <!-- Top strip -->
+    <div class="login-top-strip">
+      <span class="login-gold-dot"></span>
+      <span>Hinglish Agency</span>
+    </div>
+
+    <!-- Brand name -->
+    <div class="login-brand">Hinglish <span>Ops</span></div>
+
+    <!-- Brand subtitle -->
+    <div class="login-subtitle">Content Command Console</div>
 
     <!-- Step 1: Email entry -->
     <div id="login-email-step" class="login-step active">
-      <div class="login-label" style="margin-bottom:var(--sp-4)">Enter your work email to sign in</div>
-      <div class="form-field">
-        <input type="email" id="login-email-input" placeholder="you@gblcommunications.com"
-          style="font-size:16px;text-align:center"
-          onkeydown="if(event.key==='Enter')sendMagicLink()">
-      </div>
-      <button class="btn-modal-primary" style="width:100%;margin-top:var(--sp-2)" onclick="sendMagicLink()">
-        Send Code →
+      <label class="login-form-label" for="login-email-input">Work Email</label>
+      <input type="email" id="login-email-input" class="login-input" placeholder="you@hinglish.agency"
+        onkeydown="if(event.key==='Enter')sendMagicLink()">
+      <button class="login-submit-btn" onclick="sendMagicLink()">
+        <span>Send Code</span>
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
       </button>
-      <div class="login-error" id="login-error" style="margin-top:var(--sp-3)"></div>
+      <div class="login-error" id="login-error"></div>
     </div>
 
-    <!-- Step 2: Check email -->
+    <!-- Step 2: OTP confirmation -->
     <div id="login-code-step" class="login-step">
-  <div style="font-size:40px;text-align:center;margin-bottom:var(--sp-4)">📩</div>
-  <div class="login-label" style="text-align:center;margin-bottom:var(--sp-2)">Check your email</div>
-  <div style="font-size:14px;color:var(--text3);text-align:center;margin-bottom:var(--sp-4)">
-    We sent a 6-digit code to<br>
-    <strong id="login-code-email-display" style="color:var(--text1)"></strong>
+      <div class="login-otp-confirm">
+        <div class="login-otp-arrow">&rarr;</div>
+        <div class="login-otp-info">
+          <div class="login-otp-line1">Code sent to <span id="login-code-email-display"></span></div>
+          <div class="login-otp-line2">Check your inbox &middot; valid for 10 minutes only</div>
+        </div>
+      </div>
+      <input type="number" id="login-code-input" class="login-input" placeholder="Enter 6-digit code"
+        style="letter-spacing:8px;text-align:center;margin-top:12px"
+        onkeydown="if(event.key==='Enter')verifyOTPCode()">
+      <div class="login-error" id="login-code-error"></div>
+      <button id="login-verify-code-btn" class="login-submit-btn" style="margin-top:8px" onclick="verifyOTPCode()">
+        <span>Verify</span>
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+      </button>
+      <button class="login-back-btn" onclick="backToEmail()">&larr; Use a different email</button>
+    </div>
+
+    <!-- Bottom strip -->
+    <div class="login-bottom-strip">
+      <div class="login-bottom-dots">
+        <span class="login-dot login-dot--gold"></span>
+        <span class="login-dot"></span>
+        <span class="login-dot"></span>
+      </div>
+      <span class="login-bottom-label">Internal Tool</span>
+    </div>
+
   </div>
-  <input type="number" id="login-code-input" placeholder="Enter 6-digit code"
-    style="width:100%;padding:var(--sp-3);font-size:20px;text-align:center;letter-spacing:8px;border-radius:var(--r-md);border:1px solid var(--border);background:var(--surface2);color:var(--text1);margin-bottom:var(--sp-3)"
-    onkeydown="if(event.key==='Enter')verifyOTPCode()">
-  <div class="login-error" id="login-code-error" style="margin-bottom:var(--sp-2)"></div>
-  <button id="login-verify-code-btn" class="btn-modal-primary" style="width:100%" onclick="verifyOTPCode()">Verify →</button>
-  <button class="btn-modal-ghost" style="width:100%;margin-top:var(--sp-3)" onclick="backToEmail()">← Use a different email</button>
-</div>
- </div>
 </div>
 
 <!-- ══════════════════════════════════════════
@@ -56,7 +79,7 @@
 ══════════════════════════════════════════ -->
 <div id="approval-view">
   <div class="apv-card">
-    <div class="apv-brand">GBL <span>Ops</span> · Approval Request</div>
+    <div class="apv-brand">Hinglish <span>Ops</span> &middot; Approval Request</div>
     <div id="apv-title" class="apv-title">Loading…</div>
     <div id="apv-meta"  class="apv-meta"></div>
     <div id="apv-design-wrap"></div>
@@ -265,7 +288,7 @@
 
   <!-- Client topbar -->
   <header class="topbar">
-    <div class="topbar-brand">GBL <span>Ops</span></div>
+    <div class="topbar-brand">Hinglish <span>Ops</span></div>
     <div class="topbar-spacer"></div>
     <button class="btn-primary-action" onclick="scrollToNewRequest()">+ New Request</button>
     <div class="user-menu-wrap" id="client-menu-wrap">

--- a/styles.css
+++ b/styles.css
@@ -223,36 +223,189 @@ a:hover { text-decoration: underline; }
   inset: 0;
   z-index: 1000;
   background: var(--bg);
+  display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--sp-5);
+  padding: 24px;
 }
 #login-overlay.hidden { display: none !important; }
 
 .login-card {
   width: 100%;
-  max-width: 400px;
+  max-width: 360px;
   background: var(--surface);
-  border: 1px solid var(--border2);
-  border-radius: var(--r-xl);
-  padding: var(--sp-7) var(--sp-6);
-  box-shadow: var(--shadow-lift);
+  border: 1px dotted var(--dotline);
+  padding: 32px 28px 28px;
 }
 
-.login-logo {
-  font-family: var(--font-display);
-  font-size: 28px;
+.login-top-strip {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.22em;
+  color: var(--muted);
+  text-transform: uppercase;
+  margin-bottom: 24px;
+  padding-bottom: 14px;
+  border-bottom: 1px dotted var(--dotline);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.login-gold-dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--gold);
+  opacity: 0.7;
+}
+
+.login-brand {
+  font-family: var(--sans);
+  font-size: 26px;
   font-weight: 600;
   color: var(--text);
-  letter-spacing: -0.5px;
-  margin-bottom: var(--sp-1);
+  letter-spacing: -0.3px;
+  line-height: 1.1;
+  margin-bottom: 4px;
 }
-.login-logo span { color: var(--accent); }
+.login-brand span { color: var(--gold); }
 
-.login-tagline {
+.login-subtitle {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  text-transform: uppercase;
+  margin-bottom: 28px;
+}
+
+.login-form-label {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  display: block;
+}
+
+.login-input {
+  width: 100%;
+  background: var(--bg);
+  border: 1px dotted rgba(255,255,255,0.12);
+  border-radius: 0;
+  padding: 12px 14px;
+  font-family: var(--sans);
+  font-size: 14px;
+  color: var(--text);
+  outline: none;
+  margin-bottom: 10px;
+}
+.login-input:focus {
+  border-color: rgba(200,168,75,0.4);
+}
+
+.login-submit-btn {
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  border: 1px dotted rgba(200,168,75,0.4);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--gold);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+.login-submit-btn:hover {
+  background: var(--gold-bg);
+}
+
+.login-otp-confirm {
+  display: none;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px dotted var(--dotline);
+  flex-direction: row;
+  gap: 10px;
+}
+.login-step.active .login-otp-confirm {
+  display: flex;
+}
+.login-otp-arrow {
+  font-family: var(--mono);
+  color: var(--gold);
   font-size: 13px;
-  color: var(--text2);
-  margin-bottom: var(--sp-6);
+  line-height: 1.4;
+}
+.login-otp-info { flex: 1; }
+.login-otp-line1 {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+.login-otp-line1 span { color: var(--gold); }
+.login-otp-line2 {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+
+.login-back-btn {
+  width: 100%;
+  margin-top: 10px;
+  padding: 8px;
+  background: none;
+  border: none;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  cursor: pointer;
+}
+.login-back-btn:hover { color: var(--text); }
+
+.login-bottom-strip {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px dotted var(--dotline);
+}
+.login-bottom-dots {
+  display: flex;
+  gap: 5px;
+}
+.login-dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--muted2);
+}
+.login-dot--gold {
+  background: var(--gold);
+  opacity: 0.5;
+}
+.login-bottom-label {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  color: var(--muted2);
+  text-transform: uppercase;
 }
 
 .login-step { display: none; }


### PR DESCRIPTION
- Replace entire login screen HTML/CSS with new dotted-border card design using existing CSS variables (--bg, --surface, --gold, --mono, etc.)
- Replace all GBL/gbl references with Hinglish/hinglish across all files
- Rename localStorage keys: gbl_* -> hinglish_*
- Update page title, approval view, client topbar brand names
- All auth handlers (sendMagicLink, verifyOTPCode, backToEmail) preserved
- All existing element IDs for auth JS kept intact
- Non-ASCII strip confirmed: all JS files are clean ASCII

https://claude.ai/code/session_01MS3eDyn6Leqgrq455WKd9Q