### PR TITLE
fix: overlay scope bug, view post handler, pipeline chip filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328z">
+ <link rel="stylesheet" href="styles.css?v=20260328z1">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328z" defer></script>
-<script src="02-session.js?v=20260328z" defer></script>
-<script src="utils.js?v=20260328z" defer></script>
-<script src="03-auth.js?v=20260328z" defer></script>
-<script src="05-api.js?v=20260328z" defer></script>
-<script src="10-ui.js?v=20260328z" defer></script>
+<script src="01-config.js?v=20260328z1" defer></script>
+<script src="02-session.js?v=20260328z1" defer></script>
+<script src="utils.js?v=20260328z1" defer></script>
+<script src="03-auth.js?v=20260328z1" defer></script>
+<script src="05-api.js?v=20260328z1" defer></script>
+<script src="10-ui.js?v=20260328z1" defer></script>
 
-<script src="06-post-create.js?v=20260328z" defer></script>
-<script defer src="render/dashboard.js?v=20260328z"></script>
-<script defer src="render/client.js?v=20260328z"></script>
-<script defer src="render/pipeline.js?v=20260328z"></script>
-<script defer src="render/brief.js?v=20260328z"></script>
-<script defer src="actions/pcs.js?v=20260328z"></script>
-<script src="07-post-load.js?v=20260328z" defer></script>
-<script src="08-post-actions.js?v=20260328z" defer></script>
-<script src="09-library.js?v=20260328z" defer></script>
-<script src="09-approval.js?v=20260328z" defer></script>
-<script src="04-router.js?v=20260328z" defer></script>
+<script src="06-post-create.js?v=20260328z1" defer></script>
+<script defer src="render/dashboard.js?v=20260328z1"></script>
+<script defer src="render/client.js?v=20260328z1"></script>
+<script defer src="render/pipeline.js?v=20260328z1"></script>
+<script defer src="render/brief.js?v=20260328z1"></script>
+<script defer src="actions/pcs.js?v=20260328z1"></script>
+<script src="07-post-load.js?v=20260328z1" defer></script>
+<script src="08-post-actions.js?v=20260328z1" defer></script>
+<script src="09-library.js?v=20260328z1" defer></script>
+<script src="09-approval.js?v=20260328z1" defer></script>
+<script src="04-router.js?v=20260328z1" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -292,6 +292,22 @@ window._openBriefSheet = function(postId) {
 
   document.body.appendChild(overlay);
   document.body.style.overflow = 'hidden';
+
+  overlay.addEventListener('click', function(e) {
+    var btn = e.target.closest('[data-action]');
+    if (!btn) return;
+    if (btn.dataset.action === 'clientViewPost') {
+      var postId = btn.dataset.id;
+      var sheet = document.getElementById('brief-sheet-overlay');
+      if (sheet) sheet.remove();
+      document.body.style.overflow = '';
+      if (typeof window._openClientPostOverlay === 'function') {
+        setTimeout(function() {
+          window._openClientPostOverlay(postId);
+        }, 150);
+      }
+    }
+  });
 }
 
 window._assignBriefToPranav = function(postId) {

--- a/render/client.js
+++ b/render/client.js
@@ -933,7 +933,7 @@
 
       switch (action) {
         case 'expand-caption':
-          var capEl = document.getElementById(id);
+          var capEl = root.querySelector('#' + id);
           if (capEl) {
             var full = capEl.querySelector('[data-full]');
             if (full) {
@@ -987,15 +987,15 @@
           break;
 
         case 'focusComment':
-          var cInput = document.getElementById('comment-input-' + id);
+          var cInput = root.querySelector('#comment-input-' + id);
           if (cInput) {
             cInput.focus();
             var fcCard = cInput.closest('[data-card-id]');
             if (fcCard) fcCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
           } else {
-            var fcAnchor = document.querySelector('[data-comments-list="' + id + '"]') ||
-              document.querySelector('[data-engagement="' + id + '"]') ||
-              document.getElementById('approved-strip-' + id);
+            var fcAnchor = root.querySelector('[data-comments-list="' + id + '"]') ||
+              root.querySelector('[data-engagement="' + id + '"]') ||
+              root.querySelector('#approved-strip-' + id);
             if (fcAnchor) {
               var fcInputHtml = '<div style="display:flex;align-items:center;gap:8px;padding:8px 14px;">' +
                 '<div style="width:28px;height:28px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;background:rgba(255,255,255,0.06);">' + ICON_PERSON + '</div>' +
@@ -1004,7 +1004,7 @@
                   '<button data-action="submitComment" data-id="' + _esc(id) + '" style="background:none;border:none;color:#555;cursor:pointer;padding:4px;flex-shrink:0;">' + ICON_SEND + '</button>' +
                 '</div></div>';
               fcAnchor.insertAdjacentHTML('afterend', fcInputHtml);
-              var fcNew = document.getElementById('comment-input-' + id);
+              var fcNew = root.querySelector('#comment-input-' + id);
               if (fcNew) {
                 fcNew.focus();
                 var fcCard2 = fcNew.closest('[data-card-id]');
@@ -1015,7 +1015,7 @@
           break;
 
         case 'expandComments':
-          var clDiv = document.querySelector('[data-comments-list="' + id + '"]');
+          var clDiv = root.querySelector('[data-comments-list="' + id + '"]');
           if (clDiv) {
             try {
               var allComments = JSON.parse(clDiv.getAttribute('data-full-comments') || '[]');


### PR DESCRIPTION
## Summary
- **Overlay scope bug**: `focusComment` and `expand-caption` handlers in `_wireEvents` now use `root.querySelector` instead of `document.querySelector`/`document.getElementById`. Prevents actions firing on hidden feed elements when overlay is open.
- **View Post handler**: `clientViewPost` data-action in brief sheet now has a working click handler — closes the brief sheet and opens `_openClientPostOverlay(postId)` with a 150ms delay.
- **Pipeline chip filter**: Investigated — chips are static HTML in `index.html` (all, awaiting_approval, awaiting_brand_input, scheduled, ready, in_production). The existing `updatePipelineChipCounts()` filter at lines 431-442 already hides non-client chips (`scheduled`, `ready`, `in_production`) on every `renderPipeline()` call. No JS change needed — filter is sufficient.
- **expandComments**: Also scoped to `root.querySelector` for consistency.

## Files changed
- `render/client.js` — scoped 6 querySelector/getElementById calls to root
- `render/brief.js` — added clientViewPost click handler on brief sheet overlay
- `index.html` — version bump to `?v=20260328z1`

## Chip filter investigation (CHECK 11)
Stage chips are **static HTML** in `index.html:342-366`, not JS-rendered. Six chips exist: all, awaiting_approval, awaiting_brand_input, scheduled, ready, in_production. No `brief` or `brief_done` chips exist. `updatePipelineChipCounts()` (render/pipeline.js:431-442) runs on every `renderPipeline()` call and hides non-client chips via `display:none`. The filter uses `_clientVisibleStages = ['all','awaiting_approval','awaiting_brand_input','published']` — effectively hiding scheduled, ready, in_production for client. No code change was needed.

## Test plan
- [x] 133/133 tests pass
- [x] `node --check` passes on all 3 files
- [x] Zero non-ASCII in all 3 files
- [x] focusComment uses root.querySelector for all 4 lookups
- [x] expand-caption uses root.querySelector
- [x] clientViewPost handler exists in render/brief.js and calls _openClientPostOverlay
- [ ] Manual: Comment button injects input in correct container when overlay is open
- [ ] Manual: See-more expands correct caption in overlay
- [ ] Manual: View Post button in brief sheet opens LinkedIn overlay for client

https://claude.ai/code/session_01VAYUt1ZocphYA2YWjazZbQ