### PR TITLE
fix: scoreboard noise, linkedin save, publish flow

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -979,8 +979,6 @@ function getScoreboardData() {
   // B-01 FIX: Count ready posts for Chitra context-aware action
   var readyCount = c.ready || 0;
 
-  console.log('[SCOREBOARD]', { counts: c, runwayCount: runwayCount, pranavDeficit: pranavDeficit, failedPublish: failedPublishCount });
-
   window._lastScoreboardData = {
     runwayCount: runwayCount,
     pranavDeficit: pranavDeficit,

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -1023,39 +1023,61 @@ function _removePublishSheet() {
   if (sheet) sheet.remove();
 }
 
-async function _confirmPublish(postId) {
-  var input = document.getElementById('pcs-li-url-input');
-  var url = input ? input.value.trim() : '';
-  _removePublishSheet();
+function _confirmPublish(postId) {
+  var input = document.getElementById('publish-li-input-' + postId)
+    || document.getElementById('li-url-input-' + postId);
+  var url = input ? (input.value || '').trim() : '';
 
-  // Save LinkedIn URL if provided
-  if (url) {
-    try {
-      await apiFetch('/posts?post_id=eq.' + postId, {
-        method: 'PATCH',
-        body: JSON.stringify({ linkedin_link: url })
-      });
-      // Update allPosts in memory
-      if (window.allPosts && Array.isArray(window.allPosts)) {
-        var idx = window.allPosts.findIndex(function(p) {
-          return p.post_id === postId || p.id === postId;
-        });
-        if (idx !== -1) {
-          window.allPosts[idx].linkedinUrl = url;
-          window.allPosts[idx].linkedin_link = url;
-        }
+  var btn = document.getElementById('confirm-publish-btn-' + postId);
+  if (btn) { btn.textContent = 'Publishing...'; btn.disabled = true; }
+
+  var payload = {
+    stage: 'published',
+    status_changed_at: new Date().toISOString(),
+    updated_at: new Date().toISOString()
+  };
+  if (url) payload.linkedin_link = url;
+
+  apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
+    method: 'PATCH',
+    body: JSON.stringify(payload)
+  }).then(function() {
+    var idx = (allPosts || []).findIndex(function(p) {
+      return p.post_id === postId;
+    });
+    if (idx !== -1) {
+      allPosts[idx].stage = 'published';
+      if (url) {
+        allPosts[idx].linkedin_link = url;
+        allPosts[idx].linkedinUrl = url;
       }
-    } catch(e) {
-      console.warn('[PUBLISH] Failed to save LinkedIn URL:', e);
     }
-  }
+    logActivity({
+      post_id: postId,
+      actor: window.currentUserName || 'Shubham',
+      actor_role: window.effectiveRole || 'Admin',
+      action: 'published'
+    });
+    apiFetch('/notifications', {
+      method: 'POST',
+      body: JSON.stringify({
+        user_role: 'Admin',
+        post_id: postId,
+        type: 'published',
+        message: (window.currentUserName || 'Shubham') +
+          ' published ' +
+          ((allPosts[idx] || {}).title || postId)
+      })
+    }).catch(function(){});
 
-  // Now change stage to published
-  if (typeof quickStage === 'function') {
-    quickStage(postId, 'published');
-  } else if (typeof _showStageConfirm === 'function') {
-    _showStageConfirm(postId, 'published');
-  }
+    showToast('Published', 'success');
+    if (typeof closePCS === 'function') closePCS();
+    loadPosts();
+  }).catch(function(err) {
+    console.error('Publish failed:', err);
+    showToast('Publish failed - try again', 'error');
+    if (btn) { btn.textContent = 'Publish'; btn.disabled = false; }
+  });
 }
 window._confirmPublish = _confirmPublish;
 
@@ -1070,28 +1092,40 @@ async function _skipPublish(postId) {
 }
 window._skipPublish = _skipPublish;
 
-async function _saveLiUrlInline(postId) {
-  var input = document.getElementById('pcs-li-inline-input');
-  var url = input ? input.value.trim() : '';
+function _saveLiUrlInline(postId) {
+  var input = document.getElementById('li-url-input-' + postId);
+  if (!input) return;
+  var url = (input.value || '').trim();
   if (!url) return;
-  try {
-    await apiFetch('/posts?post_id=eq.' + postId, {
-      method: 'PATCH',
-      body: JSON.stringify({ linkedin_link: url })
-    });
-    if (window.allPosts && Array.isArray(window.allPosts)) {
-      var idx = window.allPosts.findIndex(function(p) {
-        return p.post_id === postId || p.id === postId;
-      });
-      if (idx !== -1) {
-        window.allPosts[idx].linkedinUrl = url;
-        window.allPosts[idx].linkedin_link = url;
-      }
-    }
-    if (typeof openPCS === 'function') openPCS(postId, '');
-  } catch(e) {
-    alert('Failed to save. Please try again.');
+
+  var btn = document.getElementById('li-save-btn-' + postId);
+  if (btn) {
+    btn.textContent = 'Saving...';
+    btn.disabled = true;
   }
+
+  apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
+    method: 'PATCH',
+    body: JSON.stringify({ linkedin_link: url })
+  }).then(function() {
+    var idx = (allPosts || []).findIndex(function(p) {
+      return p.post_id === postId;
+    });
+    if (idx !== -1) {
+      allPosts[idx].linkedin_link = url;
+      allPosts[idx].linkedinUrl = url;
+    }
+    showToast('LinkedIn link saved', 'success');
+    if (typeof openPCS === 'function') openPCS(postId, '');
+    loadPosts();
+  }).catch(function(err) {
+    console.error('LinkedIn save failed:', err);
+    showToast('Save failed - try again', 'error');
+    if (btn) {
+      btn.textContent = 'Save';
+      btn.disabled = false;
+    }
+  });
 }
 window._saveLiUrlInline = _saveLiUrlInline;
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326x">
+ <link rel="stylesheet" href="styles.css?v=20260326y">
 
 </head>
 <body>
@@ -909,19 +909,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326x" defer></script>
-<script src="02-session.js?v=20260326x" defer></script>
-<script src="utils.js?v=20260326x" defer></script>
-<script src="03-auth.js?v=20260326x" defer></script>
-<script src="05-api.js?v=20260326x" defer></script>
-<script src="10-ui.js?v=20260326x" defer></script>
+<script src="01-config.js?v=20260326y" defer></script>
+<script src="02-session.js?v=20260326y" defer></script>
+<script src="utils.js?v=20260326y" defer></script>
+<script src="03-auth.js?v=20260326y" defer></script>
+<script src="05-api.js?v=20260326y" defer></script>
+<script src="10-ui.js?v=20260326y" defer></script>
 
-<script src="06-post-create.js?v=20260326x" defer></script>
-<script src="07-post-load.js?v=20260326x" defer></script>
-<script src="08-post-actions.js?v=20260326x" defer></script>
-<script src="09-library.js?v=20260326x" defer></script>
-<script src="09-approval.js?v=20260326x" defer></script>
-<script src="04-router.js?v=20260326x" defer></script>
+<script src="06-post-create.js?v=20260326y" defer></script>
+<script src="07-post-load.js?v=20260326y" defer></script>
+<script src="08-post-actions.js?v=20260326y" defer></script>
+<script src="09-library.js?v=20260326y" defer></script>
+<script src="09-approval.js?v=20260326y" defer></script>
+<script src="04-router.js?v=20260326y" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- **Remove `[SCOREBOARD]` console.log** from `getScoreboardData()` in `07-post-load.js` — pure noise, logged on every render cycle (every 15s poll)
- **Rewrite `_saveLiUrlInline()`** in `08-post-actions.js` — adds save button feedback (Saving.../disabled), proper error toast, `encodeURIComponent` on postId, and calls `loadPosts()` after save to sync DB to memory
- **Rewrite `_confirmPublish()`** in `08-post-actions.js` — replaces two separate PATCHes (linkedin_link then quickStage) with a single atomic PATCH that sets stage + linkedin_link together, preventing half-saved states. Adds activity logging and admin notification inline.
- Strip all non-ASCII from both JS files
- Bump all 13 cache-bust versions in `index.html` to `?v=20260326y`

## Test plan
- [x] `node --check` passes on both JS files
- [x] `npm test` — 66/66 tests pass
- [ ] Verify PCS LinkedIn inline save shows "Saving..." feedback and toast on success
- [ ] Verify publish flow saves linkedin_link + stage in one request
- [ ] Verify no `[SCOREBOARD]` logs in browser console

https://claude.ai/code/session_01TTWtynZ5QRVNXX5ZqsiqoS