### PR TITLE
fix: nothing renders until auth complete

### DIFF
--- a/02-session.js
+++ b/02-session.js
@@ -7,7 +7,7 @@ window.allPosts        = [];
 window.cachedPosts     = [];
 window.currentRole     = 'Admin';
 // Admin-only role preview  -  overrides UI visibility without touching auth
-window.effectiveRole   = (localStorage.getItem('pcs_role_preview') || 'Admin');
+window.effectiveRole   = localStorage.getItem('pcs_role_preview') || '';
 window._renderTimer    = null;
 window._retryCount     = 0;
 window._retryTimer     = null;

--- a/03-auth.js
+++ b/03-auth.js
@@ -230,7 +230,15 @@ function activateRole(role) {
     setTimeout(function() {
       if (typeof switchTab === 'function') switchTab('tasks');
     }, 100);
-    return;
+  }
+
+  // Reveal the correct view now that role is fully set
+  var dv = document.getElementById('dashboard-view');
+  var cv = document.getElementById('client-view');
+  if (effectiveRole === 'Client') {
+    if (cv) cv.style.visibility = 'visible';
+  } else {
+    if (dv) dv.style.visibility = 'visible';
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 <!-- 
      MAIN DASHBOARD  (Admin / Servicing / Creative)
  -->
-<div id="dashboard-view">
+<div id="dashboard-view" style="visibility:hidden;">
 
   <!-- HEADER -->
   <header class="app-header">
@@ -406,7 +406,7 @@
 <!-- 
      CLIENT VIEW
  -->
-<div id="client-view">
+<div id="client-view" style="visibility:hidden;">
 
   <!-- Client header -->
   <div id="client-header"></div>
@@ -445,7 +445,7 @@
 <!-- 
      NEW POST MODAL
  -->
-<div id="new-post-overlay" style="position:fixed;inset:0;z-index:1000;background:#0a0a0f;display:flex;align-items:stretch;justify-content:center;">
+<div id="new-post-overlay" style="position:fixed;inset:0;z-index:1000;background:#0a0a0f;display:none;align-items:stretch;justify-content:center;">
   <div id="new-post-sheet" style="width:100%;max-width:390px;height:100vh;height:100dvh;background:#0a0a0f;display:flex;flex-direction:column;overflow:hidden;">
     <div class="nps-handle"></div>
     <div class="nps-color-strip" id="nps-color-strip"></div>


### PR DESCRIPTION
## Summary

- Hide `#dashboard-view` and `#client-view` with `visibility:hidden` on initial load
- Remove `Admin` default from `effectiveRole` — starts as empty string until auth resolves
- Fix `#new-post-overlay` to `display:none` instead of `display:flex` (was visible on load)
- Reveal the correct view only after `activateRole()` fully sets role and activates the view

Prevents clients from briefly seeing the agency dashboard before auth completes.

## Test plan

- [ ] Load app as Client user — should see only client portal, no flash of dashboard
- [ ] Load app as Admin user — should see dashboard immediately after auth
- [ ] Load app with no session — should see login overlay, no background content visible
- [ ] Verify new-post overlay is hidden on initial load
- [ ] Verify role preview (Admin switching to Client view) still works

https://claude.ai/code/session_014M7tYUtCVbE9cc4F8MaEnv