### PR TITLE
fix: double bottom-nav bug on client feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328f">
+ <link rel="stylesheet" href="styles.css?v=20260328g">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328f" defer></script>
-<script src="02-session.js?v=20260328f" defer></script>
-<script src="utils.js?v=20260328f" defer></script>
-<script src="03-auth.js?v=20260328f" defer></script>
-<script src="05-api.js?v=20260328f" defer></script>
-<script src="10-ui.js?v=20260328f" defer></script>
+<script src="01-config.js?v=20260328g" defer></script>
+<script src="02-session.js?v=20260328g" defer></script>
+<script src="utils.js?v=20260328g" defer></script>
+<script src="03-auth.js?v=20260328g" defer></script>
+<script src="05-api.js?v=20260328g" defer></script>
+<script src="10-ui.js?v=20260328g" defer></script>
 
-<script src="06-post-create.js?v=20260328f" defer></script>
-<script defer src="render/dashboard.js?v=20260328f"></script>
-<script defer src="render/client.js?v=20260328f"></script>
-<script defer src="render/pipeline.js?v=20260328f"></script>
-<script defer src="render/brief.js?v=20260328f"></script>
-<script defer src="actions/pcs.js?v=20260328f"></script>
-<script src="07-post-load.js?v=20260328f" defer></script>
-<script src="08-post-actions.js?v=20260328f" defer></script>
-<script src="09-library.js?v=20260328f" defer></script>
-<script src="09-approval.js?v=20260328f" defer></script>
-<script src="04-router.js?v=20260328f" defer></script>
+<script src="06-post-create.js?v=20260328g" defer></script>
+<script defer src="render/dashboard.js?v=20260328g"></script>
+<script defer src="render/client.js?v=20260328g"></script>
+<script defer src="render/pipeline.js?v=20260328g"></script>
+<script defer src="render/brief.js?v=20260328g"></script>
+<script defer src="actions/pcs.js?v=20260328g"></script>
+<script src="07-post-load.js?v=20260328g" defer></script>
+<script src="08-post-actions.js?v=20260328g" defer></script>
+<script src="09-library.js?v=20260328g" defer></script>
+<script src="09-approval.js?v=20260328g" defer></script>
+<script src="04-router.js?v=20260328g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -469,17 +469,50 @@
     '</div>';
   }
 
-  /* ---- bottom nav ---- */
+  /* ---- bottom nav (reuse existing #bottom-nav) ---- */
 
-  function _bottomNavHtml() {
-    return '<div id="bottom-nav" style="position:fixed;bottom:0;left:0;right:0;display:flex;justify-content:space-around;align-items:center;padding:8px 0 calc(8px + env(safe-area-inset-bottom));background:rgba(27,31,35,0.97);border-top:1px solid rgba(255,255,255,0.06);z-index:100;">' +
+  var _savedNavHtml = '';
+
+  function _setClientNav() {
+    var nav = document.getElementById('bottom-nav');
+    if (!nav) return;
+    if (!_savedNavHtml) _savedNavHtml = nav.innerHTML;
+    nav.style.cssText = 'position:fixed;bottom:0;left:0;right:0;display:flex;justify-content:space-around;align-items:center;padding:8px 0 calc(8px + env(safe-area-inset-bottom));background:rgba(27,31,35,0.97);border-top:1px solid rgba(255,255,255,0.06);z-index:100;';
+    nav.className = '';
+    nav.innerHTML =
       '<button data-action="nav-feed" style="display:flex;flex-direction:column;align-items:center;gap:2px;background:none;border:none;color:#C8A84B;cursor:pointer;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.04em;padding:4px 12px;">' +
         ICON_FEED + 'Feed</button>' +
       '<button data-action="nav-requests" style="display:flex;flex-direction:column;align-items:center;gap:2px;background:none;border:none;color:#555;cursor:pointer;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.04em;padding:4px 12px;">' +
         ICON_REQ + 'Requests</button>' +
       '<button data-action="nav-alerts" style="display:flex;flex-direction:column;align-items:center;gap:2px;background:none;border:none;color:#555;cursor:pointer;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.04em;padding:4px 12px;">' +
-        ICON_ALERTS + 'Alerts</button>' +
-    '</div>';
+        ICON_ALERTS + 'Alerts</button>';
+  }
+
+  window._restoreAgencyNav = function () {
+    if (!_savedNavHtml) return;
+    var nav = document.getElementById('bottom-nav');
+    if (!nav) return;
+    nav.innerHTML = _savedNavHtml;
+    nav.style.cssText = '';
+    nav.className = 'bottom-nav';
+    _savedNavHtml = '';
+  };
+
+  function _wireNavEvents() {
+    var nav = document.getElementById('bottom-nav');
+    if (!nav || nav._clientNavWired) return;
+    nav._clientNavWired = true;
+    nav.addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-action]');
+      if (!btn) return;
+      var action = btn.getAttribute('data-action');
+      if (action === 'nav-feed') { /* no-op */ }
+      else if (action === 'nav-requests') {
+        if (typeof window.openClientRequestForm === 'function') window.openClientRequestForm();
+      } else if (action === 'nav-alerts') {
+        if (typeof window.openNotifications === 'function') window.openNotifications();
+      }
+    });
   }
 
   /* ---- event delegation ---- */
@@ -893,8 +926,7 @@
 
     var fab = document.getElementById('fab-add');
     if (fab) fab.style.display = 'none';
-    var agencyNav = document.getElementById('main-bottom-nav');
-    if (agencyNav) agencyNav.style.display = 'none';
+    _setClientNav();
 
     var posts = window.allPosts || [];
     var buckets = _bucket(posts);
@@ -930,13 +962,13 @@
     }
 
     html += '</div>';
-    html += _bottomNavHtml();
     html += _approvePopupHtml();
     html += _cardMenuHtml();
     html += _lightboxHtml();
 
     cv.innerHTML = html;
     _wireEvents(cv);
+    _wireNavEvents();
     _wireLightboxTouch();
     _wireLightboxKeyboard();
   };


### PR DESCRIPTION
## Summary

- Removed `_bottomNavHtml()` that injected a second `#bottom-nav` div inside `#client-view`, causing duplicate nav elements in the DOM
- `_setClientNav()` now takes over the existing `#bottom-nav` from index.html, saves original HTML, and replaces with Feed/Requests/Alerts tabs
- `window._restoreAgencyNav()` exported to restore agency tabs (Dashboard/Posts/Library/Insights) when leaving client view
- Fixed dead reference to `main-bottom-nav` (id doesn't exist) — now correctly targets `bottom-nav`
- Added `_wireNavEvents()` to handle client nav clicks since `#bottom-nav` is outside `#client-view` delegation scope

Version strings: `?v=20260328g` (18 files). 133/133 tests pass.

## Test plan

- [ ] Only one `#bottom-nav` element in DOM when client view is active
- [ ] Client nav shows Feed / Requests / Alerts tabs
- [ ] Requests tab opens client request form
- [ ] Alerts tab opens notifications
- [ ] Switching away from client role restores agency nav

https://claude.ai/code/session_01YSpQkL8d9oF2DZYVFKHWTB