### PR TITLE
Fix Send Code button: add btn-modal-primary class expected by auth JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       <label class="login-form-label" for="login-email-input">Work Email</label>
       <input type="email" id="login-email-input" class="login-input" placeholder="you@hinglish.agency"
         onkeydown="if(event.key==='Enter')sendMagicLink()">
-      <button class="login-submit-btn" onclick="sendMagicLink()">
+      <button class="login-submit-btn btn-modal-primary" onclick="sendMagicLink()">
         <span>Send Code</span>
         <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
       </button>


### PR DESCRIPTION
03-auth.js sendMagicLink() queries for '#login-email-step .btn-modal-primary' to disable the button and show "Sending..." text. The login redesign removed that class, so querySelector returned null and the function bailed out on line 61 before ever calling the Supabase OTP endpoint.

https://claude.ai/code/session_01MS3eDyn6Leqgrq455WKd9Q