### PR TITLE
Redesign New Post modal as sheet with new CSS, HTML, and JS wiring

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -14,14 +14,15 @@ _draftDebounce = setTimeout(saveDraft, 800);
 
 function saveDraft() {
 const draft = {
-title:    document.getElementById('npm-title')?.value    || '',
-pillar:   document.getElementById('npm-pillar')?.value   || '',
-location: document.getElementById('npm-location')?.value || '',
-owner:    document.getElementById('npm-owner')?.value    || '',
-stage:    document.getElementById('npm-stage')?.value    || '',
-date:     document.getElementById('npm-date')?.value     || '',
-comments: document.getElementById('npm-comments')?.value || '',
-postLink: document.getElementById('npm-postlink')?.value || '',
+title:    document.getElementById('new-post-title')?.value    || '',
+pillar:   document.getElementById('new-post-pillar')?.value   || '',
+location: document.getElementById('new-post-location')?.value || '',
+owner:    document.getElementById('new-post-owner')?.value    || '',
+stage:    document.getElementById('new-post-stage')?.value    || '',
+date:     document.getElementById('new-post-date')?.value     || '',
+comments: document.getElementById('new-post-comments')?.value || '',
+postLink: document.getElementById('new-post-link')?.value     || '',
+format:   document.getElementById('new-post-format')?.value   || '',
 savedAt:  Date.now(),
 };
 
@@ -45,17 +46,20 @@ return false;
 
 if (!d.title && !d.comments) return false;
 
-const _npm = id => document.getElementById(id);
-if (_npm('npm-title'))    _npm('npm-title').value    = d.title    || '';
-if (_npm('npm-pillar'))   _npm('npm-pillar').value   = d.pillar   || '';
-if (_npm('npm-location')) _npm('npm-location').value = d.location || '';
-if (_npm('npm-owner'))    _npm('npm-owner').value    = d.owner    || '';
-if (_npm('npm-stage'))    _npm('npm-stage').value    = d.stage    || 'in_production';
-if (_npm('npm-date'))     _npm('npm-date').value     = d.date     || '';
-if (_npm('npm-comments')) _npm('npm-comments').value = d.comments || '';
-if (_npm('npm-postlink')) _npm('npm-postlink').value = d.postLink || '';
+const _el = id => document.getElementById(id);
+if (_el('new-post-title'))    _el('new-post-title').value    = d.title    || '';
+if (_el('new-post-pillar'))   _el('new-post-pillar').value   = d.pillar   || '';
+if (_el('new-post-location')) _el('new-post-location').value = d.location || '';
+if (_el('new-post-owner'))    _el('new-post-owner').value    = d.owner    || '';
+if (_el('new-post-stage'))    _el('new-post-stage').value    = d.stage    || 'in_production';
+if (_el('new-post-date'))     _el('new-post-date').value     = d.date     || '';
+if (_el('new-post-comments')) _el('new-post-comments').value = d.comments || '';
+if (_el('new-post-link'))     _el('new-post-link').value     = d.postLink || '';
+if (_el('new-post-format'))   _el('new-post-format').value   = d.format   || '';
 
 showDraftStatus('Draft restored');
+_npsOwnerChange();
+_npsCheckValid();
 return true;
 
 } catch (_) {
@@ -86,60 +90,91 @@ function stopDraftAutosave() {
 clearInterval(_draftTimer);
 }
 
-function _populateNewPostDropdowns() {
-
-const stageEl = document.getElementById('npm-stage');
-
-if (stageEl && typeof STAGES_DB !== 'undefined') {
-stageEl.innerHTML = STAGES_DB
-.filter(s => s !== 'parked')
-.map(s => `<option value="${s}">${STAGE_DISPLAY[s]}</option>`)
-.join('');
+function _npsOwnerChange() {
+var val = document.getElementById('new-post-owner').value;
+var strip = document.getElementById('nps-color-strip');
+if (!strip) return;
+strip.className = 'nps-color-strip';
+if (val === 'Pranav') strip.classList.add('owner-pranav');
+if (val === 'Chitra') strip.classList.add('owner-chitra');
+if (val === 'Client') strip.classList.add('owner-client');
+_npsCheckValid();
 }
 
-const pillarEl = document.getElementById('npm-pillar');
-
-if (pillarEl && typeof PILLARS_DB !== 'undefined') {
-pillarEl.innerHTML =
-'<option value="">Select pillar</option>' +
-PILLARS_DB
-.map(p => `<option value="${p}">${formatPillarDisplay(p)}</option>`)
-.join('');
+function _npsCheckValid() {
+var t = (document.getElementById('new-post-title')
+  .value || '').trim();
+var o = document.getElementById('new-post-owner').value;
+var btn = document.getElementById('nps-create-btn');
+if (btn) btn.disabled = !(t && o);
 }
+
+function _npsWireEvents() {
+var ownerEl = document.getElementById('new-post-owner');
+if (ownerEl) ownerEl.onchange = function() { _npsOwnerChange(); saveDraftDebounced(); };
+
+var titleEl = document.getElementById('new-post-title');
+if (titleEl) titleEl.oninput = function() { _npsCheckValid(); saveDraftDebounced(); };
+
+var cancelBtn = document.getElementById('nps-cancel-btn');
+if (cancelBtn) cancelBtn.onclick = function() { closeNewPostModal(); };
+
+var closeBtn = document.getElementById('nps-close-btn');
+if (closeBtn) closeBtn.onclick = function() { closeNewPostModal(); };
+
+var createBtn = document.getElementById('nps-create-btn');
+if (createBtn) createBtn.onclick = function() { submitNewPost(); };
+
+// Wire saveDraftDebounced to remaining fields
+['new-post-stage','new-post-pillar','new-post-format','new-post-location','new-post-date'].forEach(function(id) {
+  var el = document.getElementById(id);
+  if (el) el.onchange = saveDraftDebounced;
+});
+['new-post-link','new-post-comments'].forEach(function(id) {
+  var el = document.getElementById(id);
+  if (el) el.oninput = saveDraftDebounced;
+});
 }
 
 function openNewPostModal() {
-
-_populateNewPostDropdowns();
 
 const hasDraft = loadDraft();
 
 if (!hasDraft) {
 
-['npm-title','npm-comments','npm-postlink'].forEach(id => {
+['new-post-title','new-post-comments','new-post-link'].forEach(id => {
 const el = document.getElementById(id);
 if (el) el.value = '';
 });
 
 const _np = id => document.getElementById(id);
-if (_np('npm-pillar'))   _np('npm-pillar').value   = '';
-if (_np('npm-location')) _np('npm-location').value = '';
-if (_np('npm-owner'))    _np('npm-owner').value    = '';
-if (_np('npm-stage'))    _np('npm-stage').value    = 'in_production';
-if (_np('npm-date'))     _np('npm-date').value     = '';
+if (_np('new-post-pillar'))   _np('new-post-pillar').value   = '';
+if (_np('new-post-location')) _np('new-post-location').value = '';
+if (_np('new-post-owner'))    _np('new-post-owner').value    = '';
+if (_np('new-post-stage'))    _np('new-post-stage').value    = 'in_production';
+if (_np('new-post-date'))     _np('new-post-date').value     = '';
+if (_np('new-post-format'))   _np('new-post-format').value   = '';
 }
 
-const npmSubmit = document.getElementById('npm-submit-btn');
-if (npmSubmit) npmSubmit.disabled = false;
-document.getElementById('npm-saving')?.classList.remove('active');
+var strip = document.getElementById('nps-color-strip');
+if (strip) strip.className = 'nps-color-strip';
+
+var today = new Date().toISOString().split('T')[0];
+var dateEl = document.getElementById('new-post-date');
+if (dateEl && !dateEl.value) dateEl.value = today;
+
+var createBtn = document.getElementById('nps-create-btn');
+if (createBtn) createBtn.disabled = true;
 
 window._modalOpen = true;
 document.getElementById('new-post-overlay')?.classList.add('open');
 document.body.style.overflow = 'hidden';
 
+_npsWireEvents();
+_npsCheckValid();
 startDraftAutosave();
 
-setTimeout(() => document.getElementById('npm-title')?.focus(), 60);
+setTimeout(() => document.getElementById('new-post-title')?.focus(), 60);
 }
 
 function closeNewPostModal(e) {
@@ -159,34 +194,32 @@ async function submitNewPost() {
 console.log('[submitNewPost] SAVE CLICKED');
 
 const _s = id => document.getElementById(id);
-const title    = (_s('npm-title')?.value || '').trim();
-const owner    = _s('npm-owner')?.value || '';
-const pillar   = _s('npm-pillar')?.value || '';
-const location = _s('npm-location')?.value || '';
-const stage    = _s('npm-stage')?.value || '';
-const date     = _s('npm-date')?.value || '';
-const comments = (_s('npm-comments')?.value || '').trim();
-const postLink = (_s('npm-postlink')?.value || '').trim();
+const title    = (_s('new-post-title')?.value || '').trim();
+const owner    = _s('new-post-owner')?.value || '';
+const pillar   = _s('new-post-pillar')?.value || '';
+const location = _s('new-post-location')?.value || '';
+const stage    = _s('new-post-stage')?.value || '';
+const date     = _s('new-post-date')?.value || '';
+const comments = (_s('new-post-comments')?.value || '').trim();
+const postLink = (_s('new-post-link')?.value || '').trim();
 
 if (!title) {
 console.warn('[submitNewPost] BLOCKED: title empty');
 showToast('Post title is required', 'error');
-_s('npm-title')?.focus();
+_s('new-post-title')?.focus();
 return;
 }
 
 if (!owner) {
 console.warn('[submitNewPost] BLOCKED: owner empty');
 showToast('Owner is required', 'error');
-_s('npm-owner')?.focus();
+_s('new-post-owner')?.focus();
 return;
 }
 
-const submitBtn = _s('npm-submit-btn');
-const savingMsg = _s('npm-saving');
+const createBtn = _s('nps-create-btn');
 
-if (submitBtn) submitBtn.disabled = true;
-if (savingMsg) savingMsg.classList.add('active');
+if (createBtn) createBtn.disabled = true;
 
 const payload = {
 post_id: 'POST-' + Date.now(),
@@ -241,7 +274,6 @@ saveDraft();
 
 showToast('Failed to create - draft saved', 'error');
 
-if (submitBtn) submitBtn.disabled = false;
-if (savingMsg) savingMsg.classList.remove('active');
+if (createBtn) createBtn.disabled = false;
 }
 }

--- a/index.html
+++ b/index.html
@@ -539,90 +539,115 @@
      NEW POST MODAL
 ══════════════════════════════════════════ -->
 <div class="modal-overlay" id="new-post-overlay" onclick="closeNewPostModal(event)">
-  <div class="modal-card">
-    <div class="modal-handle"></div>
-    <div class="modal-header">
-      <div class="modal-title">New Post</div>
-      <button class="modal-close" onclick="closeNewPostModal()">✕</button>
+  <div class="new-post-sheet" id="new-post-sheet">
+    <div class="nps-handle"></div>
+    <div class="nps-color-strip" id="nps-color-strip"></div>
+
+    <div class="nps-hdr">
+      <div class="nps-title">New Post</div>
+      <button class="nps-close" id="nps-close-btn">&#x2715;</button>
     </div>
 
-    <div class="form-field">
-      <label class="form-label-sm">Post Title <span style="color:var(--c-red)">*</span></label>
-      <input type="text" id="npm-title" placeholder="What's this post about?" oninput="saveDraftDebounced()">
+    <div class="nps-body">
+
+      <div class="nps-title-field">
+        <div class="nps-field-label">
+          Post Title <span class="nps-req">*</span>
+        </div>
+        <input class="nps-title-input" type="text"
+          id="new-post-title"
+          placeholder="What's this post about?">
+      </div>
+
+      <div class="nps-grid">
+
+        <div class="nps-cell">
+          <div class="nps-field-label">
+            Owner <span class="nps-req">*</span>
+          </div>
+          <select class="nps-select" id="new-post-owner">
+            <option value="">Assign to...</option>
+            <option value="Pranav">Pranav</option>
+            <option value="Chitra">Chitra</option>
+            <option value="Client">Client</option>
+          </select>
+        </div>
+
+        <div class="nps-cell">
+          <div class="nps-field-label">Stage</div>
+          <select class="nps-select" id="new-post-stage">
+            <option value="in_production">In Production</option>
+            <option value="ready">Ready</option>
+            <option value="awaiting_approval">Awaiting Approval</option>
+            <option value="awaiting_brand_input">Awaiting Input</option>
+            <option value="scheduled">Scheduled</option>
+            <option value="parked">Parked</option>
+          </select>
+        </div>
+
+        <div class="nps-cell">
+          <div class="nps-field-label">Pillar</div>
+          <select class="nps-select" id="new-post-pillar">
+            <option value="">Select...</option>
+            <option value="Lead">Leadership</option>
+            <option value="Innov">Innovation</option>
+            <option value="Sustain">Sustainability</option>
+            <option value="Incl">Inclusivity</option>
+            <option value="Events">Events</option>
+            <option value="Announce">Announcements</option>
+            <option value="Growth">Growth</option>
+          </select>
+        </div>
+
+        <div class="nps-cell">
+          <div class="nps-field-label">Format</div>
+          <select class="nps-select" id="new-post-format">
+            <option value="">Select...</option>
+            <option value="Creative">Creative</option>
+            <option value="Photo">Photo</option>
+            <option value="Carousel">Carousel</option>
+            <option value="Video">Video</option>
+            <option value="Text">Text</option>
+          </select>
+        </div>
+
+        <div class="nps-cell">
+          <div class="nps-field-label">Location</div>
+          <select class="nps-select" id="new-post-location">
+            <option value="">Select...</option>
+            <option value="Mumbai">Mumbai</option>
+            <option value="Sakarwadi">Sakarwadi</option>
+            <option value="Sameerwadi">Sameerwadi</option>
+            <option value="Other">Other</option>
+          </select>
+        </div>
+
+        <div class="nps-cell">
+          <div class="nps-field-label">Target Date</div>
+          <input class="nps-date" type="date" id="new-post-date">
+        </div>
+
+      </div>
+
+      <div class="nps-full">
+        <div class="nps-field-label">Link</div>
+        <input class="nps-text" type="url" id="new-post-link"
+          placeholder="Canva &#xb7; LinkedIn &#xb7; Google Drive">
+      </div>
+
+      <div class="nps-full">
+        <div class="nps-field-label">Brief / Comments</div>
+        <textarea class="nps-textarea" id="new-post-comments"
+          placeholder="Brief, caption, or notes..."></textarea>
+      </div>
+
     </div>
 
-    <div class="form-row">
-      <div class="form-field">
-        <label class="form-label-sm">Content Pillar</label>
-       <select id="npm-pillar">
-<option value="">Select pillar</option>
-<option value="leadership">Leadership</option>
-<option value="innovation">Innovation</option>
-<option value="sustainability">Sustainability</option>
-<option value="inclusivity">Inclusivity</option>
-<option value="events">Events</option>
-<option value="announcements">Announcements</option>
-<option value="growth">Growth</option>
-</select>
-      </div>
-      <div class="form-field">
-        <label class="form-label-sm">Location</label>
-        <select id="npm-location" onchange="saveDraftDebounced()">
-          <option value="">Select location</option>
-          <option>Mumbai</option>
-          <option>Sakarwadi</option>
-          <option>Sameerwadi</option>
-          <option>Other</option>
-        </select>
-      </div>
-    </div>
-
-    <div class="form-row">
-      <div class="form-field">
-        <label class="form-label-sm">Owner <span style="color:var(--c-red)">*</span></label>
-        <select id="npm-owner" onchange="saveDraftDebounced()">
-          <option value="">Assign to…</option>
-          <option>Chitra</option>
-          <option>Pranav</option>
-        </select>
-      </div>
-      <div class="form-field">
-        <label class="form-label-sm">Stage</label>
-        <select id="npm-stage" onchange="saveDraftDebounced()">
-          <option value="in production">In Production</option>
-          <option value="awaiting brand input">Awaiting Brand Input</option>
-          <option value="rejected">Rejected</option>
-          <option value="ready">Ready</option>
-          <option value="awaiting approval">Awaiting Approval</option>
-          <option value="scheduled">Scheduled</option>
-          <option value="published">Published</option>
-        </select>
-      </div>
-    </div>
-
-    <div class="form-row">
-      <div class="form-field">
-        <label class="form-label-sm">Target Date</label>
-        <input type="date" id="npm-date" onchange="saveDraftDebounced()">
-      </div>
-      <div class="form-field">
-        <label class="form-label-sm">Link</label>
-        <input type="url" id="npm-postlink" placeholder="Canva / LinkedIn / Google Drive" oninput="saveDraftDebounced()">
-      </div>
-    </div>
-
-    <div class="form-field">
-      <label class="form-label-sm">Brief / Comments</label>
-      <textarea id="npm-comments" rows="3" placeholder="Brief, caption, or notes…" oninput="saveDraftDebounced()"></textarea>
-    </div>
-
-    <div class="modal-footer">
-      <div>
-        <span class="saving-msg" id="npm-saving">Saving…</span>
-        <span class="draft-status" id="npm-draft-status"></span>
-      </div>
-      <button class="btn-modal-ghost" onclick="closeNewPostModal()">Cancel</button>
-      <button class="btn-modal-primary" id="npm-submit-btn" onclick="submitNewPost()">Create Post</button>
+    <div class="nps-footer">
+      <button class="nps-btn-cancel" id="nps-cancel-btn">Cancel</button>
+      <button class="nps-btn-create" id="nps-create-btn" disabled>
+        &#x2192; Create Post
+      </button>
     </div>
   </div>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -6167,3 +6167,160 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   color: var(--green);
   padding: 8px 0;
 }
+
+/* ── New Post Sheet ── */
+.new-post-sheet {
+  width: 100%;
+  max-width: 480px;
+  background: var(--surface);
+  border-top: 1px dotted var(--dotline);
+  max-height: 92vh;
+  display: flex;
+  flex-direction: column;
+}
+.nps-handle {
+  width: 36px; height: 3px;
+  background: var(--muted2); border-radius: 2px;
+  margin: 10px auto 0; flex-shrink: 0;
+}
+.nps-color-strip {
+  height: 2px; background: transparent;
+  transition: background 0.25s; flex-shrink: 0;
+}
+.nps-color-strip.owner-pranav { background: var(--amber); }
+.nps-color-strip.owner-chitra { background: var(--green); }
+.nps-color-strip.owner-client { background: var(--red); }
+
+.nps-hdr {
+  display: flex; justify-content: space-between;
+  align-items: center; padding: 14px 18px 12px;
+  border-bottom: 1px dotted var(--dotline); flex-shrink: 0;
+}
+.nps-title {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--text2);
+}
+.nps-close {
+  width: 28px; height: 28px;
+  border: 1px dotted var(--dotline);
+  background: transparent; color: var(--muted);
+  font-size: 13px; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--mono); transition: color 0.15s;
+}
+.nps-close:hover { color: var(--text); }
+
+.nps-body { flex: 1; overflow-y: auto; scrollbar-width: none; }
+.nps-body::-webkit-scrollbar { display: none; }
+
+.nps-title-field {
+  padding: 16px 18px 14px;
+  border-bottom: 1px dotted var(--dotline);
+}
+.nps-field-label {
+  font-family: var(--mono); font-size: 8px;
+  letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 8px;
+  display: flex; align-items: center; gap: 4px;
+}
+.nps-req { color: var(--red); }
+.nps-title-input {
+  display: block; width: 100%;
+  background: transparent; border: none;
+  color: var(--text); font-family: var(--sans);
+  font-size: 20px; font-weight: 600;
+  letter-spacing: -0.3px; outline: none;
+  padding: 0; margin: 0;
+  caret-color: var(--gold);
+}
+.nps-title-input::placeholder {
+  color: var(--muted); font-weight: 400; font-size: 18px;
+}
+
+.nps-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+}
+.nps-cell {
+  padding: 12px 18px 10px;
+  border-bottom: 1px dotted var(--dotline);
+  border-right: 1px dotted var(--dotline);
+  min-height: 62px;
+  display: flex; flex-direction: column;
+  justify-content: flex-start;
+}
+.nps-cell:nth-child(2n) { border-right: none; }
+
+.nps-select,
+.nps-date {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  width: 100%;
+  margin: 4px 0 0 0;
+  padding: 0;
+  font-family: var(--sans);
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.3;
+  color: var(--text2);
+  background: transparent;
+  border: none;
+  outline: none;
+  text-align: left;
+  text-align-last: left;
+  -webkit-text-align: left;
+  cursor: pointer;
+  box-sizing: border-box;
+  min-height: 0; height: auto;
+}
+.nps-select:focus, .nps-date:focus { color: var(--text); }
+.nps-date { color-scheme: dark; }
+
+.nps-full {
+  padding: 12px 18px 10px;
+  border-bottom: 1px dotted var(--dotline);
+}
+.nps-full:last-child { border-bottom: none; }
+.nps-text, .nps-textarea {
+  display: block; width: 100%;
+  background: transparent; border: none;
+  color: var(--text2); font-family: var(--sans);
+  font-size: 14px; outline: none;
+  padding: 0; margin: 4px 0 0 0;
+  caret-color: var(--gold);
+}
+.nps-textarea {
+  resize: none; min-height: 68px; line-height: 1.55;
+}
+.nps-text::placeholder,
+.nps-textarea::placeholder { color: var(--muted); }
+.nps-text:focus,
+.nps-textarea:focus { color: var(--text); }
+
+.nps-footer {
+  display: flex; border-top: 1px dotted var(--dotline);
+  flex-shrink: 0;
+}
+.nps-btn-cancel {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--muted); border: none;
+  border-right: 1px dotted var(--dotline);
+  background: transparent; padding: 16px 20px;
+  cursor: pointer; transition: color 0.15s; flex-shrink: 0;
+}
+.nps-btn-cancel:hover { color: var(--text2); }
+.nps-btn-create {
+  flex: 1; font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  background: transparent; border: none;
+  padding: 16px; cursor: pointer; transition: all 0.15s;
+  display: flex; align-items: center;
+  justify-content: center; gap: 8px;
+  color: var(--muted);
+}
+.nps-btn-create:not(:disabled) { color: var(--gold); }
+.nps-btn-create:not(:disabled):hover { background: var(--gold-bg); }
+.nps-btn-create:disabled { cursor: not-allowed; }


### PR DESCRIPTION
- Added .new-post-sheet CSS component with grid layout, color strip, and footer buttons
- Replaced modal-card inner HTML with new sheet structure
- Updated all field IDs from npm-* to new-post-* / nps-*
- Added _npsOwnerChange() color strip and _npsCheckValid() validation
- Wired events via _npsWireEvents() called on modal open
- Added Format field, Client owner option, and default date on open
- Supabase insert reads from new IDs correctly
- No non-ASCII in JS files

https://claude.ai/code/session_018TVcnhZwoSKYsbPJY7Ef5k