### PR TITLE
fix: search results pass post_id instead of UUID to openPCS

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -35,6 +35,7 @@ function closePipelineSearch() {
 }
 
 function openSearchResult(postId) {
+  console.log('openSearchResult fired with:', postId);
   closePipelineSearch();
   setTimeout(function() {
     openPCS(postId);
@@ -99,7 +100,7 @@ function handlePipelineSearch(query) {
     var badgeLabel = stageDisplayMap[p.stage] || p.stage;
     var badgeClass = 'badge-' + p.stage;
     var pillar = p.contentPillar || '';
-    return '<div class="pipeline-search-result-item" onclick="openSearchResult(\'' + p.id + '\')">' +
+    return '<div class="pipeline-search-result-item" onclick="openSearchResult(\'' + (p.post_id || p.id) + '\')">' +
       '<div class="result-stage-dot" style="background:' + color + '"></div>' +
       '<div class="pipeline-result-body">' +
         '<div class="pipeline-result-title">' + highlighted + '</div>' +


### PR DESCRIPTION
- handlePipelineSearch now passes (p.post_id || p.id) matching getPostId()
- Added console.log to openSearchResult for debugging
- Notification onclick already correctly passes n.post_id — no change needed

https://claude.ai/code/session_014uhP2wcTW3LikyHYFoJyst