### PR TITLE
Add NPS CSS rules and switch new-post overlay to sheet layout

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -167,7 +167,8 @@ var createBtn = document.getElementById('nps-create-btn');
 if (createBtn) createBtn.disabled = true;
 
 window._modalOpen = true;
-document.getElementById('new-post-overlay')?.classList.add('open');
+var _npoEl = document.getElementById('new-post-overlay');
+if (_npoEl) _npoEl.style.display = 'flex';
 document.body.style.overflow = 'hidden';
 
 _npsWireEvents();
@@ -184,7 +185,8 @@ if (e && e.target !== document.getElementById('new-post-overlay')) return;
 saveDraft();
 stopDraftAutosave();
 
-document.getElementById('new-post-overlay')?.classList.remove('open');
+var _npoClose = document.getElementById('new-post-overlay');
+if (_npoClose) _npoClose.style.display = 'none';
 document.body.style.overflow = '';
 window._modalOpen = false;
 _drainDeferredRender();
@@ -258,7 +260,8 @@ console.log('[submitNewPost] API SUCCESS');
 clearDraft();
 stopDraftAutosave();
 
-document.getElementById('new-post-overlay')?.classList.remove('open');
+var _npoClose2 = document.getElementById('new-post-overlay');
+if (_npoClose2) _npoClose2.style.display = 'none';
 document.body.style.overflow = '';
 window._modalOpen = false;
 

--- a/styles.css
+++ b/styles.css
@@ -6285,3 +6285,186 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 .nrs-btn-send:not(:disabled) { color:var(--red); }
 .nrs-btn-send:not(:disabled):hover { background:rgba(255,75,75,0.06); }
 .nrs-btn-send:disabled { cursor:not-allowed; }
+
+/* -- New Post Sheet (NPS) ---------------------- */
+.new-post-sheet {
+  width:100%; max-width:480px; background:var(--surface);
+  border-top:1px dotted var(--dotline);
+  max-height:92vh; display:flex; flex-direction:column;
+}
+.nps-handle {
+  width:36px; height:3px; background:var(--muted2);
+  border-radius:2px; margin:10px auto 0; flex-shrink:0;
+}
+.nps-color-strip {
+  height:2px; background:transparent;
+  transition:background 0.25s; flex-shrink:0;
+}
+.nps-color-strip.owner-pranav { background:var(--amber); }
+.nps-color-strip.owner-chitra { background:var(--green); }
+.nps-color-strip.owner-client { background:var(--red); }
+.nps-hdr {
+  display:flex; justify-content:space-between;
+  align-items:center; padding:14px 18px 12px;
+  border-bottom:1px dotted var(--dotline); flex-shrink:0;
+}
+.nps-title {
+  font-family:var(--mono); font-size:11px;
+  letter-spacing:0.22em; text-transform:uppercase;
+  color:var(--text2);
+}
+.nps-close {
+  width:28px; height:28px; border:1px dotted var(--dotline);
+  background:transparent; color:var(--muted); font-size:13px;
+  cursor:pointer; display:flex; align-items:center;
+  justify-content:center; font-family:var(--mono);
+  transition:color 0.15s; border-radius:0;
+}
+.nps-close:hover { color:var(--text); }
+.nps-body { flex:1; overflow-y:auto; scrollbar-width:none; }
+.nps-body::-webkit-scrollbar { display:none; }
+.nps-title-field {
+  padding:16px 18px 14px;
+  border-bottom:1px dotted var(--dotline);
+}
+.nps-field-label {
+  font-family:var(--mono); font-size:8px;
+  letter-spacing:0.22em; text-transform:uppercase;
+  color:var(--muted); margin-bottom:8px;
+  display:flex; align-items:center; gap:4px;
+}
+.nps-req { color:var(--red); }
+.nps-title-input {
+  display:block; width:100%; background:transparent;
+  border:none; border-radius:0;
+  color:var(--text); font-family:var(--sans);
+  font-size:20px; font-weight:600; letter-spacing:-0.3px;
+  outline:none; padding:0; margin:0;
+  caret-color:var(--gold);
+  box-shadow:none;
+}
+.nps-title-input::placeholder {
+  color:var(--muted); font-weight:400; font-size:18px;
+}
+.nps-grid { display:grid; grid-template-columns:1fr 1fr; }
+.nps-cell {
+  padding:12px 18px 10px;
+  border-bottom:1px dotted var(--dotline);
+  border-right:1px dotted var(--dotline);
+  min-height:62px; display:flex;
+  flex-direction:column; justify-content:flex-start;
+}
+.nps-cell:nth-child(2n) { border-right:none; }
+.nps-select {
+  -webkit-appearance:none !important;
+  -moz-appearance:none !important;
+  appearance:none !important;
+  display:block !important;
+  width:100% !important;
+  margin:4px 0 0 0 !important;
+  padding:0 !important;
+  font-family:var(--sans) !important;
+  font-size:15px !important;
+  font-weight:500 !important;
+  line-height:1.3 !important;
+  color:var(--text2) !important;
+  background:transparent !important;
+  background-image:none !important;
+  border:none !important;
+  border-radius:0 !important;
+  outline:none !important;
+  text-align:left !important;
+  text-align-last:left !important;
+  cursor:pointer !important;
+  box-sizing:border-box !important;
+  min-height:0 !important;
+  height:auto !important;
+  box-shadow:none !important;
+}
+.nps-select:focus { color:var(--text) !important; }
+.nps-date {
+  -webkit-appearance:none !important;
+  appearance:none !important;
+  display:block !important;
+  width:100% !important;
+  margin:4px 0 0 0 !important;
+  padding:0 !important;
+  font-family:var(--sans) !important;
+  font-size:15px !important;
+  font-weight:500 !important;
+  line-height:1.3 !important;
+  color:var(--text2) !important;
+  background:transparent !important;
+  background-image:none !important;
+  border:none !important;
+  border-radius:0 !important;
+  outline:none !important;
+  text-align:left !important;
+  text-align-last:left !important;
+  cursor:pointer !important;
+  box-sizing:border-box !important;
+  min-height:0 !important;
+  height:auto !important;
+  color-scheme:dark;
+  box-shadow:none !important;
+}
+.nps-date:focus { color:var(--text) !important; }
+.nps-full {
+  padding:12px 18px 10px;
+  border-bottom:1px dotted var(--dotline);
+}
+.nps-full:last-child { border-bottom:none; }
+.nps-text {
+  display:block !important; width:100% !important;
+  background:transparent !important;
+  border:none !important; border-radius:0 !important;
+  color:var(--text2) !important;
+  font-family:var(--sans) !important;
+  font-size:14px !important; outline:none !important;
+  padding:0 !important; margin:4px 0 0 0 !important;
+  caret-color:var(--gold); box-shadow:none !important;
+}
+.nps-textarea {
+  display:block !important; width:100% !important;
+  background:transparent !important;
+  border:none !important; border-radius:0 !important;
+  color:var(--text2) !important;
+  font-family:var(--sans) !important;
+  font-size:14px !important; outline:none !important;
+  padding:0 !important; margin:4px 0 0 0 !important;
+  resize:none !important; min-height:68px !important;
+  line-height:1.55 !important;
+  caret-color:var(--gold); box-shadow:none !important;
+}
+.nps-text::placeholder, .nps-textarea::placeholder {
+  color:var(--muted) !important;
+}
+.nps-text:focus, .nps-textarea:focus {
+  color:var(--text) !important;
+}
+.nps-footer {
+  display:flex; border-top:1px dotted var(--dotline);
+  flex-shrink:0;
+}
+.nps-btn-cancel {
+  font-family:var(--mono); font-size:10px;
+  letter-spacing:0.14em; text-transform:uppercase;
+  color:var(--muted); border:none;
+  border-right:1px dotted var(--dotline);
+  background:transparent; padding:16px 20px;
+  cursor:pointer; transition:color 0.15s;
+  flex-shrink:0; border-radius:0;
+}
+.nps-btn-cancel:hover { color:var(--text2); }
+.nps-btn-create {
+  flex:1; font-family:var(--mono); font-size:10px;
+  letter-spacing:0.16em; text-transform:uppercase;
+  background:transparent; border:none; padding:16px;
+  cursor:pointer; transition:all 0.15s;
+  display:flex; align-items:center;
+  justify-content:center; gap:8px;
+  color:var(--muted); border-radius:0;
+}
+.nps-btn-create:not(:disabled) { color:var(--gold); }
+.nps-btn-create:not(:disabled):hover { background:var(--gold-bg); }
+.nps-btn-create:disabled { cursor:not-allowed; }


### PR DESCRIPTION
FIX 1: Add all .nps-* CSS rules to styles.css (new-post-sheet, nps-handle, nps-color-strip, nps-hdr, nps-title, nps-close, nps-body, nps-field-label, nps-title-input, nps-grid, nps-cell, nps-select, nps-date, nps-text, nps-textarea, nps-footer, nps-btn-cancel, nps-btn-create) with !important overrides to defeat global select/input styles.

FIX 2: Replace modal-card class with new-post-sheet in index.html #new-post-overlay. Update overlay to use inline style with display:none, fixed positioning, bottom-aligned flex layout. Update 06-post-create.js open/close to use style.display instead of classList toggle.

https://claude.ai/code/session_01NCcXNr4pJLDEaDvTaxHwEy