### PR TITLE
Override btn-modal-primary styles inside login email step

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2412,6 +2412,29 @@ tr:hover td { background: var(--surface2); }
 .btn-modal-primary:hover { opacity: 0.88; }
 .btn-modal-primary:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
 
+#login-email-step .btn-modal-primary {
+  background: transparent;
+  border: 1px dotted rgba(200,168,75,0.4);
+  color: var(--gold);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 12px 16px;
+  width: 100%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-radius: 0;
+}
+
+#login-email-step .btn-modal-primary:hover {
+  background: rgba(200,168,75,0.08);
+}
+
 .btn-modal-ghost {
   height: 48px;
   padding: 0 var(--sp-5);


### PR DESCRIPTION
The Send Code button inherits the gold-filled btn-modal-primary style. Add a scoped #login-email-step .btn-modal-primary rule to restore the dotted-border transparent design from the login redesign.

https://claude.ai/code/session_01MS3eDyn6Leqgrq455WKd9Q