### PR TITLE
fix: comment input bar fixed to bottom of PCS

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -1206,7 +1206,6 @@ async function loadPcsComments(postId) {
     section.style.display = 'block';
     if (inputBar) {
       inputBar.style.display = 'flex';
-      inputBar.style.flexDirection = 'row';
     }
 
     if (!Array.isArray(rows) || rows.length === 0) {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326ar">
+ <link rel="stylesheet" href="styles.css?v=20260326as">
 
 </head>
 <body>
@@ -862,11 +862,11 @@
           <span id="pcs-activity-link" onclick="togglePCSActivity()" style="font-family:'IBM Plex Mono',monospace;font-size:7px;letter-spacing:0.14em;text-transform:uppercase;color:rgba(255,255,255,0.18);cursor:pointer;">&#x2193; Show activity log</span>
         </div>
       </div>
-      <!-- STICKY COMMENT INPUT -->
-      <div id="pcs-comment-input-bar" style="display:none;position:sticky;bottom:0;background:#0e0e14;border-top:1px solid rgba(255,255,255,0.08);padding:10px 16px 16px;flex-direction:row;gap:10px;align-items:flex-end;">
-        <textarea id="pcs-comment-input" rows="1" placeholder="Add a comment..." style="flex:1;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.1);color:#e8e2d9;font-family:'DM Sans',sans-serif;font-size:13px;line-height:1.5;padding:8px 12px;outline:none;resize:none;caret-color:#C8A84B;min-height:36px;max-height:80px;"></textarea>
-        <button onclick="submitPcsComment()" style="font-family:'IBM Plex Mono',monospace;font-size:8px;letter-spacing:0.14em;text-transform:uppercase;color:#C8A84B;background:rgba(200,168,75,0.08);border:1px solid rgba(200,168,75,0.3);padding:8px 14px;cursor:pointer;height:36px;white-space:nowrap;align-self:flex-end;">Send &#x2192;</button>
-      </div>
+    </div>
+    <!-- COMMENT INPUT BAR - outside scroll, inside pcs-screen -->
+    <div id="pcs-comment-input-bar" style="display:none;position:relative;flex-shrink:0;background:#0e0e14;border-top:1px solid rgba(255,255,255,0.08);padding:10px 16px 16px;gap:10px;align-items:flex-end;">
+      <textarea id="pcs-comment-input" rows="1" placeholder="Add a comment..." style="flex:1;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.1);color:#e8e2d9;font-family:'DM Sans',sans-serif;font-size:13px;line-height:1.5;padding:8px 12px;outline:none;resize:none;caret-color:#C8A84B;min-height:36px;max-height:80px;"></textarea>
+      <button onclick="submitPcsComment()" style="font-family:'IBM Plex Mono',monospace;font-size:8px;letter-spacing:0.14em;text-transform:uppercase;color:#C8A84B;background:rgba(200,168,75,0.08);border:1px solid rgba(200,168,75,0.3);padding:8px 14px;cursor:pointer;height:36px;white-space:nowrap;align-self:flex-end;">Send &#x2192;</button>
     </div>
 
   </div>
@@ -925,19 +925,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326ar" defer></script>
-<script src="02-session.js?v=20260326ar" defer></script>
-<script src="utils.js?v=20260326ar" defer></script>
-<script src="03-auth.js?v=20260326ar" defer></script>
-<script src="05-api.js?v=20260326ar" defer></script>
-<script src="10-ui.js?v=20260326ar" defer></script>
+<script src="01-config.js?v=20260326as" defer></script>
+<script src="02-session.js?v=20260326as" defer></script>
+<script src="utils.js?v=20260326as" defer></script>
+<script src="03-auth.js?v=20260326as" defer></script>
+<script src="05-api.js?v=20260326as" defer></script>
+<script src="10-ui.js?v=20260326as" defer></script>
 
-<script src="06-post-create.js?v=20260326ar" defer></script>
-<script src="07-post-load.js?v=20260326ar" defer></script>
-<script src="08-post-actions.js?v=20260326ar" defer></script>
-<script src="09-library.js?v=20260326ar" defer></script>
-<script src="09-approval.js?v=20260326ar" defer></script>
-<script src="04-router.js?v=20260326ar" defer></script>
+<script src="06-post-create.js?v=20260326as" defer></script>
+<script src="07-post-load.js?v=20260326as" defer></script>
+<script src="08-post-actions.js?v=20260326as" defer></script>
+<script src="09-library.js?v=20260326as" defer></script>
+<script src="09-approval.js?v=20260326as" defer></script>
+<script src="04-router.js?v=20260326as" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -3430,7 +3430,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   flex: 1;
   overflow-y: auto;
   scrollbar-width: none;
-  padding-bottom: 24px;
+  padding-bottom: 80px;
 }
 .pc-scroll-body::-webkit-scrollbar { display: none; }
 


### PR DESCRIPTION
## Summary
- Moved `#pcs-comment-input-bar` outside `.pc-scroll-body` to be a sibling inside `#pcs-screen` flex column — sits fixed at bottom
- Changed from `position:sticky` to `position:relative;flex-shrink:0` so it stays pinned below the scroll area
- Increased `.pc-scroll-body` padding-bottom from 24px to 80px so last comment isn't hidden
- Simplified `loadPcsComments()` inputBar display logic (removed unnecessary flexDirection set)
- Bumped all 13 version strings to `?v=20260326as`

## Test plan
- [x] `node --check 08-post-actions.js` passes
- [x] `npm test` — 66/66 tests pass

https://claude.ai/code/session_017pUfggqcCwUiZ68yz1Spd5