### PR TITLE
feat: dual-channel comments - client thread + internal notes

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -422,6 +422,12 @@ window._renderPCS = function(postId) {
   if (typeof loadPcsComments === 'function') {
     loadPcsComments(_pcsPostId);
   }
+
+  var notesSection = document.getElementById('pcs-notes-section');
+  if (notesSection) {
+    var _r = (window.effectiveRole||'').toLowerCase();
+    notesSection.style.display = _r === 'client' ? 'none' : 'block';
+  }
 }
 
 // -- Subtitle sync (single source of truth) --------------
@@ -606,9 +612,13 @@ window._saveLiUrlInline = function(postId) {
 // -- PCS Comments --------------------------------------------------
 window.loadPcsComments = async function(postId) {
   var section = document.getElementById('pcs-comments-section');
-  var inputBar = document.getElementById('pcs-comment-input-bar');
   var list = document.getElementById('pcs-comments-list');
+  var notesList = document.getElementById('pcs-notes-list');
   if (!section || !list) return;
+
+  var _role = (window.effectiveRole || 'Admin');
+  var _roleLower = _role.toLowerCase();
+  var _name = window.currentUserName || '';
 
   try {
     var rows = await apiFetch(
@@ -616,88 +626,128 @@ window.loadPcsComments = async function(postId) {
       encodeURIComponent(postId) +
       '&order=created_at.asc&limit=100'
     );
+    if (!Array.isArray(rows)) rows = [];
+
+    var clientRows = rows.filter(function(c) {
+      return c.visibility === 'all' || !c.visibility;
+    });
+
+    var internalRows = rows.filter(function(c) {
+      if (c.visibility === 'all' || !c.visibility) return false;
+      if (_roleLower === 'admin') return true;
+      if (c.visibility === _roleLower) return true;
+      var _mu = Array.isArray(c.mentioned_users) ? c.mentioned_users : [];
+      return _mu.indexOf(_name) !== -1;
+    });
 
     section.style.display = 'block';
-    if (inputBar) {
-      inputBar.style.display = 'flex';
+    var inputBar = document.getElementById('pcs-comment-input-bar');
+    if (inputBar) inputBar.style.display = 'flex';
+
+    function _renderThread(threadRows, isEmpty) {
+      if (!threadRows.length) return isEmpty;
+      return threadRows.map(function(c) {
+        var _initial = (c.author||'?').charAt(0).toUpperCase();
+        var _ts = '';
+        if (c.created_at) {
+          var _d = new Date((c.created_at||'')
+            .replace(' ','T')
+            .replace('+00:00','Z')
+            .replace('+00','Z'));
+          if (!isNaN(_d.getTime())) {
+            _ts = _d.toLocaleDateString('en-IN',{
+              day:'numeric',month:'short',
+              timeZone:'Asia/Kolkata'}) +
+              ' \xB7 ' +
+              _d.toLocaleTimeString('en-IN',{
+              hour:'numeric',minute:'2-digit',
+              hour12:true,timeZone:'Asia/Kolkata'});
+          }
+        }
+        var _r = (c.author_role||'').toLowerCase();
+        var _avClass = 'pcs-avatar';
+        if (_r==='client') _avClass += ' av-client';
+        else if (_r==='servicing'||_r==='chitra') _avClass += ' av-servicing';
+        else if (_r==='creative'||_r==='pranav') _avClass += ' av-creative';
+        else _avClass += ' av-admin';
+
+        var _mu = Array.isArray(c.mentioned_users) ? c.mentioned_users : [];
+        var _mentionBadge = _mu.length
+          ? '<span class="pcs-mention-badge">@' + esc(_mu.join(', @')) + '</span>'
+          : '';
+
+        return '<div class="pcs-comment-item' +
+          (c.resolved ? ' pcs-resolved' : '') + '">' +
+          (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
+          '<div class="' + _avClass + '">' + esc(_initial) + '</div>' +
+          '<div class="pcs-comment-body">' +
+            '<div class="pcs-comment-meta">' +
+              '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
+              '<span class="pcs-comment-time">' + _ts + '</span>' +
+              _mentionBadge +
+            '</div>' +
+            '<div class="pcs-comment-text">' + esc(c.message) + '</div>' +
+          '</div>' +
+        '</div>';
+      }).join('');
     }
 
-    if (!Array.isArray(rows) || rows.length === 0) {
-      list.innerHTML =
-        '<div style="padding:20px 16px;text-align:center;">' +
-        '<div style="font-size:18px;opacity:0.25;margin-bottom:8px;">&#x1F4AC;</div>' +
-        '<div style="font-family:\'DM Sans\',sans-serif;font-size:13px;' +
-        'color:rgba(255,255,255,0.25);line-height:1.5;">' +
-        'Start the conversation.<br>Client and team see all comments.</div>' +
-        '</div>';
-      var countEl = document.getElementById('pcs-comments-count');
-      if (countEl) countEl.style.display = 'none';
-      return;
-    }
+    var emptyClient =
+      '<div class="pcs-empty-thread">' +
+      '<div class="pcs-empty-icon">&#x1F4AC;</div>' +
+      '<div class="pcs-empty-text">No comments yet.<br>Client and team see this thread.</div>' +
+      '</div>';
+
+    list.innerHTML = _renderThread(clientRows, emptyClient);
 
     var countEl = document.getElementById('pcs-comments-count');
     if (countEl) {
-      countEl.textContent = rows.length;
-      countEl.style.display = 'inline';
-      countEl.style.cssText = 'background:rgba(200,168,75,0.15);color:#C8A84B;font-size:7px;padding:2px 7px;letter-spacing:0.08em;font-weight:600;display:inline;';
+      if (clientRows.length) {
+        countEl.textContent = clientRows.length;
+        countEl.style.display = 'inline';
+      } else {
+        countEl.style.display = 'none';
+      }
     }
 
-    function _commentAvatarStyle(role) {
-      var r = (role||'').toLowerCase();
-      if (r === 'client') return 'background:rgba(255,75,75,0.15);color:#FF4B4B;border:1px solid rgba(255,75,75,0.2);';
-      if (r === 'servicing' || r === 'chitra') return 'background:rgba(34,211,238,0.15);color:#22D3EE;border:1px solid rgba(34,211,238,0.2);';
-      if (r === 'creative' || r === 'pranav') return 'background:rgba(155,135,245,0.15);color:#9b87f5;border:1px solid rgba(155,135,245,0.2);';
-      return 'background:rgba(200,168,75,0.15);color:#C8A84B;border:1px solid rgba(200,168,75,0.2);';
-    }
+    if (notesList && _roleLower !== 'client') {
+      var resolvedRows = internalRows.filter(function(c) { return c.resolved; });
+      var activeRows = internalRows.filter(function(c) { return !c.resolved; });
 
-    list.innerHTML = rows.map(function(c) {
-      var _initial = (c.author||'?').charAt(0).toUpperCase();
-      var _ts = '';
-      if (c.created_at) {
-        var _d = new Date((c.created_at||'').replace(' ','T').replace('+00:00','Z').replace('+00','Z'));
-        if (!isNaN(_d.getTime())) {
-          _ts = _d.toLocaleDateString('en-IN',{
-            day:'numeric',month:'short',
-            timeZone:'Asia/Kolkata'}) + ' \xB7 ' +
-            _d.toLocaleTimeString('en-IN',{
-            hour:'numeric',minute:'2-digit',
-            hour12:true,timeZone:'Asia/Kolkata'});
+      var emptyNotes =
+        '<div class="pcs-empty-thread">' +
+        '<div class="pcs-empty-icon">&#x1F512;</div>' +
+        '<div class="pcs-empty-text">No internal notes yet.</div></div>';
+
+      var notesHtml = _renderThread(activeRows, emptyNotes);
+
+      if (resolvedRows.length) {
+        notesHtml +=
+          '<details class="pcs-resolved-wrap">' +
+          '<summary class="pcs-resolved-summary">' +
+          '\u21B3 ' + resolvedRows.length +
+          ' Resolved Note' +
+          (resolvedRows.length > 1 ? 's' : '') +
+          ' (click to expand)</summary>' +
+          _renderThread(resolvedRows, '') +
+          '</details>';
+      }
+
+      notesList.innerHTML = notesHtml;
+
+      var notesCountEl = document.getElementById('pcs-notes-count');
+      if (notesCountEl) {
+        if (internalRows.length) {
+          notesCountEl.textContent = activeRows.length;
+          notesCountEl.style.display = 'inline';
+        } else {
+          notesCountEl.style.display = 'none';
         }
       }
-      return '<div style="display:flex;gap:10px;padding:10px 16px;' +
-        'border-radius:2px;position:relative;" ' +
-        'onmouseover="this.style.background=\'rgba(255,255,255,0.02)\'" ' +
-        'onmouseout="this.style.background=\'transparent\'">' +
-        (!c.read ? '<div style="position:absolute;left:6px;top:14px;' +
-        'width:4px;height:4px;border-radius:50%;background:#C8A84B;"></div>' : '') +
-        '<div style="width:28px;height:28px;border-radius:50%;flex-shrink:0;' +
-        'display:flex;align-items:center;justify-content:center;' +
-        'font-size:9px;font-weight:700;margin-top:1px;' +
-        'font-family:\'IBM Plex Mono\',monospace;' +
-        _commentAvatarStyle(c.author_role) + '">' +
-        esc(_initial) + '</div>' +
-        '<div style="flex:1;min-width:0;">' +
-        '<div style="display:flex;align-items:baseline;' +
-        'gap:6px;margin-bottom:4px;flex-wrap:wrap;">' +
-        '<span style="font-family:\'DM Sans\',sans-serif;' +
-        'font-size:12px;font-weight:700;color:#e8e2d9;line-height:1;">' +
-        esc(c.author) + '</span>' +
-        '<div style="width:2px;height:2px;border-radius:50%;' +
-        'background:rgba(255,255,255,0.2);flex-shrink:0;margin-bottom:1px;"></div>' +
-        '<span style="font-family:\'IBM Plex Mono\',monospace;' +
-        'font-size:8px;letter-spacing:0.04em;' +
-        'color:rgba(255,255,255,0.35);line-height:1;">' + _ts + '</span>' +
-        '</div>' +
-        '<div style="font-family:\'DM Sans\',sans-serif;' +
-        'font-size:13px;color:rgba(255,255,255,0.78);' +
-        'line-height:1.6;white-space:pre-wrap;">' +
-        esc(c.message) + '</div>' +
-        '</div></div>' +
-        '<div style="height:1px;background:rgba(255,255,255,0.03);' +
-        'margin:0 16px;"></div>';
-    }).join('');
+    }
 
     list.scrollTop = list.scrollHeight;
+    if (notesList) notesList.scrollTop = notesList.scrollHeight;
 
   } catch(e) {
     console.error('loadPcsComments failed:', e);
@@ -1385,53 +1435,91 @@ window._sharePostOnWhatsApp = function(postId) {
     + encodeURIComponent(message);
 };
 
-window.submitPcsComment = function() {
-  var input = document.getElementById('pcs-comment-input');
-  if (!input) return;
-  var message = (input.value || '').trim();
-  if (!message) return;
+window.submitPcsComment = async function(postId, message, visibility) {
+  visibility = visibility || 'all';
 
-  var postIdEl = document.getElementById('pcs-post-id');
-  var postId = postIdEl ? postIdEl.value : '';
-  if (!postId) return;
+  if (!postId || !message || !(message = message.trim())) return;
 
   var _post = (allPosts||[]).find(function(p) {
     return p.post_id === postId || p.id === postId;
   });
   var _realPostId = _post ? _post.post_id : postId;
-  var _title = _post ? (_post.title || _realPostId) : _realPostId;
-
+  var _title = _post ? (_post.title || postId) : postId;
   var _author = window.currentUserName || 'Team';
-  var _role = window.effectiveRole || 'Admin';
-  var _normalRole = _role.charAt(0).toUpperCase() +
-    _role.slice(1).toLowerCase();
+  var _role = (window.effectiveRole || 'Admin');
+  var _roleLower = _role.toLowerCase();
 
-  input.value = '';
-  input.style.height = 'auto';
+  var _mentionMatches = message.match(/@([a-zA-Z0-9_]+)/g) || [];
+  var _mentioned = _mentionMatches.map(function(m) {
+    return m.slice(1);
+  });
 
-  apiFetch('/post_comments', {
-    method: 'POST',
-    body: JSON.stringify({
-      post_id: _realPostId,
+  if (visibility === 'all' && _roleLower !== 'client') {
+    window._pendingComment = {
+      postId: _realPostId,
+      message: message,
+      visibility: visibility,
+      mentioned: _mentioned,
       author: _author,
-      author_role: _normalRole,
-      message: message
-    })
-  }).then(function() {
-    if (typeof loadPcsComments === 'function')
-      loadPcsComments(_realPostId);
+      role: _role,
+      title: _title
+    };
+    var confirmEl = document.getElementById('pcs-comment-confirm');
+    var previewEl = document.getElementById('pcs-comment-confirm-preview');
+    if (confirmEl && previewEl) {
+      previewEl.textContent = '"' + message + '"';
+      confirmEl.style.display = 'flex';
+    }
+    return;
+  }
+
+  await window._doSubmitComment({
+    postId: _realPostId,
+    message: message,
+    visibility: visibility,
+    mentioned: _mentioned,
+    author: _author,
+    role: _role,
+    title: _title
+  });
+};
+
+window._doSubmitComment = async function(opts) {
+  var _roleLower = (opts.role||'').toLowerCase();
+  var _normalRole = opts.role.charAt(0).toUpperCase() +
+    opts.role.slice(1).toLowerCase();
+
+  try {
+    await apiFetch('/post_comments', {
+      method: 'POST',
+      body: JSON.stringify({
+        post_id: opts.postId,
+        author: opts.author,
+        author_role: _normalRole,
+        message: opts.message,
+        visibility: opts.visibility,
+        mentioned_users: opts.mentioned
+      })
+    });
+
+    logActivity({
+      post_id: opts.postId,
+      actor: opts.author,
+      actor_role: _normalRole,
+      action: 'Commented: ' + opts.message
+    });
 
     var _targets = [];
-    if (_normalRole === 'Client') {
-      _targets = ['Servicing', 'Admin'];
-    } else if (_normalRole === 'Pranav' ||
-               _normalRole === 'Creative') {
-      _targets = ['Servicing', 'Admin'];
-    } else if (_normalRole === 'Servicing' ||
-               _normalRole === 'Chitra') {
-      _targets = ['Admin', 'Client'];
+    if (opts.visibility === 'all') {
+      if (_roleLower === 'client') {
+        _targets = ['Servicing', 'Admin', 'Creative'];
+      } else {
+        _targets = ['Client'];
+      }
     } else {
-      _targets = ['Client', 'Servicing'];
+      if (opts.mentioned && opts.mentioned.length) {
+        _targets = opts.mentioned;
+      }
     }
 
     _targets.forEach(function(role) {
@@ -1439,17 +1527,31 @@ window.submitPcsComment = function() {
         method: 'POST',
         body: JSON.stringify({
           user_role: role,
-          post_id: _realPostId,
+          post_id: opts.postId,
           type: 'comment',
-          message: _author + ' commented on ' + _title
+          message: opts.author + ' commented on ' + opts.title
         })
       }).catch(function(){});
     });
 
-  }).catch(function(err) {
-    console.error('submitPcsComment failed:', err);
-    showToast('Failed to send comment', 'error');
-    input.value = message;
-  });
-}
+    if (typeof loadPcsComments === 'function') {
+      loadPcsComments(opts.postId);
+    }
+
+    var inputEl = document.getElementById('pcs-comment-input');
+    var noteEl = document.getElementById('pcs-note-input');
+    if (inputEl) {
+      inputEl.value = '';
+      inputEl.style.height = 'auto';
+    }
+    if (noteEl) {
+      noteEl.value = '';
+      noteEl.style.height = 'auto';
+    }
+
+  } catch(e) {
+    console.error('_doSubmitComment failed:', e);
+    showToast('Failed to send. Try again.', 'error');
+  }
+};
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329u">
+ <link rel="stylesheet" href="styles.css?v=20260329v">
 
 </head>
 <body>
@@ -901,21 +901,53 @@
       <div class="pcs-activity-body" id="pcs-activity-body" style="display:none"></div>
       <!-- COMMENTS -->
       <div id="pcs-comments-section" style="display:none;">
-        <div style="height:1px;background:rgba(255,255,255,0.06);margin:0 16px;"></div>
-        <div style="display:flex;align-items:center;gap:8px;padding:14px 16px 10px;border-top:1px solid rgba(255,255,255,0.06);">
-          <div style="font-family:'IBM Plex Mono',monospace;font-size:7px;letter-spacing:0.18em;text-transform:uppercase;color:rgba(255,255,255,0.5);">Comments</div>
-          <span id="pcs-comments-count" style="background:rgba(200,168,75,0.15);color:#C8A84B;font-size:7px;padding:1px 6px;letter-spacing:0.1em;display:none;">0</span>
+
+        <!-- SECTION 1: CLIENT COMMENTS -->
+        <div class="pcs-section-header">
+          <div class="pcs-section-label">COMMENTS <span id="pcs-comments-count" class="pcs-count-badge" style="display:none;">0</span></div>
         </div>
-        <div id="pcs-comments-list" style="padding:0 0 8px;"></div>
-        <div style="text-align:center;padding:4px 0 12px;">
-          <span id="pcs-activity-link" onclick="togglePCSActivity()" style="font-family:'IBM Plex Mono',monospace;font-size:7px;letter-spacing:0.14em;text-transform:uppercase;color:rgba(255,255,255,0.18);cursor:pointer;">&#x2193; Show activity log</span>
+        <div id="pcs-comments-list" class="pcs-thread-list"></div>
+
+        <!-- SECTION 2: INTERNAL NOTES (agency only) -->
+        <div id="pcs-notes-section" class="pcs-notes-section" style="display:none;">
+          <div class="pcs-section-header pcs-notes-header">
+            <div class="pcs-section-label">INTERNAL NOTES <span class="pcs-lock-icon">&#128274;</span> <span id="pcs-notes-count" class="pcs-count-badge pcs-notes-badge" style="display:none;">0</span></div>
+            <div class="pcs-vis-selector" id="pcs-vis-selector">
+              <div class="pcs-vis-chip active" data-vis="all" onclick="setPcsVisibility(this,'all')">ALL</div>
+              <div class="pcs-vis-chip" data-vis="admin" onclick="setPcsVisibility(this,'admin')">ADMIN</div>
+              <div class="pcs-vis-chip" data-vis="servicing" onclick="setPcsVisibility(this,'servicing')">SERV</div>
+              <div class="pcs-vis-chip" data-vis="creative" onclick="setPcsVisibility(this,'creative')">CREATIVE</div>
+            </div>
+          </div>
+          <div id="pcs-notes-list" class="pcs-thread-list pcs-notes-list"></div>
+
+          <!-- NOTES INPUT BAR -->
+          <div class="pcs-input-bar pcs-notes-input-bar">
+            <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify"></textarea>
+            <button class="pcs-send-btn pcs-note-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all')">NOTE</button>
+          </div>
         </div>
+
+        <!-- CONFIRMATION DIALOG -->
+        <div id="pcs-comment-confirm" class="pcs-confirm-overlay" style="display:none;">
+          <div class="pcs-confirm-sheet">
+            <div class="pcs-confirm-title">SEND TO CLIENT?</div>
+            <div id="pcs-comment-confirm-preview" class="pcs-confirm-preview"></div>
+            <div class="pcs-confirm-warn1">Client will see this.</div>
+            <div class="pcs-confirm-warn2">This cannot be unsaid.</div>
+            <div class="pcs-confirm-btns">
+              <button class="pcs-confirm-cancel" onclick="document.getElementById('pcs-comment-confirm').style.display='none';window._pendingComment=null;">CANCEL</button>
+              <button class="pcs-confirm-send" onclick="document.getElementById('pcs-comment-confirm').style.display='none';if(window._pendingComment){window._doSubmitComment(window._pendingComment);window._pendingComment=null;}">SEND &#x2192;</button>
+            </div>
+          </div>
+        </div>
+
       </div>
     </div>
     <!-- COMMENT INPUT BAR - outside scroll, inside pcs-screen -->
-    <div id="pcs-comment-input-bar" style="display:none;position:relative;flex-shrink:0;background:#0e0e14;border-top:1px solid rgba(255,255,255,0.08);padding:10px 16px 16px;gap:10px;align-items:flex-end;">
-      <textarea id="pcs-comment-input" rows="1" placeholder="Add a comment..." oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var btn=document.getElementById('pcs-send-btn');if(btn){if(this.value.trim()){btn.style.color='#C8A84B';btn.style.background='rgba(200,168,75,0.08)';btn.style.borderColor='rgba(200,168,75,0.35)';btn.style.boxShadow='0 0 10px rgba(200,168,75,0.1)';}else{btn.style.color='rgba(200,168,75,0.4)';btn.style.background='transparent';btn.style.borderColor='rgba(200,168,75,0.15)';btn.style.boxShadow='none';}}" style="flex:1;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.1);color:#e8e2d9;font-family:'DM Sans',sans-serif;font-size:13px;line-height:1.5;padding:8px 12px;outline:none;resize:none;caret-color:#C8A84B;min-height:36px;max-height:80px;"></textarea>
-      <button id="pcs-send-btn" onclick="submitPcsComment()" style="font-family:'IBM Plex Mono',monospace;font-size:8px;letter-spacing:0.14em;text-transform:uppercase;color:rgba(200,168,75,0.4);background:transparent;border:1px solid rgba(200,168,75,0.15);padding:8px 14px;cursor:pointer;height:36px;white-space:nowrap;align-self:flex-end;">Send &#x2192;</button>
+    <div id="pcs-comment-input-bar" class="pcs-input-bar" style="display:none;">
+      <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..."></textarea>
+      <button class="pcs-send-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all')">Send &#x2192;</button>
     </div>
 
   </div>
@@ -972,26 +1004,32 @@ window.allPosts        = window.allPosts    || [];
 window.cachedPosts     = window.cachedPosts || [];
 window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
+window._pcsNoteVisibility = 'all';
+window.setPcsVisibility = function(el, vis) {
+  window._pcsNoteVisibility = vis;
+  document.querySelectorAll('.pcs-vis-chip').forEach(function(c) { c.classList.remove('active'); });
+  el.classList.add('active');
+};
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329u" defer></script>
-<script src="02-session.js?v=20260329u" defer></script>
-<script src="utils.js?v=20260329u" defer></script>
-<script src="03-auth.js?v=20260329u" defer></script>
-<script src="05-api.js?v=20260329u" defer></script>
-<script src="10-ui.js?v=20260329u" defer></script>
+<script src="01-config.js?v=20260329v" defer></script>
+<script src="02-session.js?v=20260329v" defer></script>
+<script src="utils.js?v=20260329v" defer></script>
+<script src="03-auth.js?v=20260329v" defer></script>
+<script src="05-api.js?v=20260329v" defer></script>
+<script src="10-ui.js?v=20260329v" defer></script>
 
-<script src="06-post-create.js?v=20260329u" defer></script>
-<script defer src="render/dashboard.js?v=20260329u"></script>
-<script defer src="render/client.js?v=20260329u"></script>
-<script defer src="render/pipeline.js?v=20260329u"></script>
-<script defer src="render/brief.js?v=20260329u"></script>
-<script defer src="actions/pcs.js?v=20260329u"></script>
-<script src="07-post-load.js?v=20260329u" defer></script>
-<script src="08-post-actions.js?v=20260329u" defer></script>
-<script src="09-library.js?v=20260329u" defer></script>
-<script src="09-approval.js?v=20260329u" defer></script>
-<script src="04-router.js?v=20260329u" defer></script>
+<script src="06-post-create.js?v=20260329v" defer></script>
+<script defer src="render/dashboard.js?v=20260329v"></script>
+<script defer src="render/client.js?v=20260329v"></script>
+<script defer src="render/pipeline.js?v=20260329v"></script>
+<script defer src="render/brief.js?v=20260329v"></script>
+<script defer src="actions/pcs.js?v=20260329v"></script>
+<script src="07-post-load.js?v=20260329v" defer></script>
+<script src="08-post-actions.js?v=20260329v" defer></script>
+<script src="09-library.js?v=20260329v" defer></script>
+<script src="09-approval.js?v=20260329v" defer></script>
+<script src="04-router.js?v=20260329v" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5692,3 +5692,307 @@ body.client-mode .stage-chip[data-stage="brief"],
 body.client-mode .stage-chip[data-stage="brief_done"] {
   display: none !important;
 }
+
+/* -- PCS DUAL-CHANNEL COMMENTS -- */
+.pcs-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px 10px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+}
+.pcs-section-label {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  color: rgba(255,255,255,0.4);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.pcs-lock-icon {
+  font-size: 10px;
+  color: rgba(246,166,35,0.6);
+}
+.pcs-count-badge {
+  background: rgba(200,168,75,0.15);
+  color: #C8A84B;
+  font-size: 8px;
+  padding: 1px 6px;
+  letter-spacing: 0.1em;
+}
+.pcs-notes-badge {
+  background: rgba(246,166,35,0.1);
+  color: rgba(246,166,35,0.6);
+}
+.pcs-thread-list {
+  padding: 0 0 4px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+.pcs-notes-list {
+  background: rgba(246,166,35,0.015);
+}
+.pcs-notes-section {
+  border-top: 1px solid rgba(246,166,35,0.08);
+  background: rgba(246,166,35,0.015);
+}
+.pcs-notes-header {
+  border-top: none;
+}
+.pcs-comment-item {
+  display: flex;
+  gap: 10px;
+  padding: 10px 16px;
+  position: relative;
+  border-bottom: 1px solid rgba(255,255,255,0.03);
+}
+.pcs-comment-item:last-child {
+  border-bottom: none;
+}
+.pcs-unread-dot {
+  position: absolute;
+  left: 6px;
+  top: 14px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #C8A84B;
+}
+.pcs-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 500;
+}
+.av-client {
+  background: rgba(255,75,75,0.15);
+  color: #FF4B4B;
+  border: 1px solid rgba(255,75,75,0.2);
+}
+.av-servicing {
+  background: rgba(34,211,238,0.15);
+  color: #22D3EE;
+  border: 1px solid rgba(34,211,238,0.2);
+}
+.av-creative {
+  background: rgba(155,135,245,0.15);
+  color: #9b87f5;
+  border: 1px solid rgba(155,135,245,0.2);
+}
+.av-admin {
+  background: rgba(200,168,75,0.15);
+  color: #C8A84B;
+  border: 1px solid rgba(200,168,75,0.2);
+}
+.pcs-comment-body { flex: 1; min-width: 0; }
+.pcs-comment-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-bottom: 3px;
+  flex-wrap: wrap;
+}
+.pcs-comment-author {
+  font-size: 11px;
+  font-weight: 700;
+  color: rgba(255,255,255,0.75);
+}
+.pcs-comment-time {
+  font-family: var(--mono);
+  font-size: 8px;
+  color: rgba(255,255,255,0.2);
+}
+.pcs-mention-badge {
+  font-family: var(--mono);
+  font-size: 7px;
+  color: #9b87f5;
+  background: rgba(155,135,245,0.1);
+  padding: 1px 5px;
+  border: 1px solid rgba(155,135,245,0.2);
+}
+.pcs-comment-text {
+  font-size: 13px;
+  color: rgba(255,255,255,0.65);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.pcs-empty-thread {
+  padding: 20px 16px;
+  text-align: center;
+}
+.pcs-empty-icon {
+  font-size: 18px;
+  opacity: 0.25;
+  margin-bottom: 8px;
+}
+.pcs-empty-text {
+  font-family: var(--mono);
+  font-size: 8px;
+  color: rgba(255,255,255,0.2);
+  letter-spacing: 0.08em;
+  line-height: 1.6;
+}
+.pcs-input-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 10px 16px 14px;
+  background: #0e0e14;
+  border-top: 1px solid rgba(255,255,255,0.06);
+  flex-shrink: 0;
+}
+.pcs-notes-input-bar {
+  border-top: 1px dotted rgba(246,166,35,0.1);
+  background: rgba(246,166,35,0.02);
+}
+.pcs-textarea {
+  flex: 1;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  color: rgba(255,255,255,0.8);
+  font-family: var(--sans);
+  font-size: 13px;
+  padding: 8px 10px;
+  outline: none;
+  resize: none;
+  height: 36px;
+  line-height: 1.4;
+  border-radius: 0;
+}
+.pcs-note-textarea {
+  background: rgba(246,166,35,0.03);
+  border-color: rgba(246,166,35,0.1);
+}
+.pcs-textarea::placeholder {
+  color: rgba(255,255,255,0.2);
+}
+.pcs-send-btn {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  background: none;
+  border: 1px dotted rgba(255,255,255,0.15);
+  color: rgba(255,255,255,0.4);
+  padding: 8px 12px;
+  height: 36px;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.pcs-note-btn {
+  border-color: rgba(246,166,35,0.2);
+  color: rgba(246,166,35,0.5);
+}
+.pcs-vis-selector {
+  display: flex;
+  gap: 4px;
+}
+.pcs-vis-chip {
+  font-family: var(--mono);
+  font-size: 7px;
+  letter-spacing: 0.06em;
+  padding: 3px 6px;
+  border: 1px dotted rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.25);
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.pcs-vis-chip.active {
+  color: #F6A623;
+  border-color: rgba(246,166,35,0.35);
+}
+.pcs-resolved {
+  opacity: 0.4;
+}
+.pcs-resolved-wrap {
+  margin: 4px 16px 8px;
+}
+.pcs-resolved-summary {
+  font-family: var(--mono);
+  font-size: 8px;
+  color: rgba(255,255,255,0.2);
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  padding: 4px 0;
+  list-style: none;
+}
+/* CONFIRMATION DIALOG */
+.pcs-confirm-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.75);
+  z-index: 200;
+  align-items: flex-end;
+  justify-content: center;
+}
+.pcs-confirm-sheet {
+  background: #111318;
+  width: 100%;
+  border-top: 1px solid rgba(255,255,255,0.08);
+  padding: 20px 20px 28px;
+}
+.pcs-confirm-title {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: rgba(255,255,255,0.35);
+  letter-spacing: 0.15em;
+  margin-bottom: 12px;
+}
+.pcs-confirm-preview {
+  font-size: 13px;
+  color: rgba(255,255,255,0.4);
+  font-style: italic;
+  line-height: 1.5;
+  padding: 10px 12px;
+  border-left: 2px solid rgba(255,255,255,0.06);
+  margin-bottom: 12px;
+  background: rgba(255,255,255,0.02);
+}
+.pcs-confirm-warn1 {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: rgba(255,255,255,0.4);
+  letter-spacing: 0.08em;
+  margin-bottom: 3px;
+}
+.pcs-confirm-warn2 {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: rgba(255,75,75,0.5);
+  letter-spacing: 0.08em;
+}
+.pcs-confirm-btns {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 8px;
+  margin-top: 16px;
+}
+.pcs-confirm-cancel {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  color: rgba(255,255,255,0.25);
+  border: 1px dotted rgba(255,255,255,0.1);
+  background: none;
+  padding: 11px;
+  cursor: pointer;
+}
+.pcs-confirm-send {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  color: #000;
+  background: #C8A84B;
+  border: none;
+  padding: 11px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary

- **Unified submit**: Replace old `submitPcsComment` with `window.submitPcsComment(postId, message, visibility)` + `window._doSubmitComment(opts)`
- **Dual-pane rendering**: `loadPcsComments()` now splits rows into client thread (visibility=all) and internal notes (role-filtered)
- **Confirmation dialog**: Non-client users see "SEND TO CLIENT?" confirmation before posting to client thread
- **Internal notes section**: Visibility selector (ALL/ADMIN/SERV/CREATIVE), @mention support, resolved notes in collapsible `<details>`
- **CSS class system**: Full set of `.pcs-*` classes replacing all inline comment styles
- **Purge legacy**: `submitBoardingComment`, `_submitEditorialComment` already removed by prior merges
- Bump all 18 asset versions to `?v=20260329v`

## Test plan

- [x] `node --check` passes on `actions/pcs.js`, `08-post-actions.js`, `07-post-load.js`
- [x] Zero non-ASCII in `actions/pcs.js`, `styles.css`, `index.html`
- [x] `npm test` -- 133/133 pass
- [x] Zero references to `submitBoardingComment` or `_submitEditorialComment`
- [x] Single `submitPcsComment` definition, `_doSubmitComment` exists
- [x] `pcs-comment-confirm` overlay in HTML
- [ ] Verify client thread shows only visibility=all comments
- [ ] Verify internal notes hidden from client role
- [ ] Verify confirmation dialog fires for non-client sending to client thread

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z