### PR TITLE
Fix actor resolution and streak calculation for correct display names

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -1427,6 +1427,14 @@ async function _updateStreakLines() {
     );
     if (!Array.isArray(logs)) return;
 
+    logs = logs.map(function(l) {
+      var a = l.actor || '';
+      if (a === 'system' || a === 'Admin' || a.indexOf('@') > -1) {
+        l.actor = 'Shubham';
+      }
+      return l;
+    });
+
     function getStreak(actor) {
       var days = {};
       logs.filter(function(l) {
@@ -1482,15 +1490,22 @@ async function _updateStreakLines() {
 
     var cEl = document.getElementById('metric-chitra-streak');
     if (cEl) {
-      var cStreak = getStreak('Chitra');
-      var cIdle = getIdleDays('Chitra');
-      if (cIdle >= 2) {
-        var cLast = getLastActive('Chitra');
-        cEl.innerHTML = '<span class="dms-idle">\u00b7 idle ' + cIdle + ' days \u00b7 last active ' + cLast + '</span>';
-      } else if (cStreak >= 3) {
-        cEl.innerHTML = '<span class="dms-on">\u00b7 ' + String(cStreak).padStart(2, '0') + ' day streak</span>';
-      } else {
+      var chitraRaw = logs.filter(function(l) {
+        return l.actor === 'Chitra';
+      });
+      if (chitraRaw.length === 0) {
         cEl.innerHTML = '';
+      } else {
+        var cStreak = getStreak('Chitra');
+        var cIdle = getIdleDays('Chitra');
+        if (cIdle >= 2) {
+          var cLast = getLastActive('Chitra');
+          cEl.innerHTML = '<span class="dms-idle">. idle ' + cIdle + ' days . last active ' + cLast + '</span>';
+        } else if (cStreak >= 3) {
+          cEl.innerHTML = '<span class="dms-on">. ' + String(cStreak).padStart(2, '0') + ' day streak</span>';
+        } else {
+          cEl.innerHTML = '';
+        }
       }
     }
 
@@ -1537,6 +1552,14 @@ async function _getYesterdaysWin() {
       '&order=created_at.desc'
     );
     if (!Array.isArray(logs) || !logs.length) return '';
+
+    logs = logs.map(function(l) {
+      var a = l.actor || '';
+      if (a === 'system' || a === 'Admin' || a.indexOf('@') > -1) {
+        l.actor = 'Shubham';
+      }
+      return l;
+    });
 
     var pranavBuilt = logs.filter(function(l) {
       return l.actor === 'Pranav' && l.new_stage === 'ready';

--- a/utils.js
+++ b/utils.js
@@ -100,11 +100,12 @@ function formatIST(ts) {
   });
 }
 
-// Resolve actor name for write paths  -  URL-path based, strict allowlist
+// Resolve actor name for write paths  -  always returns display name
 function resolveActor() {
-  const path = window.location.pathname.toLowerCase();
-  if (path.includes('client')) return 'Client';
-  if (path.includes('chitra') || path.includes('ops')) return 'Chitra';
-  if (path.includes('admin')) return 'Chitra';
-  return 'Pranav';
+  var role = (typeof effectiveRole !== 'undefined') ? effectiveRole : '';
+  if (role === 'Admin') return 'Shubham';
+  if (role === 'Servicing') return 'Chitra';
+  if (role === 'Creative') return 'Pranav';
+  if (role === 'Client') return 'Client';
+  return 'Shubham';
 }


### PR DESCRIPTION
- resolveActor() now uses effectiveRole to return proper display names (Admin->Shubham, Servicing->Chitra, Creative->Pranav, Client->Client)
- Normalize actor names in _updateStreakLines() and _getYesterdaysWin() mapping 'system', 'Admin', and email addresses to 'Shubham'
- Guard Chitra streak: show nothing when no Chitra logs exist (new user)

https://claude.ai/code/session_01LPtQJhNnvkir6gSzQ55Cdq