### PR TITLE
fix: notification badges all headers, client bell, VIEW button

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -3801,6 +3801,23 @@ function _renderClientViewInner() {
       '<div style="font-family:var(--mono);font-size:13px;' +
       'color:var(--c-gold);letter-spacing:0.08em;">srtd.io</div>' +
       '<div style="display:flex;align-items:center;gap:8px;">' +
+      '<button onclick="openNotifications()" ' +
+      'style="background:transparent;border:none;cursor:pointer;' +
+      'position:relative;padding:4px;display:flex;' +
+      'align-items:center;justify-content:center;">' +
+      '<svg width="18" height="18" viewBox="0 0 24 24" ' +
+      'fill="none" stroke="rgba(255,255,255,0.7)" ' +
+      'stroke-width="2" stroke-linecap="round" ' +
+      'stroke-linejoin="round">' +
+      '<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>' +
+      '<path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>' +
+      '<span id="notif-client-badge" ' +
+      'style="display:none;position:absolute;top:0;right:0;' +
+      'background:#FF4B4B;color:#fff;border-radius:50%;' +
+      'width:14px;height:14px;font-size:8px;' +
+      'align-items:center;justify-content:center;' +
+      'font-family:\'IBM Plex Mono\',monospace;">0</span>' +
+      '</button>' +
       '<button style="font-family:var(--mono);font-size:8px;' +
       'letter-spacing:0.12em;text-transform:uppercase;' +
       'color:var(--c-gold);background:transparent;' +

--- a/10-ui.js
+++ b/10-ui.js
@@ -451,7 +451,7 @@ async function openNotifItem(id, postId) {
 async function handleNotifAction(action, postId, notifId, event) {
   event.stopPropagation();
   await markNotifRead(notifId);
-  if (action === 'view' && postId) {
+  if ((action === 'view' || action === 'approve') && postId) {
     closeNotifications();
     setTimeout(function() {
       openPCS(postId, '');
@@ -464,13 +464,6 @@ async function handleNotifAction(action, postId, notifId, event) {
     var msg = 'Hi! Following up on ' + title + ' sent for approval. Please review when you get a chance.';
     if (navigator.clipboard) { navigator.clipboard.writeText(msg); }
     showChaseToast('Copied to clipboard');
-    return;
-  }
-  if (action === 'approve' && postId) {
-    closeNotifications();
-    setTimeout(function() {
-      openPCS(postId, '');
-    }, 150);
     return;
   }
 }
@@ -502,17 +495,30 @@ async function markAllNotificationsRead() {
 }
 
 function updateNotifBadge() {
-  var unread = _notifData.filter(function(n) { return !n.read; }).length;
-  var badge = document.getElementById('notif-nav-badge');
-  if (badge) {
-    badge.textContent = unread;
-    badge.style.display = unread > 0 ? '' : 'none';
-  }
-  var bellBadge = document.getElementById('notif-bell-badge');
-  if (bellBadge) {
-    bellBadge.textContent = unread;
-    bellBadge.style.display = unread > 0 ? '' : 'none';
-  }
+  var role = (window.effectiveRole || 'Admin');
+  var _badgeRole = role.charAt(0).toUpperCase() +
+    role.slice(1).toLowerCase();
+
+  apiFetch('/notifications?read=eq.false&user_role=eq.' +
+    encodeURIComponent(_badgeRole) + '&select=id')
+  .then(function(rows) {
+    var count = Array.isArray(rows) ? rows.length : 0;
+    var show = count > 0;
+    var countStr = count > 9 ? '9+' : String(count);
+
+    [
+      'notif-bell-badge',
+      'notif-pipeline-badge',
+      'notif-lib-badge',
+      'notif-ins-badge',
+      'notif-client-badge'
+    ].forEach(function(id) {
+      var el = document.getElementById(id);
+      if (!el) return;
+      el.textContent = countStr;
+      el.style.display = show ? 'flex' : 'none';
+    });
+  }).catch(function() {});
 }
 
 // -- PCS Activity toggle -----------------------


### PR DESCRIPTION
## Summary
- **updateNotifBadge()** now queries the API and updates ALL 5 bell badge elements (`notif-bell-badge`, `notif-pipeline-badge`, `notif-lib-badge`, `notif-ins-badge`, `notif-client-badge`) instead of only the dashboard badge and an orphan ID
- **Client header** now includes a bell icon with `notif-client-badge` so Client role users can access notifications
- **VIEW/approve actions** in notification panel consolidated into a single handler that closes the panel before opening PCS

## Test plan
- [x] `npm test` passes 66/66
- [x] `node --check` passes on both modified files
- [ ] Verify bell badges update on all views (Dashboard, Pipeline, Library, Insights, Client)
- [ ] Verify client header shows bell icon and opens notification panel on tap
- [ ] Verify tapping View/approve in notifications closes panel then opens PCS

https://claude.ai/code/session_013FdSRdatY567mokDLmy4xh