### PR TITLE
feat: square hero images, clickable in gallery

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -3751,7 +3751,8 @@ function _renderClientViewInner() {
             '<div onclick="_openClientEditorial(\'' + p.post_id + '\')" ' +
             'style="cursor:pointer;overflow:hidden;">' +
             '<img src="' + hero + '" loading="eager" decoding="async" ' +
-            'style="width:100%;height:220px;object-fit:cover;display:block;">' +
+            'style="aspect-ratio:1/1;width:100%;object-fit:cover;height:auto;display:block;cursor:pointer;" ' +
+            'onclick="event.stopPropagation();_edOpenLightbox(\'' + esc(p.post_id) + '\',0)">' +
             '</div>'
             :
             (p.caption
@@ -4523,7 +4524,8 @@ function _openClientEditorial(postId) {
     // Hero image
     (hero ?
       '<img src="' + hero + '" style="width:100%;max-height:280px;' +
-      'object-fit:cover;display:block;" loading="eager">'
+      'object-fit:cover;display:block;cursor:pointer;" loading="eager" ' +
+      'onclick="_edOpenLightbox(\'' + postId + '\',0)">'
       : '') +
 
     // Body

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260325j">
+ <link rel="stylesheet" href="styles.css?v=20260325k">
 
 </head>
 <body>
@@ -908,19 +908,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260325j" defer></script>
-<script src="02-session.js?v=20260325j" defer></script>
-<script src="utils.js?v=20260325j" defer></script>
-<script src="03-auth.js?v=20260325j" defer></script>
-<script src="05-api.js?v=20260325j" defer></script>
-<script src="10-ui.js?v=20260325j" defer></script>
+<script src="01-config.js?v=20260325k" defer></script>
+<script src="02-session.js?v=20260325k" defer></script>
+<script src="utils.js?v=20260325k" defer></script>
+<script src="03-auth.js?v=20260325k" defer></script>
+<script src="05-api.js?v=20260325k" defer></script>
+<script src="10-ui.js?v=20260325k" defer></script>
 
-<script src="06-post-create.js?v=20260325j" defer></script>
-<script src="07-post-load.js?v=20260325j" defer></script>
-<script src="08-post-actions.js?v=20260325j" defer></script>
-<script src="09-library.js?v=20260325j" defer></script>
-<script src="09-approval.js?v=20260325j" defer></script>
-<script src="04-router.js?v=20260325j" defer></script>
+<script src="06-post-create.js?v=20260325k" defer></script>
+<script src="07-post-load.js?v=20260325k" defer></script>
+<script src="08-post-actions.js?v=20260325k" defer></script>
+<script src="09-library.js?v=20260325k" defer></script>
+<script src="09-approval.js?v=20260325k" defer></script>
+<script src="04-router.js?v=20260325k" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary\n- Hero images on client approval cards now render as perfect squares (`aspect-ratio:1/1`) instead of fixed `height:220px`\n- Tapping the hero image on approval cards opens the full lightbox (`_edOpenLightbox`) instead of the editorial view\n- Hero image in the editorial view (`_openClientEditorial`) is also clickable to open the lightbox\n- Bumped all 12 script version strings to `?v=20260325k`\n\n## Test plan\n- [ ] Verify approval cards show square hero images regardless of original image dimensions\n- [ ] Tap hero image on approval card — should open lightbox with full uncropped image\n- [ ] Tap elsewhere on approval card — should open editorial view as before\n- [ ] In editorial view, tap hero image — should open lightbox\n\nhttps://claude.ai/code/session_01HNZH5sjLTpJuWpWFemGLWy