### PR TITLE
feat: LinkedIn dark mode client feed + fixes + image lightbox

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -222,7 +222,7 @@ async function loadPostsForClient() {
       'awaiting_approval,awaiting_brand_input,published';
     const data  = await apiFetch(
       '/posts?stage=in.(' + allowedStages +
-      ')&select=*&order=created_at.desc'
+      ')&select=*,post_comments(*)&order=created_at.desc'
     );
     if (!_commitPostsResult(reqId, 'network')) return;
     mergePosts(normalise(data));

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328d">
+ <link rel="stylesheet" href="styles.css?v=20260328e">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328d" defer></script>
-<script src="02-session.js?v=20260328d" defer></script>
-<script src="utils.js?v=20260328d" defer></script>
-<script src="03-auth.js?v=20260328d" defer></script>
-<script src="05-api.js?v=20260328d" defer></script>
-<script src="10-ui.js?v=20260328d" defer></script>
+<script src="01-config.js?v=20260328e" defer></script>
+<script src="02-session.js?v=20260328e" defer></script>
+<script src="utils.js?v=20260328e" defer></script>
+<script src="03-auth.js?v=20260328e" defer></script>
+<script src="05-api.js?v=20260328e" defer></script>
+<script src="10-ui.js?v=20260328e" defer></script>
 
-<script src="06-post-create.js?v=20260328d" defer></script>
-<script defer src="render/dashboard.js?v=20260328d"></script>
-<script defer src="render/client.js?v=20260328d"></script>
-<script defer src="render/pipeline.js?v=20260328d"></script>
-<script defer src="render/brief.js?v=20260328d"></script>
-<script defer src="actions/pcs.js?v=20260328d"></script>
-<script src="07-post-load.js?v=20260328d" defer></script>
-<script src="08-post-actions.js?v=20260328d" defer></script>
-<script src="09-library.js?v=20260328d" defer></script>
-<script src="09-approval.js?v=20260328d" defer></script>
-<script src="04-router.js?v=20260328d" defer></script>
+<script src="06-post-create.js?v=20260328e" defer></script>
+<script defer src="render/dashboard.js?v=20260328e"></script>
+<script defer src="render/client.js?v=20260328e"></script>
+<script defer src="render/pipeline.js?v=20260328e"></script>
+<script defer src="render/brief.js?v=20260328e"></script>
+<script defer src="actions/pcs.js?v=20260328e"></script>
+<script src="07-post-load.js?v=20260328e" defer></script>
+<script src="08-post-actions.js?v=20260328e" defer></script>
+<script src="09-library.js?v=20260328e" defer></script>
+<script src="09-approval.js?v=20260328e" defer></script>
+<script src="04-router.js?v=20260328e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328c">
+ <link rel="stylesheet" href="styles.css?v=20260328d">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328c" defer></script>
-<script src="02-session.js?v=20260328c" defer></script>
-<script src="utils.js?v=20260328c" defer></script>
-<script src="03-auth.js?v=20260328c" defer></script>
-<script src="05-api.js?v=20260328c" defer></script>
-<script src="10-ui.js?v=20260328c" defer></script>
+<script src="01-config.js?v=20260328d" defer></script>
+<script src="02-session.js?v=20260328d" defer></script>
+<script src="utils.js?v=20260328d" defer></script>
+<script src="03-auth.js?v=20260328d" defer></script>
+<script src="05-api.js?v=20260328d" defer></script>
+<script src="10-ui.js?v=20260328d" defer></script>
 
-<script src="06-post-create.js?v=20260328c" defer></script>
-<script defer src="render/dashboard.js?v=20260328c"></script>
-<script defer src="render/client.js?v=20260328c"></script>
-<script defer src="render/pipeline.js?v=20260328c"></script>
-<script defer src="render/brief.js?v=20260328c"></script>
-<script defer src="actions/pcs.js?v=20260328c"></script>
-<script src="07-post-load.js?v=20260328c" defer></script>
-<script src="08-post-actions.js?v=20260328c" defer></script>
-<script src="09-library.js?v=20260328c" defer></script>
-<script src="09-approval.js?v=20260328c" defer></script>
-<script src="04-router.js?v=20260328c" defer></script>
+<script src="06-post-create.js?v=20260328d" defer></script>
+<script defer src="render/dashboard.js?v=20260328d"></script>
+<script defer src="render/client.js?v=20260328d"></script>
+<script defer src="render/pipeline.js?v=20260328d"></script>
+<script defer src="render/brief.js?v=20260328d"></script>
+<script defer src="actions/pcs.js?v=20260328d"></script>
+<script src="07-post-load.js?v=20260328d" defer></script>
+<script src="08-post-actions.js?v=20260328d" defer></script>
+<script src="09-library.js?v=20260328d" defer></script>
+<script src="09-approval.js?v=20260328d" defer></script>
+<script src="04-router.js?v=20260328d" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328e">
+ <link rel="stylesheet" href="styles.css?v=20260328f">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328e" defer></script>
-<script src="02-session.js?v=20260328e" defer></script>
-<script src="utils.js?v=20260328e" defer></script>
-<script src="03-auth.js?v=20260328e" defer></script>
-<script src="05-api.js?v=20260328e" defer></script>
-<script src="10-ui.js?v=20260328e" defer></script>
+<script src="01-config.js?v=20260328f" defer></script>
+<script src="02-session.js?v=20260328f" defer></script>
+<script src="utils.js?v=20260328f" defer></script>
+<script src="03-auth.js?v=20260328f" defer></script>
+<script src="05-api.js?v=20260328f" defer></script>
+<script src="10-ui.js?v=20260328f" defer></script>
 
-<script src="06-post-create.js?v=20260328e" defer></script>
-<script defer src="render/dashboard.js?v=20260328e"></script>
-<script defer src="render/client.js?v=20260328e"></script>
-<script defer src="render/pipeline.js?v=20260328e"></script>
-<script defer src="render/brief.js?v=20260328e"></script>
-<script defer src="actions/pcs.js?v=20260328e"></script>
-<script src="07-post-load.js?v=20260328e" defer></script>
-<script src="08-post-actions.js?v=20260328e" defer></script>
-<script src="09-library.js?v=20260328e" defer></script>
-<script src="09-approval.js?v=20260328e" defer></script>
-<script src="04-router.js?v=20260328e" defer></script>
+<script src="06-post-create.js?v=20260328f" defer></script>
+<script defer src="render/dashboard.js?v=20260328f"></script>
+<script defer src="render/client.js?v=20260328f"></script>
+<script defer src="render/pipeline.js?v=20260328f"></script>
+<script defer src="render/brief.js?v=20260328f"></script>
+<script defer src="actions/pcs.js?v=20260328f"></script>
+<script src="07-post-load.js?v=20260328f" defer></script>
+<script src="08-post-actions.js?v=20260328f" defer></script>
+<script src="09-library.js?v=20260328f" defer></script>
+<script src="09-approval.js?v=20260328f" defer></script>
+<script src="04-router.js?v=20260328f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328b">
+ <link rel="stylesheet" href="styles.css?v=20260328c">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328b" defer></script>
-<script src="02-session.js?v=20260328b" defer></script>
-<script src="utils.js?v=20260328b" defer></script>
-<script src="03-auth.js?v=20260328b" defer></script>
-<script src="05-api.js?v=20260328b" defer></script>
-<script src="10-ui.js?v=20260328b" defer></script>
+<script src="01-config.js?v=20260328c" defer></script>
+<script src="02-session.js?v=20260328c" defer></script>
+<script src="utils.js?v=20260328c" defer></script>
+<script src="03-auth.js?v=20260328c" defer></script>
+<script src="05-api.js?v=20260328c" defer></script>
+<script src="10-ui.js?v=20260328c" defer></script>
 
-<script src="06-post-create.js?v=20260328b" defer></script>
-<script defer src="render/dashboard.js?v=20260328b"></script>
-<script defer src="render/client.js?v=20260328b"></script>
-<script defer src="render/pipeline.js?v=20260328b"></script>
-<script defer src="render/brief.js?v=20260328b"></script>
-<script defer src="actions/pcs.js?v=20260328b"></script>
-<script src="07-post-load.js?v=20260328b" defer></script>
-<script src="08-post-actions.js?v=20260328b" defer></script>
-<script src="09-library.js?v=20260328b" defer></script>
-<script src="09-approval.js?v=20260328b" defer></script>
-<script src="04-router.js?v=20260328b" defer></script>
+<script src="06-post-create.js?v=20260328c" defer></script>
+<script defer src="render/dashboard.js?v=20260328c"></script>
+<script defer src="render/client.js?v=20260328c"></script>
+<script defer src="render/pipeline.js?v=20260328c"></script>
+<script defer src="render/brief.js?v=20260328c"></script>
+<script defer src="actions/pcs.js?v=20260328c"></script>
+<script src="07-post-load.js?v=20260328c" defer></script>
+<script src="08-post-actions.js?v=20260328c" defer></script>
+<script src="09-library.js?v=20260328c" defer></script>
+<script src="09-approval.js?v=20260328c" defer></script>
+<script src="04-router.js?v=20260328c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1,10 +1,19 @@
-/* render/client.js -- Client portal feed (Pass 3 of 3) */
+/* render/client.js -- Client portal feed (style pass) */
 (function () {
   'use strict';
 
   /* ---- helpers ---- */
 
   var SUPABASE_URL = window.SUPABASE_URL || '';
+
+  function _greeting() {
+    var h = new Date().toLocaleString('en-IN', { hour: 'numeric', hour12: false, timeZone: 'Asia/Kolkata' });
+    var hr = parseInt(h, 10);
+    if (isNaN(hr)) hr = 12;
+    if (hr < 12) return 'Good morning,';
+    if (hr < 17) return 'Good afternoon,';
+    return 'Good evening,';
+  }
 
   function _esc(s) { return typeof esc === 'function' ? esc(s) : String(s || ''); }
 
@@ -37,7 +46,7 @@
   var ICON_CLOCK = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>';
   var ICON_COMMENT = '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>';
   var ICON_THUMBUP = '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z"/><path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/></svg>';
-  var ICON_WA = '<svg width="15" height="15" viewBox="0 0 24 24" fill="#25D366"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg>';
+  var ICON_WA = '<svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg>';
   var ICON_COMMENT_SM = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>';
   var ICON_SEND = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 2L11 13"/><path d="M22 2l-7 20-4-9-9-4 20-7z"/></svg>';
 
@@ -111,17 +120,17 @@
 
   function _badgeHtml(stage) {
     if (stage === 'awaiting_approval') {
-      return '<span style="display:inline-flex;align-items:center;gap:5px;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.04em;color:#f59e0b;">' +
-        '<span style="width:7px;height:7px;border-radius:50%;background:#f59e0b;animation:clientPulse 2s infinite;"></span>' +
+      return '<span style="display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:4px;background:rgba(245,158,11,0.04);border:1px solid rgba(245,158,11,0.15);font-family:\'IBM Plex Mono\',monospace;font-size:8px;letter-spacing:0.04em;color:#f59e0b;">' +
+        '<span style="width:4px;height:4px;border-radius:50%;background:#f59e0b;animation:clientPulse 2s infinite;"></span>' +
         'Awaiting Approval</span>';
     }
     if (stage === 'awaiting_brand_input') {
-      return '<span style="display:inline-flex;align-items:center;gap:5px;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.04em;color:#06b6d4;">' +
-        '<span style="width:7px;height:7px;border-radius:50%;background:#06b6d4;animation:clientPulse 2s infinite;"></span>' +
+      return '<span style="display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:4px;background:rgba(6,182,212,0.04);border:1px solid rgba(6,182,212,0.15);font-family:\'IBM Plex Mono\',monospace;font-size:8px;letter-spacing:0.04em;color:#06b6d4;">' +
+        '<span style="width:4px;height:4px;border-radius:50%;background:#06b6d4;animation:clientPulse 2s infinite;"></span>' +
         'Needs Your Input</span>';
     }
     if (stage === 'published') {
-      return '<span style="display:inline-flex;align-items:center;gap:5px;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.04em;color:#22c55e;">' +
+      return '<span style="display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:4px;background:rgba(34,197,94,0.04);border:1px solid rgba(34,197,94,0.15);font-family:\'IBM Plex Mono\',monospace;font-size:8px;letter-spacing:0.04em;color:#22c55e;">' +
         ICON_CHECK + ' Published</span>';
     }
     return '';
@@ -213,13 +222,13 @@
     if (post.location) parts.push(_esc(post.location));
     if (post.owner) parts.push(_esc(post.owner));
     if (!parts.length) return '';
-    return '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#444;margin-top:2px;">' + parts.join(' &middot; ') + '</div>';
+    return '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#555;margin-top:2px;">' + parts.join(' &middot; ') + '</div>';
   }
 
   function _metaRow2(post) {
     if (!post.targetDate) return '';
-    return '<div style="display:flex;align-items:center;gap:4px;font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#444;margin-top:2px;">' +
-      ICON_GLOBE + ' ' + _esc(_fmtDate(post.targetDate)) +
+    return '<div style="display:flex;align-items:center;gap:4px;font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#555;margin-top:2px;">' +
+      '<span style="color:#333;">' + ICON_GLOBE + '</span> ' + _esc(_fmtDate(post.targetDate)) +
       '</div>';
   }
 
@@ -256,7 +265,7 @@
     var count = _commentCount(post);
     var right = '<span style="display:inline-flex;align-items:center;gap:4px;color:#444;">' +
       ICON_COMMENT_SM + ' ' + count + '</span>';
-    return '<div style="display:flex;align-items:center;justify-content:space-between;padding:10px 14px 0;font-family:\'IBM Plex Mono\',monospace;font-size:9px;">' +
+    return '<div style="display:flex;align-items:center;justify-content:space-between;padding:10px 14px 4px;font-family:\'IBM Plex Mono\',monospace;font-size:9px;">' +
       left + right + '</div>';
   }
 
@@ -267,27 +276,26 @@
     var pid = _esc(post.post_id || post.id || '');
     var title = _esc(post.title || '');
     var btnStyle = 'flex:1;display:flex;align-items:center;justify-content:center;gap:5px;' +
-      'background:none;border:none;border-right:1px solid rgba(255,255,255,0.06);' +
-      'padding:10px 0;cursor:pointer;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.03em;';
-    var lastBtnStyle = btnStyle.replace('border-right:1px solid rgba(255,255,255,0.06);', '');
+      'background:none;border:none;' +
+      'padding:10px 0;cursor:pointer;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.03em;color:#666;';
 
     var btn1 = '';
     if (post.stage === 'awaiting_approval') {
-      btn1 = '<button data-action="clientApprovePrompt" data-id="' + pid + '" data-title="' + title + '" style="' + btnStyle + 'color:#22c55e;">' +
+      btn1 = '<button data-action="clientApprovePrompt" data-id="' + pid + '" data-title="' + title + '" style="' + btnStyle + '">' +
         ICON_THUMBUP + ' Approve</button>';
     } else {
       btn1 = '<div style="flex:1;"></div>';
     }
 
-    var btn2 = '<button data-action="focusComment" data-id="' + pid + '" style="' + btnStyle + 'color:#888;">' +
+    var btn2 = '<button data-action="focusComment" data-id="' + pid + '" style="' + btnStyle + '">' +
       ICON_COMMENT + ' Comment</button>';
 
-    var btn3 = '<button data-action="shareWA" data-id="' + pid + '" style="' + lastBtnStyle + 'color:#25D366;">' +
+    var btn3 = '<button data-action="shareWA" data-id="' + pid + '" style="' + btnStyle + '">' +
       ICON_WA + ' WhatsApp</button>';
 
-    return '<div data-engagement="' + pid + '" style="display:flex;border-top:1px solid rgba(255,255,255,0.06);margin-top:8px;">' +
+    return '<div data-engagement="' + pid + '" style="display:flex;margin-top:6px;">' +
       btn1 + btn2 + btn3 + '</div>' +
-      '<div id="approved-strip-' + pid + '" style="display:none;padding:10px 14px;font-family:\'IBM Plex Mono\',monospace;font-size:10px;color:#444;border-top:1px solid rgba(255,255,255,0.06);margin-top:8px;">' +
+      '<div id="approved-strip-' + pid + '" style="display:none;padding:10px 14px;font-family:\'IBM Plex Mono\',monospace;font-size:10px;color:#3ECF8E;background:rgba(62,207,142,0.05);margin-top:6px;">' +
       '</div>';
   }
 
@@ -365,10 +373,12 @@
     var placeholder = post.stage === 'awaiting_brand_input'
       ? 'Share the information here...'
       : 'Add your thoughts...';
-    return '<div style="display:flex;align-items:center;gap:8px;padding:8px 14px;border-top:1px solid rgba(255,255,255,0.04);">' +
+    return '<div style="display:flex;align-items:center;gap:8px;padding:8px 14px;">' +
       '<div style="width:30px;height:30px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:700;color:#FF4B4B;background:rgba(255,75,75,0.1);">' + _esc(initial) + '</div>' +
-      '<input id="comment-input-' + pid + '" type="text" placeholder="' + _esc(placeholder) + '" style="flex:1;background:transparent;border:none;outline:none;font-family:\'DM Sans\',sans-serif;font-size:13px;color:#ccc;padding:6px 0;" data-post-id="' + pid + '">' +
-      '<button data-action="submitComment" data-id="' + pid + '" style="background:none;border:none;color:#555;cursor:pointer;padding:4px;flex-shrink:0;">' + ICON_SEND + '</button>' +
+      '<div style="flex:1;display:flex;align-items:center;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.1);border-radius:24px;padding:0 4px 0 14px;">' +
+        '<input id="comment-input-' + pid + '" type="text" placeholder="' + _esc(placeholder) + '" style="flex:1;background:transparent;border:none;outline:none;font-family:\'DM Sans\',sans-serif;font-size:13px;color:#ccc;padding:8px 0;" data-post-id="' + pid + '">' +
+        '<button data-action="submitComment" data-id="' + pid + '" style="background:none;border:none;color:#555;cursor:pointer;padding:4px;flex-shrink:0;">' + ICON_SEND + '</button>' +
+      '</div>' +
     '</div>';
   }
 
@@ -377,7 +387,7 @@
   function _cardHtml(post, isPublished) {
     var opacity = isPublished ? 'opacity:0.45;' : '';
     var pid = _esc(post.post_id || post.id || '');
-    return '<div data-card-id="' + pid + '" style="padding:14px;border-bottom:1px solid rgba(255,255,255,0.06);' + opacity + '">' +
+    return '<div data-card-id="' + pid + '" style="padding:14px;margin-bottom:8px;background:#000000;' + opacity + '">' +
       /* header row */
       '<div style="display:flex;align-items:flex-start;gap:10px;">' +
         _avatarHtml(post) +
@@ -410,29 +420,28 @@
   /* ---- section label ---- */
 
   function _sectionLabel(text) {
-    return '<div style="padding:14px 14px 6px;font-family:\'IBM Plex Mono\',monospace;font-size:10px;letter-spacing:0.06em;color:#666;text-transform:uppercase;">' + text + '</div>';
+    return '<div style="padding:20px 14px 6px;font-family:\'IBM Plex Mono\',monospace;font-size:10px;letter-spacing:0.16em;color:#333;text-transform:uppercase;">' + text + '</div>';
   }
 
   /* ---- top bar ---- */
 
   function _topBarHtml(awaitCount) {
-    var pill = awaitCount > 0
-      ? '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;padding:2px 8px;border-radius:10px;background:rgba(245,158,11,0.12);color:#f59e0b;margin-left:10px;">' + awaitCount + ' awaiting</span>'
-      : '';
-    return '<div style="display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid rgba(255,255,255,0.06);position:sticky;top:0;background:#0a0a0a;z-index:100;">' +
-      '<div style="display:flex;align-items:center;">' +
-        '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:14px;font-weight:700;text-transform:uppercase;letter-spacing:0.22em;color:#888;">SRTD.IO</span>' +
-        pill +
+    var clientName = _esc(window.currentUserName || '');
+    return '<div style="display:flex;align-items:center;justify-content:space-between;padding:14px 16px;position:sticky;top:0;background:rgba(27,31,35,0.96);z-index:100;">' +
+      '<div style="display:flex;align-items:baseline;">' +
+        '<span style="font-family:\'DM Sans\',sans-serif;font-size:14px;color:#888;">' + _greeting() + '</span>' +
+        (clientName ? '<span style="font-family:\'DM Sans\',sans-serif;font-weight:600;font-size:14px;color:#C8A84B;margin-left:5px;">' + clientName + '</span>' : '') +
       '</div>' +
       '<div style="display:flex;align-items:center;gap:14px;">' +
-        '<button data-action="open-notifications" style="position:relative;background:none;border:none;color:#888;cursor:pointer;padding:4px;">' +
+        '<button data-action="open-notifications" style="position:relative;background:none;border:none;color:#666;cursor:pointer;padding:4px;">' +
           ICON_BELL +
           '<span data-bell-dot style="position:absolute;top:2px;right:2px;width:7px;height:7px;border-radius:50%;background:#ef4444;"></span>' +
         '</button>' +
         '<div style="position:relative;">' +
-          '<button data-action="top-menu-toggle" style="background:none;border:none;color:#888;cursor:pointer;padding:4px;">' + ICON_DOTS + '</button>' +
+          '<button data-action="top-menu-toggle" style="background:none;border:none;color:#666;cursor:pointer;padding:4px;">' + ICON_DOTS + '</button>' +
           '<div data-top-menu style="display:none;position:absolute;right:0;top:28px;background:#1a1a1a;border:1px solid rgba(255,255,255,0.08);border-radius:8px;min-width:160px;z-index:200;box-shadow:0 8px 24px rgba(0,0,0,0.5);">' +
             '<button data-action="new-request" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#ccc;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;">New Request</button>' +
+            '<button data-action="light-mode" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#555;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;border-top:1px solid rgba(255,255,255,0.06);">Light Mode</button>' +
             '<button data-action="sign-out" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#888;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;border-top:1px solid rgba(255,255,255,0.06);">Sign Out</button>' +
           '</div>' +
         '</div>' +
@@ -443,7 +452,7 @@
   /* ---- bottom nav ---- */
 
   function _bottomNavHtml() {
-    return '<div id="bottom-nav" style="position:fixed;bottom:0;left:0;right:0;display:flex;justify-content:space-around;align-items:center;padding:8px 0 calc(8px + env(safe-area-inset-bottom));background:#0a0a0a;border-top:1px solid rgba(255,255,255,0.06);z-index:100;">' +
+    return '<div id="bottom-nav" style="position:fixed;bottom:0;left:0;right:0;display:flex;justify-content:space-around;align-items:center;padding:8px 0 calc(8px + env(safe-area-inset-bottom));background:rgba(27,31,35,0.97);border-top:1px solid rgba(255,255,255,0.06);z-index:100;">' +
       '<button data-action="nav-feed" style="display:flex;flex-direction:column;align-items:center;gap:2px;background:none;border:none;color:#C8A84B;cursor:pointer;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.04em;padding:4px 12px;">' +
         ICON_FEED + 'Feed</button>' +
       '<button data-action="nav-requests" style="display:flex;flex-direction:column;align-items:center;gap:2px;background:none;border:none;color:#555;cursor:pointer;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.04em;padding:4px 12px;">' +
@@ -573,6 +582,12 @@
           var menu2 = root.querySelector('[data-top-menu]');
           if (menu2) menu2.style.display = 'none';
           if (typeof window.openClientRequestForm === 'function') window.openClientRequestForm();
+          break;
+
+        case 'light-mode':
+          var menu3a = root.querySelector('[data-top-menu]');
+          if (menu3a) menu3a.style.display = 'none';
+          if (typeof window.showToast === 'function') window.showToast('Coming soon', 'info');
           break;
 
         case 'sign-out':
@@ -705,6 +720,12 @@
     if (!cv) return;
 
     _ensurePulseStyle();
+    cv.style.background = '#1b1f23';
+
+    var fab = document.getElementById('fab-add');
+    if (fab) fab.style.display = 'none';
+    var agencyNav = document.getElementById('main-bottom-nav');
+    if (agencyNav) agencyNav.style.display = 'none';
 
     var posts = window.allPosts || [];
     var buckets = _bucket(posts);

--- a/render/client.js
+++ b/render/client.js
@@ -174,43 +174,44 @@
     var n = imgs.length;
     if (n === 0) return '';
 
-    var wrap = function (src, css, overlay) {
-      return '<div style="' + css + 'overflow:hidden;position:relative;background:#111;">' +
-        '<img src="' + _esc(src) + '" alt="" style="width:100%;height:100%;object-fit:cover;display:block;" loading="lazy">' +
+    var imgsJson = _esc(JSON.stringify(imgs));
+    var wrap = function (src, idx, css, overlay) {
+      return '<div data-action="openLightbox" data-images="' + imgsJson + '" data-index="' + idx + '" style="' + css + 'overflow:hidden;position:relative;background:#111;cursor:pointer;">' +
+        '<img src="' + _esc(src) + '" alt="" style="width:100%;height:100%;object-fit:cover;display:block;pointer-events:none;" loading="lazy">' +
         (overlay || '') + '</div>';
     };
 
     if (n === 1) {
       return '<div style="padding:0 14px;margin-top:10px;">' +
-        wrap(imgs[0], 'aspect-ratio:4/3;border-radius:8px;') +
+        wrap(imgs[0], 0, 'aspect-ratio:4/3;border-radius:8px;') +
         '</div>';
     }
 
     if (n === 2) {
       return '<div style="display:grid;grid-template-columns:1fr 1fr;gap:2px;padding:0 14px;margin-top:10px;">' +
-        wrap(imgs[0], 'aspect-ratio:1/1;border-radius:8px 0 0 8px;') +
-        wrap(imgs[1], 'aspect-ratio:1/1;border-radius:0 8px 8px 0;') +
+        wrap(imgs[0], 0, 'aspect-ratio:1/1;border-radius:8px 0 0 8px;') +
+        wrap(imgs[1], 1, 'aspect-ratio:1/1;border-radius:0 8px 8px 0;') +
         '</div>';
     }
 
     if (n === 3) {
       return '<div style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:130px 130px;gap:2px;padding:0 14px;margin-top:10px;height:260px;">' +
-        wrap(imgs[0], 'grid-row:1/3;border-radius:8px 0 0 8px;') +
-        wrap(imgs[1], 'border-radius:0 8px 0 0;') +
-        wrap(imgs[2], 'border-radius:0 0 8px 0;') +
+        wrap(imgs[0], 0, 'grid-row:1/3;border-radius:8px 0 0 8px;') +
+        wrap(imgs[1], 1, 'border-radius:0 8px 0 0;') +
+        wrap(imgs[2], 2, 'border-radius:0 0 8px 0;') +
         '</div>';
     }
 
     /* 4+ : 2x2 grid with +N overlay on last cell */
     var extra = n > 4 ? n - 4 : 0;
     var overlayHtml = extra > 0
-      ? '<div style="position:absolute;inset:0;background:rgba(0,0,0,0.55);display:flex;align-items:center;justify-content:center;font-family:\'DM Sans\',sans-serif;font-size:20px;font-weight:700;color:#fff;">+' + extra + '</div>'
+      ? '<div style="position:absolute;inset:0;background:rgba(0,0,0,0.55);display:flex;align-items:center;justify-content:center;font-family:\'DM Sans\',sans-serif;font-size:20px;font-weight:700;color:#fff;pointer-events:none;">+' + extra + '</div>'
       : '';
     return '<div style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:150px 150px;gap:2px;padding:0 14px;margin-top:10px;height:300px;">' +
-      wrap(imgs[0], 'border-radius:8px 0 0 0;') +
-      wrap(imgs[1], 'border-radius:0 8px 0 0;') +
-      wrap(imgs[2], 'border-radius:0 0 0 8px;') +
-      wrap(imgs[3] || imgs[2], 'border-radius:0 0 8px 0;', overlayHtml) +
+      wrap(imgs[0], 0, 'border-radius:8px 0 0 0;') +
+      wrap(imgs[1], 1, 'border-radius:0 8px 0 0;') +
+      wrap(imgs[2], 2, 'border-radius:0 0 0 8px;') +
+      wrap(imgs[3] || imgs[2], 3, 'border-radius:0 0 8px 0;', overlayHtml) +
       '</div>';
   }
 
@@ -753,6 +754,26 @@
           if (typeof window._sharePostOnWhatsApp === 'function') window._sharePostOnWhatsApp(id);
           break;
 
+        case 'openLightbox':
+          try {
+            var lbImgs = JSON.parse(btn.getAttribute('data-images') || '[]');
+            var lbIdx = parseInt(btn.getAttribute('data-index') || '0', 10);
+            if (lbImgs.length) _lbOpen(lbImgs, lbIdx);
+          } catch (_e) {}
+          break;
+
+        case 'lbClose':
+          _lbClose();
+          break;
+
+        case 'lbPrev':
+          _lbPrev();
+          break;
+
+        case 'lbNext':
+          _lbNext();
+          break;
+
         default:
           break;
       }
@@ -767,6 +788,97 @@
       if (!e.target.closest('[data-action="openCardMenu"]') && !e.target.closest('#client-card-menu')) {
         _closeCardMenu();
       }
+    });
+  }
+
+  /* ---- lightbox ---- */
+
+  var _lbImages = [];
+  var _lbIndex = 0;
+  var _lbTouchX = 0;
+
+  function _lightboxHtml() {
+    return '<div id="client-lightbox" style="display:none;position:fixed;inset:0;z-index:9000;background:#000000;flex-direction:column;align-items:center;justify-content:center;">' +
+      '<button data-action="lbClose" style="position:absolute;top:14px;left:14px;background:none;border:none;color:#888;font-size:24px;cursor:pointer;z-index:1;padding:8px;">&#x2715;</button>' +
+      '<span id="client-lb-counter" style="position:absolute;top:18px;right:14px;font-family:\'IBM Plex Mono\',monospace;font-size:11px;color:#666;z-index:1;"></span>' +
+      '<button id="client-lb-prev" data-action="lbPrev" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);background:none;border:none;color:#888;font-size:28px;cursor:pointer;z-index:1;padding:12px;">&#x2039;</button>' +
+      '<button id="client-lb-next" data-action="lbNext" style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;color:#888;font-size:28px;cursor:pointer;z-index:1;padding:12px;">&#x203A;</button>' +
+      '<img id="client-lb-img" src="" alt="" style="max-width:100%;max-height:100%;object-fit:contain;">' +
+    '</div>';
+  }
+
+  function _lbUpdate() {
+    var img = document.getElementById('client-lb-img');
+    var counter = document.getElementById('client-lb-counter');
+    var prev = document.getElementById('client-lb-prev');
+    var next = document.getElementById('client-lb-next');
+    if (img) img.src = _lbImages[_lbIndex] || '';
+    var multi = _lbImages.length > 1;
+    if (counter) {
+      counter.textContent = multi ? (_lbIndex + 1) + ' / ' + _lbImages.length : '';
+    }
+    if (prev) prev.style.display = multi ? 'block' : 'none';
+    if (next) next.style.display = multi ? 'block' : 'none';
+  }
+
+  function _lbOpen(images, index) {
+    _lbImages = images;
+    _lbIndex = Math.max(0, Math.min(index, images.length - 1));
+    var el = document.getElementById('client-lightbox');
+    if (el) {
+      el.style.display = 'flex';
+      _lbUpdate();
+      window._modalOpen = true;
+      document.body.style.overflow = 'hidden';
+    }
+  }
+
+  function _lbClose() {
+    var el = document.getElementById('client-lightbox');
+    if (el) el.style.display = 'none';
+    _lbImages = [];
+    _lbIndex = 0;
+    window._modalOpen = false;
+    document.body.style.overflow = '';
+  }
+
+  function _lbPrev() {
+    if (_lbImages.length < 2) return;
+    _lbIndex = (_lbIndex - 1 + _lbImages.length) % _lbImages.length;
+    _lbUpdate();
+  }
+
+  function _lbNext() {
+    if (_lbImages.length < 2) return;
+    _lbIndex = (_lbIndex + 1) % _lbImages.length;
+    _lbUpdate();
+  }
+
+  function _wireLightboxTouch() {
+    var el = document.getElementById('client-lightbox');
+    if (!el || el._touchWired) return;
+    el._touchWired = true;
+    el.addEventListener('touchstart', function (e) {
+      _lbTouchX = e.changedTouches[0].clientX;
+    }, { passive: true });
+    el.addEventListener('touchend', function (e) {
+      var diff = e.changedTouches[0].clientX - _lbTouchX;
+      if (Math.abs(diff) >= 50) {
+        if (diff < 0) _lbNext();
+        else _lbPrev();
+      }
+    }, { passive: true });
+  }
+
+  function _wireLightboxKeyboard() {
+    if (window._clientLbKeyWired) return;
+    window._clientLbKeyWired = true;
+    document.addEventListener('keydown', function (e) {
+      var el = document.getElementById('client-lightbox');
+      if (!el || el.style.display === 'none') return;
+      if (e.key === 'Escape') _lbClose();
+      else if (e.key === 'ArrowLeft') _lbPrev();
+      else if (e.key === 'ArrowRight') _lbNext();
     });
   }
 
@@ -821,9 +933,12 @@
     html += _bottomNavHtml();
     html += _approvePopupHtml();
     html += _cardMenuHtml();
+    html += _lightboxHtml();
 
     cv.innerHTML = html;
     _wireEvents(cv);
+    _wireLightboxTouch();
+    _wireLightboxKeyboard();
   };
 
 })();

--- a/render/client.js
+++ b/render/client.js
@@ -317,11 +317,26 @@
 
   /* ---- card 3-dot menu (singleton, repositioned on open) ---- */
 
+  var _menuBtnStyle = 'display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#ccc;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;';
+  var _menuBtnBorder = 'border-top:1px solid rgba(255,255,255,0.06);';
+
   function _cardMenuHtml() {
-    return '<div id="client-card-menu" style="display:none;position:fixed;z-index:300;background:#1a1a1a;border:1px solid rgba(255,255,255,0.08);border-radius:8px;min-width:170px;box-shadow:0 8px 24px rgba(0,0,0,0.5);">' +
-      '<button data-action="cardMenuWA" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#ccc;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;">Share on WhatsApp</button>' +
-      '<button data-action="cardMenuRequest" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#ccc;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;border-top:1px solid rgba(255,255,255,0.06);">New Request</button>' +
-    '</div>';
+    return '<div id="client-card-menu" style="display:none;position:fixed;z-index:300;background:#1a1a1a;border:1px solid rgba(255,255,255,0.08);border-radius:8px;min-width:170px;box-shadow:0 8px 24px rgba(0,0,0,0.5);"></div>';
+  }
+
+  function _populateCardMenu(menuEl, stage) {
+    var html = '';
+    if (stage === 'awaiting_approval') {
+      html += '<button data-action="cardMenuApprove" style="' + _menuBtnStyle + '">Approve Post</button>';
+      html += '<button data-action="cardMenuWA" style="' + _menuBtnStyle + _menuBtnBorder + '">Share on WhatsApp</button>';
+    } else if (stage === 'awaiting_brand_input') {
+      html += '<button data-action="cardMenuInput" style="' + _menuBtnStyle + '">Add Your Input</button>';
+      html += '<button data-action="cardMenuWA" style="' + _menuBtnStyle + _menuBtnBorder + '">Share on WhatsApp</button>';
+    } else if (stage === 'published') {
+      html += '<button data-action="cardMenuLinkedIn" style="' + _menuBtnStyle + '">View on LinkedIn</button>';
+      html += '<button data-action="cardMenuWA" style="' + _menuBtnStyle + _menuBtnBorder + '">Share on WhatsApp</button>';
+    }
+    menuEl.innerHTML = html;
   }
 
   /* ---- comments display ---- */
@@ -387,7 +402,7 @@
   function _cardHtml(post, isPublished) {
     var opacity = isPublished ? 'opacity:0.45;' : '';
     var pid = _esc(post.post_id || post.id || '');
-    return '<div data-card-id="' + pid + '" style="padding:14px;margin-bottom:8px;background:#000000;' + opacity + '">' +
+    return '<div data-card-id="' + pid + '" data-stage="' + _esc(post.stage || '') + '" style="padding:14px;margin-bottom:8px;background:#000000;' + opacity + '">' +
       /* header row */
       '<div style="display:flex;align-items:flex-start;gap:10px;">' +
         _avatarHtml(post) +
@@ -427,12 +442,16 @@
 
   function _topBarHtml(awaitCount) {
     var clientName = _esc(window.currentUserName || '');
+    var pill = awaitCount > 0
+      ? '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;padding:2px 8px;border-radius:10px;background:rgba(245,158,11,0.12);color:#f59e0b;">' + awaitCount + ' awaiting</span>'
+      : '';
     return '<div style="display:flex;align-items:center;justify-content:space-between;padding:14px 16px;position:sticky;top:0;background:rgba(27,31,35,0.96);z-index:100;">' +
       '<div style="display:flex;align-items:baseline;">' +
         '<span style="font-family:\'DM Sans\',sans-serif;font-size:14px;color:#888;">' + _greeting() + '</span>' +
         (clientName ? '<span style="font-family:\'DM Sans\',sans-serif;font-weight:600;font-size:14px;color:#C8A84B;margin-left:5px;">' + clientName + '</span>' : '') +
       '</div>' +
       '<div style="display:flex;align-items:center;gap:14px;">' +
+        pill +
         '<button data-action="open-notifications" style="position:relative;background:none;border:none;color:#666;cursor:pointer;padding:4px;">' +
           ICON_BELL +
           '<span data-bell-dot style="position:absolute;top:2px;right:2px;width:7px;height:7px;border-radius:50%;background:#ef4444;"></span>' +
@@ -627,6 +646,9 @@
             break;
           }
           _cardMenuActiveId = id;
+          var cardEl = btn.closest('[data-card-id]');
+          var cardStage = cardEl ? cardEl.getAttribute('data-stage') : '';
+          _populateCardMenu(cm, cardStage);
           var rect = btn.getBoundingClientRect();
           cm.style.top = (rect.bottom + 4) + 'px';
           cm.style.left = Math.max(0, rect.right - 170) + 'px';
@@ -634,8 +656,43 @@
           break;
 
         case 'cardMenuWA':
+          var waId1 = _cardMenuActiveId || id;
           _closeCardMenu();
-          if (typeof window._clientShareWA === 'function') window._clientShareWA(_cardMenuActiveId || id);
+          if (typeof window._sharePostOnWhatsApp === 'function') window._sharePostOnWhatsApp(waId1);
+          break;
+
+        case 'cardMenuApprove':
+          var cmApId = _cardMenuActiveId || id;
+          _closeCardMenu();
+          _pendingApproveId = cmApId;
+          var cmPopup = document.getElementById('client-approve-popup');
+          var cmTitleEl = document.getElementById('client-approve-title');
+          var cmPost = (window.allPosts || []).find(function (p) { return p.post_id === cmApId || p.id === cmApId; });
+          if (cmTitleEl) cmTitleEl.textContent = cmPost ? (cmPost.title || '') : '';
+          if (cmPopup) cmPopup.style.display = 'flex';
+          break;
+
+        case 'cardMenuInput':
+          var cmInId = _cardMenuActiveId || id;
+          _closeCardMenu();
+          var cmIn = document.getElementById('comment-input-' + cmInId);
+          if (cmIn) {
+            cmIn.focus();
+            var cmCard = cmIn.closest('[data-card-id]');
+            if (cmCard) cmCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          }
+          break;
+
+        case 'cardMenuLinkedIn':
+          var liId = _cardMenuActiveId || id;
+          _closeCardMenu();
+          var liPost = (window.allPosts || []).find(function (p) { return p.post_id === liId || p.id === liId; });
+          var liUrl = liPost ? (liPost.linkedinUrl || liPost.linkedin_link || '') : '';
+          if (liUrl) {
+            window.open(liUrl, '_blank');
+          } else {
+            if (typeof window.showToast === 'function') window.showToast('LinkedIn link not available yet.', 'info');
+          }
           break;
 
         case 'cardMenuRequest':
@@ -693,7 +750,7 @@
           break;
 
         case 'shareWA':
-          if (typeof window._clientShareWA === 'function') window._clientShareWA(id);
+          if (typeof window._sharePostOnWhatsApp === 'function') window._sharePostOnWhatsApp(id);
           break;
 
         default:


### PR DESCRIPTION
## Summary

**Style pass:**
- Feed bg `#1b1f23`, cards `#000000` with 8px gap, no borders
- IST greeting + gold client name, muted engagement bar, pill comment input
- Smaller badges, approved strip only green, FAB hidden for client

**Fixes:**
- Top nav: greeting left, awaiting pill + bell + dots right
- Caption 210-char truncation with inline ...more expand
- WhatsApp wired to `_sharePostOnWhatsApp()`
- Card 3-dot menu: stage-aware (Approve / Add Input / View on LinkedIn / WhatsApp)

**Image lightbox (latest):**
- Fullscreen overlay (z-index 9000, `#000` bg, object-fit contain)
- X close top-left, position indicator top-right ("1 / 3"), arrows for multi-image
- Swipe left/right (50px threshold), keyboard Escape/ArrowLeft/ArrowRight
- Sets `_modalOpen` on open, clears on close

Version strings: `?v=20260328e` (18 files). 133/133 tests pass.

## Test plan

- [ ] Tap any image in feed: lightbox opens fullscreen
- [ ] Multi-image posts: arrows visible, swipe left/right navigates, counter shows "1 / N"
- [ ] Single-image posts: no arrows, no counter
- [ ] Escape key closes, X button closes
- [ ] Lightbox blocks background poll renders via `_modalOpen`
- [ ] All previous fixes still work (nav order, caption, WhatsApp, card menu)

https://claude.ai/code/session_01YSpQkL8d9oF2DZYVFKHWTB