### PR TITLE
fix: comment timestamp parsing

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -1240,7 +1240,7 @@ async function loadPcsComments(postId) {
       var _initial = (c.author||'?').charAt(0).toUpperCase();
       var _ts = '';
       if (c.created_at) {
-        var _d = new Date((c.created_at||'').replace(' ','T').replace('+00','Z'));
+        var _d = new Date((c.created_at||'').replace(' ','T').replace('+00:00','Z').replace('+00','Z'));
         if (!isNaN(_d.getTime())) {
           _ts = _d.toLocaleDateString('en-IN',{
             day:'numeric',month:'short',

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326az">
+ <link rel="stylesheet" href="styles.css?v=20260326bc">
 
 </head>
 <body>
@@ -925,19 +925,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326az" defer></script>
-<script src="02-session.js?v=20260326az" defer></script>
-<script src="utils.js?v=20260326az" defer></script>
-<script src="03-auth.js?v=20260326az" defer></script>
-<script src="05-api.js?v=20260326az" defer></script>
-<script src="10-ui.js?v=20260326az" defer></script>
+<script src="01-config.js?v=20260326bc" defer></script>
+<script src="02-session.js?v=20260326bc" defer></script>
+<script src="utils.js?v=20260326bc" defer></script>
+<script src="03-auth.js?v=20260326bc" defer></script>
+<script src="05-api.js?v=20260326bc" defer></script>
+<script src="10-ui.js?v=20260326bc" defer></script>
 
-<script src="06-post-create.js?v=20260326az" defer></script>
-<script src="07-post-load.js?v=20260326az" defer></script>
-<script src="08-post-actions.js?v=20260326az" defer></script>
-<script src="09-library.js?v=20260326az" defer></script>
-<script src="09-approval.js?v=20260326az" defer></script>
-<script src="04-router.js?v=20260326az" defer></script>
+<script src="06-post-create.js?v=20260326bc" defer></script>
+<script src="07-post-load.js?v=20260326bc" defer></script>
+<script src="08-post-actions.js?v=20260326bc" defer></script>
+<script src="09-library.js?v=20260326bc" defer></script>
+<script src="09-approval.js?v=20260326bc" defer></script>
+<script src="04-router.js?v=20260326bc" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- Fix `loadPcsComments()` timestamp parsing in `08-post-actions.js` — replace `.replace('+00','Z')` with `.replace('+00:00','Z').replace('+00','Z')` so the standard `+00:00` offset returned by Supabase REST is correctly normalized instead of producing an invalid date string like `...Z:00`
- Bump all 12 asset versions in `index.html` to `?v=20260326bc`

## Test plan

- [x] `node --check 08-post-actions.js` passes
- [x] `npm test` — 66/66 tests pass
- [ ] Verify PCS comment timestamps render correctly for comments with `+00:00` offsets

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z