### PR TITLE
Fix pipeline search: header overlay, field name mismatch, click-outsi…

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -70,7 +70,7 @@ function handlePipelineSearch(query) {
 
   var matches = pipelinePosts.filter(function(p) {
     return (p.title && p.title.toLowerCase().indexOf(q) > -1) ||
-           (p.content_pillar && p.content_pillar.toLowerCase().indexOf(q) > -1) ||
+           (p.contentPillar && p.contentPillar.toLowerCase().indexOf(q) > -1) ||
            (p.owner && p.owner.toLowerCase().indexOf(q) > -1);
   });
 
@@ -91,7 +91,7 @@ function handlePipelineSearch(query) {
     var color = stageColorMap[p.stage] || '#555';
     var badgeLabel = stageDisplayMap[p.stage] || p.stage;
     var badgeClass = 'badge-' + p.stage;
-    var pillar = p.content_pillar || '';
+    var pillar = p.contentPillar || '';
     return '<div class="pipeline-search-result-item" onclick="closePipelineSearch(); openPCS(\'' + p.id + '\')">' +
       '<div class="result-stage-dot" style="background:' + color + '"></div>' +
       '<div class="pipeline-result-body">' +
@@ -2477,6 +2477,15 @@ document.addEventListener('DOMContentLoaded', function() {
   var inputBtn = document.getElementById('batch-input-btn');
   if (inputBtn) inputBtn.addEventListener('click', function() {
     executeBatchAction('awaiting_brand_input');
+  });
+
+  document.addEventListener('click', function(e) {
+    if (!_pipelineSearchOpen) return;
+    var bar = document.getElementById('pipeline-search-bar');
+    var trigger = document.getElementById('pipeline-search-trigger');
+    if (bar && !bar.contains(e.target) && trigger && !trigger.contains(e.target)) {
+      closePipelineSearch();
+    }
   });
 });
 

--- a/styles.css
+++ b/styles.css
@@ -5495,7 +5495,25 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   pointer-events: none;
   transition: opacity 0.15s;
 }
-#pipeline-hdr { overflow: hidden; position: relative; }
+.hdr {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px 9px;
+  position: relative;
+  overflow: hidden;
+}
+.hdr-title {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--text);
+  font-weight: 500;
+}
+.hdr-icons {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
 
 .pipeline-search-results {
   display: none;


### PR DESCRIPTION
…de close

BUG 1: Added missing .hdr, .hdr-title, .hdr-icons CSS rules so the pipeline header renders as a flex row with position:relative and overflow:hidden, allowing the absolute-positioned search bar to overlay correctly.

BUG 2: Verified cancel button class names match between HTML and CSS — no mismatch found; closePipelineSearch() is correctly wired.

BUG 3: Fixed handlePipelineSearch() to use p.contentPillar instead of p.content_pillar, matching the camelCase field name set by normalise().

BUG 4: Added click-outside listener to close pipeline search when tapping outside the search bar or trigger button.

Non-ASCII: Scanned all JS files — no non-ASCII characters found.

https://claude.ai/code/session_0155ZP3R2P454di157vveamq