### PR TITLE
fix: Pranav role detection includes preview role

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -3222,8 +3222,9 @@ function _renderPipelineInner() {
   // -- ROLE-BASED PIPELINE FILTERING --
   var _rolePL = (effectiveRole || '').toLowerCase();
   var _isPranavPL = _rolePL === 'creative' ||
+    _rolePL === 'pranav' ||
     (window.currentUserEmail || '').toLowerCase().includes('pranav');
-  var _isChitraPL = _rolePL === 'servicing' && !_isPranavPL;
+  var _isChitraPL = (_rolePL === 'servicing' || _rolePL === 'chitra') && !_isPranavPL;
   var _isAdminPL = !_isClient && !_isPranavPL && !_isChitraPL;
 
   if (_isPranavPL) {
@@ -5576,6 +5577,7 @@ function _openBriefSheet(postId) {
   var _role = (window.effectiveRole || '').toLowerCase();
   var _isClient = _role === 'client';
   var _isPranav = _role === 'creative' ||
+    _role === 'pranav' ||
     (window.currentUserEmail || '').toLowerCase().includes('pranav');
   var _isChitra = !_isClient && !_isPranav;
   var _isBriefDone = (post.stage || '') === 'brief_done';

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -623,6 +623,7 @@ function _renderPCS(postId) {
   const linkedinUrl = post.linkedinUrl || '';
   var _pcsRole = (effectiveRole || '').toLowerCase();
   var _isPranavPCS = _pcsRole === 'creative' ||
+    _pcsRole === 'pranav' ||
     (window.currentUserEmail || '').toLowerCase().includes('pranav');
   const canEdit = _pcsRole !== 'client' && !_isPranavPCS;
   const canEditCreative = _isPranavPCS;
@@ -1586,6 +1587,7 @@ var _ADVANCE_CLS = {
 function _renderAdvanceButton(stageLC) {
   var _advRole = (effectiveRole || '').toLowerCase();
   var _isPranavAdv = _advRole === 'creative' ||
+    _advRole === 'pranav' ||
     (window.currentUserEmail||'').toLowerCase().includes('pranav');
   if (_advRole === 'client' || _isPranavAdv) return '';
   var block = document.getElementById('pc-advance-block');

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326ac">
+ <link rel="stylesheet" href="styles.css?v=20260326ad">
 
 </head>
 <body>
@@ -909,19 +909,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326ac" defer></script>
-<script src="02-session.js?v=20260326ac" defer></script>
-<script src="utils.js?v=20260326ac" defer></script>
-<script src="03-auth.js?v=20260326ac" defer></script>
-<script src="05-api.js?v=20260326ac" defer></script>
-<script src="10-ui.js?v=20260326ac" defer></script>
+<script src="01-config.js?v=20260326ad" defer></script>
+<script src="02-session.js?v=20260326ad" defer></script>
+<script src="utils.js?v=20260326ad" defer></script>
+<script src="03-auth.js?v=20260326ad" defer></script>
+<script src="05-api.js?v=20260326ad" defer></script>
+<script src="10-ui.js?v=20260326ad" defer></script>
 
-<script src="06-post-create.js?v=20260326ac" defer></script>
-<script src="07-post-load.js?v=20260326ac" defer></script>
-<script src="08-post-actions.js?v=20260326ac" defer></script>
-<script src="09-library.js?v=20260326ac" defer></script>
-<script src="09-approval.js?v=20260326ac" defer></script>
-<script src="04-router.js?v=20260326ac" defer></script>
+<script src="06-post-create.js?v=20260326ad" defer></script>
+<script src="07-post-load.js?v=20260326ad" defer></script>
+<script src="08-post-actions.js?v=20260326ad" defer></script>
+<script src="09-library.js?v=20260326ad" defer></script>
+<script src="09-approval.js?v=20260326ad" defer></script>
+<script src="04-router.js?v=20260326ad" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- All four `_isPranav` detection checks now include `_role === 'pranav'` so Admin role-preview as Pranav gets the correct creative-restricted view
- Adds `'chitra'` to `_isChitraPL` so Admin previewing as Chitra also gets correct filtering
- Bumps all 13 script version strings to `?v=20260326ad`

### Locations fixed
| File | Function | Variable |
|------|----------|----------|
| `07-post-load.js` | `_renderPipelineInner()` | `_isPranavPL`, `_isChitraPL` |
| `07-post-load.js` | `_openBriefSheet()` | `_isPranav` |
| `08-post-actions.js` | `_renderPCS()` | `_isPranavPCS` |
| `08-post-actions.js` | `_renderAdvanceButton()` | `_isPranavAdv` |

## Test plan
- [x] `node --check` passes on both JS files
- [x] `npm test` — 66/66 passing
- [ ] Manual: Log in as Admin -> switch to Pranav view -> verify pipeline is filtered to creative-owned posts
- [ ] Manual: In Pranav preview, open PCS -> verify advance button is hidden and edit is creative-restricted
- [ ] Manual: Switch to Chitra view -> verify pipeline shows servicing-filtered posts

https://claude.ai/code/session_01WtpkGELjNmme1joksCgLGv