### PR TITLE
fix: remove backdrop-filter from overlay header — stacking context fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260328z7">
+ <link rel="stylesheet" href="styles.css?v=20260329i">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260328z7" defer></script>
-<script src="02-session.js?v=20260328z7" defer></script>
-<script src="utils.js?v=20260328z7" defer></script>
-<script src="03-auth.js?v=20260328z7" defer></script>
-<script src="05-api.js?v=20260328z7" defer></script>
-<script src="10-ui.js?v=20260328z7" defer></script>
+<script src="01-config.js?v=20260329i" defer></script>
+<script src="02-session.js?v=20260329i" defer></script>
+<script src="utils.js?v=20260329i" defer></script>
+<script src="03-auth.js?v=20260329i" defer></script>
+<script src="05-api.js?v=20260329i" defer></script>
+<script src="10-ui.js?v=20260329i" defer></script>
 
-<script src="06-post-create.js?v=20260328z7" defer></script>
-<script defer src="render/dashboard.js?v=20260328z7"></script>
-<script defer src="render/client.js?v=20260328z7"></script>
-<script defer src="render/pipeline.js?v=20260328z7"></script>
-<script defer src="render/brief.js?v=20260328z7"></script>
-<script defer src="actions/pcs.js?v=20260328z7"></script>
-<script src="07-post-load.js?v=20260328z7" defer></script>
-<script src="08-post-actions.js?v=20260328z7" defer></script>
-<script src="09-library.js?v=20260328z7" defer></script>
-<script src="09-approval.js?v=20260328z7" defer></script>
-<script src="04-router.js?v=20260328z7" defer></script>
+<script src="06-post-create.js?v=20260329i" defer></script>
+<script defer src="render/dashboard.js?v=20260329i"></script>
+<script defer src="render/client.js?v=20260329i"></script>
+<script defer src="render/pipeline.js?v=20260329i"></script>
+<script defer src="render/brief.js?v=20260329i"></script>
+<script defer src="actions/pcs.js?v=20260329i"></script>
+<script src="07-post-load.js?v=20260329i" defer></script>
+<script src="08-post-actions.js?v=20260329i" defer></script>
+<script src="09-library.js?v=20260329i" defer></script>
+<script src="09-approval.js?v=20260329i" defer></script>
+<script src="04-router.js?v=20260329i" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1382,7 +1382,7 @@
     overlay.id = 'client-post-overlay';
     overlay.style.cssText = 'position:fixed;inset:0;z-index:9000;background:#1b1f23;overflow-y:auto;-webkit-overflow-scrolling:touch;font-family:\'DM Sans\',sans-serif;';
     overlay.innerHTML =
-      '<div style="position:sticky;top:0;z-index:10;background:rgba(27,31,35,0.95);backdrop-filter:blur(8px);padding:0;border-bottom:1px solid rgba(255,255,255,0.06);">' +
+      '<div style="position:sticky;top:0;z-index:10;background:rgba(27,31,35,0.98);padding:0;border-bottom:1px solid rgba(255,255,255,0.06);">' +
         '<button id="client-overlay-close" style="background:none;border:none;color:#888;font-size:24px;cursor:pointer;padding:12px 16px;">&#x2715;</button>' +
       '</div>' +
       '<div style="padding-bottom:72px;">' +


### PR DESCRIPTION
## Summary

- Removed `backdrop-filter:blur(8px)` from the sticky header in `_openClientPostOverlay()` (render/client.js line 1385)
- Replaced with solid `background:rgba(27,31,35,0.98)` — visually identical, no compositing layer promotion
- This eliminates the stacking context that was trapping the lightbox (z-index:9500) below the overlay (z-index:9000)
- Version bump: all 18 cache-bust strings → `?v=20260329i`

## Pre-commit checks
- [x] `node --check render/client.js` passes
- [x] No non-ASCII characters
- [x] 133/133 tests pass
- [x] Zero `backdrop-filter` references inside `_openClientPostOverlay`

https://claude.ai/code/session_01EzxK99J8Sx6Dp538bKQzvp