### PR TITLE
fix: direct click listeners on image cells — bypass delegation for lightbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328z6">
+ <link rel="stylesheet" href="styles.css?v=20260328z7">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328z6" defer></script>
-<script src="02-session.js?v=20260328z6" defer></script>
-<script src="utils.js?v=20260328z6" defer></script>
-<script src="03-auth.js?v=20260328z6" defer></script>
-<script src="05-api.js?v=20260328z6" defer></script>
-<script src="10-ui.js?v=20260328z6" defer></script>
+<script src="01-config.js?v=20260328z7" defer></script>
+<script src="02-session.js?v=20260328z7" defer></script>
+<script src="utils.js?v=20260328z7" defer></script>
+<script src="03-auth.js?v=20260328z7" defer></script>
+<script src="05-api.js?v=20260328z7" defer></script>
+<script src="10-ui.js?v=20260328z7" defer></script>
 
-<script src="06-post-create.js?v=20260328z6" defer></script>
-<script defer src="render/dashboard.js?v=20260328z6"></script>
-<script defer src="render/client.js?v=20260328z6"></script>
-<script defer src="render/pipeline.js?v=20260328z6"></script>
-<script defer src="render/brief.js?v=20260328z6"></script>
-<script defer src="actions/pcs.js?v=20260328z6"></script>
-<script src="07-post-load.js?v=20260328z6" defer></script>
-<script src="08-post-actions.js?v=20260328z6" defer></script>
-<script src="09-library.js?v=20260328z6" defer></script>
-<script src="09-approval.js?v=20260328z6" defer></script>
-<script src="04-router.js?v=20260328z6" defer></script>
+<script src="06-post-create.js?v=20260328z7" defer></script>
+<script defer src="render/dashboard.js?v=20260328z7"></script>
+<script defer src="render/client.js?v=20260328z7"></script>
+<script defer src="render/pipeline.js?v=20260328z7"></script>
+<script defer src="render/brief.js?v=20260328z7"></script>
+<script defer src="actions/pcs.js?v=20260328z7"></script>
+<script src="07-post-load.js?v=20260328z7" defer></script>
+<script src="08-post-actions.js?v=20260328z7" defer></script>
+<script src="09-library.js?v=20260328z7" defer></script>
+<script src="09-approval.js?v=20260328z7" defer></script>
+<script src="04-router.js?v=20260328z7" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1315,6 +1315,19 @@
     cv.innerHTML = html;
     _wireTopNavOnce();
     _wireEvents(cv);
+    cv.querySelectorAll('[data-action="openLightbox"]')
+      .forEach(function(cell) {
+        cell.addEventListener('click', function(e) {
+          e.stopPropagation();
+          try {
+            var imgs = JSON.parse(
+              cell.getAttribute('data-images') || '[]');
+            var idx = parseInt(
+              cell.getAttribute('data-index') || '0', 10);
+            if (imgs.length) _lbOpen(imgs, idx);
+          } catch (_e) {}
+        });
+      });
     _wireNavEvents();
     _wireLightboxTouch();
     _wireLightboxKeyboard();
@@ -1383,6 +1396,19 @@
     document.body.style.overflow = 'hidden';
 
     _wireEvents(overlay);
+    overlay.querySelectorAll('[data-action="openLightbox"]')
+      .forEach(function(cell) {
+        cell.addEventListener('click', function(e) {
+          e.stopPropagation();
+          try {
+            var imgs = JSON.parse(
+              cell.getAttribute('data-images') || '[]');
+            var idx = parseInt(
+              cell.getAttribute('data-index') || '0', 10);
+            if (imgs.length) _lbOpen(imgs, idx);
+          } catch (_e) {}
+        });
+      });
     var approvePopup = document.getElementById('client-approve-popup');
     if (approvePopup && !approvePopup.dataset.wired) {
       _wireEvents(approvePopup);


### PR DESCRIPTION
## Summary

- Added direct `click` listeners via `querySelectorAll('[data-action="openLightbox"]')` on every image cell in **both** the client feed (`renderClientView` → `cv`) and the post overlay (`_openClientPostOverlay` → `overlay`).
- Each listener calls `e.stopPropagation()` to bypass event delegation entirely, then parses `data-images` / `data-index` and calls `_lbOpen()`.
- Version bump: all 18 cache-bust strings in index.html → `?v=20260328z7`.

## Files changed
- `render/client.js` — two identical listener blocks added (lines ~1318 and ~1399)
- `index.html` — version bump z6 → z7

## Pre-commit checks
- [x] `node --check render/client.js` passes
- [x] No non-ASCII characters
- [x] 133/133 tests pass
- [x] `querySelectorAll('[data-action="openLightbox"]')` present in both feed and overlay paths

https://claude.ai/code/session_01EzxK99J8Sx6Dp538bKQzvp