### PR TITLE
fix: two-step fetch for client post comments

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -222,9 +222,26 @@ async function loadPostsForClient() {
       'awaiting_approval,awaiting_brand_input,published';
     const data  = await apiFetch(
       '/posts?stage=in.(' + allowedStages +
-      ')&select=*,post_comments(*)&order=created_at.desc'
+      ')&select=*&order=created_at.desc'
     );
     if (!_commitPostsResult(reqId, 'network')) return;
+
+    var postIds = data.map(function(p) { return p.post_id || p.id; }).filter(Boolean);
+    if (postIds.length) {
+      try {
+        var comments = await apiFetch(
+          '/post_comments?post_id=in.(' + postIds.join(',') +
+          ')&order=created_at.asc'
+        );
+        if (Array.isArray(comments)) {
+          data.forEach(function(p) {
+            var pid = p.post_id || p.id;
+            p.post_comments = comments.filter(function(c) { return c.post_id === pid; });
+          });
+        }
+      } catch (_) { /* comments fetch failed — render without them */ }
+    }
+
     mergePosts(normalise(data));
     hideErrorBanner();
     renderClientView();

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328g">
+ <link rel="stylesheet" href="styles.css?v=20260328h">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328g" defer></script>
-<script src="02-session.js?v=20260328g" defer></script>
-<script src="utils.js?v=20260328g" defer></script>
-<script src="03-auth.js?v=20260328g" defer></script>
-<script src="05-api.js?v=20260328g" defer></script>
-<script src="10-ui.js?v=20260328g" defer></script>
+<script src="01-config.js?v=20260328h" defer></script>
+<script src="02-session.js?v=20260328h" defer></script>
+<script src="utils.js?v=20260328h" defer></script>
+<script src="03-auth.js?v=20260328h" defer></script>
+<script src="05-api.js?v=20260328h" defer></script>
+<script src="10-ui.js?v=20260328h" defer></script>
 
-<script src="06-post-create.js?v=20260328g" defer></script>
-<script defer src="render/dashboard.js?v=20260328g"></script>
-<script defer src="render/client.js?v=20260328g"></script>
-<script defer src="render/pipeline.js?v=20260328g"></script>
-<script defer src="render/brief.js?v=20260328g"></script>
-<script defer src="actions/pcs.js?v=20260328g"></script>
-<script src="07-post-load.js?v=20260328g" defer></script>
-<script src="08-post-actions.js?v=20260328g" defer></script>
-<script src="09-library.js?v=20260328g" defer></script>
-<script src="09-approval.js?v=20260328g" defer></script>
-<script src="04-router.js?v=20260328g" defer></script>
+<script src="06-post-create.js?v=20260328h" defer></script>
+<script defer src="render/dashboard.js?v=20260328h"></script>
+<script defer src="render/client.js?v=20260328h"></script>
+<script defer src="render/pipeline.js?v=20260328h"></script>
+<script defer src="render/brief.js?v=20260328h"></script>
+<script defer src="actions/pcs.js?v=20260328h"></script>
+<script src="07-post-load.js?v=20260328h" defer></script>
+<script src="08-post-actions.js?v=20260328h" defer></script>
+<script src="09-library.js?v=20260328h" defer></script>
+<script src="09-approval.js?v=20260328h" defer></script>
+<script src="04-router.js?v=20260328h" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- Replaced `select=*,post_comments(*)` embedded join with two-step fetch
- Step 1: Fetch posts with `select=*` (no join)
- Step 2: Fetch `/post_comments?post_id=in.(ids)&order=created_at.asc` separately
- Step 3: Attach `post_comments` array to each post by matching `post_id`
- Comments fetch failure is caught silently — feed still renders without comments
- Avoids embedded join that may fail due to missing FK constraint in Supabase

Version strings: `?v=20260328h` (18 files). 133/133 tests pass.

## Test plan

- [ ] Client feed loads posts with comments displayed per card
- [ ] Comments show correct author, role color, timestamp
- [ ] If post_comments table is unreachable, feed still renders (no crash)
- [ ] New comments submitted via input still appear immediately

https://claude.ai/code/session_01YSpQkL8d9oF2DZYVFKHWTB