### PR TITLE
feat: PCS comments redesign - two distinct sections, inputs inside zones

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -424,12 +424,9 @@ window._renderPCS = function(postId) {
   }
 
   var notesSection = document.getElementById('pcs-notes-section');
-  var notesInputBar = document.getElementById('pcs-notes-input-bar');
   if (notesSection) {
     var _r = (window.effectiveRole||'').toLowerCase();
-    var _showNotes = _r !== 'client';
-    notesSection.style.display = _showNotes ? 'block' : 'none';
-    if (notesInputBar) notesInputBar.style.display = _showNotes ? 'flex' : 'none';
+    notesSection.style.display = _r === 'client' ? 'none' : 'block';
   }
 }
 
@@ -652,50 +649,71 @@ window.loadPcsComments = async function(postId) {
     });
 
     section.style.display = 'block';
-    var inputBar = document.getElementById('pcs-comment-input-bar');
-    if (inputBar) inputBar.style.display = 'flex';
 
-    function _renderThread(threadRows, isEmpty) {
+    function _formatTs(c) {
+      if (!c.created_at) return '';
+      var _d = new Date((c.created_at||'')
+        .replace(' ','T')
+        .replace('+00:00','Z')
+        .replace('+00','Z'));
+      if (isNaN(_d.getTime())) return '';
+      return _d.toLocaleDateString('en-IN',{
+        day:'numeric',month:'short',
+        timeZone:'Asia/Kolkata'}) +
+        ' \xB7 ' +
+        _d.toLocaleTimeString('en-IN',{
+        hour:'numeric',minute:'2-digit',
+        hour12:true,timeZone:'Asia/Kolkata'});
+    }
+
+    function _avatarClass(c) {
+      var _r = (c.author_role||'').toLowerCase();
+      if (_r==='client') return 'pcs-avatar av-client';
+      if (_r==='servicing'||_r==='chitra') return 'pcs-avatar av-servicing';
+      if (_r==='creative'||_r==='pranav') return 'pcs-avatar av-creative';
+      return 'pcs-avatar av-admin';
+    }
+
+    function _renderClientThread(threadRows, isEmpty) {
       if (!threadRows.length) return isEmpty;
       return threadRows.map(function(c) {
         var _initial = (c.author||'?').charAt(0).toUpperCase();
-        var _ts = '';
-        if (c.created_at) {
-          var _d = new Date((c.created_at||'')
-            .replace(' ','T')
-            .replace('+00:00','Z')
-            .replace('+00','Z'));
-          if (!isNaN(_d.getTime())) {
-            _ts = _d.toLocaleDateString('en-IN',{
-              day:'numeric',month:'short',
-              timeZone:'Asia/Kolkata'}) +
-              ' \xB7 ' +
-              _d.toLocaleTimeString('en-IN',{
-              hour:'numeric',minute:'2-digit',
-              hour12:true,timeZone:'Asia/Kolkata'});
-          }
-        }
-        var _r = (c.author_role||'').toLowerCase();
-        var _avClass = 'pcs-avatar';
-        if (_r==='client') _avClass += ' av-client';
-        else if (_r==='servicing'||_r==='chitra') _avClass += ' av-servicing';
-        else if (_r==='creative'||_r==='pranav') _avClass += ' av-creative';
-        else _avClass += ' av-admin';
+        return '<div class="pcs-comment-item">' +
+          (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
+          '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>' +
+          '<div class="pcs-comment-body">' +
+            '<div class="pcs-comment-meta">' +
+              '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
+              '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
+            '</div>' +
+            '<div class="pcs-comment-text">' + esc(c.message) + '</div>' +
+          '</div>' +
+        '</div>';
+      }).join('');
+    }
 
+    function _renderNoteThread(threadRows, isEmpty) {
+      if (!threadRows.length) return isEmpty;
+      return threadRows.map(function(c) {
+        var _initial = (c.author||'?').charAt(0).toUpperCase();
         var _mu = Array.isArray(c.mentioned_users) ? c.mentioned_users : [];
         var _mentionBadge = _mu.length
           ? '<span class="pcs-mention-badge">@' + esc(_mu.join(', @')) + '</span>'
           : '';
+        var _vis = (c.visibility||'all').toUpperCase();
+        if (_vis === 'SERVICING') _vis = 'SERV';
+        var _visTag = '<span class="pcs-vis-tag">' + _vis + '</span>';
 
-        return '<div class="pcs-comment-item' +
+        return '<div class="pcs-note-item' +
           (c.resolved ? ' pcs-resolved' : '') + '">' +
           (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
-          '<div class="' + _avClass + '">' + esc(_initial) + '</div>' +
+          '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>' +
           '<div class="pcs-comment-body">' +
             '<div class="pcs-comment-meta">' +
               '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
-              '<span class="pcs-comment-time">' + _ts + '</span>' +
+              '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
               _mentionBadge +
+              _visTag +
             '</div>' +
             '<div class="pcs-comment-text">' + esc(c.message) + '</div>' +
           '</div>' +
@@ -709,7 +727,7 @@ window.loadPcsComments = async function(postId) {
       '<div class="pcs-empty-text">No client comments yet.<br>Client and team see this thread.</div>' +
       '</div>';
 
-    list.innerHTML = _renderThread(clientRows, emptyClient);
+    list.innerHTML = _renderClientThread(clientRows, emptyClient);
 
     var countEl = document.getElementById('pcs-comments-count');
     if (countEl) {
@@ -730,7 +748,7 @@ window.loadPcsComments = async function(postId) {
         '<div class="pcs-empty-icon">&#x1F512;</div>' +
         '<div class="pcs-empty-text">No internal notes yet.</div></div>';
 
-      var notesHtml = _renderThread(activeRows, emptyNotes);
+      var notesHtml = _renderNoteThread(activeRows, emptyNotes);
 
       if (resolvedRows.length) {
         notesHtml +=
@@ -740,7 +758,7 @@ window.loadPcsComments = async function(postId) {
           ' Resolved Note' +
           (resolvedRows.length > 1 ? 's' : '') +
           ' (click to expand)</summary>' +
-          _renderThread(resolvedRows, '') +
+          _renderNoteThread(resolvedRows, '') +
           '</details>';
       }
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329y">
+ <link rel="stylesheet" href="styles.css?v=20260329z">
 
 </head>
 <body>
@@ -903,15 +903,22 @@
       <div id="pcs-comments-section" style="display:none;">
 
         <!-- SECTION 1: CLIENT COMMENTS -->
-        <div class="pcs-section-header">
-          <div class="pcs-section-label">CLIENT COMMENTS <span id="pcs-comments-count" class="pcs-count-badge" style="display:none;">0</span></div>
+        <div class="client-comments-section">
+          <div class="client-section-header">
+            <div class="client-comments-label">CLIENT COMMENTS <span id="pcs-comments-count" class="pcs-count-badge" style="display:none;">0</span></div>
+            <div class="client-sublabel">CLIENT + AGENCY</div>
+          </div>
+          <div id="pcs-comments-list" class="pcs-thread-list" style="min-height:60px;"></div>
+          <div class="client-input-zone">
+            <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..." oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-client');if(b){b.classList.toggle('active',!!this.value.trim())}"></textarea>
+            <button id="pcs-send-btn-client" class="pcs-send-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all')">SEND &#x2192;</button>
+          </div>
         </div>
-        <div id="pcs-comments-list" class="pcs-thread-list"></div>
 
         <!-- SECTION 2: INTERNAL NOTES (agency only) -->
         <div id="pcs-notes-section" class="pcs-notes-section" style="display:none;">
-          <div class="pcs-section-header pcs-notes-header">
-            <div class="pcs-section-label">INTERNAL NOTES <span class="pcs-lock-icon">&#128274;</span> <span id="pcs-notes-count" class="pcs-count-badge pcs-notes-badge" style="display:none;">0</span></div>
+          <div class="pcs-notes-header">
+            <div class="pcs-notes-label">INTERNAL NOTES <span class="pcs-lock-icon">&#128274;</span> <span id="pcs-notes-count" class="pcs-notes-count-badge" style="display:none;">0</span></div>
             <div class="pcs-vis-selector" id="pcs-vis-selector">
               <div class="pcs-vis-chip active" data-vis="all" onclick="setPcsVisibility(this,'all')">ALL</div>
               <div class="pcs-vis-chip" data-vis="admin" onclick="setPcsVisibility(this,'admin')">ADMIN</div>
@@ -919,8 +926,11 @@
               <div class="pcs-vis-chip" data-vis="creative" onclick="setPcsVisibility(this,'creative')">CREATIVE</div>
             </div>
           </div>
-          <div id="pcs-notes-list" class="pcs-thread-list pcs-notes-list"></div>
-
+          <div id="pcs-notes-list" class="pcs-notes-list" style="min-height:60px;"></div>
+          <div class="notes-input-zone">
+            <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');if(b){b.classList.toggle('active',!!this.value.trim())}"></textarea>
+            <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all')">NOTE</button>
+          </div>
         </div>
 
         <!-- CONFIRMATION DIALOG -->
@@ -938,16 +948,6 @@
         </div>
 
       </div>
-    </div>
-    <!-- NOTES INPUT BAR - outside scroll, inside pcs-screen -->
-    <div id="pcs-notes-input-bar" class="pcs-input-bar pcs-notes-input-bar" style="display:none;">
-      <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');if(b){if(this.value.trim()){b.style.color='#F6A623';b.style.borderColor='rgba(246,166,35,0.5)';}else{b.style.color='rgba(246,166,35,0.4)';b.style.borderColor='rgba(246,166,35,0.15)';}}"></textarea>
-      <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all')">NOTE</button>
-    </div>
-    <!-- COMMENT INPUT BAR - outside scroll, inside pcs-screen -->
-    <div id="pcs-comment-input-bar" class="pcs-input-bar" style="display:none;">
-      <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..." oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-client');if(b){if(this.value.trim()){b.style.color='#C8A84B';b.style.borderColor='rgba(200,168,75,0.4)';}else{b.style.color='rgba(255,255,255,0.3)';b.style.borderColor='rgba(255,255,255,0.1)';}}"></textarea>
-      <button id="pcs-send-btn-client" class="pcs-send-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all')">Send &#x2192;</button>
     </div>
 
   </div>
@@ -1012,24 +1012,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329y" defer></script>
-<script src="02-session.js?v=20260329y" defer></script>
-<script src="utils.js?v=20260329y" defer></script>
-<script src="03-auth.js?v=20260329y" defer></script>
-<script src="05-api.js?v=20260329y" defer></script>
-<script src="10-ui.js?v=20260329y" defer></script>
+<script src="01-config.js?v=20260329z" defer></script>
+<script src="02-session.js?v=20260329z" defer></script>
+<script src="utils.js?v=20260329z" defer></script>
+<script src="03-auth.js?v=20260329z" defer></script>
+<script src="05-api.js?v=20260329z" defer></script>
+<script src="10-ui.js?v=20260329z" defer></script>
 
-<script src="06-post-create.js?v=20260329y" defer></script>
-<script defer src="render/dashboard.js?v=20260329y"></script>
-<script defer src="render/client.js?v=20260329y"></script>
-<script defer src="render/pipeline.js?v=20260329y"></script>
-<script defer src="render/brief.js?v=20260329y"></script>
-<script defer src="actions/pcs.js?v=20260329y"></script>
-<script src="07-post-load.js?v=20260329y" defer></script>
-<script src="08-post-actions.js?v=20260329y" defer></script>
-<script src="09-library.js?v=20260329y" defer></script>
-<script src="09-approval.js?v=20260329y" defer></script>
-<script src="04-router.js?v=20260329y" defer></script>
+<script src="06-post-create.js?v=20260329z" defer></script>
+<script defer src="render/dashboard.js?v=20260329z"></script>
+<script defer src="render/client.js?v=20260329z"></script>
+<script defer src="render/pipeline.js?v=20260329z"></script>
+<script defer src="render/brief.js?v=20260329z"></script>
+<script defer src="actions/pcs.js?v=20260329z"></script>
+<script src="07-post-load.js?v=20260329z" defer></script>
+<script src="08-post-actions.js?v=20260329z" defer></script>
+<script src="09-library.js?v=20260329z" defer></script>
+<script src="09-approval.js?v=20260329z" defer></script>
+<script src="04-router.js?v=20260329z" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5694,18 +5694,65 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 /* -- PCS DUAL-CHANNEL COMMENTS -- */
-.pcs-section-header {
+
+/* CLIENT COMMENTS SECTION */
+.client-comments-section {
+  background: #0d0d12;
+  border: 1px solid rgba(255,255,255,0.07);
+  margin-bottom: 3px;
+}
+.client-section-header {
+  padding: 12px 16px 10px;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px 10px;
-  border-top: 1px solid rgba(255,255,255,0.06);
 }
-.pcs-section-label {
+.client-comments-label {
   font-family: var(--mono);
   font-size: 9px;
   letter-spacing: 0.15em;
-  color: rgba(255,255,255,0.4);
+  color: rgba(255,255,255,0.35);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.client-sublabel {
+  font-family: var(--mono);
+  font-size: 7px;
+  color: rgba(255,255,255,0.15);
+  letter-spacing: 0.08em;
+}
+.client-input-zone {
+  border-top: 1px solid rgba(255,255,255,0.05);
+  padding: 10px 16px 12px;
+  background: #0d0d12;
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+/* INTERNAL NOTES SECTION */
+.pcs-notes-section {
+  background: #111008;
+  border: 1px solid rgba(246,166,35,0.15);
+  border-top: 2px solid rgba(246,166,35,0.25);
+  margin-bottom: 3px;
+}
+.pcs-notes-header {
+  padding: 12px 16px 10px;
+  border-bottom: 1px solid rgba(246,166,35,0.08);
+  background: rgba(246,166,35,0.04);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: none;
+}
+.pcs-notes-label {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  color: rgba(246,166,35,0.6);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -5714,33 +5761,21 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-size: 10px;
   color: rgba(246,166,35,0.6);
 }
-.pcs-count-badge {
-  background: rgba(200,168,75,0.15);
-  color: #C8A84B;
-  font-size: 8px;
-  padding: 1px 6px;
-  letter-spacing: 0.1em;
-}
-.pcs-notes-badge {
-  background: rgba(246,166,35,0.1);
-  color: rgba(246,166,35,0.6);
-}
-.pcs-thread-list {
-  padding: 0 0 4px;
-  max-height: 240px;
-  overflow-y: auto;
-}
 .pcs-notes-list {
-  background: transparent;
+  padding: 4px 0;
+  background: rgba(246,166,35,0.02);
+  min-height: 60px;
 }
-.pcs-notes-section {
-  border-top: 2px solid rgba(246,166,35,0.2);
-  background: rgba(246,166,35,0.06);
+.notes-input-zone {
+  border-top: 1px solid rgba(246,166,35,0.1);
+  padding: 10px 16px 12px;
+  background: rgba(246,166,35,0.03);
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
 }
-.pcs-notes-header {
-  border-top: none;
-  background: rgba(246,166,35,0.04);
-}
+
+/* SHARED COMMENT ITEMS */
 .pcs-comment-item {
   display: flex;
   gap: 10px;
@@ -5748,9 +5783,15 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   position: relative;
   border-bottom: 1px solid rgba(255,255,255,0.03);
 }
-.pcs-comment-item:last-child {
-  border-bottom: none;
+.pcs-comment-item:last-child { border-bottom: none; }
+.pcs-note-item {
+  display: flex;
+  gap: 10px;
+  padding: 10px 16px;
+  position: relative;
+  border-bottom: 1px solid rgba(246,166,35,0.05);
 }
+.pcs-note-item:last-child { border-bottom: none; }
 .pcs-unread-dot {
   position: absolute;
   left: 6px;
@@ -5773,54 +5814,64 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-weight: 500;
 }
 .av-client {
-  background: rgba(255,75,75,0.15);
+  background: rgba(255,75,75,0.12);
   color: #FF4B4B;
   border: 1px solid rgba(255,75,75,0.2);
 }
 .av-servicing {
-  background: rgba(34,211,238,0.15);
+  background: rgba(34,211,238,0.12);
   color: #22D3EE;
   border: 1px solid rgba(34,211,238,0.2);
 }
 .av-creative {
-  background: rgba(155,135,245,0.15);
+  background: rgba(155,135,245,0.12);
   color: #9b87f5;
   border: 1px solid rgba(155,135,245,0.2);
 }
 .av-admin {
-  background: rgba(200,168,75,0.15);
+  background: rgba(200,168,75,0.12);
   color: #C8A84B;
   border: 1px solid rgba(200,168,75,0.2);
 }
 .pcs-comment-body { flex: 1; min-width: 0; }
 .pcs-comment-meta {
   display: flex;
-  align-items: baseline;
-  gap: 6px;
+  align-items: center;
+  gap: 5px;
   margin-bottom: 3px;
   flex-wrap: wrap;
 }
 .pcs-comment-author {
   font-size: 11px;
-  font-weight: 700;
+  font-weight: 600;
   color: rgba(255,255,255,0.75);
 }
 .pcs-comment-time {
   font-family: var(--mono);
-  font-size: 8px;
+  font-size: 7px;
   color: rgba(255,255,255,0.2);
+}
+.pcs-vis-tag {
+  font-family: var(--mono);
+  font-size: 7px;
+  color: rgba(246,166,35,0.4);
+  border: 1px dotted rgba(246,166,35,0.2);
+  padding: 1px 4px;
+  margin-left: auto;
+  flex-shrink: 0;
+  align-self: flex-start;
 }
 .pcs-mention-badge {
   font-family: var(--mono);
   font-size: 7px;
   color: #9b87f5;
-  background: rgba(155,135,245,0.1);
-  padding: 1px 5px;
+  background: rgba(155,135,245,0.08);
   border: 1px solid rgba(155,135,245,0.2);
+  padding: 1px 4px;
 }
 .pcs-comment-text {
   font-size: 13px;
-  color: rgba(255,255,255,0.65);
+  color: rgba(255,255,255,0.6);
   line-height: 1.5;
   white-space: pre-wrap;
   word-break: break-word;
@@ -5831,7 +5882,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .pcs-empty-icon {
   font-size: 18px;
-  opacity: 0.25;
+  opacity: 0.2;
   margin-bottom: 8px;
 }
 .pcs-empty-text {
@@ -5839,24 +5890,13 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-size: 8px;
   color: rgba(255,255,255,0.2);
   letter-spacing: 0.08em;
-  line-height: 1.6;
+  line-height: 1.7;
 }
-.pcs-input-bar {
-  display: flex;
-  align-items: flex-end;
-  gap: 8px;
-  padding: 10px 16px 14px;
-  background: #0e0e14;
-  border-top: 1px solid rgba(255,255,255,0.06);
-  flex-shrink: 0;
-}
-.pcs-notes-input-bar {
-  border-top: 1px solid rgba(246,166,35,0.15);
-  background: rgba(246,166,35,0.05);
-}
+
+/* TEXTAREAS */
 .pcs-textarea {
   flex: 1;
-  background: rgba(255,255,255,0.04);
+  background: rgba(255,255,255,0.03);
   border: 1px solid rgba(255,255,255,0.07);
   color: rgba(255,255,255,0.8);
   font-family: var(--sans);
@@ -5868,47 +5908,55 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   line-height: 1.4;
   border-radius: 0;
   caret-color: #C8A84B;
+  transition: border-color 0.15s, background 0.15s;
 }
 .pcs-textarea:focus {
-  border-color: rgba(200,168,75,0.4);
-  background: rgba(255,255,255,0.06);
-  outline: none;
-  caret-color: #C8A84B;
+  border-color: rgba(200,168,75,0.35);
+  background: rgba(255,255,255,0.05);
 }
+.pcs-textarea::placeholder { color: rgba(255,255,255,0.18); }
 .pcs-note-textarea {
-  background: rgba(246,166,35,0.03);
-  border-color: rgba(246,166,35,0.1);
+  background: rgba(246,166,35,0.04);
+  border-color: rgba(246,166,35,0.12);
   caret-color: #F6A623;
 }
 .pcs-note-textarea:focus {
   border-color: rgba(246,166,35,0.35);
-  background: rgba(246,166,35,0.06);
-  outline: none;
-  caret-color: #F6A623;
+  background: rgba(246,166,35,0.07);
 }
-.pcs-textarea::placeholder {
-  color: rgba(255,255,255,0.2);
+.pcs-note-textarea::placeholder {
+  color: rgba(246,166,35,0.25);
 }
+
+/* SEND BUTTONS */
 .pcs-send-btn {
   font-family: var(--mono);
   font-size: 9px;
   letter-spacing: 0.08em;
   background: none;
-  border: 1px dotted rgba(255,255,255,0.15);
-  color: rgba(255,255,255,0.4);
+  border: 1px dotted rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.25);
   padding: 8px 12px;
   height: 36px;
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
-}
-.pcs-send-btn:not(:disabled) {
   transition: color 0.15s, border-color 0.15s;
 }
-.pcs-note-btn {
-  border-color: rgba(246,166,35,0.2);
-  color: rgba(246,166,35,0.5);
+.pcs-send-btn.active {
+  color: #C8A84B;
+  border-color: rgba(200,168,75,0.4);
 }
+.pcs-note-btn {
+  border-color: rgba(246,166,35,0.15);
+  color: rgba(246,166,35,0.3);
+}
+.pcs-note-btn.active {
+  color: #F6A623;
+  border-color: rgba(246,166,35,0.5);
+}
+
+/* VIS CHIPS */
 .pcs-vis-selector {
   display: flex;
   gap: 4px;
@@ -5917,20 +5965,113 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-family: var(--mono);
   font-size: 7px;
   letter-spacing: 0.06em;
-  padding: 3px 6px;
-  border: 1px dotted rgba(255,255,255,0.1);
-  color: rgba(255,255,255,0.25);
+  padding: 3px 7px;
+  border: 1px dotted rgba(246,166,35,0.15);
+  color: rgba(246,166,35,0.3);
   cursor: pointer;
   user-select: none;
   -webkit-user-select: none;
+  transition: all 0.15s;
 }
 .pcs-vis-chip.active {
   color: #F6A623;
-  border-color: rgba(246,166,35,0.35);
+  border-color: rgba(246,166,35,0.45);
+  background: rgba(246,166,35,0.06);
 }
-.pcs-resolved {
-  opacity: 0.4;
+
+/* COUNT BADGES */
+.pcs-count-badge {
+  background: rgba(255,255,255,0.06);
+  color: rgba(255,255,255,0.3);
+  font-size: 8px;
+  padding: 1px 5px;
+  font-family: var(--mono);
 }
+.pcs-notes-count-badge {
+  background: rgba(246,166,35,0.1);
+  color: rgba(246,166,35,0.5);
+  font-size: 8px;
+  padding: 1px 5px;
+  font-family: var(--mono);
+}
+
+/* CONFIRM DIALOG */
+.pcs-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.78);
+  z-index: 9999;
+  align-items: flex-end;
+  justify-content: center;
+  display: none;
+}
+.pcs-confirm-overlay.open { display: flex; }
+.pcs-confirm-sheet {
+  background: #111318;
+  width: 100%;
+  max-width: 480px;
+  border-top: 1px solid rgba(255,255,255,0.08);
+  padding: 20px 20px 36px;
+}
+.pcs-confirm-title {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: rgba(255,255,255,0.35);
+  letter-spacing: 0.15em;
+  margin-bottom: 14px;
+}
+.pcs-confirm-preview {
+  font-size: 13px;
+  color: rgba(255,255,255,0.4);
+  font-style: italic;
+  line-height: 1.5;
+  padding: 10px 12px;
+  border-left: 2px solid rgba(255,255,255,0.06);
+  margin-bottom: 14px;
+  background: rgba(255,255,255,0.02);
+}
+.pcs-confirm-warn1 {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: rgba(255,255,255,0.4);
+  letter-spacing: 0.08em;
+  margin-bottom: 4px;
+}
+.pcs-confirm-warn2 {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: rgba(255,75,75,0.55);
+  letter-spacing: 0.08em;
+}
+.pcs-confirm-btns {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 8px;
+  margin-top: 18px;
+}
+.pcs-confirm-cancel {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: rgba(255,255,255,0.25);
+  border: 1px dotted rgba(255,255,255,0.1);
+  background: none;
+  padding: 12px;
+  cursor: pointer;
+  letter-spacing: 0.1em;
+}
+.pcs-confirm-send {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: #000;
+  background: #C8A84B;
+  border: none;
+  padding: 12px;
+  cursor: pointer;
+  letter-spacing: 0.1em;
+}
+
+/* RESOLVED */
+.pcs-resolved { opacity: 0.4; }
 .pcs-resolved-wrap {
   margin: 4px 16px 8px;
 }
@@ -5942,75 +6083,4 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   cursor: pointer;
   padding: 4px 0;
   list-style: none;
-}
-/* CONFIRMATION DIALOG */
-.pcs-confirm-overlay {
-  position: absolute;
-  inset: 0;
-  background: rgba(0,0,0,0.75);
-  z-index: 200;
-  align-items: flex-end;
-  justify-content: center;
-}
-.pcs-confirm-sheet {
-  background: #111318;
-  width: 100%;
-  border-top: 1px solid rgba(255,255,255,0.08);
-  padding: 20px 20px 28px;
-}
-.pcs-confirm-title {
-  font-family: var(--mono);
-  font-size: 9px;
-  color: rgba(255,255,255,0.35);
-  letter-spacing: 0.15em;
-  margin-bottom: 12px;
-}
-.pcs-confirm-preview {
-  font-size: 13px;
-  color: rgba(255,255,255,0.4);
-  font-style: italic;
-  line-height: 1.5;
-  padding: 10px 12px;
-  border-left: 2px solid rgba(255,255,255,0.06);
-  margin-bottom: 12px;
-  background: rgba(255,255,255,0.02);
-}
-.pcs-confirm-warn1 {
-  font-family: var(--mono);
-  font-size: 9px;
-  color: rgba(255,255,255,0.4);
-  letter-spacing: 0.08em;
-  margin-bottom: 3px;
-}
-.pcs-confirm-warn2 {
-  font-family: var(--mono);
-  font-size: 9px;
-  color: rgba(255,75,75,0.5);
-  letter-spacing: 0.08em;
-}
-.pcs-confirm-btns {
-  display: grid;
-  grid-template-columns: 1fr 2fr;
-  gap: 8px;
-  margin-top: 16px;
-}
-.pcs-confirm-cancel {
-  font-family: var(--mono);
-  font-size: 9px;
-  letter-spacing: 0.1em;
-  color: rgba(255,255,255,0.25);
-  border: 1px dotted rgba(255,255,255,0.1);
-  background: none;
-  padding: 11px;
-  cursor: pointer;
-}
-.pcs-confirm-send {
-  font-family: var(--mono);
-  font-size: 9px;
-  letter-spacing: 0.1em;
-  color: #000;
-  background: #C8A84B;
-  border: none;
-  padding: 11px;
-  cursor: pointer;
 }


### PR DESCRIPTION
## Summary

- **Two distinct sections**: CLIENT COMMENTS (`#0d0d12` dark) and INTERNAL NOTES (`#111008` amber-tinted) with clear visual separation
- **Inputs inside sections**: Both input zones live inside their respective sections -- no more external floating bars
- **Split renderers**: `_renderClientThread` for client comments, `_renderNoteThread` for internal notes with visibility tags (ALL/ADMIN/SERV/CREATIVE)
- **New CSS classes**: `client-comments-section`, `client-input-zone`, `notes-input-zone`, `pcs-note-item`, `pcs-vis-tag`, `pcs-notes-label`
- **Confirmation dialog**: Now `position:fixed` at `z-index:9999` with `max-width:480px`
- **Button states**: `.active` class toggle via `classList` instead of inline style manipulation
- Bump all 18 asset versions to `?v=20260329z`

**Zero changes to `render/client.js` or `preview/index.html`.**

## Test plan

- [x] `node --check actions/pcs.js` passes
- [x] Zero non-ASCII in all modified files
- [x] `npm test` -- 133/133 pass
- [x] Old `#pcs-comment-input-bar` deleted from HTML
- [x] Client input inside `.client-comments-section`
- [x] Notes input inside `#pcs-notes-section`
- [x] `.pcs-notes-section` background is `#111008`
- [x] `.client-comments-section` background is `#0d0d12`
- [x] `render/client.js` not modified
- [ ] Verify two sections render with distinct backgrounds
- [ ] Verify note items show vis-tag on right side

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z