### PR TITLE
feat: notification triggers for all key actions

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -36,6 +36,30 @@ async function quickStage(postId, newStage) {
     post._isSaving = false;
     scheduleRender();
     await logActivity({ post_id: postId, actor: actor, actor_role: currentRole, action: `Stage -> ${newStage}` });
+    if (newStage === 'awaiting_approval') {
+      var _qaPost = (typeof getPostById === 'function')
+        ? getPostById(postId) : null;
+      var _qaTitle = _qaPost ? _qaPost.title : postId;
+      apiFetch('/notifications', {
+        method: 'POST',
+        body: JSON.stringify({
+          user_role: 'Client',
+          post_id:   postId,
+          type:      'awaiting_approval',
+          message:   _qaTitle + ' is ready for your approval'
+        })
+      }).catch(function(){});
+    }
+    apiFetch('/notifications', {
+      method: 'POST',
+      body: JSON.stringify({
+        user_role: 'Admin',
+        post_id:   postId,
+        type:      'stage_change',
+        message:   resolveActor() + ' moved ' +
+                   ((typeof getPostById === 'function' && getPostById(postId)) ? getPostById(postId).title : postId) + ' to ' + newStage
+      })
+    }).catch(function(){});
     showUndoToast(`Moved to ${newStage}`, () => quickStage(postId, oldStage));
   } catch (err) {
     post._isSaving = false;
@@ -150,6 +174,19 @@ async function clientApprove(postId, btn) {
       body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: 'Client' }),
     });
     await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
+    var _approvedTitle = post.title || postId;
+    ['Servicing', 'Admin'].forEach(function(role) {
+      apiFetch('/notifications', {
+        method: 'POST',
+        body: JSON.stringify({
+          user_role: role,
+          post_id:   postId,
+          type:      'awaiting_approval',
+          message:   'Client approved -- ' + _approvedTitle +
+                     ' is ready to schedule'
+        })
+      }).catch(function(){});
+    });
     const confirmEl = document.getElementById(`approved-confirm-${postId}`);
     if (confirmEl) confirmEl.classList.add('show');
     var cardEl = document.getElementById('approved-confirm-' + postId);
@@ -187,6 +224,20 @@ async function submitClientChanges(postId) {
       body: JSON.stringify({ stage: 'in_production', client_feedback: text, status_changed_at: new Date().toISOString(), updated_at: new Date().toISOString() }),
     });
     await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Client feedback: ' + text });
+    var _changesPost = (typeof getPostById === 'function')
+      ? getPostById(postId) : null;
+    var _changesTitle = _changesPost ? _changesPost.title : postId;
+    ['Servicing', 'Admin'].forEach(function(role) {
+      apiFetch('/notifications', {
+        method: 'POST',
+        body: JSON.stringify({
+          user_role: role,
+          post_id:   postId,
+          type:      'awaiting_brand_input',
+          message:   'Client requested changes -- ' + _changesTitle
+        })
+      }).catch(function(){});
+    });
     const item = document.getElementById(`apv-item-${postId}`);
     if (item) item.innerHTML =
       '<div style="padding:20px 16px;text-align:center;' +
@@ -340,6 +391,19 @@ async function submitClientRequest() {
     });
     console.log('[REQUEST] API SUCCESS');
     await logActivity({ post_id: postId, actor: email, actor_role: 'Client', action: 'New request: ' + brief.substring(0, 60) });
+    var _reqTitle = (document.getElementById('req-name') || {}).value ||
+      'New request';
+    ['Servicing', 'Admin'].forEach(function(role) {
+      apiFetch('/notifications', {
+        method: 'POST',
+        body: JSON.stringify({
+          user_role: role,
+          post_id:   postId,
+          type:      'stage_change',
+          message:   'Client submitted a brief -- ' + _reqTitle
+        })
+      }).catch(function(){});
+    });
     const topicEl = document.getElementById('req-topic');
     if (topicEl) topicEl.value = '';
     var nameResetEl = document.getElementById('req-name');

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326w">
+ <link rel="stylesheet" href="styles.css?v=20260326x">
 
 </head>
 <body>
@@ -909,19 +909,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326w" defer></script>
-<script src="02-session.js?v=20260326w" defer></script>
-<script src="utils.js?v=20260326w" defer></script>
-<script src="03-auth.js?v=20260326w" defer></script>
-<script src="05-api.js?v=20260326w" defer></script>
-<script src="10-ui.js?v=20260326w" defer></script>
+<script src="01-config.js?v=20260326x" defer></script>
+<script src="02-session.js?v=20260326x" defer></script>
+<script src="utils.js?v=20260326x" defer></script>
+<script src="03-auth.js?v=20260326x" defer></script>
+<script src="05-api.js?v=20260326x" defer></script>
+<script src="10-ui.js?v=20260326x" defer></script>
 
-<script src="06-post-create.js?v=20260326w" defer></script>
-<script src="07-post-load.js?v=20260326w" defer></script>
-<script src="08-post-actions.js?v=20260326w" defer></script>
-<script src="09-library.js?v=20260326w" defer></script>
-<script src="09-approval.js?v=20260326w" defer></script>
-<script src="04-router.js?v=20260326w" defer></script>
+<script src="06-post-create.js?v=20260326x" defer></script>
+<script src="07-post-load.js?v=20260326x" defer></script>
+<script src="08-post-actions.js?v=20260326x" defer></script>
+<script src="09-library.js?v=20260326x" defer></script>
+<script src="09-approval.js?v=20260326x" defer></script>
+<script src="04-router.js?v=20260326x" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Added notification inserts after `clientApprove()`, `submitClientChanges()`, `submitClientRequest()`, and `quickStage()` in `08-post-actions.js`
- Notifications target appropriate roles (Servicing/Admin for client actions, Client for awaiting_approval, Admin for all stage changes)
- All notification calls wrapped in `.catch(function(){})` so failures never block main actions
- Bumped all 13 asset version strings in `index.html` to `?v=20260326x`

## Test plan
- [x] Verify `clientApprove()` sends notifications to Servicing and Admin
- [x] Verify `submitClientChanges()` sends notifications to Servicing and Admin
- [x] Verify `submitClientRequest()` sends notifications to Servicing and Admin
- [x] Verify `quickStage()` to `awaiting_approval` notifies Client
- [x] Verify `quickStage()` notifies Admin on any stage change
- [x] Confirm notification failures do not block primary actions
- [x] Run `npm test` to ensure no regressions

https://claude.ai/code/session_016eFEutR1rYbrGHyz6zFgTx