### PR TITLE
fix: editorial button order, labels, no-image placeholder

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -5403,11 +5403,20 @@ function _openClientEditorial(postId) {
     '</div>' +
 
     // Hero image
-    (hero ?
-      '<img src="' + hero + '" style="width:100%;max-height:280px;' +
+    (imgs.length === 0 ?
+      '<div style="width:100%;height:240px;' +
+      'background:rgba(255,255,255,0.03);' +
+      'display:flex;align-items:center;' +
+      'justify-content:center;' +
+      'border-bottom:1px solid rgba(255,255,255,0.06);">' +
+      '<div style="font-family:\'IBM Plex Mono\',monospace;' +
+      'font-size:8px;letter-spacing:0.16em;' +
+      'text-transform:uppercase;' +
+      'color:rgba(255,255,255,0.2);">No images yet</div>' +
+      '</div>'
+      : '<img src="' + esc(hero) + '" style="width:100%;max-height:280px;' +
       'object-fit:cover;display:block;cursor:pointer;" loading="eager" ' +
-      'onclick="_edOpenLightbox(\'' + postId + '\',0)">'
-      : '') +
+      'onclick="_edOpenLightbox(\'' + postId + '\',0)">') +
 
     // Body
     '<div style="padding:28px 22px 0;max-width:390px;margin:0 auto;">' +
@@ -5422,7 +5431,7 @@ function _openClientEditorial(postId) {
     // Title
     '<div style="font-family:\'DM Sans\',sans-serif;font-size:26px;' +
     'font-weight:700;color:#f0ece4;line-height:1.2;margin-bottom:20px;' +
-    'letter-spacing:-0.01em;">' + title + '</div>' +
+    'letter-spacing:-0.01em;">' + esc(title) + '</div>' +
 
     // Gold divider
     '<div style="width:32px;height:1px;background:#C8A84B;' +
@@ -5431,7 +5440,7 @@ function _openClientEditorial(postId) {
     // Caption
     '<div id="ed-caption-' + postId + '" style="font-family:\'DM Sans\',sans-serif;font-size:15px;' +
     'color:#888;line-height:1.8;white-space:pre-wrap;' +
-    'word-wrap:break-word;margin-bottom:28px;">' + caption + '</div>' +
+    'word-wrap:break-word;margin-bottom:28px;">' + esc(caption) + '</div>' +
 
     '</div>' +
 
@@ -5497,10 +5506,8 @@ function _openClientEditorial(postId) {
 
     // WhatsApp share
     (function(){
-      var _isDesktop = window.innerWidth > 768 && !('ontouchstart' in window);
       var rawSlug = (post.title||'').toLowerCase().replace(/[^a-z0-9\s]/g,' ').trim().replace(/\s+/g,'-').replace(/-+/g,'-').slice(0,50);
-      return '<div style="display:' + (_isDesktop ? 'flex' : 'block') + ';gap:8px;margin-bottom:10px;">' +
-      '<button onclick="(function(){' +
+      return '<button onclick="(function(){' +
       'var msg=\'' + (post.title||'').replace(/'/g,"\\'") + '\\n\\n\'+' +
       '(document.getElementById(\'ed-caption-\'+\'' + postId + '\') ? ' +
       'document.getElementById(\'ed-caption-\'+\'' + postId + '\').textContent : ' +
@@ -5510,49 +5517,28 @@ function _openClientEditorial(postId) {
       '\'\\nChanges: https://srtd.io/no/?p=' + rawSlug + '\';' +
       'window.open(\'https://wa.me/?text=\'+encodeURIComponent(msg),\'_blank\');' +
       '})()" ' +
-      'style="flex:1;width:100%;font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
-      'letter-spacing:0.14em;text-transform:uppercase;color:#e8e2d9;' +
-      'background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.12);' +
-      'padding:14px 0;cursor:pointer;display:block;">' +
-      '&#x2197; Share on WhatsApp</button>' +
-      (_isDesktop ?
-        '<button onclick="(function(){' +
-        'var msg=\'' + (post.title||'').replace(/'/g,"\\'") + '\\n\\n\'+' +
-        '(document.getElementById(\'ed-caption-' + postId + '\') ? ' +
-        'document.getElementById(\'ed-caption-' + postId + '\').textContent : ' +
-        '\'' + (post.caption||'').replace(/'/g,"\\'").slice(0,200) + '\') +' +
-        '\'\\n\\nApprove: https://srtd.io/ok/?p=' + rawSlug + '\'+' +
-        '\'\\nChanges: https://srtd.io/no/?p=' + rawSlug + '\';' +
-        'navigator.clipboard.writeText(msg).then(function(){' +
-        'var b=document.getElementById(\'ed-copy-' + postId + '\');' +
-        'if(b){b.textContent=\'Copied\';' +
-        'setTimeout(function(){b.textContent=\'&#x2318; Copy to Share\';},2000);}' +
-        '});' +
-        '})()" id="ed-copy-' + postId + '" ' +
-        'style="flex:1;font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
-        'letter-spacing:0.14em;text-transform:uppercase;color:#888;' +
-        'background:transparent;border:1px solid rgba(255,255,255,0.12);' +
-        'padding:14px 0;cursor:pointer;">' +
-        '\u2398 Copy to Share</button>'
-        : '') +
-      '</div>';
+      'style="width:100%;font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
+      'letter-spacing:0.14em;text-transform:uppercase;color:#25D366;' +
+      'background:rgba(37,211,102,0.06);border:1px solid rgba(37,211,102,0.25);' +
+      'padding:14px 0;cursor:pointer;display:block;margin-bottom:10px;">' +
+      '&#x2197; Share on WhatsApp</button>';
     })() +
-
-    // Approve button
-    '<button onclick="_editorialApprove(\'' + postId + '\')" ' +
-    'style="width:100%;font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
-    'letter-spacing:0.2em;text-transform:uppercase;color:#3ECF8E;' +
-    'background:rgba(62,207,142,0.08);border:1px solid rgba(62,207,142,0.35);' +
-    'padding:16px 0;cursor:pointer;display:block;margin-bottom:10px;">' +
-    '&#x2713; Approve Post</button>' +
 
     // Comment button
     '<button onclick="_editorialChanges(\'' + postId + '\')" ' +
     'style="width:100%;font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
-    'letter-spacing:0.2em;text-transform:uppercase;color:rgba(255,255,255,0.7);' +
-    'background:transparent;border:1px solid rgba(255,255,255,0.07);' +
-    'padding:14px 0;cursor:pointer;display:block;">' +
-    '&#x1F4AC; Comment</button>' +
+    'letter-spacing:0.16em;text-transform:uppercase;color:rgba(255,255,255,0.7);' +
+    'background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.12);' +
+    'padding:14px 0;cursor:pointer;display:block;margin-bottom:10px;">' +
+    '&#x1F4AC; Leave a Comment</button>' +
+
+    // Approve button
+    '<button onclick="_editorialApprove(\'' + postId + '\')" ' +
+    'style="width:100%;font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
+    'letter-spacing:0.16em;text-transform:uppercase;color:#3ECF8E;' +
+    'background:rgba(62,207,142,0.06);border:1px solid rgba(62,207,142,0.25);' +
+    'padding:16px 0;cursor:pointer;display:block;">' +
+    '&#x2713; Approve Post</button>' +
 
     '</div>';
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260326bf">
+ <link rel="stylesheet" href="styles.css?v=20260327a">
 
 </head>
 <body>
@@ -924,19 +924,19 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260326bf" defer></script>
-<script src="02-session.js?v=20260326bf" defer></script>
-<script src="utils.js?v=20260326bf" defer></script>
-<script src="03-auth.js?v=20260326bf" defer></script>
-<script src="05-api.js?v=20260326bf" defer></script>
-<script src="10-ui.js?v=20260326bf" defer></script>
+<script src="01-config.js?v=20260327a" defer></script>
+<script src="02-session.js?v=20260327a" defer></script>
+<script src="utils.js?v=20260327a" defer></script>
+<script src="03-auth.js?v=20260327a" defer></script>
+<script src="05-api.js?v=20260327a" defer></script>
+<script src="10-ui.js?v=20260327a" defer></script>
 
-<script src="06-post-create.js?v=20260326bf" defer></script>
-<script src="07-post-load.js?v=20260326bf" defer></script>
-<script src="08-post-actions.js?v=20260326bf" defer></script>
-<script src="09-library.js?v=20260326bf" defer></script>
-<script src="09-approval.js?v=20260326bf" defer></script>
-<script src="04-router.js?v=20260326bf" defer></script>
+<script src="06-post-create.js?v=20260327a" defer></script>
+<script src="07-post-load.js?v=20260327a" defer></script>
+<script src="08-post-actions.js?v=20260327a" defer></script>
+<script src="09-library.js?v=20260327a" defer></script>
+<script src="09-approval.js?v=20260327a" defer></script>
+<script src="04-router.js?v=20260327a" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- Reordered editorial overlay action bar: WhatsApp (top, #25D366) → Comment (middle) → Approve (bottom, primary green)
- Removed desktop-only "Copy to Share" button
- Replaced "Request Changes" with "Leave a Comment" button calling `_editorialChanges()`
- Added no-image placeholder (240px box with "No images yet") when post has no images
- Fixed XSS: wrapped `title`, `caption`, and hero image URL with `esc()` in editorial overlay
- Added `id="apv-item-{id}"` to approval card wrapper for `submitClientChanges()`
- Added confirmation overlays for `_editorialApprove()` and `_editorialChanges()`
- Made changes close button visible with background, border, larger font
- Stripped non-ASCII, bumped all 12 version strings to `?v=20260327a`

## Test plan

- [ ] Verify editorial overlay button order: WhatsApp → Comment → Approve
- [ ] Verify no-image placeholder appears for posts without images
- [ ] Verify title/caption are escaped in editorial overlay
- [ ] npm test: 132/132 passing

https://claude.ai/code/session_01RmuXfRjfQ2ayyivngsRAAQ