### PR TITLE
fix: login overlay z-index above bottom nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326af">
+ <link rel="stylesheet" href="styles.css?v=20260326ag">
 
 </head>
 <body>
@@ -909,19 +909,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326af" defer></script>
-<script src="02-session.js?v=20260326af" defer></script>
-<script src="utils.js?v=20260326af" defer></script>
-<script src="03-auth.js?v=20260326af" defer></script>
-<script src="05-api.js?v=20260326af" defer></script>
-<script src="10-ui.js?v=20260326af" defer></script>
+<script src="01-config.js?v=20260326ag" defer></script>
+<script src="02-session.js?v=20260326ag" defer></script>
+<script src="utils.js?v=20260326ag" defer></script>
+<script src="03-auth.js?v=20260326ag" defer></script>
+<script src="05-api.js?v=20260326ag" defer></script>
+<script src="10-ui.js?v=20260326ag" defer></script>
 
-<script src="06-post-create.js?v=20260326af" defer></script>
-<script src="07-post-load.js?v=20260326af" defer></script>
-<script src="08-post-actions.js?v=20260326af" defer></script>
-<script src="09-library.js?v=20260326af" defer></script>
-<script src="09-approval.js?v=20260326af" defer></script>
-<script src="04-router.js?v=20260326af" defer></script>
+<script src="06-post-create.js?v=20260326ag" defer></script>
+<script src="07-post-load.js?v=20260326ag" defer></script>
+<script src="08-post-actions.js?v=20260326ag" defer></script>
+<script src="09-library.js?v=20260326ag" defer></script>
+<script src="09-approval.js?v=20260326ag" defer></script>
+<script src="04-router.js?v=20260326ag" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -222,7 +222,7 @@ a:hover { text-decoration: underline; }
 #login-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: 1100;
   background: var(--bg);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Bump `#login-overlay` z-index from `1000` to `1100` so it fully covers `.bottom-nav` (z-index `1000`) during login
- Bump all 13 cache-bust version strings from `?v=20260326af` to `?v=20260326ag`

## Files changed
- `styles.css` — z-index fix on `#login-overlay`
- `index.html` — version string bump (13 occurrences)

## Test plan
- [ ] Open app logged out — confirm bottom nav is not visible behind login overlay
- [ ] Log in — confirm dashboard loads normally
- [ ] Hard refresh to pick up new cache-bust version

## Post-merge
Purge Cloudflare cache: **srtd.io → Caching → Configuration → Purge Everything**. Hard refresh all devices.

https://claude.ai/code/session_01Jh6bjsPYPxvnrLc728svVX