### PR TITLE
fix: PCS notes input position, color contrast, focus states, input alive on keypress

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -424,9 +424,12 @@ window._renderPCS = function(postId) {
   }
 
   var notesSection = document.getElementById('pcs-notes-section');
+  var notesInputBar = document.getElementById('pcs-notes-input-bar');
   if (notesSection) {
     var _r = (window.effectiveRole||'').toLowerCase();
-    notesSection.style.display = _r === 'client' ? 'none' : 'block';
+    var _showNotes = _r !== 'client';
+    notesSection.style.display = _showNotes ? 'block' : 'none';
+    if (notesInputBar) notesInputBar.style.display = _showNotes ? 'flex' : 'none';
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329x">
+ <link rel="stylesheet" href="styles.css?v=20260329y">
 
 </head>
 <body>
@@ -921,11 +921,6 @@
           </div>
           <div id="pcs-notes-list" class="pcs-thread-list pcs-notes-list"></div>
 
-          <!-- NOTES INPUT BAR -->
-          <div class="pcs-input-bar pcs-notes-input-bar">
-            <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify"></textarea>
-            <button class="pcs-send-btn pcs-note-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all')">NOTE</button>
-          </div>
         </div>
 
         <!-- CONFIRMATION DIALOG -->
@@ -944,10 +939,15 @@
 
       </div>
     </div>
+    <!-- NOTES INPUT BAR - outside scroll, inside pcs-screen -->
+    <div id="pcs-notes-input-bar" class="pcs-input-bar pcs-notes-input-bar" style="display:none;">
+      <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');if(b){if(this.value.trim()){b.style.color='#F6A623';b.style.borderColor='rgba(246,166,35,0.5)';}else{b.style.color='rgba(246,166,35,0.4)';b.style.borderColor='rgba(246,166,35,0.15)';}}"></textarea>
+      <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all')">NOTE</button>
+    </div>
     <!-- COMMENT INPUT BAR - outside scroll, inside pcs-screen -->
     <div id="pcs-comment-input-bar" class="pcs-input-bar" style="display:none;">
-      <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..."></textarea>
-      <button class="pcs-send-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all')">Send &#x2192;</button>
+      <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..." oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-client');if(b){if(this.value.trim()){b.style.color='#C8A84B';b.style.borderColor='rgba(200,168,75,0.4)';}else{b.style.color='rgba(255,255,255,0.3)';b.style.borderColor='rgba(255,255,255,0.1)';}}"></textarea>
+      <button id="pcs-send-btn-client" class="pcs-send-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all')">Send &#x2192;</button>
     </div>
 
   </div>
@@ -1012,24 +1012,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329x" defer></script>
-<script src="02-session.js?v=20260329x" defer></script>
-<script src="utils.js?v=20260329x" defer></script>
-<script src="03-auth.js?v=20260329x" defer></script>
-<script src="05-api.js?v=20260329x" defer></script>
-<script src="10-ui.js?v=20260329x" defer></script>
+<script src="01-config.js?v=20260329y" defer></script>
+<script src="02-session.js?v=20260329y" defer></script>
+<script src="utils.js?v=20260329y" defer></script>
+<script src="03-auth.js?v=20260329y" defer></script>
+<script src="05-api.js?v=20260329y" defer></script>
+<script src="10-ui.js?v=20260329y" defer></script>
 
-<script src="06-post-create.js?v=20260329x" defer></script>
-<script defer src="render/dashboard.js?v=20260329x"></script>
-<script defer src="render/client.js?v=20260329x"></script>
-<script defer src="render/pipeline.js?v=20260329x"></script>
-<script defer src="render/brief.js?v=20260329x"></script>
-<script defer src="actions/pcs.js?v=20260329x"></script>
-<script src="07-post-load.js?v=20260329x" defer></script>
-<script src="08-post-actions.js?v=20260329x" defer></script>
-<script src="09-library.js?v=20260329x" defer></script>
-<script src="09-approval.js?v=20260329x" defer></script>
-<script src="04-router.js?v=20260329x" defer></script>
+<script src="06-post-create.js?v=20260329y" defer></script>
+<script defer src="render/dashboard.js?v=20260329y"></script>
+<script defer src="render/client.js?v=20260329y"></script>
+<script defer src="render/pipeline.js?v=20260329y"></script>
+<script defer src="render/brief.js?v=20260329y"></script>
+<script defer src="actions/pcs.js?v=20260329y"></script>
+<script src="07-post-load.js?v=20260329y" defer></script>
+<script src="08-post-actions.js?v=20260329y" defer></script>
+<script src="09-library.js?v=20260329y" defer></script>
+<script src="09-approval.js?v=20260329y" defer></script>
+<script src="04-router.js?v=20260329y" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5734,11 +5734,12 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   background: transparent;
 }
 .pcs-notes-section {
-  border-top: 1px solid rgba(246,166,35,0.12);
-  background: rgba(246,166,35,0.03);
+  border-top: 2px solid rgba(246,166,35,0.2);
+  background: rgba(246,166,35,0.06);
 }
 .pcs-notes-header {
   border-top: none;
+  background: rgba(246,166,35,0.04);
 }
 .pcs-comment-item {
   display: flex;
@@ -5850,8 +5851,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   flex-shrink: 0;
 }
 .pcs-notes-input-bar {
-  border-top: 1px dotted rgba(246,166,35,0.1);
-  background: rgba(246,166,35,0.02);
+  border-top: 1px solid rgba(246,166,35,0.15);
+  background: rgba(246,166,35,0.05);
 }
 .pcs-textarea {
   flex: 1;
@@ -5866,10 +5867,24 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   height: 36px;
   line-height: 1.4;
   border-radius: 0;
+  caret-color: #C8A84B;
+}
+.pcs-textarea:focus {
+  border-color: rgba(200,168,75,0.4);
+  background: rgba(255,255,255,0.06);
+  outline: none;
+  caret-color: #C8A84B;
 }
 .pcs-note-textarea {
   background: rgba(246,166,35,0.03);
   border-color: rgba(246,166,35,0.1);
+  caret-color: #F6A623;
+}
+.pcs-note-textarea:focus {
+  border-color: rgba(246,166,35,0.35);
+  background: rgba(246,166,35,0.06);
+  outline: none;
+  caret-color: #F6A623;
 }
 .pcs-textarea::placeholder {
   color: rgba(255,255,255,0.2);
@@ -5886,6 +5901,9 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
+}
+.pcs-send-btn:not(:disabled) {
+  transition: color 0.15s, border-color 0.15s;
 }
 .pcs-note-btn {
   border-color: rgba(246,166,35,0.2);


### PR DESCRIPTION
## Summary

- **Move notes input outside scroll**: Notes input bar moved from inside `#pcs-notes-section` (scrollable) to outside `pc-scroll-body` (fixed at bottom), stacked above client input bar
- **Stronger color contrast**: Notes section background `0.06`, border `2px 0.2`, header `0.04`, input bar `0.05` -- clearly distinct amber zone vs dark client zone
- **Focus states**: `.pcs-textarea:focus` gets gold border+bg, `.pcs-note-textarea:focus` gets amber border+bg, both with `caret-color`
- **Input alive on keypress**: `oninput` handlers auto-resize textareas and change Send/NOTE button colors when text is entered
- **Button IDs**: Added `pcs-send-btn-client` and `pcs-send-btn-note` for targeted style updates
- Bump all 18 asset versions to `?v=20260329y`

**Zero changes to `render/client.js` or `preview/index.html`.**

## Test plan

- [x] `node --check actions/pcs.js` passes
- [x] Zero non-ASCII in `styles.css`, `index.html`, `actions/pcs.js`
- [x] `npm test` -- 133/133 pass
- [x] Notes input bar outside `pc-scroll-body` in DOM
- [x] `.pcs-textarea:focus` and `.pcs-note-textarea:focus` rules exist
- [x] `render/client.js` and `preview/index.html` not modified
- [ ] Verify notes input stays visible when scrolling long notes list
- [ ] Verify textarea grows on multiline input
- [ ] Verify Send/NOTE button colors change on input

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z