### PR TITLE
fix: brief sheet eyebrow label, content type separate

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -5493,6 +5493,16 @@ function _openBriefSheet(postId) {
       {hour:'numeric',minute:'2-digit',hour12:true,timeZone:'Asia/Kolkata'});
   }
 
+  var rawComments = post.comments || '';
+  var contentType = '';
+  var typeMatch = rawComments.match(/\[Type:\s*([^\]]+)\]/);
+  if (typeMatch) {
+    contentType = typeMatch[1].trim();
+    rawComments = rawComments.replace(/\s*\[Type:[^\]]+\]/, '').trim();
+  }
+  var briefText = rawComments;
+  briefText = briefText.replace(/^\[URGENT\]\s*/, '').trim();
+
   var overlay = document.createElement('div');
   overlay.id = 'brief-sheet-overlay';
   overlay.style.cssText = 'position:fixed;inset:0;z-index:9500;' +
@@ -5518,7 +5528,7 @@ function _openBriefSheet(postId) {
     '<div style="padding:24px 18px 20px;">' +
     '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
     'letter-spacing:0.18em;text-transform:uppercase;color:rgba(255,255,255,0.4);' +
-    'margin-bottom:8px;">Client Request</div>' +
+    'margin-bottom:8px;">Brief Title</div>' +
     '<div style="font-family:\'DM Sans\',sans-serif;font-size:24px;' +
     'font-weight:700;color:#e8e2d9;line-height:1.2;margin-bottom:6px;">' +
     esc(post.title || '') + '</div>' +
@@ -5527,6 +5537,24 @@ function _openBriefSheet(postId) {
     esc(sentTime) + '</div>' +
     '</div>' +
 
+    // Divider
+    '<div style="height:1px;background:rgba(200,168,75,0.12);margin:0 18px;"></div>' +
+
+    // Content type (extracted from comments)
+    (contentType ?
+      '<div style="padding:16px 18px;">' +
+      '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
+      'letter-spacing:0.2em;text-transform:uppercase;' +
+      'color:#C8A84B;margin-bottom:10px;display:block;">Content Type</div>' +
+      '<div style="display:inline-flex;align-items:center;' +
+      'border:1px dashed rgba(200,168,75,0.3);padding:5px 10px;">' +
+      '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
+      'letter-spacing:0.1em;text-transform:uppercase;' +
+      'color:#e8e2d9;font-weight:500;">' + esc(contentType) + '</span>' +
+      '</div></div>' +
+      '<div style="height:1px;background:rgba(200,168,75,0.12);margin:0 18px;"></div>'
+      : '') +
+
     // Brief text
     '<div style="padding:0 18px 24px;">' +
     '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
@@ -5534,7 +5562,7 @@ function _openBriefSheet(postId) {
     'color:#C8A84B;margin-bottom:10px;">The Brief</div>' +
     '<div style="font-family:\'DM Sans\',sans-serif;font-size:15px;' +
     'color:#e8e2d9;line-height:1.7;white-space:pre-wrap;">' +
-    esc(post.comments || 'No brief text provided.') + '</div>' +
+    esc(briefText || 'No brief text provided.') + '</div>' +
     '</div>' +
 
     // Reference photos

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326t">
+ <link rel="stylesheet" href="styles.css?v=20260326v">
 
 </head>
 <body>
@@ -909,19 +909,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326t" defer></script>
-<script src="02-session.js?v=20260326t" defer></script>
-<script src="utils.js?v=20260326t" defer></script>
-<script src="03-auth.js?v=20260326t" defer></script>
-<script src="05-api.js?v=20260326t" defer></script>
-<script src="10-ui.js?v=20260326t" defer></script>
+<script src="01-config.js?v=20260326v" defer></script>
+<script src="02-session.js?v=20260326v" defer></script>
+<script src="utils.js?v=20260326v" defer></script>
+<script src="03-auth.js?v=20260326v" defer></script>
+<script src="05-api.js?v=20260326v" defer></script>
+<script src="10-ui.js?v=20260326v" defer></script>
 
-<script src="06-post-create.js?v=20260326t" defer></script>
-<script src="07-post-load.js?v=20260326t" defer></script>
-<script src="08-post-actions.js?v=20260326t" defer></script>
-<script src="09-library.js?v=20260326t" defer></script>
-<script src="09-approval.js?v=20260326t" defer></script>
-<script src="04-router.js?v=20260326t" defer></script>
+<script src="06-post-create.js?v=20260326v" defer></script>
+<script src="07-post-load.js?v=20260326v" defer></script>
+<script src="08-post-actions.js?v=20260326v" defer></script>
+<script src="09-library.js?v=20260326v" defer></script>
+<script src="09-approval.js?v=20260326v" defer></script>
+<script src="04-router.js?v=20260326v" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Changed eyebrow label from "Client Request" to "Brief Title" in `_openBriefSheet()`
- Extracted `[Type: ...]` tag from `post.comments`, rendering it as a separate "Content Type" section with styled badge between the title meta and brief text
- Stripped `[URGENT]` prefix from brief text before display
- Bumped all 12 script version strings in `index.html` to `?v=20260326v`

## Files changed
- `07-post-load.js` — label fix + content type extraction logic + brief text cleanup
- `index.html` — version string bump (13 occurrences including styles.css)

https://claude.ai/code/session_018jerz7hJFdRnpP6jDnVftp