### PR TITLE
fix: restore internal notes elevation color

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329A">
+ <link rel="stylesheet" href="styles.css?v=20260329B">
 
 </head>
 <body>
@@ -1012,24 +1012,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329A" defer></script>
-<script src="02-session.js?v=20260329A" defer></script>
-<script src="utils.js?v=20260329A" defer></script>
-<script src="03-auth.js?v=20260329A" defer></script>
-<script src="05-api.js?v=20260329A" defer></script>
-<script src="10-ui.js?v=20260329A" defer></script>
+<script src="01-config.js?v=20260329B" defer></script>
+<script src="02-session.js?v=20260329B" defer></script>
+<script src="utils.js?v=20260329B" defer></script>
+<script src="03-auth.js?v=20260329B" defer></script>
+<script src="05-api.js?v=20260329B" defer></script>
+<script src="10-ui.js?v=20260329B" defer></script>
 
-<script src="06-post-create.js?v=20260329A" defer></script>
-<script defer src="render/dashboard.js?v=20260329A"></script>
-<script defer src="render/client.js?v=20260329A"></script>
-<script defer src="render/pipeline.js?v=20260329A"></script>
-<script defer src="render/brief.js?v=20260329A"></script>
-<script defer src="actions/pcs.js?v=20260329A"></script>
-<script src="07-post-load.js?v=20260329A" defer></script>
-<script src="08-post-actions.js?v=20260329A" defer></script>
-<script src="09-library.js?v=20260329A" defer></script>
-<script src="09-approval.js?v=20260329A" defer></script>
-<script src="04-router.js?v=20260329A" defer></script>
+<script src="06-post-create.js?v=20260329B" defer></script>
+<script defer src="render/dashboard.js?v=20260329B"></script>
+<script defer src="render/client.js?v=20260329B"></script>
+<script defer src="render/pipeline.js?v=20260329B"></script>
+<script defer src="render/brief.js?v=20260329B"></script>
+<script defer src="actions/pcs.js?v=20260329B"></script>
+<script src="07-post-load.js?v=20260329B" defer></script>
+<script src="08-post-actions.js?v=20260329B" defer></script>
+<script src="09-library.js?v=20260329B" defer></script>
+<script src="09-approval.js?v=20260329B" defer></script>
+<script src="04-router.js?v=20260329B" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5734,7 +5734,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* INTERNAL NOTES SECTION */
 .pcs-notes-section {
-  background: #191920;
+  background: #1a1a24;
   border: 1px solid rgba(246,166,35,0.15);
   border-top: 2px solid rgba(246,166,35,0.25);
   margin-bottom: 3px;


### PR DESCRIPTION
## Summary

- `.pcs-notes-section` background: `#191920` -> `#1a1a24`
- Bump all 18 asset versions to `?v=20260329B`

One value, one line.

## Test plan

- [x] `npm test` -- 133/133 pass
- [x] Zero non-ASCII

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z