### PR TITLE
fix: PCS guard, FAB flash, menu design, header contrast, CTO guards

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -222,6 +222,13 @@ function activateRole(role) {
   if ((role || '').toLowerCase() === 'client') {
     window.currentRole = _normaliseRole('Client');
     window.effectiveRole = _normaliseRole('Client');
+    var fab = document.getElementById('fab');
+    var fab2 = document.getElementById('main-fab-btn');
+    var nav = document.getElementById('bottom-nav');
+    if (fab) fab.style.display = 'none';
+    if (fab2) fab2.style.display = 'none';
+    if (nav) nav.style.display = 'none';
+    document.body.classList.add('client-mode');
     _buildUserMenu();
     var loginOv = document.getElementById('login-overlay');
     if (loginOv) loginOv.classList.add('hidden');

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -239,7 +239,7 @@ async function loadPostsForClient() {
             p.post_comments = comments.filter(function(c) { return c.post_id === pid; });
           });
         }
-      } catch (_) { /* comments fetch failed — render without them */ }
+      } catch (_) { /* comments fetch failed - render without them */ }
     }
 
     mergePosts(normalise(data));
@@ -2471,6 +2471,8 @@ function toggleStageOverflow(btn, totalHidden) {
 // Covers: .row-tile, .pcs-cal-cell, .upc-list-row (any element with data-post-id)
 // ===============================================
 document.addEventListener('click', function _cardClickDelegate(e) {
+  if (!window.effectiveRole) return;
+  if (window.effectiveRole === 'Client' || window.effectiveRole === 'client') return;
   var card = e.target.closest('[data-post-id]');
   if (!card) return;
   var postId  = card.dataset.postId;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328n">
+ <link rel="stylesheet" href="styles.css?v=20260328o">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328n" defer></script>
-<script src="02-session.js?v=20260328n" defer></script>
-<script src="utils.js?v=20260328n" defer></script>
-<script src="03-auth.js?v=20260328n" defer></script>
-<script src="05-api.js?v=20260328n" defer></script>
-<script src="10-ui.js?v=20260328n" defer></script>
+<script src="01-config.js?v=20260328o" defer></script>
+<script src="02-session.js?v=20260328o" defer></script>
+<script src="utils.js?v=20260328o" defer></script>
+<script src="03-auth.js?v=20260328o" defer></script>
+<script src="05-api.js?v=20260328o" defer></script>
+<script src="10-ui.js?v=20260328o" defer></script>
 
-<script src="06-post-create.js?v=20260328n" defer></script>
-<script defer src="render/dashboard.js?v=20260328n"></script>
-<script defer src="render/client.js?v=20260328n"></script>
-<script defer src="render/pipeline.js?v=20260328n"></script>
-<script defer src="render/brief.js?v=20260328n"></script>
-<script defer src="actions/pcs.js?v=20260328n"></script>
-<script src="07-post-load.js?v=20260328n" defer></script>
-<script src="08-post-actions.js?v=20260328n" defer></script>
-<script src="09-library.js?v=20260328n" defer></script>
-<script src="09-approval.js?v=20260328n" defer></script>
-<script src="04-router.js?v=20260328n" defer></script>
+<script src="06-post-create.js?v=20260328o" defer></script>
+<script defer src="render/dashboard.js?v=20260328o"></script>
+<script defer src="render/client.js?v=20260328o"></script>
+<script defer src="render/pipeline.js?v=20260328o"></script>
+<script defer src="render/brief.js?v=20260328o"></script>
+<script defer src="actions/pcs.js?v=20260328o"></script>
+<script src="07-post-load.js?v=20260328o" defer></script>
+<script src="08-post-actions.js?v=20260328o" defer></script>
+<script src="09-library.js?v=20260328o" defer></script>
+<script src="09-approval.js?v=20260328o" defer></script>
+<script src="04-router.js?v=20260328o" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -33,9 +33,9 @@
     } catch (_) { return ''; }
   }
 
-  function _toTitleCase(str) {
-    if (!str) return '';
-    return str.replace(/\b\w/g, function (c) { return c.toUpperCase(); });
+  function _toTitleCase(value) {
+    if (!value) return '';
+    return String(value).replace(/\b\w/g, function (c) { return c.toUpperCase(); });
   }
 
   function _truncate(text, max) {
@@ -188,7 +188,8 @@
     var style = document.createElement('style');
     style.id = 'client-pulse-style';
     style.textContent = '@keyframes clientPulse{0%,100%{opacity:1;}50%{opacity:0.35;}}' +
-      '.menu-root-absolute{position:absolute!important;z-index:999999;transform:none!important;background:#1c1c26;border:1px solid rgba(255,255,255,0.13);border-radius:8px;min-width:180px;box-shadow:0 8px 24px rgba(0,0,0,0.6);}';
+      '.menu-root-absolute{position:absolute!important;z-index:999999!important;transform:none!important;background:#0d0d0d;border:1px dotted rgba(255,255,255,0.12);border-radius:0;min-width:180px;box-shadow:0 8px 24px rgba(0,0,0,0.6);}' +
+      '#app,#root,#client-view{transform:none!important;}';
     document.head.appendChild(style);
   }
 
@@ -200,6 +201,7 @@
     var noTruncate = post.stage === 'awaiting_brand_input';
     var limit = 210;
     var short = noTruncate ? null : _truncate(text, limit);
+    if (short) short = short.replace(/\)\s*$/, '');
     var id = 'cap-' + (post.post_id || post.id || '');
 
     if (short) {
@@ -459,7 +461,7 @@
           document.removeEventListener('click', closeMenu);
         }
       });
-    }, 10);
+    }, 100);
   };
 
   function _makeSlug(title) {
@@ -468,14 +470,15 @@
   }
 
   function _populateCardMenu(menuEl, stage) {
+    var isDesktop = window.matchMedia('(min-width: 768px)').matches;
     var html = '';
     if (stage === 'awaiting_approval') {
       html += '<button data-action="cardMenuApprove" style="' + _menuBtnStyle + '">Approve Post</button>';
       html += '<button data-action="cardMenuWA" style="' + _menuBtnStyle + _menuBtnBorder + '">Share on WhatsApp</button>';
-      html += '<button data-action="cardMenuCopyApproval" style="' + _menuBtnStyle + _menuBtnBorder + '">Copy Approval Link</button>';
+      if (isDesktop) html += '<button data-action="cardMenuCopyApproval" style="' + _menuBtnStyle + _menuBtnBorder + '">Copy Approval Link</button>';
     } else if (stage === 'awaiting_brand_input') {
       html += '<button data-action="cardMenuInput" style="' + _menuBtnStyle + '">Add Your Input</button>';
-      html += '<button data-action="cardMenuCopyApproval" style="' + _menuBtnStyle + _menuBtnBorder + '">Copy Approval Link</button>';
+      if (isDesktop) html += '<button data-action="cardMenuCopyApproval" style="' + _menuBtnStyle + _menuBtnBorder + '">Copy Approval Link</button>';
     } else if (stage === 'published') {
       html += '<button data-action="cardMenuLinkedIn" style="' + _menuBtnStyle + '">View on LinkedIn</button>';
       html += '<button data-action="cardMenuCopyLink" style="' + _menuBtnStyle + _menuBtnBorder + '">Copy Post Link</button>';
@@ -569,7 +572,7 @@
         '</div>' +
       '</div>' +
       /* badge */
-      '<div style="margin:10px 0 10px 52px;">' + _badgeHtml(post) + '</div>' +
+      '<div style="margin:5px 0 10px 52px;">' + _badgeHtml(post) + '</div>' +
       /* caption */
       _captionHtml(post) +
       /* images */
@@ -621,7 +624,7 @@
         '</button>' +
         '<div style="position:relative;">' +
           '<button data-action="top-menu-toggle" style="background:none;border:none;color:#444;cursor:pointer;padding:4px;">' + ICON_DOTS + '</button>' +
-          '<div data-top-menu style="display:none;position:fixed;background:#1a1a1a;border:1px solid rgba(255,255,255,0.08);border-radius:8px;min-width:160px;z-index:500;box-shadow:0 8px 24px rgba(0,0,0,0.5);">' +
+          '<div data-top-menu style="display:none;position:fixed;background:#0d0d0d;border:1px dotted rgba(255,255,255,0.12);border-radius:0;min-width:160px;z-index:999999;box-shadow:0 8px 24px rgba(0,0,0,0.6);">' +
             '<button data-action="new-request" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#ccc;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;">New Request</button>' +
             '<button data-action="light-mode" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#555;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;border-top:1px solid rgba(255,255,255,0.06);">Light Mode</button>' +
             '<button data-action="sign-out" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#888;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;border-top:1px solid rgba(255,255,255,0.06);">Sign Out</button>' +
@@ -813,6 +816,7 @@
           break;
 
         case 'new-request':
+          e.stopPropagation();
           var menu2 = root.querySelector('[data-top-menu]');
           if (menu2) menu2.style.display = 'none';
           if (typeof window.openClientRequestForm === 'function') window.openClientRequestForm();


### PR DESCRIPTION
## Summary

**P0 - Comment opens PCS (07-post-load.js):**
- Added two guards as first lines of `_cardClickDelegate`: bail if `effectiveRole` is undefined or Client
- Client feed handles all its own taps — agency click delegate is now a complete no-op for client role

**P0 - New Request not clickable (render/client.js):**
- Added `e.stopPropagation()` to new-request handler to prevent outside-click race on mobile
- Changed card menu outside-click setTimeout from 10ms to 100ms

**P1 - FAB flash on load (03-auth.js):**
- In `activateRole()`, when role is Client: hides FAB (`#fab`, `#main-fab-btn`), hides `#bottom-nav`, adds `document.body.classList.add('client-mode')` — all before any render call

**P1 - Menu design (render/client.js):**
- Both menus: background `#0d0d0d`, border-radius `0`, border `1px dotted rgba(255,255,255,0.12)`
- `.menu-root-absolute` z-index `999999!important`
- Top nav menu z-index `999999`

**P1 - Header contrast:**
- Top bar confirmed `background:#1b1f23` (solid, no rgba/filter)
- Added CSS: `#app,#root,#client-view{transform:none!important;}` to prevent stacking context breaks

**P2 - Copy Approval Link desktop only:**
- `_populateCardMenu` uses `window.matchMedia('(min-width: 768px)').matches` to gate Copy Approval Link

**P2 - Badge spacing:** margin-top 5px (attached to header block)

**P3 - Caption bracket artifact:** `.replace(/\)\s*$/, '')` on truncated text

**P3 - Title Case audit:** `_toTitleCase(value)` guards with `if (!value) return ''` and wraps in `String(value)`

**Pre-commit checklist — all 11 passed.**

Version strings: `?v=20260328o` (18 files). 133/133 tests pass.

## Test plan

- [ ] Tapping any card in client feed does NOT open PCS
- [ ] New Request menu item fires openClientRequestForm on mobile
- [ ] No FAB flash on client login
- [ ] Menus have #0d0d0d bg, square corners, dotted border
- [ ] Copy Approval Link hidden on mobile (<768px)
- [ ] Badge sits tight below header, not floating with extra gap

https://claude.ai/code/session_01YSpQkL8d9oF2DZYVFKHWTB