### PR TITLE
feat: replace feedback with comments on boarding pass

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -4431,13 +4431,8 @@ function _renderClientViewInner() {
         'padding:14px 0;display:flex;align-items:center;justify-content:center;gap:6px;' +
         'box-shadow:inset 0 1px 0 rgba(255,255,255,0.04);cursor:pointer;">&#x25C8; Approve</button>' +
 
-        '<button onclick="showChangeInput(\'' + esc(id) + '\')" ' +
-        'style="flex:3;font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
-        'letter-spacing:0.14em;text-transform:uppercase;color:rgba(255,255,255,0.55);' +
-        'background:transparent;border:none;' +
-        'border-right:1px solid rgba(255,255,255,0.22);' +
-        'padding:14px 0;display:flex;align-items:center;justify-content:center;gap:6px;' +
-        'box-shadow:inset 0 1px 0 rgba(255,255,255,0.04);cursor:pointer;">&#x21A9; Changes</button>' +
+        '<button onclick="showBoardingComment(\'' + esc(id) + '\')" ' +
+        'style="flex:3;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.14em;text-transform:uppercase;color:rgba(255,255,255,0.55);background:transparent;border:none;border-right:1px solid rgba(255,255,255,0.22);padding:14px 0;display:flex;align-items:center;justify-content:center;gap:6px;box-shadow:inset 0 1px 0 rgba(255,255,255,0.04);cursor:pointer;">&#x1F4AC; Comment</button>' +
 
         '<a href="' + esc(waLink) + '" target="_blank" ' +
         'style="flex:2;display:flex;align-items:center;justify-content:center;' +
@@ -4453,23 +4448,13 @@ function _renderClientViewInner() {
 
         '</div>' +
 
-        '<div class="change-input-wrap" id="change-wrap-' + esc(id) + '">' +
-        '<div style="display:flex;align-items:center;' +
-        'justify-content:space-between;margin-bottom:10px;">' +
-        '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
-        'letter-spacing:0.16em;text-transform:uppercase;color:#F6A623;">' +
-        'What needs to change?</div>' +
-        '<button onclick="showChangeInput(\'' + esc(id) + '\')" ' +
-        'style="font-family:\'IBM Plex Mono\',monospace;font-size:11px;' +
-        'color:#e8e2d9;background:rgba(255,255,255,0.08);' +
-        'border:1px solid rgba(255,255,255,0.2);' +
-        'cursor:pointer;padding:4px 10px;' +
-        'line-height:1;letter-spacing:0;">&#x2715;</button>' +
-        '</div>' +
-        '<textarea class="change-textarea" id="change-text-' + esc(id) + '" ' +
-        'placeholder="Be specific -- tone, image, hashtags..." rows="3"></textarea>' +
-        '<button class="btn-send-changes" ' +
-        'onclick="submitClientChanges(\'' + esc(id) + '\')">&#x2192; Send Feedback</button>' +
+        '<div id="boarding-comment-wrap-' + esc(id) + '" ' +
+        'style="display:none;padding:12px 16px;">' +
+        '<textarea id="boarding-comment-input-' + esc(id) + '" ' +
+        'placeholder="Leave a comment or ask a question..." ' +
+        'style="width:100%;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.08);color:#e8e2d9;font-family:\'DM Sans\',sans-serif;font-size:13px;line-height:1.5;padding:10px 12px;outline:none;resize:none;min-height:80px;caret-color:#C8A84B;"></textarea>' +
+        '<button onclick="submitBoardingComment(\'' + esc(id) + '\')" ' +
+        'style="width:100%;font-family:\'IBM Plex Mono\',monospace;font-size:8px;letter-spacing:0.12em;text-transform:uppercase;color:#C8A84B;background:transparent;border:1px solid rgba(200,168,75,0.3);padding:9px 0;cursor:pointer;margin-top:8px;">Send Comment &#x2192;</button>' +
         '</div>' +
 
         '<div class="approval-confirmed" ' +
@@ -5612,17 +5597,17 @@ function _editorialChanges(postId) {
       '<div style="position:fixed;inset:0;background:#0a0a0f;' +
       'display:flex;flex-direction:column;align-items:center;' +
       'justify-content:center;gap:14px;z-index:6000;">' +
-      '<div style="font-size:28px;color:#F6A623;line-height:1;">&#x25C8;</div>' +
+      '<div style="font-size:28px;color:#C8A84B;line-height:1;">&#x1F4AC;</div>' +
       '<div style="font-family:\'DM Sans\',sans-serif;font-size:20px;' +
-      'font-weight:600;color:#e8e2d9;letter-spacing:-0.01em;">Opening feedback...</div>' +
+      'font-weight:600;color:#e8e2d9;letter-spacing:-0.01em;">Opening comments...</div>' +
       '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
       'letter-spacing:0.18em;text-transform:uppercase;color:rgba(255,255,255,0.5);">' +
-      'Tell us what to change.</div>' +
+      'Leave a comment or question.</div>' +
       '</div>';
   }
   setTimeout(function() {
     _closeClientEditorial();
-    if (typeof showChangeInput === 'function') showChangeInput(postId);
+    if (typeof showBoardingComment === 'function') showBoardingComment(postId);
   }, 1200);
 }
 window._editorialChanges = _editorialChanges;

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -238,43 +238,86 @@ function showChangeInput(postId) {
 }
 
 async function submitClientChanges(postId) {
-  const text = (document.getElementById(`change-text-${postId}`)?.value||'').trim();
-  if (!text) { showToast('Please describe what you want changed', 'error'); return; }
+  submitBoardingComment(postId);
+}
+window.submitClientChanges = submitClientChanges;
+
+function showBoardingComment(postId) {
+  var wrap = document.getElementById('boarding-comment-wrap-' + postId);
+  if (!wrap) return;
+  var isOpen = wrap.style.display === 'block';
+  wrap.style.display = isOpen ? 'none' : 'block';
+  if (!isOpen) {
+    var input = document.getElementById('boarding-comment-input-' + postId);
+    if (input) input.focus();
+  }
+}
+window.showBoardingComment = showBoardingComment;
+
+async function submitBoardingComment(postId) {
+  var input = document.getElementById('boarding-comment-input-' + postId);
+  if (!input) return;
+  var message = (input.value || '').trim();
+  if (!message) {
+    showToast('Please write a comment first', 'error');
+    return;
+  }
+
+  var _post = (allPosts||[]).find(function(p) {
+    return p.post_id === postId || p.id === postId;
+  });
+  var _realPostId = _post ? _post.post_id : postId;
+  var _title = _post ? (_post.title || postId) : postId;
+  var _author = window.currentUserName || 'Client';
+  var _role = window.effectiveRole || 'Client';
+  var _normalRole = _role.charAt(0).toUpperCase() + _role.slice(1).toLowerCase();
+
   try {
-    await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
-      method: 'PATCH',
-      body: JSON.stringify({ stage: 'in_production', client_feedback: text, status_changed_at: new Date().toISOString(), updated_at: new Date().toISOString() }),
+    await apiFetch('/post_comments', {
+      method: 'POST',
+      body: JSON.stringify({
+        post_id: _realPostId,
+        author: _author,
+        author_role: _normalRole,
+        message: message
+      })
     });
-    await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Client feedback: ' + text });
-    var _changesPost = (typeof getPostById === 'function')
-      ? getPostById(postId) : null;
-    var _changesTitle = _changesPost ? (_changesPost.title || postId) : postId;
-    var _changesPostId = _changesPost ? _changesPost.post_id : postId;
+
+    logActivity({
+      post_id: _realPostId,
+      actor: _author,
+      actor_role: _normalRole,
+      action: 'Commented: ' + message
+    });
+
     ['Servicing', 'Admin'].forEach(function(role) {
       apiFetch('/notifications', {
         method: 'POST',
         body: JSON.stringify({
           user_role: role,
-          post_id:   _changesPostId,
-          type:      'awaiting_brand_input',
-          message:   'Client requested changes -- ' + _changesTitle
+          post_id: _realPostId,
+          type: 'comment',
+          message: _author + ' commented on ' + _title
         })
       }).catch(function(){});
     });
-    const item = document.getElementById(`apv-item-${postId}`);
-    if (item) item.innerHTML =
-      '<div style="padding:20px 16px;text-align:center;' +
-      'border-top:1px dashed rgba(255,255,255,0.07);">' +
-      '<div style="font-size:20px;color:#F6A623;margin-bottom:10px;">&#x25C8;</div>' +
-      '<div style="font-family:\'DM Sans\',sans-serif;font-size:16px;' +
-      'font-weight:600;color:#e8e2d9;margin-bottom:6px;">Feedback sent.</div>' +
-      '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
-      'letter-spacing:0.08em;color:rgba(255,255,255,0.5);">' +
-      'The team will take care of it.</div>' +
-      '</div>';
-    setTimeout(() => loadPostsForClient(), 1000);
-  } catch { showToast('Failed  -  try again', 'error'); }
+
+    var item = document.getElementById('apv-item-' + postId);
+    if (item) {
+      item.innerHTML =
+        '<div style="padding:20px 16px;text-align:center;">' +
+        '<div style="font-size:20px;margin-bottom:8px;">&#x1F4AC;</div>' +
+        '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.16em;text-transform:uppercase;color:#C8A84B;">Comment sent</div>' +
+        '<div style="font-family:\'DM Sans\',sans-serif;font-size:12px;color:rgba(255,255,255,0.4);margin-top:6px;">The team has been notified.</div>' +
+        '</div>';
+    }
+
+  } catch(e) {
+    console.error('submitBoardingComment failed:', e);
+    showToast('Failed to send comment', 'error');
+  }
 }
+window.submitBoardingComment = submitBoardingComment;
 
 async function clientAcknowledge(postId) {
   try {
@@ -1754,49 +1797,17 @@ function _buildInfoGrid(post, canEdit, canEditCreative, id) {
 }
 
 function _buildNotes(post, canEdit, id) {
-  // Client feedback banner - read only, always visible if exists
-  var feedbackHtml = '';
-  if (post.client_feedback && post.client_feedback.trim()) {
-    feedbackHtml =
-      '<div style="background:rgba(255,75,75,0.06);' +
-      'border:1px solid rgba(255,75,75,0.25);' +
-      'border-left:3px solid #FF4B4B;' +
-      'padding:12px 14px;margin-bottom:14px;">' +
-      '<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">' +
-      '<div style="width:6px;height:6px;border-radius:50%;' +
-      'background:#FF4B4B;flex-shrink:0;"></div>' +
-      '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
-      'letter-spacing:0.16em;text-transform:uppercase;color:#FF4B4B;">' +
-      'Client Feedback</div>' +
-      '</div>' +
-      '<div style="font-family:\'DM Sans\',sans-serif;font-size:13px;' +
-      'color:#e8e2d9;line-height:1.6;">' +
-      esc(post.client_feedback) +
-      '</div>' +
-      '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
-      'letter-spacing:0.08em;color:rgba(255,255,255,0.4);margin-top:8px;">' +
-      (post.status_changed_at
-        ? new Date((post.status_changed_at || '') + 'Z').toLocaleDateString('en-IN',
-            {day:'numeric',month:'short',timeZone:'Asia/Kolkata'}) + ' -- ' +
-          new Date((post.status_changed_at || '') + 'Z').toLocaleTimeString('en-IN',
-            {hour:'numeric',minute:'2-digit',hour12:true,timeZone:'Asia/Kolkata'})
-        : ''
-      ) +
-      '</div>' +
-      '</div>';
-  }
-
   var _isClient = (window.effectiveRole || '').toLowerCase() === 'client';
-  if (_isClient) return feedbackHtml || '';
+  if (_isClient) return '';
 
-  if (!canEdit && !post.comments) return feedbackHtml;
+  if (!canEdit && !post.comments) return '';
 
   var notesInput = (canEdit || canEditCreative)
     ? '<textarea class="pc-notes-area" placeholder="Brief or caption..."' +
       ' onblur="updatePost(\'' + esc(id) + '\',\'comments\',this.value)">' + esc(post.comments || '') + '</textarea>'
     : (post.comments ? '<div class="pc-notes-ro">' + esc(post.comments) + '</div>' : '');
 
-  return feedbackHtml + '<div class="pc-notes-block">' +
+  return '<div class="pc-notes-block">' +
     '<div class="pc-notes-lbl" style="display:flex;align-items:center;gap:8px;">Internal Notes' +
     '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:6px;color:rgba(255,166,35,0.6);background:rgba(255,166,35,0.08);padding:2px 6px;letter-spacing:0.1em;text-transform:uppercase;">Agency only</span></div>' +
     (notesInput || '<div class="pcs-activity-empty">No notes.</div>') +

--- a/10-ui.js
+++ b/10-ui.js
@@ -456,15 +456,8 @@ function renderNotifications(name, role) {
       if (_postStage === 'brief')      { _chipColor='#C8A84B'; _chipBg='rgba(200,168,75,0.12)'; }
       if (_postStage === 'in_production') { _chipColor='#9b87f5'; _chipBg='rgba(155,135,245,0.12)'; }
       if (n.type === 'awaiting_brand_input') { _chipColor='#F6A623'; _chipBg='rgba(246,166,35,0.12)'; }
-      if (_postStage === 'in_production' && _notifPost &&
-          _notifPost.client_feedback) {
-        _chipColor='#FF4B4B'; _chipBg='rgba(255,75,75,0.12)';
-      }
-
       var _stageLabel = (_postStage||'').replace(/_/g,' ');
       if (_postStage === 'awaiting_approval') _stageLabel = 'Awaiting Approval';
-      if (_postStage === 'in_production' && _notifPost &&
-          _notifPost.client_feedback) _stageLabel = 'Feedback';
 
       var _actorName = parseActor(n.message).name;
       var _initial = _actorName ? _actorName.charAt(0).toUpperCase() : 'S';

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326bd">
+ <link rel="stylesheet" href="styles.css?v=20260326be">
 
 </head>
 <body>
@@ -924,19 +924,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326bd" defer></script>
-<script src="02-session.js?v=20260326bd" defer></script>
-<script src="utils.js?v=20260326bd" defer></script>
-<script src="03-auth.js?v=20260326bd" defer></script>
-<script src="05-api.js?v=20260326bd" defer></script>
-<script src="10-ui.js?v=20260326bd" defer></script>
+<script src="01-config.js?v=20260326be" defer></script>
+<script src="02-session.js?v=20260326be" defer></script>
+<script src="utils.js?v=20260326be" defer></script>
+<script src="03-auth.js?v=20260326be" defer></script>
+<script src="05-api.js?v=20260326be" defer></script>
+<script src="10-ui.js?v=20260326be" defer></script>
 
-<script src="06-post-create.js?v=20260326bd" defer></script>
-<script src="07-post-load.js?v=20260326bd" defer></script>
-<script src="08-post-actions.js?v=20260326bd" defer></script>
-<script src="09-library.js?v=20260326bd" defer></script>
-<script src="09-approval.js?v=20260326bd" defer></script>
-<script src="04-router.js?v=20260326bd" defer></script>
+<script src="06-post-create.js?v=20260326be" defer></script>
+<script src="07-post-load.js?v=20260326be" defer></script>
+<script src="08-post-actions.js?v=20260326be" defer></script>
+<script src="09-library.js?v=20260326be" defer></script>
+<script src="09-approval.js?v=20260326be" defer></script>
+<script src="04-router.js?v=20260326be" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- Replace "Changes" button with "Comment" button on boarding pass action bar
- Replace change-input-wrap with comment input that posts to `post_comments` table
- Update `_editorialChanges()` to open comment input instead of change input
- Add `showBoardingComment()` and `submitBoardingComment()` functions
- Gut `submitClientChanges()` to delegate to `submitBoardingComment()`
- Remove red `client_feedback` banner from `_buildNotes()`
- Remove `client_feedback` references from notification rendering in `10-ui.js`
- Bump all 12 asset versions to `?v=20260326be`

## Test plan

- [x] `node --check` passes on all 3 modified JS files
- [x] `npm test` — 66/66 tests pass
- [ ] Verify Comment button appears on boarding pass cards
- [ ] Verify submitting a comment posts to `post_comments` and notifies Servicing + Admin
- [ ] Verify red feedback banner no longer appears in PCS modal notes

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z