### PR TITLE
fix: pipeline search results use position:fixed to avoid overflow cli…

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5510,7 +5510,17 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 .pipeline-search-results {
   display: none;
   flex-direction: column;
+  position: fixed;
+  top: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 480px;
+  z-index: 100;
+  background: var(--bg);
   border-bottom: 1px dotted var(--dotline);
+  max-height: 60vh;
+  overflow-y: auto;
 }
 .pipeline-search-results.visible { display: flex; }
 
@@ -5579,6 +5589,14 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   color: var(--muted);
   text-transform: uppercase;
   text-align: center;
+  position: fixed;
+  top: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 480px;
+  z-index: 100;
+  background: var(--bg);
   border-bottom: 1px dotted var(--dotline);
 }
 .pipeline-search-empty.visible { display: block; }


### PR DESCRIPTION
…pping

Search results and empty state were position:absolute inside #panel-pipeline which has overflow:hidden, causing results to be clipped after renderPipeline() changed layout height on second use. Changed to position:fixed so they float above the layout independently.

https://claude.ai/code/session_014uhP2wcTW3LikyHYFoJyst