### PR TITLE
feat: copy to share button on desktop

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -3781,14 +3781,36 @@ function _renderClientViewInner() {
             '<button class="btn-send-changes" onclick="submitClientChanges(\'' + esc(id) + '\')">Send Change Request</button>' +
           '</div>' +
           '<div class="approval-confirmed" id="approved-confirm-' + esc(id) + '">Approved - the team has been notified.</div>' +
-          '<div style="padding:8px 16px 14px 20px;">' +
-          '<a href="' + esc(waLink) + '" target="_blank" rel="noopener" ' +
-          'style="display:block;width:100%;font-family:\'IBM Plex Mono\',monospace;' +
-          'font-size:7px;letter-spacing:0.1em;text-transform:uppercase;' +
-          'color:#888;background:transparent;' +
-          'border:1px solid rgba(255,255,255,0.15);' +
-          'padding:10px 0;width:100%;cursor:pointer;text-align:center;text-decoration:none;">Share on WhatsApp</a>' +
-          '</div>' +
+          (function(){
+            var _isDesktop = window.innerWidth > 768 && !('ontouchstart' in window);
+            return '<div style="padding:0 16px 14px 20px;display:flex;gap:8px;">' +
+            '<a href="' + esc(waLink) + '" target="_blank" ' +
+            'style="flex:1;font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
+            'letter-spacing:0.1em;text-transform:uppercase;color:#888;' +
+            'background:transparent;border:1px solid rgba(255,255,255,0.12);' +
+            'padding:10px 0;cursor:pointer;text-align:center;text-decoration:none;' +
+            'display:block;">Share on WhatsApp</a>' +
+            (_isDesktop ?
+              '<button onclick="(function(){' +
+              'var msg=\'' + (p.title||'').replace(/'/g,"\\'") + '\\n\\n' +
+              (p.caption||'').replace(/'/g,"\\'").slice(0,300).replace(/\n/g,'\\n') +
+              '\\n\\nApprove: https://srtd.io/ok/?p=' +
+              (p.title||'').toLowerCase().replace(/[^a-z0-9\s]/g,' ').trim().replace(/\s+/g,'-').replace(/-+/g,'-').slice(0,50) +
+              '\\nChanges: https://srtd.io/no/?p=' +
+              (p.title||'').toLowerCase().replace(/[^a-z0-9\s]/g,' ').trim().replace(/\s+/g,'-').replace(/-+/g,'-').slice(0,50) + '\';' +
+              'navigator.clipboard.writeText(msg).then(function(){' +
+              'var b=this;b.textContent=\'Copied\';' +
+              'setTimeout(function(){b.textContent=\'\u2398 Copy to Share\';},2000);' +
+              '}.bind(this));' +
+              '})()" ' +
+              'style="flex:1;font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
+              'letter-spacing:0.1em;text-transform:uppercase;color:#888;' +
+              'background:transparent;border:1px solid rgba(255,255,255,0.12);' +
+              'padding:10px 0;cursor:pointer;">' +
+              '\u2398 Copy to Share</button>'
+              : '') +
+            '</div>';
+          })() +
           '</div>';
       }).join('');
     }
@@ -4581,19 +4603,43 @@ function _openClientEditorial(postId) {
     '</div>' +
 
     // WhatsApp share
-    '<button onclick="(function(){' +
-    'var msg=\'' + (post.title||'').replace(/'/g,"\\'") + '\\n\\n\'+' +
-    '(document.getElementById(\'ed-caption-\'+\'' + postId + '\') ? ' +
-    'document.getElementById(\'ed-caption-\'+\'' + postId + '\').textContent : ' +
-    '\'' + (post.caption||'').replace(/'/g,"\\'").slice(0,200) + '\') +' +
-    '\'\\n\\nPlease review and let me know.\';' +
-    'window.open(\'https://wa.me/?text=\'+encodeURIComponent(msg),\'_blank\');' +
-    '})()" ' +
-    'style="width:100%;font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
-    'letter-spacing:0.14em;text-transform:uppercase;color:#e8e2d9;' +
-    'background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.12);' +
-    'padding:14px 0;cursor:pointer;display:block;margin-bottom:10px;">' +
-    '&#x2197; Share on WhatsApp</button>' +
+    (function(){
+      var _isDesktop = window.innerWidth > 768 && !('ontouchstart' in window);
+      var rawSlug = (post.title||'').toLowerCase().replace(/[^a-z0-9\s]/g,' ').trim().replace(/\s+/g,'-').replace(/-+/g,'-').slice(0,50);
+      return '<div style="display:' + (_isDesktop ? 'flex' : 'block') + ';gap:8px;margin-bottom:10px;">' +
+      '<button onclick="(function(){' +
+      'var msg=\'' + (post.title||'').replace(/'/g,"\\'") + '\\n\\n\'+' +
+      '(document.getElementById(\'ed-caption-\'+\'' + postId + '\') ? ' +
+      'document.getElementById(\'ed-caption-\'+\'' + postId + '\').textContent : ' +
+      '\'' + (post.caption||'').replace(/'/g,"\\'").slice(0,200) + '\') +' +
+      '\'\\n\\nPlease review and let me know.\';' +
+      'window.open(\'https://wa.me/?text=\'+encodeURIComponent(msg),\'_blank\');' +
+      '})()" ' +
+      'style="flex:1;width:100%;font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
+      'letter-spacing:0.14em;text-transform:uppercase;color:#e8e2d9;' +
+      'background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.12);' +
+      'padding:14px 0;cursor:pointer;display:block;">' +
+      '&#x2197; Share on WhatsApp</button>' +
+      (_isDesktop ?
+        '<button onclick="(function(){' +
+        'var msg=\'' + (post.title||'').replace(/'/g,"\\'") + '\\n\\n\'+' +
+        'document.getElementById(\'ed-caption-' + postId + '\')?.textContent+' +
+        '\'\\n\\nApprove: https://srtd.io/ok/?p=' + rawSlug + '\'+' +
+        '\'\\nChanges: https://srtd.io/no/?p=' + rawSlug + '\';' +
+        'navigator.clipboard.writeText(msg).then(function(){' +
+        'var b=document.getElementById(\'ed-copy-' + postId + '\');' +
+        'if(b){b.textContent=\'Copied\';' +
+        'setTimeout(function(){b.textContent=\'\u2398 Copy to Share\';},2000);}' +
+        '});' +
+        '})()" id="ed-copy-' + postId + '" ' +
+        'style="flex:1;font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
+        'letter-spacing:0.14em;text-transform:uppercase;color:#888;' +
+        'background:transparent;border:1px solid rgba(255,255,255,0.12);' +
+        'padding:14px 0;cursor:pointer;">' +
+        '\u2398 Copy to Share</button>'
+        : '') +
+      '</div>';
+    })() +
 
     // Approve button
     '<button onclick="_editorialApprove(\'' + postId + '\')" ' +

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -684,6 +684,32 @@ function _renderPCS(postId) {
       'letter-spacing:0.14em;text-transform:uppercase;color:#25D366;' +
       'background:transparent;border:1px solid rgba(37,211,102,0.25);' +
       'padding:11px 0;cursor:pointer;">Share on WhatsApp</button>' +
+      (function(){
+        var _isDesktop = window.innerWidth > 768 && !('ontouchstart' in window);
+        var _copyHtml = _isDesktop ?
+          '<button onclick="(function(){' +
+          'var post=(typeof getPostById===\'function\')?getPostById(\'' + postId + '\'):null;' +
+          'if(!post)return;' +
+          'var slug=(post.title||\'\').toLowerCase()' +
+          '.replace(/[^a-z0-9\\s]/g,\' \').trim()' +
+          '.replace(/\\s+/g,\'-\').replace(/-+/g,\'-\').slice(0,50);' +
+          'var msg=(post.title||\'\')+\'\\n\\n\'+(post.caption||\'\')+' +
+          '\'\\n\\nApprove: https://srtd.io/ok/?p=\'+slug+' +
+          '\'\\nChanges: https://srtd.io/no/?p=\'+slug;' +
+          'navigator.clipboard.writeText(msg).then(function(){' +
+          'var b=document.getElementById(\'pcs-copy-btn\');' +
+          'if(b){b.textContent=\'Copied\';' +
+          'setTimeout(function(){b.textContent=\'\u2398 Copy to Share\';},2000);}' +
+          '});' +
+          '})()" id="pcs-copy-btn" ' +
+          'style="width:100%;font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
+          'letter-spacing:0.14em;text-transform:uppercase;color:#888;' +
+          'background:transparent;border:1px solid rgba(255,255,255,0.12);' +
+          'padding:10px 0;cursor:pointer;margin-top:6px;">' +
+          '\u2398 Copy to Share</button>'
+          : '';
+        return _copyHtml;
+      })() +
       '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
       'color:#333;letter-spacing:0.06em;margin-top:6px;text-align:center;">' +
       'Sends copy + approval link to client</div>' +

--- a/index.html
+++ b/index.html
@@ -908,19 +908,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260325" defer></script>
-<script src="02-session.js?v=20260325" defer></script>
-<script src="utils.js?v=20260325" defer></script>
-<script src="03-auth.js?v=20260325" defer></script>
-<script src="05-api.js?v=20260325" defer></script>
-<script src="10-ui.js?v=20260325" defer></script>
+<script src="01-config.js?v=20260325c" defer></script>
+<script src="02-session.js?v=20260325c" defer></script>
+<script src="utils.js?v=20260325c" defer></script>
+<script src="03-auth.js?v=20260325c" defer></script>
+<script src="05-api.js?v=20260325c" defer></script>
+<script src="10-ui.js?v=20260325c" defer></script>
 
-<script src="06-post-create.js?v=20260325" defer></script>
-<script src="07-post-load.js?v=20260325" defer></script>
-<script src="08-post-actions.js?v=20260325" defer></script>
-<script src="09-library.js?v=20260325" defer></script>
-<script src="09-approval.js?v=20260325" defer></script>
-<script src="04-router.js?v=20260325" defer></script>
+<script src="06-post-create.js?v=20260325c" defer></script>
+<script src="07-post-load.js?v=20260325c" defer></script>
+<script src="08-post-actions.js?v=20260325c" defer></script>
+<script src="09-library.js?v=20260325c" defer></script>
+<script src="09-approval.js?v=20260325c" defer></script>
+<script src="04-router.js?v=20260325c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Added "Copy to Share" button (desktop only, `width > 768 && !ontouchstart`) in three locations: PCS card, client approval cards, and editorial view
- Button copies post title, caption, and approval/changes links to clipboard with "Copied" feedback
- Styled consistently with existing WhatsApp share buttons using IBM Plex Mono
- Stripped all non-ASCII from 07-post-load.js and 08-post-actions.js
- Bumped all 12 script version strings in index.html to `?v=20260325c`

## Test plan
- [ ] Verify "Copy to Share" button appears on desktop browsers (width > 768, no touch)
- [ ] Verify button is hidden on mobile/touch devices
- [ ] Test clipboard copy works and shows "Copied" feedback in PCS modal
- [ ] Test clipboard copy works in client approval card view
- [ ] Test clipboard copy works in editorial overlay view
- [ ] Verify WhatsApp share buttons still work in all three locations
- [ ] Confirm no syntax errors (`node --check` passes)

https://claude.ai/code/session_01FFHZVJSdfgyho4KsHB82DL