### PR TITLE
fix: PCS client comments rename, color separation, visibility logic, remove scratchpad

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -635,9 +635,17 @@ window.loadPcsComments = async function(postId) {
     var internalRows = rows.filter(function(c) {
       if (c.visibility === 'all' || !c.visibility) return false;
       if (_roleLower === 'admin') return true;
-      if (c.visibility === _roleLower) return true;
-      var _mu = Array.isArray(c.mentioned_users) ? c.mentioned_users : [];
-      return _mu.indexOf(_name) !== -1;
+      if (_roleLower === 'servicing' || _roleLower === 'chitra') {
+        if (c.visibility === 'all' || c.visibility === 'servicing') return true;
+        var _mu = Array.isArray(c.mentioned_users) ? c.mentioned_users : [];
+        return _mu.indexOf(_name) !== -1;
+      }
+      if (_roleLower === 'creative' || _roleLower === 'pranav') {
+        if (c.visibility === 'all' || c.visibility === 'creative') return true;
+        var _mu = Array.isArray(c.mentioned_users) ? c.mentioned_users : [];
+        return _mu.indexOf(_name) !== -1;
+      }
+      return false;
     });
 
     section.style.display = 'block';
@@ -695,7 +703,7 @@ window.loadPcsComments = async function(postId) {
     var emptyClient =
       '<div class="pcs-empty-thread">' +
       '<div class="pcs-empty-icon">&#x1F4AC;</div>' +
-      '<div class="pcs-empty-text">No comments yet.<br>Client and team see this thread.</div>' +
+      '<div class="pcs-empty-text">No client comments yet.<br>Client and team see this thread.</div>' +
       '</div>';
 
     list.innerHTML = _renderThread(clientRows, emptyClient);
@@ -979,22 +987,8 @@ window._buildInfoGrid = function(post, canEdit, canEditCreative, id) {
   '</div></div>';
 }
 
-window._buildNotes = function(post, canEdit, id) {
-  var _isClient = (window.effectiveRole || '').toLowerCase() === 'client';
-  if (_isClient) return '';
-
-  if (!canEdit && !post.comments) return '';
-
-  var notesInput = (canEdit || canEditCreative)
-    ? '<textarea class="pc-notes-area" placeholder="Brief or caption..."' +
-      ' onblur="updatePost(\'' + esc(id) + '\',\'comments\',this.value)">' + esc(post.comments || '') + '</textarea>'
-    : (post.comments ? '<div class="pc-notes-ro">' + esc(post.comments) + '</div>' : '');
-
-  return '<div class="pc-notes-block">' +
-    '<div class="pc-notes-lbl" style="display:flex;align-items:center;gap:8px;">Internal Notes' +
-    '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:6px;color:rgba(255,166,35,0.6);background:rgba(255,166,35,0.08);padding:2px 6px;letter-spacing:0.1em;text-transform:uppercase;">Agency only</span></div>' +
-    (notesInput || '<div class="pcs-activity-empty">No notes.</div>') +
-  '</div>';
+window._buildNotes = function() {
+  return '';
 }
 
 // -- Stage advance button (FIX 7) --

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329v">
+ <link rel="stylesheet" href="styles.css?v=20260329x">
 
 </head>
 <body>
@@ -904,7 +904,7 @@
 
         <!-- SECTION 1: CLIENT COMMENTS -->
         <div class="pcs-section-header">
-          <div class="pcs-section-label">COMMENTS <span id="pcs-comments-count" class="pcs-count-badge" style="display:none;">0</span></div>
+          <div class="pcs-section-label">CLIENT COMMENTS <span id="pcs-comments-count" class="pcs-count-badge" style="display:none;">0</span></div>
         </div>
         <div id="pcs-comments-list" class="pcs-thread-list"></div>
 
@@ -1012,24 +1012,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329v" defer></script>
-<script src="02-session.js?v=20260329v" defer></script>
-<script src="utils.js?v=20260329v" defer></script>
-<script src="03-auth.js?v=20260329v" defer></script>
-<script src="05-api.js?v=20260329v" defer></script>
-<script src="10-ui.js?v=20260329v" defer></script>
+<script src="01-config.js?v=20260329x" defer></script>
+<script src="02-session.js?v=20260329x" defer></script>
+<script src="utils.js?v=20260329x" defer></script>
+<script src="03-auth.js?v=20260329x" defer></script>
+<script src="05-api.js?v=20260329x" defer></script>
+<script src="10-ui.js?v=20260329x" defer></script>
 
-<script src="06-post-create.js?v=20260329v" defer></script>
-<script defer src="render/dashboard.js?v=20260329v"></script>
-<script defer src="render/client.js?v=20260329v"></script>
-<script defer src="render/pipeline.js?v=20260329v"></script>
-<script defer src="render/brief.js?v=20260329v"></script>
-<script defer src="actions/pcs.js?v=20260329v"></script>
-<script src="07-post-load.js?v=20260329v" defer></script>
-<script src="08-post-actions.js?v=20260329v" defer></script>
-<script src="09-library.js?v=20260329v" defer></script>
-<script src="09-approval.js?v=20260329v" defer></script>
-<script src="04-router.js?v=20260329v" defer></script>
+<script src="06-post-create.js?v=20260329x" defer></script>
+<script defer src="render/dashboard.js?v=20260329x"></script>
+<script defer src="render/client.js?v=20260329x"></script>
+<script defer src="render/pipeline.js?v=20260329x"></script>
+<script defer src="render/brief.js?v=20260329x"></script>
+<script defer src="actions/pcs.js?v=20260329x"></script>
+<script src="07-post-load.js?v=20260329x" defer></script>
+<script src="08-post-actions.js?v=20260329x" defer></script>
+<script src="09-library.js?v=20260329x" defer></script>
+<script src="09-approval.js?v=20260329x" defer></script>
+<script src="04-router.js?v=20260329x" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5731,11 +5731,11 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   overflow-y: auto;
 }
 .pcs-notes-list {
-  background: rgba(246,166,35,0.015);
+  background: transparent;
 }
 .pcs-notes-section {
-  border-top: 1px solid rgba(246,166,35,0.08);
-  background: rgba(246,166,35,0.015);
+  border-top: 1px solid rgba(246,166,35,0.12);
+  background: rgba(246,166,35,0.03);
 }
 .pcs-notes-header {
   border-top: none;


### PR DESCRIPTION
## Summary

- Rename COMMENTS to CLIENT COMMENTS in PCS section label and empty state text
- Fix internal notes section background to `rgba(246,166,35,0.03)` with `0.12` border for clear visual separation
- Fix visibility logic: Admin sees all notes, Servicing sees all+servicing+@mentions, Creative sees all+creative+@mentions (case-insensitive)
- Remove old `_buildNotes` scratchpad (textarea for `posts.comments` field) -- replaced by new Internal Notes channel
- Bump all 18 asset versions to `?v=20260329x`

**Zero changes to `render/client.js` or `preview/index.html`.**

## Test plan

- [x] `node --check actions/pcs.js` + `render/pipeline.js` pass
- [x] Zero non-ASCII in `actions/pcs.js`, `render/pipeline.js`, `styles.css`
- [x] `npm test` -- 133/133 pass
- [x] Zero `AGENCY ONLY` in `render/pipeline.js`
- [x] `CLIENT COMMENTS` label in `index.html` and `actions/pcs.js`
- [x] `render/client.js` not modified
- [ ] Verify Servicing user only sees all+servicing visibility notes
- [ ] Verify Creative user only sees all+creative visibility notes

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z