### PR TITLE
feat: brief create post, Pranav view, title spacing

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -323,6 +323,19 @@ if (npo) {
 
 await loadPosts();
 
+// Park the brief post if this was created from a brief
+if (window._activeBriefPostId) {
+  var _bid = window._activeBriefPostId;
+  window._activeBriefPostId = null;
+  apiFetch('/posts?post_id=eq.' + encodeURIComponent(_bid), {
+    method: 'PATCH',
+    body: JSON.stringify({
+      stage: 'parked',
+      updated_at: new Date().toISOString()
+    })
+  }).catch(function(){});
+}
+
 setTimeout(function() {
   // Restore original form DOM before closing
   if (npo && _npoOriginalHTML) npo.innerHTML = _npoOriginalHTML;

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -3238,6 +3238,18 @@ function _renderPipelineInner() {
 
   const grouped = {};
   source.forEach(p => { const s = p.stage || 'Unknown'; if (!grouped[s]) grouped[s] = []; grouped[s].push(p); });
+  // Pranav only sees briefs assigned to him
+  if (grouped['brief']) {
+    var _roleBF = (effectiveRole || '').toLowerCase();
+    var _isPranavBF = _roleBF === 'creative' ||
+      (window.currentUserEmail || '').toLowerCase().includes('pranav');
+    if (_isPranavBF) {
+      grouped['brief'] = (grouped['brief'] || []).filter(function(p) {
+        return (p.owner || '').toLowerCase() === 'pranav';
+      });
+      if (!grouped['brief'].length) delete grouped['brief'];
+    }
+  }
   const stages = Object.keys(grouped).sort((a,b) => {
     const ia = PIPELINE_RENDER_ORDER.indexOf(a), ib = PIPELINE_RENDER_ORDER.indexOf(b);
     if (ia===-1 && ib===-1) return a.localeCompare(b);
@@ -5483,7 +5495,11 @@ function _openBriefSheet(postId) {
   var existing = document.getElementById('brief-sheet-overlay');
   if (existing) existing.remove();
 
-  var isChitra = (window.effectiveRole || '').toLowerCase() !== 'client';
+  var _role = (window.effectiveRole || '').toLowerCase();
+  var _isClient = _role === 'client';
+  var _isPranav = _role === 'creative' ||
+    (window.currentUserEmail || '').toLowerCase().includes('pranav');
+  var _isChitra = !_isClient && !_isPranav;
   var sentTime = '';
   if (post.status_changed_at) {
     var d = new Date((post.status_changed_at || '') + 'Z');
@@ -5525,12 +5541,12 @@ function _openBriefSheet(postId) {
     '</div>' +
 
     // Title + meta
-    '<div style="padding:24px 18px 20px;">' +
+    '<div style="padding:28px 18px 0;">' +
     '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
     'letter-spacing:0.18em;text-transform:uppercase;color:rgba(255,255,255,0.4);' +
     'margin-bottom:8px;">Brief Title</div>' +
     '<div style="font-family:\'DM Sans\',sans-serif;font-size:24px;' +
-    'font-weight:700;color:#e8e2d9;line-height:1.2;margin-bottom:6px;">' +
+    'font-weight:700;color:#e8e2d9;line-height:1.2;margin-bottom:10px;">' +
     esc(post.title || '') + '</div>' +
     '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
     'letter-spacing:0.04em;color:rgba(255,255,255,0.4);">' +
@@ -5581,8 +5597,8 @@ function _openBriefSheet(postId) {
       '</div></div>'
       : '') +
 
-    // Chitra direction input (agency only)
-    (isChitra ?
+    // Role-based bottom action
+    (_isChitra ?
       '<div style="padding:0 18px 24px;">' +
       '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
       'letter-spacing:0.18em;text-transform:uppercase;' +
@@ -5595,7 +5611,6 @@ function _openBriefSheet(postId) {
       'padding:8px 0 10px;outline:none;resize:none;line-height:1.7;' +
       'caret-color:#C8A84B;"></textarea>' +
       '</div>' +
-      // Assign to Pranav button
       '<div style="padding:0 18px 32px;">' +
       '<button onclick="_assignBriefToPranav(\'' + postId + '\')" ' +
       'style="width:100%;font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
@@ -5604,8 +5619,16 @@ function _openBriefSheet(postId) {
       'padding:16px 0;cursor:pointer;' +
       'box-shadow:0 0 14px rgba(200,168,75,0.12);">&#x2192; Assign to Pranav</button>' +
       '</div>'
+      : _isPranav ?
+      '<div style="padding:0 18px 32px;">' +
+      '<button onclick="_createPostFromBrief(\'' + postId + '\')" ' +
+      'style="width:100%;font-family:\'IBM Plex Mono\',monospace;' +
+      'font-size:9px;letter-spacing:0.2em;text-transform:uppercase;' +
+      'color:#C8A84B;background:rgba(200,168,75,0.06);' +
+      'border:1px solid #C8A84B;padding:16px 0;cursor:pointer;' +
+      'box-shadow:0 0 14px rgba(200,168,75,0.12);">&#x2192; Create Post</button>' +
+      '</div>'
       :
-      // Client view - read only
       '<div style="padding:0 18px 32px;">' +
       '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
       'letter-spacing:0.12em;text-transform:uppercase;' +
@@ -5652,3 +5675,52 @@ function _assignBriefToPranav(postId) {
   });
 }
 window._assignBriefToPranav = _assignBriefToPranav;
+
+function _createPostFromBrief(briefPostId) {
+  var brief = (typeof getPostById === 'function')
+    ? getPostById(briefPostId) : null;
+  if (!brief) return;
+
+  // Close brief sheet
+  var overlay = document.getElementById('brief-sheet-overlay');
+  if (overlay) overlay.remove();
+  document.body.style.overflow = '';
+
+  // Open new post form
+  if (typeof openNewPostModal === 'function') {
+    openNewPostModal();
+  }
+
+  // Pre-fill after short delay to let form render
+  setTimeout(function() {
+    var titleEl = document.getElementById('new-post-title');
+    var captionEl = document.getElementById('new-post-caption');
+    var ownerEl = document.getElementById('new-post-owner');
+
+    if (titleEl) {
+      titleEl.value = brief.title || '';
+      titleEl.dispatchEvent(new Event('input'));
+    }
+    if (captionEl && brief.comments) {
+      // Strip [CHITRA NOTE] and [URGENT] from comments
+      var cleanBrief = (brief.comments || '')
+        .replace(/\[URGENT\]\s*/g, '')
+        .replace(/\[CHITRA NOTE\][^]*/gi, '')
+        .trim();
+      captionEl.value = cleanBrief;
+      captionEl.style.height = 'auto';
+      captionEl.style.height = captionEl.scrollHeight + 'px';
+    }
+    if (ownerEl) {
+      ownerEl.value = 'Pranav';
+      ownerEl.dispatchEvent(new Event('change'));
+    }
+
+    // Trigger validation so Create Post button enables
+    if (typeof _npsCheckValid === 'function') _npsCheckValid();
+
+    // Store brief post ID so we can park it after creation
+    window._activeBriefPostId = briefPostId;
+  }, 150);
+}
+window._createPostFromBrief = _createPostFromBrief;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326v">
+ <link rel="stylesheet" href="styles.css?v=20260326w">
 
 </head>
 <body>
@@ -909,19 +909,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326v" defer></script>
-<script src="02-session.js?v=20260326v" defer></script>
-<script src="utils.js?v=20260326v" defer></script>
-<script src="03-auth.js?v=20260326v" defer></script>
-<script src="05-api.js?v=20260326v" defer></script>
-<script src="10-ui.js?v=20260326v" defer></script>
+<script src="01-config.js?v=20260326w" defer></script>
+<script src="02-session.js?v=20260326w" defer></script>
+<script src="utils.js?v=20260326w" defer></script>
+<script src="03-auth.js?v=20260326w" defer></script>
+<script src="05-api.js?v=20260326w" defer></script>
+<script src="10-ui.js?v=20260326w" defer></script>
 
-<script src="06-post-create.js?v=20260326v" defer></script>
-<script src="07-post-load.js?v=20260326v" defer></script>
-<script src="08-post-actions.js?v=20260326v" defer></script>
-<script src="09-library.js?v=20260326v" defer></script>
-<script src="09-approval.js?v=20260326v" defer></script>
-<script src="04-router.js?v=20260326v" defer></script>
+<script src="06-post-create.js?v=20260326w" defer></script>
+<script src="07-post-load.js?v=20260326w" defer></script>
+<script src="08-post-actions.js?v=20260326w" defer></script>
+<script src="09-library.js?v=20260326w" defer></script>
+<script src="09-approval.js?v=20260326w" defer></script>
+<script src="04-router.js?v=20260326w" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- **Brief title spacing**: Increased hero padding (28px top), title margin-bottom (10px), removed bottom padding (divider handles gap)
- **Pranav view**: Pranav/Creative role sees only own briefs in pipeline, gets "Create Post" button instead of "Assign to Pranav"; Admin/Chitra sees all briefs with assign button; Client sees read-only message
- **_createPostFromBrief()**: Opens new post modal pre-filled with brief title, cleaned comments as caption, owner set to Pranav; parks the brief post after successful creation
- Bumped all 13 version strings to `?v=20260326w`
- Stripped all non-ASCII from 07-post-load.js and 06-post-create.js

## Files changed
- `07-post-load.js` — spacing fix, role checks, brief filter, _createPostFromBrief()
- `06-post-create.js` — brief parking after post creation
- `index.html` — version bump

## Test plan
- [ ] Verify brief sheet title has comfortable spacing between topbar and content type
- [ ] Login as Creative/Pranav: confirm only own briefs visible, "Create Post" button shown
- [ ] Login as Admin/Servicing: confirm all briefs visible, "Assign to Pranav" button shown
- [ ] Login as Client: confirm read-only message, no action button
- [ ] Click "Create Post" from brief: verify title, caption, owner pre-filled
- [ ] Submit post from brief: verify brief gets parked

https://claude.ai/code/session_01GxytxjWgmU52ZqUPPKAjkm