### PR TITLE
fix: image max-height constraint for desktop and Android

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328t">
+ <link rel="stylesheet" href="styles.css?v=20260328u">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328t" defer></script>
-<script src="02-session.js?v=20260328t" defer></script>
-<script src="utils.js?v=20260328t" defer></script>
-<script src="03-auth.js?v=20260328t" defer></script>
-<script src="05-api.js?v=20260328t" defer></script>
-<script src="10-ui.js?v=20260328t" defer></script>
+<script src="01-config.js?v=20260328u" defer></script>
+<script src="02-session.js?v=20260328u" defer></script>
+<script src="utils.js?v=20260328u" defer></script>
+<script src="03-auth.js?v=20260328u" defer></script>
+<script src="05-api.js?v=20260328u" defer></script>
+<script src="10-ui.js?v=20260328u" defer></script>
 
-<script src="06-post-create.js?v=20260328t" defer></script>
-<script defer src="render/dashboard.js?v=20260328t"></script>
-<script defer src="render/client.js?v=20260328t"></script>
-<script defer src="render/pipeline.js?v=20260328t"></script>
-<script defer src="render/brief.js?v=20260328t"></script>
-<script defer src="actions/pcs.js?v=20260328t"></script>
-<script src="07-post-load.js?v=20260328t" defer></script>
-<script src="08-post-actions.js?v=20260328t" defer></script>
-<script src="09-library.js?v=20260328t" defer></script>
-<script src="09-approval.js?v=20260328t" defer></script>
-<script src="04-router.js?v=20260328t" defer></script>
+<script src="06-post-create.js?v=20260328u" defer></script>
+<script defer src="render/dashboard.js?v=20260328u"></script>
+<script defer src="render/client.js?v=20260328u"></script>
+<script defer src="render/pipeline.js?v=20260328u"></script>
+<script defer src="render/brief.js?v=20260328u"></script>
+<script defer src="actions/pcs.js?v=20260328u"></script>
+<script src="07-post-load.js?v=20260328u" defer></script>
+<script src="08-post-actions.js?v=20260328u" defer></script>
+<script src="09-library.js?v=20260328u" defer></script>
+<script src="09-approval.js?v=20260328u" defer></script>
+<script src="04-router.js?v=20260328u" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -230,20 +230,20 @@
     };
 
     if (n === 1) {
-      return '<div style="padding:0 14px;margin-top:10px;">' +
+      return '<div class="img-single" style="padding:0 14px;margin-top:10px;">' +
         wrap(imgs[0], 0, 'aspect-ratio:4/3;border-radius:8px;') +
         '</div>';
     }
 
     if (n === 2) {
-      return '<div style="display:grid;grid-template-columns:1fr 1fr;gap:2px;padding:0 14px;margin-top:10px;">' +
+      return '<div class="img-duo" style="display:grid;grid-template-columns:1fr 1fr;gap:2px;padding:0 14px;margin-top:10px;">' +
         wrap(imgs[0], 0, 'aspect-ratio:1/1;border-radius:8px 0 0 8px;') +
         wrap(imgs[1], 1, 'aspect-ratio:1/1;border-radius:0 8px 8px 0;') +
         '</div>';
     }
 
     if (n === 3) {
-      return '<div style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:130px 130px;gap:2px;padding:0 14px;margin-top:10px;height:260px;">' +
+      return '<div class="img-trio" style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:130px 130px;gap:2px;padding:0 14px;margin-top:10px;height:260px;">' +
         wrap(imgs[0], 0, 'grid-row:1/3;border-radius:8px 0 0 8px;') +
         wrap(imgs[1], 1, 'border-radius:0 8px 0 0;') +
         wrap(imgs[2], 2, 'border-radius:0 0 8px 0;') +
@@ -255,7 +255,7 @@
     var overlayHtml = extra > 0
       ? '<div style="position:absolute;inset:0;background:rgba(0,0,0,0.55);display:flex;align-items:center;justify-content:center;font-family:\'DM Sans\',sans-serif;font-size:20px;font-weight:700;color:#fff;pointer-events:none;">+' + extra + '</div>'
       : '';
-    return '<div style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:150px 150px;gap:2px;padding:0 14px;margin-top:10px;height:300px;">' +
+    return '<div class="img-quad" style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:150px 150px;gap:2px;padding:0 14px;margin-top:10px;height:300px;">' +
       wrap(imgs[0], 0, 'border-radius:8px 0 0 0;') +
       wrap(imgs[1], 1, 'border-radius:0 8px 0 0;') +
       wrap(imgs[2], 2, 'border-radius:0 0 0 8px;') +
@@ -1100,7 +1100,7 @@
 
     var hasContent = buckets.approval.length || buckets.input.length || buckets.published.length;
 
-    html += '<div style="padding-bottom:72px;">';
+    html += '<div style="padding-bottom:72px;max-width:560px;margin:0 auto;">';
 
     if (!hasContent) {
       html += '<div style="padding:48px 16px;text-align:center;font-family:\'IBM Plex Mono\',monospace;font-size:11px;letter-spacing:0.06em;color:rgba(255,255,255,0.35);">Nothing awaiting your review.</div>';

--- a/styles.css
+++ b/styles.css
@@ -5653,3 +5653,16 @@ body.client-mode .section-label {
   color: var(--text-tertiary);
   padding: var(--space-3) var(--space-4) var(--space-2);
 }
+
+body.client-mode .img-single {
+  max-height: 480px;
+  width: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+body.client-mode .img-duo,
+body.client-mode .img-trio,
+body.client-mode .img-quad {
+  max-height: 400px;
+}


### PR DESCRIPTION
## Summary

- Added `body.client-mode .img-single` max-height 480px with object-fit cover
- Added `body.client-mode .img-duo/trio/quad` max-height 400px
- Added classes `img-single`, `img-duo`, `img-trio`, `img-quad` to image grid containers in render/client.js
- Feed container now has `max-width:560px;margin:0 auto` to prevent stretching on desktop

Version strings: `?v=20260328u` (18 files). 133/133 tests pass.

## Test plan

- [ ] Single images capped at 480px height on desktop
- [ ] Multi-image grids capped at 400px height
- [ ] Feed stays phone-width centered on wide screens
- [ ] Images still fill correctly on mobile

https://claude.ai/code/session_01YSpQkL8d9oF2DZYVFKHWTB