### PR TITLE
Add expandable search to pipeline header

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -3,6 +3,108 @@
 =============================================== */
 console.log("LOADED:", "07-post-load.js");
 
+// -- Pipeline search state --
+var _pipelineSearchOpen = false;
+
+function openPipelineSearch() {
+  _pipelineSearchOpen = true;
+  var hdr = document.getElementById('pipeline-hdr');
+  var bar = document.getElementById('pipeline-search-bar');
+  if (hdr) hdr.classList.add('searching');
+  if (bar) bar.classList.add('open');
+  setTimeout(function() {
+    var input = document.getElementById('pipeline-search-input');
+    if (input) input.focus();
+  }, 200);
+}
+
+function closePipelineSearch() {
+  _pipelineSearchOpen = false;
+  var hdr = document.getElementById('pipeline-hdr');
+  var bar = document.getElementById('pipeline-search-bar');
+  var results = document.getElementById('pipeline-search-results');
+  var empty = document.getElementById('pipeline-search-empty');
+  var container = document.getElementById('pipeline-container');
+  var input = document.getElementById('pipeline-search-input');
+  if (hdr) hdr.classList.remove('searching');
+  if (bar) bar.classList.remove('open');
+  if (results) { results.classList.remove('visible'); results.innerHTML = ''; }
+  if (empty) empty.classList.remove('visible');
+  if (container) container.classList.remove('search-dimmed');
+  if (input) input.value = '';
+}
+
+function handlePipelineSearch(query) {
+  var results = document.getElementById('pipeline-search-results');
+  var empty = document.getElementById('pipeline-search-empty');
+  var container = document.getElementById('pipeline-container');
+  var posts = Array.isArray(window.allPosts) ? window.allPosts : [];
+
+  var pipelineStages = ['awaiting_approval','awaiting_brand_input','scheduled','ready','in_production'];
+  var pipelinePosts = posts.filter(function(p) { return pipelineStages.indexOf(p.stage) > -1; });
+
+  if (!query || query.trim() === '') {
+    if (results) { results.classList.remove('visible'); results.innerHTML = ''; }
+    if (empty) empty.classList.remove('visible');
+    if (container) container.classList.remove('search-dimmed');
+    return;
+  }
+
+  if (container) container.classList.add('search-dimmed');
+  var q = query.toLowerCase().trim();
+
+  var stageDisplayMap = {
+    'awaiting_approval': 'Approval',
+    'awaiting_brand_input': 'Input',
+    'scheduled': 'Scheduled',
+    'ready': 'Ready',
+    'in_production': 'Production'
+  };
+  var stageColorMap = {
+    'awaiting_approval': '#FF4B4B',
+    'awaiting_brand_input': '#9b87f5',
+    'scheduled': '#22D3EE',
+    'ready': '#3ECF8E',
+    'in_production': '#F6A623'
+  };
+
+  var matches = pipelinePosts.filter(function(p) {
+    return (p.title && p.title.toLowerCase().indexOf(q) > -1) ||
+           (p.content_pillar && p.content_pillar.toLowerCase().indexOf(q) > -1) ||
+           (p.owner && p.owner.toLowerCase().indexOf(q) > -1);
+  });
+
+  if (matches.length === 0) {
+    if (results) { results.classList.remove('visible'); results.innerHTML = ''; }
+    if (empty) empty.classList.add('visible');
+    return;
+  }
+
+  if (empty) empty.classList.remove('visible');
+
+  var escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  var html = matches.map(function(p) {
+    var highlighted = (p.title || '').replace(
+      new RegExp('(' + escaped + ')', 'gi'),
+      '<mark>$1</mark>'
+    );
+    var color = stageColorMap[p.stage] || '#555';
+    var badgeLabel = stageDisplayMap[p.stage] || p.stage;
+    var badgeClass = 'badge-' + p.stage;
+    var pillar = p.content_pillar || '';
+    return '<div class="pipeline-search-result-item" onclick="closePipelineSearch(); openPCS(\'' + p.id + '\')">' +
+      '<div class="result-stage-dot" style="background:' + color + '"></div>' +
+      '<div class="pipeline-result-body">' +
+        '<div class="pipeline-result-title">' + highlighted + '</div>' +
+        '<div class="pipeline-result-meta">' + pillar + '</div>' +
+      '</div>' +
+      '<span class="result-stage-badge ' + badgeClass + '">' + badgeLabel + '</span>' +
+    '</div>';
+  }).join('');
+
+  if (results) { results.innerHTML = html; results.classList.add('visible'); }
+}
+
 // -- Batch selection state --
 var _batchMode = false;
 var _batchSelected = new Set();

--- a/10-ui.js
+++ b/10-ui.js
@@ -184,9 +184,8 @@ function switchTab(btn) {
   // Update header title
   const titleEl = document.getElementById('app-header-title');
   if (titleEl) titleEl.textContent = (tab === 'tasks') ? _getHeaderDate() : (_TAB_TITLES[tab] || tab);
-  // Show pipeline search icon only on Pipeline tab
-  const searchBtn = document.getElementById('pipeline-search-btn');
-  if (searchBtn) searchBtn.style.display = (tab === 'pipeline') ? 'flex' : 'none';
+  // Close pipeline search when leaving pipeline tab
+  if (tab !== 'pipeline' && typeof closePipelineSearch === 'function') closePipelineSearch();
   // Reset task chip filter when leaving tasks tab
   if (tab !== 'tasks' && typeof _taskFilter !== 'undefined') {
     window._taskFilter = null;
@@ -196,19 +195,7 @@ function switchTab(btn) {
   _fabAttachScroll();
 }
 
-function openPipelineSearch() {
-  const overlay = document.getElementById('pipeline-search-overlay');
-  if (overlay) {
-    overlay.style.display = 'flex';
-    const input = document.getElementById('pipeline-search-input');
-    if (input) { input.value = ''; input.focus(); }
-  }
-}
-
-function closePipelineSearch() {
-  const overlay = document.getElementById('pipeline-search-overlay');
-  if (overlay) overlay.style.display = 'none';
-}
+/* openPipelineSearch / closePipelineSearch / handlePipelineSearch moved to 07-post-load.js */
 
 function switchClientTab(tab) {
   document.querySelectorAll('.client-tab-btn').forEach(b => b.classList.remove('active'));

--- a/index.html
+++ b/index.html
@@ -104,10 +104,6 @@
   <header class="app-header">
     <span class="app-header-title" id="app-header-title"></span>
     <div class="app-header-right">
-      <!-- Pipeline search (visible only on Pipeline tab) -->
-      <button class="pipeline-search-btn" id="pipeline-search-btn" onclick="openPipelineSearch()" title="Search" style="display:none">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"></circle><line x1="16.65" y1="16.65" x2="21" y2="21"></line></svg>
-      </button>
       <!-- Notification bell (internal roles only) -->
       <div class="notif-wrap" id="notif-wrap">
         <button class="app-icon-btn" onclick="toggleNotifPanel()" title="Notifications">
@@ -165,6 +161,35 @@
 
   <!-- TAB: PIPELINE -->
   <div class="tab-panel" id="panel-pipeline">
+    <div class="hdr" id="pipeline-hdr">
+      <div class="hdr-title" id="pipeline-hdr-title">Pipeline</div>
+      <div class="hdr-icons" id="pipeline-hdr-icons">
+        <button class="search-icon-btn" id="pipeline-search-trigger" onclick="openPipelineSearch()">
+          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" width="18" height="18">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803 7.5 7.5 0 0016.803 15.803z"/>
+          </svg>
+        </button>
+      </div>
+      <div class="pipeline-search-bar" id="pipeline-search-bar">
+        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" style="width:16px;height:16px;color:var(--muted);flex-shrink:0">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803 7.5 7.5 0 0016.803 15.803z"/>
+        </svg>
+        <input
+          class="pipeline-search-input"
+          id="pipeline-search-input"
+          type="text"
+          placeholder="Search posts..."
+          oninput="handlePipelineSearch(this.value)"
+          autocomplete="off"
+          autocorrect="off"
+          spellcheck="false"
+        />
+        <button class="pipeline-search-cancel" onclick="closePipelineSearch()">Cancel</button>
+        <div class="pipeline-search-underline"></div>
+      </div>
+    </div>
+    <div class="pipeline-search-results" id="pipeline-search-results"></div>
+    <div class="pipeline-search-empty" id="pipeline-search-empty">No posts found</div>
     <div class="person-strip" id="person-strip">
       <div class="person-btn client" id="person-btn-client" data-person="client" onclick="filterPipelineByPerson('client')">
         <div class="person-num" id="person-num-client">0</div>
@@ -776,13 +801,6 @@ window.allTasks        = window.allTasks    || [];
 <script src="03-auth.js?v=20260315" defer></script>
 <script src="05-api.js?v=20260315" defer></script>
 <script src="10-ui.js?v=20260315" defer></script>
-<!-- Pipeline search overlay -->
-<div id="pipeline-search-overlay" class="search-overlay" style="display:none;">
-  <div class="search-container">
-    <input type="text" placeholder="Search posts..." class="search-input" id="pipeline-search-input" autofocus />
-    <button class="search-close-btn" onclick="closePipelineSearch()">Close</button>
-  </div>
-</div>
 
 <script src="06-post-create.js?v=20260315" defer></script>
 <script src="07-post-load.js?v=20260315" defer></script>

--- a/styles.css
+++ b/styles.css
@@ -5404,3 +5404,177 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   opacity: 0.7;
 }
 .chase-all-btn:hover { opacity: 1; }
+
+/* ── Pipeline Expandable Search ── */
+.search-icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--muted);
+  padding: 0;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s;
+}
+.search-icon-btn:hover { color: var(--text2); }
+
+.pipeline-search-bar {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 16px 0 12px;
+  background: var(--bg);
+  transform: translateX(100%);
+  opacity: 0;
+  transition: transform 0.2s ease, opacity 0.15s;
+  pointer-events: none;
+}
+.pipeline-search-bar.open {
+  transform: translateX(0);
+  opacity: 1;
+  pointer-events: all;
+}
+
+.pipeline-search-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-family: var(--sans);
+  font-size: 15px;
+  color: var(--text);
+  caret-color: var(--gold);
+}
+.pipeline-search-input::placeholder { color: var(--muted); font-size: 14px; }
+
+.pipeline-search-underline {
+  position: absolute;
+  bottom: 0;
+  left: 16px;
+  right: 16px;
+  height: 1px;
+  background: var(--dotline);
+  overflow: hidden;
+}
+.pipeline-search-underline::after {
+  content: '';
+  position: absolute;
+  top: 0; left: -100%;
+  width: 100%;
+  height: 100%;
+  background: var(--gold);
+  transition: left 0.3s ease;
+}
+.pipeline-search-bar.open .pipeline-search-underline::after { left: 0; }
+
+.pipeline-search-cancel {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0 4px 0 0;
+  white-space: nowrap;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+.pipeline-search-cancel:hover { color: var(--text2); }
+
+#pipeline-hdr.searching #pipeline-hdr-title {
+  opacity: 0;
+  transform: translateX(-20px);
+  transition: opacity 0.15s, transform 0.15s;
+}
+#pipeline-hdr.searching #pipeline-hdr-icons {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
+}
+#pipeline-hdr { overflow: hidden; position: relative; }
+
+.pipeline-search-results {
+  display: none;
+  flex-direction: column;
+  border-bottom: 1px dotted var(--dotline);
+}
+.pipeline-search-results.visible { display: flex; }
+
+.pipeline-search-result-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 16px;
+  cursor: pointer;
+  border-bottom: 1px dotted var(--dotline);
+  transition: background 0.15s;
+}
+.pipeline-search-result-item:last-child { border-bottom: none; }
+.pipeline-search-result-item:hover { background: var(--surface2); }
+
+.result-stage-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.pipeline-result-body { flex: 1; min-width: 0; }
+.pipeline-result-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 2px;
+}
+.pipeline-result-title mark {
+  background: rgba(200,168,75,0.25);
+  color: var(--gold);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+.pipeline-result-meta {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+.result-stage-badge {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+.badge-awaiting_approval { color: var(--red); background: rgba(255,75,75,0.1); }
+.badge-awaiting_brand_input { color: var(--purple); background: rgba(155,135,245,0.1); }
+.badge-scheduled { color: var(--cyan); background: rgba(34,211,238,0.1); }
+.badge-ready { color: var(--green); background: rgba(62,207,142,0.1); }
+.badge-in_production { color: var(--amber); background: rgba(246,166,35,0.1); }
+
+.pipeline-search-empty {
+  display: none;
+  padding: 20px 16px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  text-transform: uppercase;
+  text-align: center;
+  border-bottom: 1px dotted var(--dotline);
+}
+.pipeline-search-empty.visible { display: block; }
+
+#pipeline-container.search-dimmed {
+  opacity: 0.3;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}


### PR DESCRIPTION
Replace the old full-screen search overlay with an inline expandable search bar in the pipeline tab. Search filters only pipeline-stage posts and shows results with highlighted matches, stage badges, and content pillar metadata.

https://claude.ai/code/session_01CDqLMCrWgTn2bsQvUmu3ip