### PR TITLE
fix: top bar background contrast in client mode via styles.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328o">
+ <link rel="stylesheet" href="styles.css?v=20260328p">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328o" defer></script>
-<script src="02-session.js?v=20260328o" defer></script>
-<script src="utils.js?v=20260328o" defer></script>
-<script src="03-auth.js?v=20260328o" defer></script>
-<script src="05-api.js?v=20260328o" defer></script>
-<script src="10-ui.js?v=20260328o" defer></script>
+<script src="01-config.js?v=20260328p" defer></script>
+<script src="02-session.js?v=20260328p" defer></script>
+<script src="utils.js?v=20260328p" defer></script>
+<script src="03-auth.js?v=20260328p" defer></script>
+<script src="05-api.js?v=20260328p" defer></script>
+<script src="10-ui.js?v=20260328p" defer></script>
 
-<script src="06-post-create.js?v=20260328o" defer></script>
-<script defer src="render/dashboard.js?v=20260328o"></script>
-<script defer src="render/client.js?v=20260328o"></script>
-<script defer src="render/pipeline.js?v=20260328o"></script>
-<script defer src="render/brief.js?v=20260328o"></script>
-<script defer src="actions/pcs.js?v=20260328o"></script>
-<script src="07-post-load.js?v=20260328o" defer></script>
-<script src="08-post-actions.js?v=20260328o" defer></script>
-<script src="09-library.js?v=20260328o" defer></script>
-<script src="09-approval.js?v=20260328o" defer></script>
-<script src="04-router.js?v=20260328o" defer></script>
+<script src="06-post-create.js?v=20260328p" defer></script>
+<script defer src="render/dashboard.js?v=20260328p"></script>
+<script defer src="render/client.js?v=20260328p"></script>
+<script defer src="render/pipeline.js?v=20260328p"></script>
+<script defer src="render/brief.js?v=20260328p"></script>
+<script defer src="actions/pcs.js?v=20260328p"></script>
+<script src="07-post-load.js?v=20260328p" defer></script>
+<script src="08-post-actions.js?v=20260328p" defer></script>
+<script src="09-library.js?v=20260328p" defer></script>
+<script src="09-approval.js?v=20260328p" defer></script>
+<script src="04-router.js?v=20260328p" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5499,3 +5499,20 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 #lib-card-overlay .pc-action-btn:hover { background: var(--surface2); }
 .pf-chip { font-family:var(--mono);font-size:8px;letter-spacing:0.1em;text-transform:uppercase;padding:5px 12px;border:1px solid var(--dotline);color:#555;cursor:pointer;background:transparent;min-width:80px;text-align:center;transition:all 0.1s; }
 .pf-chip.pf-on { border-color:var(--c-gold);color:var(--c-gold);background:rgba(200,168,75,0.06); }
+
+body.client-mode .topbar,
+body.client-mode header,
+body.client-mode #top-bar {
+  background: #1b1f23 !important;
+  backdrop-filter: none !important;
+  filter: none !important;
+  box-shadow: none !important;
+}
+
+body.client-mode .bottom-nav {
+  background: #1b1f23 !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  filter: none !important;
+  box-shadow: none !important;
+}


### PR DESCRIPTION
## Summary

- Found `.topbar` rule (line 455) with `background: var(--surface)` = `#111111`. No backdrop-filter on it — left unchanged for agency view.
- Found `.bottom-nav` rule (line 2862) with `background: rgba(8,8,8,0.97)` + `backdrop-filter: blur(12px)`. Left unchanged for agency view.
- Added `body.client-mode .topbar, body.client-mode header, body.client-mode #top-bar` override: `background: #1b1f23 !important`, strips backdrop-filter/filter/box-shadow
- Added `body.client-mode .bottom-nav` override: same treatment
- Uses the `client-mode` class added to `document.body` in `03-auth.js activateRole()` — only affects client view

Version strings: `?v=20260328p` (18 files). 133/133 tests pass.

## Test plan

- [ ] Client view top bar visually matches feed background (#1b1f23)
- [ ] No visible line or tone shift between top bar and feed content
- [ ] Agency view top bar unchanged (still uses var(--surface))
- [ ] Bottom nav in client mode matches feed background

https://claude.ai/code/session_01YSpQkL8d9oF2DZYVFKHWTB