### PR TITLE
fix: canEditCreative scope in _buildInfoGrid

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -877,7 +877,7 @@ function _renderPCS(postId) {
       '</div>';
   }
 
-  if (elFields)   elFields.innerHTML = captionHtml + whatsappHtml + _buildInfoGrid(post, canEdit, id) + _buildNotes(post, canEdit, id) + liHtml + '<input type="hidden" id="pcs-post-id" value="' + esc(id) + '">';
+  if (elFields)   elFields.innerHTML = captionHtml + whatsappHtml + _buildInfoGrid(post, canEdit, canEditCreative, id) + _buildNotes(post, canEdit, id) + liHtml + '<input type="hidden" id="pcs-post-id" value="' + esc(id) + '">';
 
   // Stage advance button
   _renderAdvanceButton(stageLC);
@@ -1439,7 +1439,7 @@ function _loadPCSActivity(postId, bodyEl) {
   bodyEl.innerHTML = '<div class="pcs-activity-empty">No activity yet.</div>';
 }
 
-function _buildInfoGrid(post, canEdit, id) {
+function _buildInfoGrid(post, canEdit, canEditCreative, id) {
   var LOCS     = ['Mumbai','Sakarwadi','Sameerwadi','Other'];
   var OWNERS   = ALLOWED_OWNERS;
   var FORMATS  = ['Creative','Photo','Carousel','Video','Text'];

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326ae">
+ <link rel="stylesheet" href="styles.css?v=20260326af">
 
 </head>
 <body>
@@ -909,19 +909,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326ae" defer></script>
-<script src="02-session.js?v=20260326ae" defer></script>
-<script src="utils.js?v=20260326ae" defer></script>
-<script src="03-auth.js?v=20260326ae" defer></script>
-<script src="05-api.js?v=20260326ae" defer></script>
-<script src="10-ui.js?v=20260326ae" defer></script>
+<script src="01-config.js?v=20260326af" defer></script>
+<script src="02-session.js?v=20260326af" defer></script>
+<script src="utils.js?v=20260326af" defer></script>
+<script src="03-auth.js?v=20260326af" defer></script>
+<script src="05-api.js?v=20260326af" defer></script>
+<script src="10-ui.js?v=20260326af" defer></script>
 
-<script src="06-post-create.js?v=20260326ae" defer></script>
-<script src="07-post-load.js?v=20260326ae" defer></script>
-<script src="08-post-actions.js?v=20260326ae" defer></script>
-<script src="09-library.js?v=20260326ae" defer></script>
-<script src="09-approval.js?v=20260326ae" defer></script>
-<script src="04-router.js?v=20260326ae" defer></script>
+<script src="06-post-create.js?v=20260326af" defer></script>
+<script src="07-post-load.js?v=20260326af" defer></script>
+<script src="08-post-actions.js?v=20260326af" defer></script>
+<script src="09-library.js?v=20260326af" defer></script>
+<script src="09-approval.js?v=20260326af" defer></script>
+<script src="04-router.js?v=20260326af" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Pass `canEditCreative` as explicit parameter from `_renderPCS()` call site into `_buildInfoGrid()` function definition
- Previously `canEditCreative` was defined in `_renderPCS()` but used inside `_buildInfoGrid()` without being passed — relied on closure/global leak
- Call site (line 880): `_buildInfoGrid(post, canEdit, canEditCreative, id)`
- Definition (line 1442): `function _buildInfoGrid(post, canEdit, canEditCreative, id)`
- Bumped all 13 version strings to `?v=20260326af`

## Test plan
- [x] `node --check 08-post-actions.js` passes
- [x] `npm test` — 66/66 tests pass
- [ ] Open PCS modal as Pranav — verify Pillar/Location/Format dropdowns are editable
- [ ] Open PCS modal as Admin — verify all fields remain editable
- [ ] After merge: purge Cloudflare cache (srtd.io → Caching → Configuration → Purge Everything), hard refresh all devices

https://claude.ai/code/session_013JfTvYx3VwWoxaGmDrNfTy