### PR TITLE
fix: seat box waiting logic, hide request eyebrow

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -3973,9 +3973,24 @@ function _renderClientViewInner() {
         );
         var waLink = 'https://wa.me/?text=' + waText;
 
-        var urgencyBorder = daysWaiting >= 5
-          ? 'rgba(255,75,75,0.45)'
-          : (daysWaiting >= 2 ? 'rgba(246,166,35,0.45)' : 'rgba(62,207,142,0.45)');
+        var seatLabel, seatNum, seatColor, seatBorder;
+        if (daysWaiting === 0) {
+          seatLabel = '';
+          seatNum = 'New';
+          seatColor = '#3ECF8E';
+          seatBorder = 'rgba(62,207,142,0.45)';
+        } else if (daysWaiting >= 5) {
+          seatLabel = 'WAITING';
+          seatNum = daysWaiting + 'D';
+          seatColor = '#FF4B4B';
+          seatBorder = 'rgba(255,75,75,0.45)';
+        } else {
+          seatLabel = 'WAITING';
+          seatNum = daysWaiting + 'D';
+          seatColor = '#F6A623';
+          seatBorder = 'rgba(246,166,35,0.45)';
+        }
+
         var urgencyGrad = daysWaiting >= 5
           ? 'linear-gradient(to right,#FF4B4B,rgba(255,75,75,0))'
           : (daysWaiting >= 2
@@ -4017,12 +4032,16 @@ function _renderClientViewInner() {
 
         '<div style="flex-shrink:0;text-align:center;' +
         'padding:7px 12px 8px;min-width:64px;' +
-        'border:1px dashed ' + urgencyBorder + ';">' +
-        '<span style="font-size:7px;letter-spacing:0.18em;text-transform:uppercase;' +
-        'color:rgba(255,255,255,0.45);display:block;margin-bottom:3px;line-height:1;">Waiting</span>' +
+        'border:1px dashed ' + seatBorder + ';">' +
+        (seatLabel
+          ? '<span style="font-size:7px;letter-spacing:0.18em;' +
+            'text-transform:uppercase;color:rgba(255,255,255,0.45);' +
+            'display:block;margin-bottom:3px;line-height:1;">' +
+            seatLabel + '</span>'
+          : '') +
         '<span style="font-family:\'DM Sans\',sans-serif;font-size:28px;font-weight:700;' +
-        'line-height:1;display:block;color:' + waitColor + ';">' +
-        waitLabel + '</span>' +
+        'line-height:1;display:block;color:' + seatColor + ';">' +
+        seatNum + '</span>' +
         '</div>' +
 
         '</div>' +
@@ -4178,15 +4197,7 @@ function _renderClientViewInner() {
 
   // CHANGE 8 - New Request section
   var reqEyebrow = document.getElementById('client-request-eyebrow');
-  if (reqEyebrow) {
-    reqEyebrow.innerHTML =
-      '<div style="display:flex;align-items:center;' +
-      'padding:8px 18px;font-family:var(--mono);font-size:7px;' +
-      'letter-spacing:0.22em;text-transform:uppercase;' +
-      'color:var(--c-gold);' +
-      'border-bottom:1px solid rgba(255,255,255,0.07);">' +
-      'New Request</div>';
-  }
+  if (reqEyebrow) reqEyebrow.style.display = 'none';
 
   var reqForm = document.getElementById('client-request-form');
   if (reqForm && !reqForm.dataset.init) {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326o">
+ <link rel="stylesheet" href="styles.css?v=20260326p">
 
 </head>
 <body>
@@ -909,19 +909,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326o" defer></script>
-<script src="02-session.js?v=20260326o" defer></script>
-<script src="utils.js?v=20260326o" defer></script>
-<script src="03-auth.js?v=20260326o" defer></script>
-<script src="05-api.js?v=20260326o" defer></script>
-<script src="10-ui.js?v=20260326o" defer></script>
+<script src="01-config.js?v=20260326p" defer></script>
+<script src="02-session.js?v=20260326p" defer></script>
+<script src="utils.js?v=20260326p" defer></script>
+<script src="03-auth.js?v=20260326p" defer></script>
+<script src="05-api.js?v=20260326p" defer></script>
+<script src="10-ui.js?v=20260326p" defer></script>
 
-<script src="06-post-create.js?v=20260326o" defer></script>
-<script src="07-post-load.js?v=20260326o" defer></script>
-<script src="08-post-actions.js?v=20260326o" defer></script>
-<script src="09-library.js?v=20260326o" defer></script>
-<script src="09-approval.js?v=20260326o" defer></script>
-<script src="04-router.js?v=20260326o" defer></script>
+<script src="06-post-create.js?v=20260326p" defer></script>
+<script src="07-post-load.js?v=20260326p" defer></script>
+<script src="08-post-actions.js?v=20260326p" defer></script>
+<script src="09-library.js?v=20260326p" defer></script>
+<script src="09-approval.js?v=20260326p" defer></script>
+<script src="04-router.js?v=20260326p" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Seat box: no WAITING label when daysWaiting is 0 (shows just "New"); separate seatLabel/seatNum/seatColor/seatBorder variables for correct urgency thresholds
- Hidden redundant "New Request" eyebrow below approval cards (button already in header)
- Stripped non-ASCII, bumped all 13 version strings to `?v=20260326p`

## Test plan
- [ ] Verify new posts show "New" in green with no WAITING label
- [ ] Verify 1-4 day posts show "WAITING" + amber "XD"
- [ ] Verify 5+ day posts show "WAITING" + red "XD"
- [ ] Confirm "New Request" eyebrow is hidden
- [ ] `node --check` passes on both JS files

https://claude.ai/code/session_01UPF9WvxX8GofC91GUChgxq