### PR TITLE
Fix search result taps destroyed by click-outside handler

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -34,6 +34,13 @@ function closePipelineSearch() {
   if (input) input.value = '';
 }
 
+function openSearchResult(postId) {
+  closePipelineSearch();
+  setTimeout(function() {
+    openPCS(postId);
+  }, 50);
+}
+
 function handlePipelineSearch(query) {
   var results = document.getElementById('pipeline-search-results');
   var empty = document.getElementById('pipeline-search-empty');
@@ -92,7 +99,7 @@ function handlePipelineSearch(query) {
     var badgeLabel = stageDisplayMap[p.stage] || p.stage;
     var badgeClass = 'badge-' + p.stage;
     var pillar = p.contentPillar || '';
-    return '<div class="pipeline-search-result-item" onclick="closePipelineSearch(); openPCS(\'' + p.id + '\')">' +
+    return '<div class="pipeline-search-result-item" onclick="openSearchResult(\'' + p.id + '\')">' +
       '<div class="result-stage-dot" style="background:' + color + '"></div>' +
       '<div class="pipeline-result-body">' +
         '<div class="pipeline-result-title">' + highlighted + '</div>' +
@@ -2483,7 +2490,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!_pipelineSearchOpen) return;
     var bar = document.getElementById('pipeline-search-bar');
     var trigger = document.getElementById('pipeline-search-trigger');
-    if (bar && !bar.contains(e.target) && trigger && !trigger.contains(e.target)) {
+    var resultsEl = document.getElementById('pipeline-search-results');
+    if (bar && !bar.contains(e.target) &&
+        trigger && !trigger.contains(e.target) &&
+        (!resultsEl || !resultsEl.contains(e.target))) {
       closePipelineSearch();
     }
   });


### PR DESCRIPTION
Root cause: The click-outside handler checked if the click was inside #pipeline-search-bar or #pipeline-search-trigger, but the search RESULTS div (#pipeline-search-results) is a sibling element in #panel-pipeline, not inside the search bar. Clicking a result triggered the click-outside handler first, which called closePipelineSearch() and set results.innerHTML = '', destroying the clicked element before its own onclick could fire.

Fixes applied:
1. Added openSearchResult(postId) wrapper that calls closePipelineSearch() then opens openPCS() after a 50ms delay, ensuring clean teardown before opening the post sheet.
2. Changed result item onclick from inline "closePipelineSearch(); openPCS('...')" to "openSearchResult('...')".
3. Updated click-outside handler to also exclude #pipeline-search-results from triggering close.

Non-ASCII scan: no non-ASCII characters in any JS file.

https://claude.ai/code/session_0155ZP3R2P454di157vveamq