### PR TITLE
fix: brief first in pipeline order

### DIFF
--- a/01-config.js
+++ b/01-config.js
@@ -60,12 +60,12 @@ const PIPELINE_ORDER = [...STAGE_ORDER];
 
 // Pipeline RENDER order  -  visual pipeline excludes parked/rejected (they live in Library only)
 const PIPELINE_RENDER_ORDER = [
+  'brief',
   'awaiting_approval',
   'awaiting_brand_input',
   'scheduled',
   'ready',
   'in_production',
-  'brief',
 ];
 
 // Backward-compatible aliases

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326s">
+ <link rel="stylesheet" href="styles.css?v=20260326t">
 
 </head>
 <body>
@@ -909,19 +909,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326s" defer></script>
-<script src="02-session.js?v=20260326s" defer></script>
-<script src="utils.js?v=20260326s" defer></script>
-<script src="03-auth.js?v=20260326s" defer></script>
-<script src="05-api.js?v=20260326s" defer></script>
-<script src="10-ui.js?v=20260326s" defer></script>
+<script src="01-config.js?v=20260326t" defer></script>
+<script src="02-session.js?v=20260326t" defer></script>
+<script src="utils.js?v=20260326t" defer></script>
+<script src="03-auth.js?v=20260326t" defer></script>
+<script src="05-api.js?v=20260326t" defer></script>
+<script src="10-ui.js?v=20260326t" defer></script>
 
-<script src="06-post-create.js?v=20260326s" defer></script>
-<script src="07-post-load.js?v=20260326s" defer></script>
-<script src="08-post-actions.js?v=20260326s" defer></script>
-<script src="09-library.js?v=20260326s" defer></script>
-<script src="09-approval.js?v=20260326s" defer></script>
-<script src="04-router.js?v=20260326s" defer></script>
+<script src="06-post-create.js?v=20260326t" defer></script>
+<script src="07-post-load.js?v=20260326t" defer></script>
+<script src="08-post-actions.js?v=20260326t" defer></script>
+<script src="09-library.js?v=20260326t" defer></script>
+<script src="09-approval.js?v=20260326t" defer></script>
+<script src="04-router.js?v=20260326t" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Moved `brief` from the end to the beginning of `PIPELINE_RENDER_ORDER` in `01-config.js`
- Bumped all 12 version cache-busters in `index.html` from `?v=20260326s` to `?v=20260326t`

## Test plan
- [x] `node --check 01-config.js` passes
- [x] `npm test` passes 66/66

https://claude.ai/code/session_01817FT3F3iYd4Lzr7vSwMA7