### PR TITLE
fix: wire openInsights to showInsights in admin task widget

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -743,7 +743,7 @@ function renderAdminInsight() {
   const readyPillClass = readyCount >= READY_TO_SEND_TARGET ? 'green' : readyCount >= READY_TO_SEND_TARGET * 0.5 ? 'amber' : 'red';
 
   section.innerHTML = `
-    <div class="insight-summary-bar" onclick="openInsights()">
+    <div class="insight-summary-bar" onclick="showInsights()">
       <span class="insight-summary-pill ${blockPillClass}">[!] ${blockers === 0 ? 'No blockers' : `${blockers} blocked`}</span>
       <span class="insight-summary-pill ${readyPillClass}">OK ${readyCount}/${READY_TO_SEND_TARGET} ready</span>
       <span class="insight-summary-pill blue">[date] ${published} published this week</span>


### PR DESCRIPTION
## Summary
- Fixed `ReferenceError: openInsights is not defined` when clicking "Details ->" on the admin tasks tab
- Replaced `onclick="openInsights()"` with `onclick="showInsights()"` in `renderAdminInsight()` (`07-post-load.js:746`)
- `showInsights()` already exists in `10-ui.js:712` and correctly opens the insights panel

## Test plan
- [x] `npm test` — 133/133 passing
- [x] `npm run test:e2e` — 1/1 passing

https://claude.ai/code/session_01MMnAFzFri97Q76TZJVMDJR