### PR TITLE
Remove duplicate pipeline header, move search into real app-header

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -8,7 +8,7 @@ var _pipelineSearchOpen = false;
 
 function openPipelineSearch() {
   _pipelineSearchOpen = true;
-  var hdr = document.getElementById('pipeline-hdr');
+  var hdr = document.querySelector('.app-header');
   var bar = document.getElementById('pipeline-search-bar');
   if (hdr) hdr.classList.add('searching');
   if (bar) bar.classList.add('open');
@@ -20,7 +20,7 @@ function openPipelineSearch() {
 
 function closePipelineSearch() {
   _pipelineSearchOpen = false;
-  var hdr = document.getElementById('pipeline-hdr');
+  var hdr = document.querySelector('.app-header');
   var bar = document.getElementById('pipeline-search-bar');
   var results = document.getElementById('pipeline-search-results');
   var empty = document.getElementById('pipeline-search-empty');

--- a/10-ui.js
+++ b/10-ui.js
@@ -184,6 +184,9 @@ function switchTab(btn) {
   // Update header title
   const titleEl = document.getElementById('app-header-title');
   if (titleEl) titleEl.textContent = (tab === 'tasks') ? _getHeaderDate() : (_TAB_TITLES[tab] || tab);
+  // Show/hide pipeline search trigger based on active tab
+  var searchTrigger = document.getElementById('pipeline-search-trigger');
+  if (searchTrigger) searchTrigger.style.display = (tab === 'pipeline') ? '' : 'none';
   // Close pipeline search when leaving pipeline tab
   if (tab !== 'pipeline' && typeof closePipelineSearch === 'function') closePipelineSearch();
   // Reset task chip filter when leaving tasks tab

--- a/index.html
+++ b/index.html
@@ -104,6 +104,12 @@
   <header class="app-header">
     <span class="app-header-title" id="app-header-title"></span>
     <div class="app-header-right">
+      <!-- Pipeline search trigger (visible only on Pipeline tab) -->
+      <button class="search-icon-btn" id="pipeline-search-trigger" onclick="openPipelineSearch()" style="display:none">
+        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" width="18" height="18">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803 7.5 7.5 0 0016.803 15.803z"/>
+        </svg>
+      </button>
       <!-- Notification bell (internal roles only) -->
       <div class="notif-wrap" id="notif-wrap">
         <button class="app-icon-btn" onclick="toggleNotifPanel()" title="Notifications">
@@ -130,6 +136,24 @@
         </button>
         <div class="user-menu" id="user-menu"></div>
       </div>
+    </div>
+    <!-- Pipeline search overlay (slides over header) -->
+    <div class="pipeline-search-bar" id="pipeline-search-bar">
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" style="width:16px;height:16px;color:var(--muted);flex-shrink:0">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803 7.5 7.5 0 0016.803 15.803z"/>
+      </svg>
+      <input
+        class="pipeline-search-input"
+        id="pipeline-search-input"
+        type="text"
+        placeholder="Search posts..."
+        oninput="handlePipelineSearch(this.value)"
+        autocomplete="off"
+        autocorrect="off"
+        spellcheck="false"
+      />
+      <button class="pipeline-search-cancel" onclick="closePipelineSearch()">Cancel</button>
+      <div class="pipeline-search-underline"></div>
     </div>
   </header>
 
@@ -161,33 +185,6 @@
 
   <!-- TAB: PIPELINE -->
   <div class="tab-panel" id="panel-pipeline">
-    <div class="hdr" id="pipeline-hdr">
-      <div class="hdr-title" id="pipeline-hdr-title">Pipeline</div>
-      <div class="hdr-icons" id="pipeline-hdr-icons">
-        <button class="search-icon-btn" id="pipeline-search-trigger" onclick="openPipelineSearch()">
-          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" width="18" height="18">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803 7.5 7.5 0 0016.803 15.803z"/>
-          </svg>
-        </button>
-      </div>
-      <div class="pipeline-search-bar" id="pipeline-search-bar">
-        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" style="width:16px;height:16px;color:var(--muted);flex-shrink:0">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803 7.5 7.5 0 0016.803 15.803z"/>
-        </svg>
-        <input
-          class="pipeline-search-input"
-          id="pipeline-search-input"
-          type="text"
-          placeholder="Search posts..."
-          oninput="handlePipelineSearch(this.value)"
-          autocomplete="off"
-          autocorrect="off"
-          spellcheck="false"
-        />
-        <button class="pipeline-search-cancel" onclick="closePipelineSearch()">Cancel</button>
-        <div class="pipeline-search-underline"></div>
-      </div>
-    </div>
     <div class="pipeline-search-results" id="pipeline-search-results"></div>
     <div class="pipeline-search-empty" id="pipeline-search-empty">No posts found</div>
     <div class="person-strip" id="person-strip">

--- a/styles.css
+++ b/styles.css
@@ -3805,6 +3805,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   top: 0;
   z-index: 100;
   background: var(--bg);
+  overflow: hidden;
 }
 .app-header-title {
   font-family: var(--mono);
@@ -5485,34 +5486,15 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 }
 .pipeline-search-cancel:hover { color: var(--text2); }
 
-#pipeline-hdr.searching #pipeline-hdr-title {
+.app-header.searching .app-header-title {
   opacity: 0;
   transform: translateX(-20px);
   transition: opacity 0.15s, transform 0.15s;
 }
-#pipeline-hdr.searching #pipeline-hdr-icons {
+.app-header.searching .app-header-right {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.15s;
-}
-.hdr {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 10px 16px 9px;
-  position: relative;
-  overflow: hidden;
-}
-.hdr-title {
-  font-family: var(--mono);
-  font-size: 13px;
-  color: var(--text);
-  font-weight: 500;
-}
-.hdr-icons {
-  display: flex;
-  align-items: center;
-  gap: 4px;
 }
 
 .pipeline-search-results {


### PR DESCRIPTION
FIX 1: Deleted the entire .hdr#pipeline-hdr block from #panel-pipeline (lines 164-190 old). This was a second header row showing "Pipeline" title again with a search icon, duplicating the real .app-header.

FIX 2: Added search trigger button (#pipeline-search-trigger) to .app-header-right, before the bell icon. Hidden by default via style="display:none", shown only when Pipeline tab is active via switchTab() in 10-ui.js.

FIX 3: Moved .pipeline-search-bar overlay into <header class="app-header">
as a direct child. Added overflow:hidden to .app-header CSS. Updated CSS selectors from #pipeline-hdr.searching to .app-header.searching. Updated JS in openPipelineSearch/closePipelineSearch to target .app-header instead of #pipeline-hdr.

FIX 4: pipeline-search-results and pipeline-search-empty are now the first children of #panel-pipeline, immediately before the person-strip.

Removed orphaned .hdr, .hdr-title, .hdr-icons CSS rules (no longer needed). Non-ASCII scan: no non-ASCII characters found in any JS file.

https://claude.ai/code/session_0155ZP3R2P454di157vveamq