### PR TITLE
fix: notifications title, view button, mark read, linkedin save

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -36,17 +36,18 @@ async function quickStage(postId, newStage) {
     post._isSaving = false;
     scheduleRender();
     await logActivity({ post_id: postId, actor: actor, actor_role: currentRole, action: `Stage -> ${newStage}` });
+    var _qsPost = (typeof getPostById === 'function')
+      ? getPostById(postId) : null;
+    var _qsTitle = _qsPost ? (_qsPost.title || postId) : postId;
+    var _qsPostId = _qsPost ? _qsPost.post_id : postId;
     if (newStage === 'awaiting_approval') {
-      var _qaPost = (typeof getPostById === 'function')
-        ? getPostById(postId) : null;
-      var _qaTitle = _qaPost ? _qaPost.title : postId;
       apiFetch('/notifications', {
         method: 'POST',
         body: JSON.stringify({
           user_role: 'Client',
-          post_id:   postId,
+          post_id:   _qsPostId,
           type:      'awaiting_approval',
-          message:   _qaTitle + ' is ready for your approval'
+          message:   _qsTitle + ' is ready for your approval'
         })
       }).catch(function(){});
     }
@@ -54,10 +55,9 @@ async function quickStage(postId, newStage) {
       method: 'POST',
       body: JSON.stringify({
         user_role: 'Admin',
-        post_id:   postId,
+        post_id:   _qsPostId,
         type:      'stage_change',
-        message:   resolveActor() + ' moved ' +
-                   ((typeof getPostById === 'function' && getPostById(postId)) ? getPostById(postId).title : postId) + ' to ' + newStage
+        message:   resolveActor() + ' moved ' + _qsTitle + ' to ' + newStage
       })
     }).catch(function(){});
     showUndoToast(`Moved to ${newStage}`, () => quickStage(postId, oldStage));
@@ -175,12 +175,13 @@ async function clientApprove(postId, btn) {
     });
     await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
     var _approvedTitle = post.title || postId;
+    var _approvedPostId = post.post_id || postId;
     ['Servicing', 'Admin'].forEach(function(role) {
       apiFetch('/notifications', {
         method: 'POST',
         body: JSON.stringify({
           user_role: role,
-          post_id:   postId,
+          post_id:   _approvedPostId,
           type:      'awaiting_approval',
           message:   'Client approved -- ' + _approvedTitle +
                      ' is ready to schedule'
@@ -226,13 +227,14 @@ async function submitClientChanges(postId) {
     await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Client feedback: ' + text });
     var _changesPost = (typeof getPostById === 'function')
       ? getPostById(postId) : null;
-    var _changesTitle = _changesPost ? _changesPost.title : postId;
+    var _changesTitle = _changesPost ? (_changesPost.title || postId) : postId;
+    var _changesPostId = _changesPost ? _changesPost.post_id : postId;
     ['Servicing', 'Admin'].forEach(function(role) {
       apiFetch('/notifications', {
         method: 'POST',
         body: JSON.stringify({
           user_role: role,
-          post_id:   postId,
+          post_id:   _changesPostId,
           type:      'awaiting_brand_input',
           message:   'Client requested changes -- ' + _changesTitle
         })
@@ -1063,15 +1065,18 @@ function _confirmPublish(postId) {
       actor_role: window.effectiveRole || 'Admin',
       action: 'published'
     });
+    var _notifPost = (allPosts||[]).find(function(p) {
+      return p.post_id === postId || p.id === postId;
+    });
+    var _notifTitle = _notifPost ? (_notifPost.title || postId) : postId;
     apiFetch('/notifications', {
       method: 'POST',
       body: JSON.stringify({
         user_role: 'Admin',
-        post_id: postId,
+        post_id: (_notifPost ? _notifPost.post_id : postId),
         type: 'published',
         message: (window.currentUserName || 'Shubham') +
-          ' published ' +
-          ((allPosts[idx] || {}).title || postId)
+          ' published ' + _notifTitle
       })
     }).catch(function(){});
 
@@ -1098,10 +1103,14 @@ async function _skipPublish(postId) {
 window._skipPublish = _skipPublish;
 
 function _saveLiUrlInline(postId) {
-  var input = document.getElementById('li-url-input-' + postId);
+  var input = document.getElementById('li-url-input-' + postId)
+    || document.getElementById('pcs-li-inline-input');
   if (!input) return;
   var url = (input.value || '').trim();
-  if (!url) return;
+  if (!url) {
+    showToast('Please enter a URL', 'error');
+    return;
+  }
 
   var btn = document.getElementById('li-save-btn-' + postId);
   if (btn) {

--- a/10-ui.js
+++ b/10-ui.js
@@ -481,7 +481,8 @@ async function markAllNotificationsRead() {
     var currentName = resolveActor() || 'there';
     renderNotifications(currentName, currentRole);
     updateNotifBadge();
-    await apiFetch('/notifications?read=eq.false', {
+    var _marRole = (window.effectiveRole || 'Admin');
+    await apiFetch('/notifications?read=eq.false&user_role=eq.' + encodeURIComponent(_marRole), {
       method: 'PATCH',
       body: JSON.stringify({ read: true }),
     });

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326ah">
+ <link rel="stylesheet" href="styles.css?v=20260326ai">
 
 </head>
 <body>
@@ -909,19 +909,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326ah" defer></script>
-<script src="02-session.js?v=20260326ah" defer></script>
-<script src="utils.js?v=20260326ah" defer></script>
-<script src="03-auth.js?v=20260326ah" defer></script>
-<script src="05-api.js?v=20260326ah" defer></script>
-<script src="10-ui.js?v=20260326ah" defer></script>
+<script src="01-config.js?v=20260326ai" defer></script>
+<script src="02-session.js?v=20260326ai" defer></script>
+<script src="utils.js?v=20260326ai" defer></script>
+<script src="03-auth.js?v=20260326ai" defer></script>
+<script src="05-api.js?v=20260326ai" defer></script>
+<script src="10-ui.js?v=20260326ai" defer></script>
 
-<script src="06-post-create.js?v=20260326ah" defer></script>
-<script src="07-post-load.js?v=20260326ah" defer></script>
-<script src="08-post-actions.js?v=20260326ah" defer></script>
-<script src="09-library.js?v=20260326ah" defer></script>
-<script src="09-approval.js?v=20260326ah" defer></script>
-<script src="04-router.js?v=20260326ah" defer></script>
+<script src="06-post-create.js?v=20260326ai" defer></script>
+<script src="07-post-load.js?v=20260326ai" defer></script>
+<script src="08-post-actions.js?v=20260326ai" defer></script>
+<script src="09-library.js?v=20260326ai" defer></script>
+<script src="09-approval.js?v=20260326ai" defer></script>
+<script src="04-router.js?v=20260326ai" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4333,7 +4333,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 .notif-time {
   font-family: var(--mono);
   font-size: 8px;
-  color: var(--muted);
+  color: rgba(255,255,255,0.55);
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary

- **FIX 1**: All notification POST calls in `08-post-actions.js` now resolve post title (not raw UUID) for messages, and store text `post_id` (e.g. `POST-030`) in notification records
- **FIX 2**: `markAllNotificationsRead()` in `10-ui.js` now filters PATCH by `user_role=eq.<currentRole>` so only the active role's notifications are marked read
- **FIX 3**: `.notif-time` color changed from `var(--muted)` (#555) to `rgba(255,255,255,0.55)` for better timestamp visibility in dark theme
- **FIX 4**: `_saveLiUrlInline()` now falls back to `pcs-li-inline-input` when `li-url-input-{postId}` is missing (fixes silent save failure on PCS); shows error toast when URL is empty
- Bumped all script version strings in `index.html` to `?v=20260326ai`

## Test plan

- [x] All 66 existing tests pass (`npx vitest run`)
- [ ] Verify notification messages show post title not UUID after stage changes
- [ ] Verify "Mark all read" only marks current role's notifications
- [ ] Verify notification timestamps are visible in dark theme
- [ ] Verify LinkedIn URL save works from PCS published view

https://claude.ai/code/session_018UUN6AqepukciQm6oFmmnd