### PR TITLE
fix: remove client FAB, redundant with menu

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -4721,22 +4721,6 @@ function _renderClientViewInner() {
 
   renderClientApproved();
 
-  // Client FAB for New Request
-  var clientFab = document.getElementById('client-req-fab');
-  if (!clientFab) {
-    clientFab = document.createElement('div');
-    clientFab.id = 'client-req-fab';
-    clientFab.style.cssText = 'position:fixed;bottom:84px;right:20px;z-index:900;';
-    clientFab.innerHTML =
-      '<button onclick="openClientRequestForm()" ' +
-      'style="width:52px;height:52px;border-radius:50%;' +
-      'background:#C8A84B;border:none;cursor:pointer;' +
-      'display:flex;align-items:center;justify-content:center;' +
-      'box-shadow:0 4px 16px rgba(200,168,75,0.4);' +
-      'font-size:24px;color:#000;">+</button>';
-    document.body.appendChild(clientFab);
-  }
-  clientFab.style.display = '';
 }
 
 function openClientRequestForm() {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326bc">
+ <link rel="stylesheet" href="styles.css?v=20260326bd">
 
 </head>
 <body>
@@ -924,19 +924,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326bc" defer></script>
-<script src="02-session.js?v=20260326bc" defer></script>
-<script src="utils.js?v=20260326bc" defer></script>
-<script src="03-auth.js?v=20260326bc" defer></script>
-<script src="05-api.js?v=20260326bc" defer></script>
-<script src="10-ui.js?v=20260326bc" defer></script>
+<script src="01-config.js?v=20260326bd" defer></script>
+<script src="02-session.js?v=20260326bd" defer></script>
+<script src="utils.js?v=20260326bd" defer></script>
+<script src="03-auth.js?v=20260326bd" defer></script>
+<script src="05-api.js?v=20260326bd" defer></script>
+<script src="10-ui.js?v=20260326bd" defer></script>
 
-<script src="06-post-create.js?v=20260326bc" defer></script>
-<script src="07-post-load.js?v=20260326bc" defer></script>
-<script src="08-post-actions.js?v=20260326bc" defer></script>
-<script src="09-library.js?v=20260326bc" defer></script>
-<script src="09-approval.js?v=20260326bc" defer></script>
-<script src="04-router.js?v=20260326bc" defer></script>
+<script src="06-post-create.js?v=20260326bd" defer></script>
+<script src="07-post-load.js?v=20260326bd" defer></script>
+<script src="08-post-actions.js?v=20260326bd" defer></script>
+<script src="09-library.js?v=20260326bd" defer></script>
+<script src="09-approval.js?v=20260326bd" defer></script>
+<script src="04-router.js?v=20260326bd" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary\n- Removed the gold circular + FAB button (`#client-req-fab`) from the client view in `07-post-load.js`\n- Client can already access New Request via the ··· menu in the header\n- Bumped all 12 cache-bust versions in `index.html` to `?v=20260326bd`\n\n## Test plan\n- [x] `node --check 07-post-load.js` passes\n- [x] All 66 tests pass (`npm test`)\n- [x] No non-ASCII characters in codebase\n\nhttps://claude.ai/code/session_01Kivx1DptriYQCUJiZuDng4