### PR TITLE
feat: send notification after batch stage update

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -1898,6 +1898,21 @@ async function executeBatchAction(targetStage) {
       }),
     });
 
+    var notifActor = resolveActor() || 'Chitra';
+    var count = ids.length;
+    var stageLabel = targetStage === 'awaiting_approval'
+      ? 'for approval' : 'for brand input';
+
+    await apiFetch('/notifications', {
+      method: 'POST',
+      body: JSON.stringify({
+        user_role: 'Admin',
+        post_id: null,
+        type: targetStage,
+        message: notifActor + ' sent ' + count + ' posts ' + stageLabel
+      })
+    });
+
     toggleBatchMode();
     loadPosts();
 


### PR DESCRIPTION
After a successful batch action in executeBatchAction(), post a notification to the Admin role summarizing how many posts were sent for approval or brand input.

https://claude.ai/code/session_01GGnxv85McxMafG8QrFeChv