### PR TITLE
fix: hide agency UI from client role

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -83,6 +83,8 @@ function closePipelineSearch() {
 function updatePipelineCritical(posts) {
   var el = document.getElementById('pipeline-critical');
   if (!el) return;
+  var _isClientCrit = (effectiveRole || '').toLowerCase() === 'client';
+  if (_isClientCrit) { el.textContent = ''; return; }
   var allP = posts || allPosts || [];
   var now = new Date();
   var overdue = allP.filter(function(p) {
@@ -2541,8 +2543,9 @@ function buildPipelineCard(p, listKey) {
   var metaLine = metaParts.join(' \u00b7 ');
 
   // FIX 5 -- Chase button (plain text, no border)
+  var _isClientCard = (effectiveRole || '').toLowerCase() === 'client';
   var rightHtml = '';
-  if (stage === 'awaiting_approval') {
+  if (!_isClientCard && stage === 'awaiting_approval') {
     var changed = p.status_changed_at ? new Date(p.status_changed_at) : null;
     var daysWaiting = changed ? Math.floor((new Date() - changed) / 86400000) : 0;
     if (daysWaiting >= 3) {
@@ -2615,9 +2618,15 @@ function updatePipelineChipCounts() {
     var el = document.getElementById('chip-count-' + chipKey);
     if (el) el.textContent = stageCounts[keys[k]];
   }
-  // Hide chips with zero count (except ALL)
+  // Hide chips with zero count (except ALL); also filter for Client role
+  var _isClientChip = (effectiveRole || '').toLowerCase() === 'client';
+  var _clientVisibleStages = ['all', 'awaiting_approval', 'awaiting_brand_input', 'published'];
   document.querySelectorAll('#stage-strip .stage-chip').forEach(function(chip) {
     var stage = chip.dataset.stage;
+    if (_isClientChip && _clientVisibleStages.indexOf(stage) === -1) {
+      chip.style.display = 'none';
+      return;
+    }
     if (stage === 'all') return;
     var count = stageCounts[stage] || 0;
     chip.style.display = count > 0 ? 'flex' : 'none';
@@ -3195,8 +3204,9 @@ function _renderPipelineInner() {
       ? '<button class="batch-select-btn" id="batch-select-btn" onclick="event.stopPropagation();toggleBatchMode()">Select</button>'
       : '';
     // Chase All button for awaiting_approval group
+    var _isClientCA = (effectiveRole || '').toLowerCase() === 'client';
     var chaseAllBtn = '';
-    if (stage === 'awaiting_approval') {
+    if (!_isClientCA && stage === 'awaiting_approval') {
       var nowCA = new Date();
       var threeDaysAgoCA = new Date();
       threeDaysAgoCA.setDate(threeDaysAgoCA.getDate() - 3);
@@ -3209,11 +3219,14 @@ function _renderPipelineInner() {
       }
     }
     // Per-stage summary line
+    var _isClientSum = (effectiveRole || '').toLowerCase() === 'client';
     var summaryText = '';
     var now5 = new Date();
     var stageKey = stage;
     var stagePosts = posts;
-    if (stageKey === 'awaiting_approval') {
+    if (_isClientSum) {
+      // Client sees no summary lines
+    } else if (stageKey === 'awaiting_approval') {
       var clientCount = stagePosts.filter(function(p) { return (p.owner||'').toLowerCase() === 'client'; }).length;
       var sortedByUpdate = stagePosts.slice().sort(function(a,b) { return new Date(a.updated_at||a.updatedAt) - new Date(b.updated_at||b.updatedAt); });
       var oldestPost = sortedByUpdate[0];

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -472,6 +472,10 @@ function _renderPCS(postId) {
     }
   }
 
+  // Hide delete button for Client role
+  var _pcsDelBtn = document.querySelector('.pc-topbar .pc-icon-btn.danger');
+  if (_pcsDelBtn) _pcsDelBtn.style.display = canEdit ? '' : 'none';
+
   _updateSubtitle(post);
   if (elProgress) elProgress.innerHTML = _buildStageProgress(stageLC);
 
@@ -650,8 +654,10 @@ function _renderPCS(postId) {
   }
 
   var whatsappHtml = '';
-  var showWA = post.caption &&
-    stageLC === 'awaiting_approval';
+  var showWA = post.caption && (
+    (effectiveRole || '').toLowerCase() === 'client' ||
+    stageLC === 'awaiting_approval'
+  );
 
   if (showWA) {
     whatsappHtml = '<div style="padding:10px 18px 12px;' +
@@ -1308,6 +1314,7 @@ var _ADVANCE_CLS = {
 };
 
 function _renderAdvanceButton(stageLC) {
+  if ((effectiveRole || '').toLowerCase() === 'client') return '';
   var block = document.getElementById('pc-advance-block');
   var btn = document.getElementById('pc-advance-btn');
   var label = document.getElementById('pc-advance-label');
@@ -1718,11 +1725,21 @@ function _sharePostOnWhatsApp(postId) {
   var approveUrl = 'https://srtd.io/ok/?p=' + rawSlug;
   var changesUrl = 'https://srtd.io/no/?p=' + rawSlug;
 
-  var message =
-    'Hi, ' + title + ' is ready for your review.\n\n' +
-    caption + '\n\n' +
-    'Approve: ' + approveUrl + '\n' +
-    'Request changes: ' + changesUrl;
+  var _isClient = (effectiveRole || '').toLowerCase() === 'client';
+
+  var message;
+  if (_isClient) {
+    message =
+      title + '\n\n' +
+      caption + '\n\n' +
+      'Please review and let me know.';
+  } else {
+    message =
+      'Hi, ' + title + ' is ready for your review.\n\n' +
+      caption + '\n\n' +
+      'Approve: ' + approveUrl + '\n' +
+      'Request changes: ' + changesUrl;
+  }
 
   var waUrl = 'https://wa.me/?text=' + encodeURIComponent(message);
   window.open(waUrl, '_blank');


### PR DESCRIPTION
## Summary

- **FIX 1**: Hide PCS delete button for Client role (08-post-actions.js:478)
- **FIX 2**: Hide stage advance button for Client role (08-post-actions.js:1314)
- **FIX 3**: WhatsApp button shows for Client with clean forward message (no approval links); agency gets full message as before (08-post-actions.js:655, 1725)
- **FIX 4**: Hide Chase All button for Client role (07-post-load.js:3199)
- **FIX 5**: Hide individual CHASE buttons on pipeline cards for Client (07-post-load.js:2546)
- **FIX 6**: Hide per-stage summary lines (internal ops messages) for Client (07-post-load.js:3214)
- **FIX 7**: Person filter strip already removed from index.html - no change needed
- **FIX 8**: Filter stage chips for Client to only show: All, Approval, Input, Published (07-post-load.js:2621)
- **FIX 9**: Hide pipeline critical header for Client role (07-post-load.js:87)

## Test plan
- [x] `node --check` passes on both JS files
- [x] All 66 tests pass (`npm test`)
- [ ] Verify Client role sees no delete button in PCS
- [ ] Verify Client role sees no advance button
- [ ] Verify Client WhatsApp shares clean message without approval links
- [ ] Verify Client sees no Chase buttons
- [ ] Verify Client sees only relevant stage chips
- [ ] Verify agency roles still see all UI elements as before

https://claude.ai/code/session_01J3ck2BkpKga5Pe9KwGWuMa