### PR TITLE
fix: approve confirm, changes UX, departure board cleanup

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -3862,17 +3862,6 @@ function _renderClientViewInner() {
 
       '<div style="padding:16px 16px 0;position:relative;z-index:2;">' +
 
-      // Pulsing status line
-      '<div style="font-family:\'IBM Plex Mono\',monospace;' +
-      'font-size:8px;letter-spacing:0.18em;text-transform:uppercase;' +
-      'color:#3ECF8E;display:flex;align-items:center;gap:8px;' +
-      'margin-bottom:14px;">' +
-      '<div style="width:5px;height:5px;border-radius:50%;' +
-      'background:#3ECF8E;animation:clientPulse 2s infinite;' +
-      'flex-shrink:0;"></div>' +
-      'Posts require your decision' +
-      '</div>' +
-
       // Big count
       '<div style="font-family:\'DM Sans\',sans-serif;font-size:64px;' +
       'font-weight:600;line-height:1;letter-spacing:-0.03em;' +
@@ -4126,11 +4115,20 @@ function _renderClientViewInner() {
         '</div>' +
 
         '<div class="change-input-wrap" id="change-wrap-' + esc(id) + '">' +
+        '<div style="display:flex;align-items:center;' +
+        'justify-content:space-between;margin-bottom:10px;">' +
+        '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
+        'letter-spacing:0.16em;text-transform:uppercase;color:#F6A623;">' +
+        'What needs to change?</div>' +
+        '<button onclick="showChangeInput(\'' + esc(id) + '\')" ' +
+        'style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
+        'color:rgba(255,255,255,0.4);background:transparent;border:none;' +
+        'cursor:pointer;padding:2px 6px;">&#x2715;</button>' +
+        '</div>' +
         '<textarea class="change-textarea" id="change-text-' + esc(id) + '" ' +
-        'placeholder="What would you like changed? Be as specific as possible..." ' +
-        'rows="3"></textarea>' +
+        'placeholder="Be specific -- tone, image, hashtags..." rows="3"></textarea>' +
         '<button class="btn-send-changes" ' +
-        'onclick="submitClientChanges(\'' + esc(id) + '\')">Send Change Request</button>' +
+        'onclick="submitClientChanges(\'' + esc(id) + '\')">&#x2192; Send Feedback</button>' +
         '</div>' +
 
         '<div class="approval-confirmed" ' +

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -151,7 +151,23 @@ async function clientApprove(postId, btn) {
     });
     await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
     const confirmEl = document.getElementById(`approved-confirm-${postId}`);
-    if (confirmEl) confirmEl.classList.add('active');
+    if (confirmEl) confirmEl.classList.add('show');
+    var cardEl = document.getElementById('approved-confirm-' + postId);
+    if (cardEl) {
+      var parent = cardEl.parentNode;
+      if (parent) {
+        var actions = parent.querySelector('[style*="display:flex;border-top"]') ||
+          parent.querySelector('.bp-actions');
+        if (actions) {
+          actions.innerHTML =
+            '<div style="flex:1;padding:13px 16px;' +
+            'font-family:\'IBM Plex Mono\',monospace;' +
+            'font-size:10px;letter-spacing:0.1em;text-transform:uppercase;' +
+            'color:#3ECF8E;display:flex;align-items:center;gap:8px;">' +
+            '&#x2713; Approved -- team notified</div>';
+        }
+      }
+    }
     setStage(post, 'scheduled', 'clientApprove');
     setTimeout(() => loadPostsForClient(), 1200);
   } catch { if (btn) btn.disabled = false; showToast('Failed  -  try again', 'error'); }
@@ -172,7 +188,16 @@ async function submitClientChanges(postId) {
     });
     await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Client feedback: ' + text });
     const item = document.getElementById(`apv-item-${postId}`);
-    if (item) item.innerHTML = `<div style="padding:var(--sp-4);text-align:center;color:var(--text2);font-size:14px">Changes sent  -  the team will take care of it.</div>`;
+    if (item) item.innerHTML =
+      '<div style="padding:20px 16px;text-align:center;' +
+      'border-top:1px dashed rgba(255,255,255,0.07);">' +
+      '<div style="font-size:20px;color:#F6A623;margin-bottom:10px;">&#x25C8;</div>' +
+      '<div style="font-family:\'DM Sans\',sans-serif;font-size:16px;' +
+      'font-weight:600;color:#e8e2d9;margin-bottom:6px;">Feedback sent.</div>' +
+      '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
+      'letter-spacing:0.08em;color:rgba(255,255,255,0.5);">' +
+      'The team will take care of it.</div>' +
+      '</div>';
     setTimeout(() => loadPostsForClient(), 1000);
   } catch { showToast('Failed  -  try again', 'error'); }
 }
@@ -1412,9 +1437,16 @@ function _buildNotes(post, canEdit, id) {
       'color:#e8e2d9;line-height:1.6;">' +
       esc(post.client_feedback) +
       '</div>' +
-      '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:6px;' +
-      'letter-spacing:0.1em;text-transform:uppercase;color:#333;margin-top:8px;">' +
-      'Read only</div>' +
+      '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
+      'letter-spacing:0.08em;color:rgba(255,255,255,0.4);margin-top:8px;">' +
+      (post.status_changed_at
+        ? new Date(post.status_changed_at).toLocaleDateString('en-IN',
+            {day:'numeric',month:'short'}) + ' -- ' +
+          new Date(post.status_changed_at).toLocaleTimeString('en-IN',
+            {hour:'numeric',minute:'2-digit',hour12:true})
+        : ''
+      ) +
+      '</div>' +
       '</div>';
   }
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326i">
+ <link rel="stylesheet" href="styles.css?v=20260326j">
 
 </head>
 <body>
@@ -909,19 +909,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326i" defer></script>
-<script src="02-session.js?v=20260326i" defer></script>
-<script src="utils.js?v=20260326i" defer></script>
-<script src="03-auth.js?v=20260326i" defer></script>
-<script src="05-api.js?v=20260326i" defer></script>
-<script src="10-ui.js?v=20260326i" defer></script>
+<script src="01-config.js?v=20260326j" defer></script>
+<script src="02-session.js?v=20260326j" defer></script>
+<script src="utils.js?v=20260326j" defer></script>
+<script src="03-auth.js?v=20260326j" defer></script>
+<script src="05-api.js?v=20260326j" defer></script>
+<script src="10-ui.js?v=20260326j" defer></script>
 
-<script src="06-post-create.js?v=20260326i" defer></script>
-<script src="07-post-load.js?v=20260326i" defer></script>
-<script src="08-post-actions.js?v=20260326i" defer></script>
-<script src="09-library.js?v=20260326i" defer></script>
-<script src="09-approval.js?v=20260326i" defer></script>
-<script src="04-router.js?v=20260326i" defer></script>
+<script src="06-post-create.js?v=20260326j" defer></script>
+<script src="07-post-load.js?v=20260326j" defer></script>
+<script src="08-post-actions.js?v=20260326j" defer></script>
+<script src="09-library.js?v=20260326j" defer></script>
+<script src="09-approval.js?v=20260326j" defer></script>
+<script src="04-router.js?v=20260326j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -1482,12 +1482,12 @@ tr:hover td { background: var(--surface2); }
 .approval-confirmed {
   display: none;
   font-family: var(--mono);
-  font-size: 8px;
+  font-size: 10px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--c-green);
-  padding: 9px 12px;
-  margin-top: 8px;
+  color: #3ECF8E;
+  padding: 13px 16px;
+  border-top: 1px dashed rgba(255,255,255,0.07);
 }
 .approval-confirmed.show { display: block; }
 


### PR DESCRIPTION
## Summary

- **Fix .active → .show bug**: `clientApprove()` was adding class `active` but CSS expects `show` — approval confirmation div was never visible
- **Action bar replacement**: After approve, the Approve/Changes/WhatsApp buttons are replaced with "Approved -- team notified" green confirmation
- **CSS update**: `.approval-confirmed` bumped to 10px font, dashed border-top to match terminal style
- **Styled feedback confirmation**: `submitClientChanges()` now shows a proper diamond icon + "Feedback sent" card instead of plain text
- **Close button on change box**: Added header "What needs to change?" with × close button inside the feedback textarea wrap
- **Removed redundant status line**: Deleted pulsing dot + "Posts require your decision" from departure board (zone header already says this)
- **Feedback timestamp**: Client feedback banner in PCS now shows date + time from `status_changed_at`
- **Version bump**: All 12 script tags → `?v=20260326j`

## Test plan

- [x] All 66 vitest tests pass
- [x] `node --check` passes on both JS files
- [x] No non-ASCII characters in changed files
- [ ] Verify client approval card shows green "Approved -- team notified" after clicking Approve
- [ ] Verify × button closes the change feedback box
- [ ] Verify "Feedback sent" styled card appears after submitting changes
- [ ] Verify departure board no longer shows pulsing dot line
- [ ] Verify PCS client feedback banner shows timestamp

https://claude.ai/code/session_016Yz4EuYiHkZtiFTLySy7La