### PR TITLE
fix: delegated click listeners for image grid lightbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328z7">
+ <link rel="stylesheet" href="styles.css?v=20260328z9">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328z7" defer></script>
-<script src="02-session.js?v=20260328z7" defer></script>
-<script src="utils.js?v=20260328z7" defer></script>
-<script src="03-auth.js?v=20260328z7" defer></script>
-<script src="05-api.js?v=20260328z7" defer></script>
-<script src="10-ui.js?v=20260328z7" defer></script>
+<script src="01-config.js?v=20260328z9" defer></script>
+<script src="02-session.js?v=20260328z9" defer></script>
+<script src="utils.js?v=20260328z9" defer></script>
+<script src="03-auth.js?v=20260328z9" defer></script>
+<script src="05-api.js?v=20260328z9" defer></script>
+<script src="10-ui.js?v=20260328z9" defer></script>
 
-<script src="06-post-create.js?v=20260328z7" defer></script>
-<script defer src="render/dashboard.js?v=20260328z7"></script>
-<script defer src="render/client.js?v=20260328z7"></script>
-<script defer src="render/pipeline.js?v=20260328z7"></script>
-<script defer src="render/brief.js?v=20260328z7"></script>
-<script defer src="actions/pcs.js?v=20260328z7"></script>
-<script src="07-post-load.js?v=20260328z7" defer></script>
-<script src="08-post-actions.js?v=20260328z7" defer></script>
-<script src="09-library.js?v=20260328z7" defer></script>
-<script src="09-approval.js?v=20260328z7" defer></script>
-<script src="04-router.js?v=20260328z7" defer></script>
+<script src="06-post-create.js?v=20260328z9" defer></script>
+<script defer src="render/dashboard.js?v=20260328z9"></script>
+<script defer src="render/client.js?v=20260328z9"></script>
+<script defer src="render/pipeline.js?v=20260328z9"></script>
+<script defer src="render/brief.js?v=20260328z9"></script>
+<script defer src="actions/pcs.js?v=20260328z9"></script>
+<script src="07-post-load.js?v=20260328z9" defer></script>
+<script src="08-post-actions.js?v=20260328z9" defer></script>
+<script src="09-library.js?v=20260328z9" defer></script>
+<script src="09-approval.js?v=20260328z9" defer></script>
+<script src="04-router.js?v=20260328z9" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1315,19 +1315,18 @@
     cv.innerHTML = html;
     _wireTopNavOnce();
     _wireEvents(cv);
-    cv.querySelectorAll('[data-action="openLightbox"]')
-      .forEach(function(cell) {
-        cell.addEventListener('click', function(e) {
-          e.stopPropagation();
-          try {
-            var imgs = JSON.parse(
-              cell.getAttribute('data-images') || '[]');
-            var idx = parseInt(
-              cell.getAttribute('data-index') || '0', 10);
-            if (imgs.length) _lbOpen(imgs, idx);
-          } catch (_e) {}
-        });
-      });
+    cv.addEventListener('click', function(e) {
+      var cell = e.target.closest('[data-action="openLightbox"]');
+      if (!cell) return;
+      e.stopPropagation();
+      try {
+        var imgs = JSON.parse(
+          cell.getAttribute('data-images') || '[]');
+        var idx = parseInt(
+          cell.getAttribute('data-index') || '0', 10);
+        if (imgs.length) _lbOpen(imgs, idx);
+      } catch (_e) {}
+    });
     _wireNavEvents();
     _wireLightboxTouch();
     _wireLightboxKeyboard();
@@ -1396,19 +1395,18 @@
     document.body.style.overflow = 'hidden';
 
     _wireEvents(overlay);
-    overlay.querySelectorAll('[data-action="openLightbox"]')
-      .forEach(function(cell) {
-        cell.addEventListener('click', function(e) {
-          e.stopPropagation();
-          try {
-            var imgs = JSON.parse(
-              cell.getAttribute('data-images') || '[]');
-            var idx = parseInt(
-              cell.getAttribute('data-index') || '0', 10);
-            if (imgs.length) _lbOpen(imgs, idx);
-          } catch (_e) {}
-        });
-      });
+    overlay.addEventListener('click', function(e) {
+      var cell = e.target.closest('[data-action="openLightbox"]');
+      if (!cell) return;
+      e.stopPropagation();
+      try {
+        var imgs = JSON.parse(
+          cell.getAttribute('data-images') || '[]');
+        var idx = parseInt(
+          cell.getAttribute('data-index') || '0', 10);
+        if (imgs.length) _lbOpen(imgs, idx);
+      } catch (_e) {}
+    });
     var approvePopup = document.getElementById('client-approve-popup');
     if (approvePopup && !approvePopup.dataset.wired) {
       _wireEvents(approvePopup);


### PR DESCRIPTION
## Summary
- Replaced `querySelectorAll('[data-action="openLightbox"]').forEach(...)` with single delegated `addEventListener('click')` on both `overlay` and `cv` elements
- Listeners use `e.target.closest('[data-action="openLightbox"]')` — works for dynamically added content, no re-binding needed
- Bumped all 18 version strings in index.html to `?v=20260328z9`

## Pre-commit checks
- [x] `node --check render/client.js` — syntax OK
- [x] Zero non-ASCII characters
- [x] 133/133 tests pass
- [x] Zero `root.querySelectorAll` occurrences
- [x] `overlay.addEventListener('click')` in `_openClientPostOverlay`
- [x] `cv.addEventListener('click')` in `renderClientView`

## Test plan
- [ ] Open client view — tap image grid, lightbox should open
- [ ] Open client post overlay — tap image grid, lightbox should open
- [ ] Verify single/duo/trio/quad layouts all trigger lightbox
- [ ] Confirm no console errors on tap

https://claude.ai/code/session_01VmqU23EAMUuEBZVg5Q8r5J