### PR TITLE
fix: remove preview banner, clear stale preview role for non-admins

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -206,6 +206,13 @@ function logout() {
 }
 
 function activateRole(role) {
+  // Clear stale preview role for non-admin users
+  var _dbRole = (role || '').toLowerCase();
+  if (_dbRole !== 'admin') {
+    localStorage.removeItem('pcs_role_preview');
+    window._previewRole = null;
+  }
+
   var rolePreview = localStorage.getItem('pcs_role_preview');
   if (rolePreview && rolePreview !== 'Admin') {
     window.effectiveRole = _normaliseRole(rolePreview);
@@ -266,8 +273,6 @@ function activateRole(role) {
   }
   // Build the : menu contents (role-switch shown only for Admin)
   _buildUserMenu();
-  // Show/hide exit-preview bar
-  if (typeof updateExitPreviewBar === 'function') updateExitPreviewBar();
   // Update FAB visibility after role change
   setTimeout(function() { if (typeof updateFabVisibility === 'function') updateFabVisibility(); }, 0);
 

--- a/10-ui.js
+++ b/10-ui.js
@@ -115,31 +115,6 @@ function gamSwitchRole(role) {
 }
 window.gamSwitchRole = gamSwitchRole;
 
-// -- Exit Preview Bar -------------------------
-function updateExitPreviewBar() {
-  var existing = document.getElementById('exit-preview-bar');
-  if (existing) existing.remove();
-
-  if (window.effectiveRole !== 'Admin' &&
-      window.effectiveRole !== 'admin') {
-    var bar = document.createElement('div');
-    bar.id = 'exit-preview-bar';
-    bar.style.cssText = 'position:fixed;top:0;left:0;right:0;' +
-      'z-index:9999;background:#C8A84B;' +
-      'font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
-      'letter-spacing:0.12em;text-transform:uppercase;' +
-      'color:#000;padding:6px 18px;' +
-      'display:flex;align-items:center;justify-content:space-between;' +
-      'cursor:pointer;';
-    bar.innerHTML = '<span>Viewing as ' + window.effectiveRole + '</span>' +
-      '<span>Tap to exit &rarr;</span>';
-    bar.onclick = function() {
-      localStorage.removeItem('pcs_role_preview');
-      location.reload();
-    };
-    document.body.appendChild(bar);
-  }
-}
 
 // -- Tabs --------------------------------------
 function goToTab(tabName) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328z5">
+ <link rel="stylesheet" href="styles.css?v=20260328z6">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328z5" defer></script>
-<script src="02-session.js?v=20260328z5" defer></script>
-<script src="utils.js?v=20260328z5" defer></script>
-<script src="03-auth.js?v=20260328z5" defer></script>
-<script src="05-api.js?v=20260328z5" defer></script>
-<script src="10-ui.js?v=20260328z5" defer></script>
+<script src="01-config.js?v=20260328z6" defer></script>
+<script src="02-session.js?v=20260328z6" defer></script>
+<script src="utils.js?v=20260328z6" defer></script>
+<script src="03-auth.js?v=20260328z6" defer></script>
+<script src="05-api.js?v=20260328z6" defer></script>
+<script src="10-ui.js?v=20260328z6" defer></script>
 
-<script src="06-post-create.js?v=20260328z5" defer></script>
-<script defer src="render/dashboard.js?v=20260328z5"></script>
-<script defer src="render/client.js?v=20260328z5"></script>
-<script defer src="render/pipeline.js?v=20260328z5"></script>
-<script defer src="render/brief.js?v=20260328z5"></script>
-<script defer src="actions/pcs.js?v=20260328z5"></script>
-<script src="07-post-load.js?v=20260328z5" defer></script>
-<script src="08-post-actions.js?v=20260328z5" defer></script>
-<script src="09-library.js?v=20260328z5" defer></script>
-<script src="09-approval.js?v=20260328z5" defer></script>
-<script src="04-router.js?v=20260328z5" defer></script>
+<script src="06-post-create.js?v=20260328z6" defer></script>
+<script defer src="render/dashboard.js?v=20260328z6"></script>
+<script defer src="render/client.js?v=20260328z6"></script>
+<script defer src="render/pipeline.js?v=20260328z6"></script>
+<script defer src="render/brief.js?v=20260328z6"></script>
+<script defer src="actions/pcs.js?v=20260328z6"></script>
+<script src="07-post-load.js?v=20260328z6" defer></script>
+<script src="08-post-actions.js?v=20260328z6" defer></script>
+<script src="09-library.js?v=20260328z6" defer></script>
+<script src="09-approval.js?v=20260328z6" defer></script>
+<script src="04-router.js?v=20260328z6" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- **Clear stale preview role for non-admins**: Added guard in `activateRole()` (03-auth.js) that removes `pcs_role_preview` from localStorage and nulls `window._previewRole` when the DB role is not admin — prevents non-admin users from getting stuck in a preview state.
- **Remove preview banner entirely**: Deleted `updateExitPreviewBar()` function from 10-ui.js and its call in 03-auth.js — the "Viewing as [ROLE]" yellow bar no longer renders. Role-switch logic in the dots menu is preserved.
- **Version bump**: All 18 cache-bust strings in index.html bumped to `?v=20260328z6`.

## Pre-commit checks
- [x] `node --check` passes on all modified JS files
- [x] No non-ASCII characters in modified files
- [x] 133/133 tests pass
- [x] Zero results for `VIEWING AS` across all JS files
- [x] `localStorage.removeItem('pcs_role_preview')` present in non-admin guard

## Files changed
- `03-auth.js` — added non-admin guard, removed `updateExitPreviewBar` call
- `10-ui.js` — deleted `updateExitPreviewBar()` function
- `index.html` — version bump z5 → z6

https://claude.ai/code/session_01EzxK99J8Sx6Dp538bKQzvp