### PR TITLE
feat: upload new images to Cloudflare R2 via Worker

### DIFF
--- a/05-api.js
+++ b/05-api.js
@@ -118,7 +118,7 @@ async function uploadPostAsset(file, postId) {
   file = await _compressImage(file);
   var ext = file.name.split('.').pop();
   var filename = 'post-assets/' + postId + '/' + Date.now() + '.' + ext;
-  var workerUrl = 'https://srtd-og-inject.ksg-kumarshubhamgune.workers.dev/upload'
+  var workerUrl = 'https://srtd-r2-upload.ksg-kumarshubhamgune.workers.dev/upload'
     + '?filename=' + encodeURIComponent(filename);
   var res = await fetch(workerUrl, {
     method: 'POST',

--- a/05-api.js
+++ b/05-api.js
@@ -116,23 +116,21 @@ async function _compressImage(file) {
 
 async function uploadPostAsset(file, postId) {
   file = await _compressImage(file);
-  const ext      = file.name.split('.').pop();
-  const filename = `${postId}/${Date.now()}.${ext}`;
-  const url      = `${SUPABASE_URL}/storage/v1/object/post-assets/${filename}`;
-  const res = await fetch(url, {
+  var ext = file.name.split('.').pop();
+  var filename = 'post-assets/' + postId + '/' + Date.now() + '.' + ext;
+  var workerUrl = 'https://srtd-og-inject.ksg-kumarshubhamgune.workers.dev/upload'
+    + '?filename=' + encodeURIComponent(filename);
+  var res = await fetch(workerUrl, {
     method: 'POST',
-    headers: getAuthHeaders({
-      'Content-Type':  file.type,
-      'Cache-Control': '3600',
-    }),
+    headers: {
+      'Content-Type': file.type,
+      'X-Upload-Secret': 'srtd2026xK9mN3pQ',
+    },
     body: file,
   });
-  if (!res.ok) throw new Error(`Upload ${res.status}`);
-  var publicUrl = `${SUPABASE_URL}/storage/v1/object/public/post-assets/${filename}`;
-  try {
-    fetch(publicUrl, { method: 'GET', mode: 'no-cors' });
-  } catch (e) {}
-  return publicUrl;
+  if (!res.ok) throw new Error('Upload ' + res.status);
+  var data = await res.json();
+  return data.url;
 }
 
 async function logActivity({ post_id, actor, actor_role, action }) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329i">
+ <link rel="stylesheet" href="styles.css?v=20260329j">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329i" defer></script>
-<script src="02-session.js?v=20260329i" defer></script>
-<script src="utils.js?v=20260329i" defer></script>
-<script src="03-auth.js?v=20260329i" defer></script>
-<script src="05-api.js?v=20260329i" defer></script>
-<script src="10-ui.js?v=20260329i" defer></script>
+<script src="01-config.js?v=20260329j" defer></script>
+<script src="02-session.js?v=20260329j" defer></script>
+<script src="utils.js?v=20260329j" defer></script>
+<script src="03-auth.js?v=20260329j" defer></script>
+<script src="05-api.js?v=20260329j" defer></script>
+<script src="10-ui.js?v=20260329j" defer></script>
 
-<script src="06-post-create.js?v=20260329i" defer></script>
-<script defer src="render/dashboard.js?v=20260329i"></script>
-<script defer src="render/client.js?v=20260329i"></script>
-<script defer src="render/pipeline.js?v=20260329i"></script>
-<script defer src="render/brief.js?v=20260329i"></script>
-<script defer src="actions/pcs.js?v=20260329i"></script>
-<script src="07-post-load.js?v=20260329i" defer></script>
-<script src="08-post-actions.js?v=20260329i" defer></script>
-<script src="09-library.js?v=20260329i" defer></script>
-<script src="09-approval.js?v=20260329i" defer></script>
-<script src="04-router.js?v=20260329i" defer></script>
+<script src="06-post-create.js?v=20260329j" defer></script>
+<script defer src="render/dashboard.js?v=20260329j"></script>
+<script defer src="render/client.js?v=20260329j"></script>
+<script defer src="render/pipeline.js?v=20260329j"></script>
+<script defer src="render/brief.js?v=20260329j"></script>
+<script defer src="actions/pcs.js?v=20260329j"></script>
+<script src="07-post-load.js?v=20260329j" defer></script>
+<script src="08-post-actions.js?v=20260329j" defer></script>
+<script src="09-library.js?v=20260329j" defer></script>
+<script src="09-approval.js?v=20260329j" defer></script>
+<script src="04-router.js?v=20260329j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/r2-upload-worker.js
+++ b/r2-upload-worker.js
@@ -1,0 +1,40 @@
+export default {
+  async fetch(request, env) {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        headers: {
+          'Access-Control-Allow-Origin': 'https://srtd.io',
+          'Access-Control-Allow-Methods': 'POST, OPTIONS',
+          'Access-Control-Allow-Headers': '*',
+        }
+      });
+    }
+    if (request.method !== 'POST') {
+      return new Response('Method not allowed', { status: 405 });
+    }
+    const secret = request.headers.get('X-Upload-Secret');
+    if (secret !== 'srtd2026xK9mN3pQ') {
+      return new Response('Unauthorized', { status: 401 });
+    }
+    const url = new URL(request.url);
+    const filename = url.searchParams.get('filename');
+    if (!filename) {
+      return new Response('Missing filename', { status: 400 });
+    }
+    const body = await request.arrayBuffer();
+    const contentType = request.headers.get('Content-Type')
+      || 'image/jpeg';
+    await env.SORTED_IMAGES.put(filename, body, {
+      httpMetadata: { contentType }
+    });
+    const publicUrl =
+      'https://pub-6a2a4aa8073d454ab9aeee69ef841635.r2.dev/'
+      + filename;
+    return new Response(JSON.stringify({ url: publicUrl }), {
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': 'https://srtd.io',
+      }
+    });
+  }
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,7 @@
+name = "srtd-r2-upload"
+main = "r2-upload-worker.js"
+compatibility_date = "2024-01-01"
+
+[[r2_buckets]]
+binding = "SORTED_IMAGES"
+bucket_name = "sorted-images"


### PR DESCRIPTION
## Summary\n\n- **Migrated all 52 existing images** (25 posts) from Supabase Storage to Cloudflare R2 `sorted-images` bucket (already done, DB updated)\n- **New uploads now go to R2** — `uploadPostAsset()` in `05-api.js` sends files to a Cloudflare Worker instead of Supabase Storage\n- **Added `r2-upload-worker.js`** — new Cloudflare Worker (`srtd-r2-upload`) that receives uploads and writes to R2\n- **Added `wrangler.toml`** for deploying the worker\n- Cache version bumped to `20260329j`\n\n## Before merging\n\n- [ ] Deploy the worker: `CLOUDFLARE_API_TOKEN=xxx npx wrangler deploy` from repo root\n- [ ] Verify worker responds at `https://srtd-r2-upload.ksg-kumarshubhamgune.workers.dev/upload`\n- [ ] Test an image upload in the app\n\n## Test plan\n\n- [x] `node --check 05-api.js` — syntax valid\n- [x] `npm test` — 133/133 tests pass\n- [x] No non-ASCII characters in 05-api.js\n- [x] `uploadPostAsset()` returns R2 public URL, not Supabase URL\n\nhttps://claude.ai/code/session_012g9gHy1e8Hq4n4HCC6f6xX