### PR TITLE
fix: client card meta location, greeting name, lazy images

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -132,7 +132,7 @@ window.verifyOTPCode = async function verifyOTPCode() {
 async function resolveRoleFromToken(accessToken, email) {
   try {
     const roleRes = await fetch(
-      `${SUPABASE_URL}/rest/v1/user_roles?email=eq.${encodeURIComponent(email)}&select=role&limit=1`,
+      `${SUPABASE_URL}/rest/v1/user_roles?email=eq.${encodeURIComponent(email)}&select=role,name&limit=1`,
       { headers: { 'apikey': SUPABASE_KEY, 'Authorization': `Bearer ${accessToken}` } }
     );
     const roleData = await roleRes.json();
@@ -142,6 +142,9 @@ async function resolveRoleFromToken(accessToken, email) {
       if (el) el.textContent = `No role found for ${email}. Ask your admin.`;
       return;
     }
+    var userName = Array.isArray(roleData) && roleData[0]?.name;
+    if (userName) window.currentUserName = userName;
+    window.currentUserEmail = email;
     localStorage.setItem('hinglish_role', role);
     localStorage.setItem('hinglish_email', email);
     const overlay = document.getElementById('login-overlay');

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -3516,8 +3516,10 @@ function _renderClientViewInner() {
 
   var h = new Date().getHours();
   var timeOfDay = h < 12 ? 'morning' : h < 17 ? 'afternoon' : 'evening';
-  var clientName = (localStorage.getItem('hinglish_email') || 'there').split('@')[0];
-  clientName = clientName.charAt(0).toUpperCase() + clientName.slice(1);
+  var greetName = window.currentUserName ||
+    window.currentUser?.name ||
+    (window.currentUserEmail || localStorage.getItem('hinglish_email') || 'there').split('@')[0];
+  var clientName = greetName.charAt(0).toUpperCase() + greetName.slice(1);
 
   // CHANGE 2 - Header
   var headerEl = document.getElementById('client-header');
@@ -3584,16 +3586,16 @@ function _renderClientViewInner() {
         var barCls = days >= 3 ? 'red' : days >= 1 ? 'amber' : 'muted';
         var statusCls = barCls;
         var statusText = days >= 1 ? days + 'd waiting' : 'New';
-        var pillar = (p.contentPillar || '').toUpperCase();
-        var owner = (p.owner || '').toUpperCase();
-        var metaText = [pillar, owner].filter(Boolean).join(' / ');
+        var metaLocation = (p.location || '').toUpperCase();
+        var metaPillar = (p.content_pillar || p.contentPillar || '').toUpperCase();
+        var metaLine = metaPillar + (metaLocation ? ' / ' + metaLocation : '');
 
         return '<div class="cp-card">' +
           '<div class="cp-bar ' + barCls + '"></div>' +
           '<div class="cp-body">' +
             '<div class="cp-status ' + statusCls + '">Waiting for your input &middot; ' + statusText + '</div>' +
             '<div class="cp-title">' + esc(getTitle(p)) + '</div>' +
-            '<div class="cp-meta">' + esc(metaText) + '</div>' +
+            '<div class="cp-meta">' + esc(metaLine) + '</div>' +
             '<div class="cp-need-label">What we need</div>' +
             '<div class="cp-need-text">' + esc(p.comments || 'We need your input to move this post forward.') + '</div>' +
             '<div class="cp-actions">' +
@@ -3636,9 +3638,9 @@ function _renderClientViewInner() {
         var barCls   = days >= 3 ? 'red' : days >= 1 ? 'amber' : 'muted';
         var statusCls = barCls;
         var statusText = days >= 3 ? days + 'd waiting - oldest in queue' : days >= 1 ? days + 'd waiting' : 'New';
-        var pillar = (p.contentPillar || '').toUpperCase();
-        var owner  = (p.owner || '').toUpperCase();
-        var metaText = [pillar, owner].filter(Boolean).join(' / ');
+        var metaLocation = (p.location || '').toUpperCase();
+        var metaPillar = (p.content_pillar || p.contentPillar || '').toUpperCase();
+        var metaLine = metaPillar + (metaLocation ? ' / ' + metaLocation : '');
         var approvalUrl = window.location.origin + '/p/' + id;
         var waText = encodeURIComponent('LinkedIn post ready for review\n\nPreview and approve here:\n' + approvalUrl + '\n\nTakes 5 seconds.');
         var waLink = 'https://wa.me/?text=' + waText;
@@ -3652,7 +3654,7 @@ function _renderClientViewInner() {
             imgs.map(function(url, idx) {
               return '<div style="flex-shrink:0;width:90px;height:90px;' +
                 'background:#111;overflow:hidden;">' +
-                '<img src="' + url + '" loading="eager" width="90" height="90" ' +
+                '<img src="' + url + '" loading="lazy" decoding="async" width="90" height="90" ' +
                 'style="width:90px;height:90px;object-fit:cover;display:block;"></div>';
             }).join('') +
             '</div>';
@@ -3685,7 +3687,7 @@ function _renderClientViewInner() {
           '<div class="cp-body">' +
             '<div class="cp-status ' + statusCls + '">' + esc(statusText) + '</div>' +
             '<div class="cp-title">' + esc(getTitle(p)) + '</div>' +
-            '<div class="cp-meta">' + esc(metaText) + '</div>' +
+            '<div class="cp-meta">' + esc(metaLine) + '</div>' +
             imgStripHtml +
             capHtml +
             '<div class="cp-actions" style="margin-top:12px;border-top:1px solid rgba(255,255,255,0.07);">' +


### PR DESCRIPTION
## Summary\n- **Card meta**: Replaced hardcoded owner/CLIENT with post location in both awaiting_brand_input and awaiting_approval card meta lines\n- **Greeting name**: Uses `window.currentUserName` (fetched from `user_roles.name` column) instead of email prefix\n- **Lazy images**: Changed card thumbnail `<img>` tags from `loading=\"eager\"` to `loading=\"lazy\" decoding=\"async\"`\n\n## Test plan\n- [ ] Verify client portal cards show PILLAR / LOCATION instead of PILLAR / CLIENT\n- [ ] Verify greeting shows proper name from user_roles, not email prefix\n- [ ] Verify card thumbnails load lazily without scroll lag\n\nhttps://claude.ai/code/session_013pxdc43m4eSatkAS6Tq9RP