### PR TITLE
fix: purge amber from internal notes, chip filtering, per-chip counts, recipient hint

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -740,8 +740,12 @@ window.loadPcsComments = async function(postId) {
     }
 
     if (notesList && _roleLower !== 'client') {
-      var resolvedRows = internalRows.filter(function(c) { return c.resolved; });
-      var activeRows = internalRows.filter(function(c) { return !c.resolved; });
+      var _activeVis = window._pcsNoteVisibility || 'all';
+      var filteredNotes = internalRows.filter(function(c) {
+        return (c.visibility || 'all') === _activeVis;
+      });
+      var resolvedRows = filteredNotes.filter(function(c) { return c.resolved; });
+      var activeRows = filteredNotes.filter(function(c) { return !c.resolved; });
 
       var emptyNotes =
         '<div class="pcs-empty-thread">' +
@@ -766,13 +770,30 @@ window.loadPcsComments = async function(postId) {
 
       var notesCountEl = document.getElementById('pcs-notes-count');
       if (notesCountEl) {
-        if (internalRows.length) {
+        if (filteredNotes.length) {
           notesCountEl.textContent = activeRows.length;
           notesCountEl.style.display = 'inline';
         } else {
           notesCountEl.style.display = 'none';
         }
       }
+
+      // Per-chip counts
+      var allCount = internalRows.filter(function(r) { return (r.visibility||'all')==='all'; }).length;
+      var adminCount = internalRows.filter(function(r) { return r.visibility==='admin'; }).length;
+      var servCount = internalRows.filter(function(r) { return r.visibility==='servicing'; }).length;
+      var creativeCount = internalRows.filter(function(r) { return r.visibility==='creative'; }).length;
+      var chips = document.querySelectorAll('.pcs-vis-chip');
+      chips.forEach(function(chip) {
+        var v = chip.getAttribute('data-vis');
+        var cnt = 0;
+        if (v === 'all') cnt = allCount;
+        else if (v === 'admin') cnt = adminCount;
+        else if (v === 'servicing') cnt = servCount;
+        else if (v === 'creative') cnt = creativeCount;
+        var label = v === 'all' ? 'ALL' : v === 'admin' ? 'ADMIN' : v === 'servicing' ? 'SERV' : 'CREATIVE';
+        chip.textContent = cnt > 0 ? label + ' (' + cnt + ')' : label;
+      });
     }
 
     list.scrollTop = list.scrollHeight;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329B">
+ <link rel="stylesheet" href="styles.css?v=20260329C">
 
 </head>
 <body>
@@ -930,6 +930,7 @@
           <div class="notes-input-zone">
             <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');if(b){b.classList.toggle('active',!!this.value.trim())}"></textarea>
             <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all')">NOTE</button>
+            <div id="pcs-note-recipient" class="pcs-note-recipient">Entire agency will see this</div>
           </div>
         </div>
 
@@ -1009,27 +1010,34 @@ window.setPcsVisibility = function(el, vis) {
   window._pcsNoteVisibility = vis;
   document.querySelectorAll('.pcs-vis-chip').forEach(function(c) { c.classList.remove('active'); });
   el.classList.add('active');
+  var r = document.getElementById('pcs-note-recipient');
+  if (r) {
+    var labels = {all:'Entire agency will see this',admin:'Only you will see this',servicing:'Only Chitra will see this',creative:'Only Pranav will see this'};
+    r.textContent = labels[vis] || labels.all;
+  }
+  var postId = document.getElementById('pcs-post-id');
+  if (postId && postId.value && typeof loadPcsComments === 'function') loadPcsComments(postId.value);
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329B" defer></script>
-<script src="02-session.js?v=20260329B" defer></script>
-<script src="utils.js?v=20260329B" defer></script>
-<script src="03-auth.js?v=20260329B" defer></script>
-<script src="05-api.js?v=20260329B" defer></script>
-<script src="10-ui.js?v=20260329B" defer></script>
+<script src="01-config.js?v=20260329C" defer></script>
+<script src="02-session.js?v=20260329C" defer></script>
+<script src="utils.js?v=20260329C" defer></script>
+<script src="03-auth.js?v=20260329C" defer></script>
+<script src="05-api.js?v=20260329C" defer></script>
+<script src="10-ui.js?v=20260329C" defer></script>
 
-<script src="06-post-create.js?v=20260329B" defer></script>
-<script defer src="render/dashboard.js?v=20260329B"></script>
-<script defer src="render/client.js?v=20260329B"></script>
-<script defer src="render/pipeline.js?v=20260329B"></script>
-<script defer src="render/brief.js?v=20260329B"></script>
-<script defer src="actions/pcs.js?v=20260329B"></script>
-<script src="07-post-load.js?v=20260329B" defer></script>
-<script src="08-post-actions.js?v=20260329B" defer></script>
-<script src="09-library.js?v=20260329B" defer></script>
-<script src="09-approval.js?v=20260329B" defer></script>
-<script src="04-router.js?v=20260329B" defer></script>
+<script src="06-post-create.js?v=20260329C" defer></script>
+<script defer src="render/dashboard.js?v=20260329C"></script>
+<script defer src="render/client.js?v=20260329C"></script>
+<script defer src="render/pipeline.js?v=20260329C"></script>
+<script defer src="render/brief.js?v=20260329C"></script>
+<script defer src="actions/pcs.js?v=20260329C"></script>
+<script src="07-post-load.js?v=20260329C" defer></script>
+<script src="08-post-actions.js?v=20260329C" defer></script>
+<script src="09-library.js?v=20260329C" defer></script>
+<script src="09-approval.js?v=20260329C" defer></script>
+<script src="04-router.js?v=20260329C" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5735,14 +5735,14 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 /* INTERNAL NOTES SECTION */
 .pcs-notes-section {
   background: #1a1a24;
-  border: 1px solid rgba(246,166,35,0.15);
-  border-top: 2px solid rgba(246,166,35,0.25);
+  border: 1px solid rgba(255,255,255,0.09);
+  border-top: 2px solid rgba(255,255,255,0.12);
   margin-bottom: 3px;
 }
 .pcs-notes-header {
   padding: 12px 16px 10px;
-  border-bottom: 1px solid rgba(246,166,35,0.08);
-  background: rgba(246,166,35,0.04);
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  background: rgba(255,255,255,0.02);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -5752,27 +5752,36 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-family: var(--mono);
   font-size: 9px;
   letter-spacing: 0.15em;
-  color: rgba(246,166,35,0.6);
+  color: rgba(255,255,255,0.35);
   display: flex;
   align-items: center;
   gap: 6px;
 }
 .pcs-lock-icon {
   font-size: 10px;
-  color: rgba(246,166,35,0.6);
+  color: rgba(255,255,255,0.25);
 }
 .pcs-notes-list {
   padding: 4px 0;
-  background: rgba(246,166,35,0.02);
+  background: transparent;
   min-height: 60px;
 }
 .notes-input-zone {
-  border-top: 1px solid rgba(246,166,35,0.1);
+  border-top: 1px solid rgba(255,255,255,0.05);
   padding: 10px 16px 12px;
-  background: rgba(246,166,35,0.03);
+  background: #1a1a24;
   display: flex;
   gap: 8px;
   align-items: flex-end;
+  flex-wrap: wrap;
+}
+.pcs-note-recipient {
+  width: 100%;
+  font-family: var(--mono);
+  font-size: 8px;
+  color: rgba(255,255,255,0.25);
+  letter-spacing: 0.04em;
+  margin-top: -4px;
 }
 
 /* SHARED COMMENT ITEMS */
@@ -5789,7 +5798,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   gap: 10px;
   padding: 10px 16px;
   position: relative;
-  border-bottom: 1px solid rgba(246,166,35,0.05);
+  border-bottom: 1px solid rgba(255,255,255,0.03);
 }
 .pcs-note-item:last-child { border-bottom: none; }
 .pcs-unread-dot {
@@ -5854,8 +5863,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-vis-tag {
   font-family: var(--mono);
   font-size: 7px;
-  color: rgba(246,166,35,0.4);
-  border: 1px dotted rgba(246,166,35,0.2);
+  color: rgba(255,255,255,0.25);
+  border: 1px dotted rgba(255,255,255,0.12);
   padding: 1px 4px;
   margin-left: auto;
   flex-shrink: 0;
@@ -5916,16 +5925,16 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .pcs-textarea::placeholder { color: rgba(255,255,255,0.18); }
 .pcs-note-textarea {
-  background: rgba(246,166,35,0.04);
-  border-color: rgba(246,166,35,0.12);
-  caret-color: #F6A623;
+  background: rgba(255,255,255,0.03);
+  border-color: rgba(255,255,255,0.08);
+  caret-color: rgba(255,255,255,0.6);
 }
 .pcs-note-textarea:focus {
-  border-color: rgba(246,166,35,0.35);
-  background: rgba(246,166,35,0.07);
+  border-color: rgba(255,255,255,0.2);
+  background: rgba(255,255,255,0.05);
 }
 .pcs-note-textarea::placeholder {
-  color: rgba(246,166,35,0.25);
+  color: rgba(255,255,255,0.15);
 }
 
 /* SEND BUTTONS */
@@ -5948,12 +5957,12 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   border-color: rgba(200,168,75,0.4);
 }
 .pcs-note-btn {
-  border-color: rgba(246,166,35,0.15);
-  color: rgba(246,166,35,0.3);
+  border-color: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.22);
 }
 .pcs-note-btn.active {
-  color: #F6A623;
-  border-color: rgba(246,166,35,0.5);
+  color: rgba(255,255,255,0.7);
+  border-color: rgba(255,255,255,0.35);
 }
 
 /* VIS CHIPS */
@@ -5966,17 +5975,17 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-size: 7px;
   letter-spacing: 0.06em;
   padding: 3px 7px;
-  border: 1px dotted rgba(246,166,35,0.15);
-  color: rgba(246,166,35,0.3);
+  border: 1px dotted rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.2);
   cursor: pointer;
   user-select: none;
   -webkit-user-select: none;
   transition: all 0.15s;
 }
 .pcs-vis-chip.active {
-  color: #F6A623;
-  border-color: rgba(246,166,35,0.45);
-  background: rgba(246,166,35,0.06);
+  color: rgba(255,255,255,0.7);
+  border-color: rgba(255,255,255,0.3);
+  background: rgba(255,255,255,0.05);
 }
 
 /* COUNT BADGES */
@@ -5988,8 +5997,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-family: var(--mono);
 }
 .pcs-notes-count-badge {
-  background: rgba(246,166,35,0.1);
-  color: rgba(246,166,35,0.5);
+  background: rgba(255,255,255,0.06);
+  color: rgba(255,255,255,0.3);
   font-size: 8px;
   padding: 1px 5px;
   font-family: var(--mono);


### PR DESCRIPTION
## Summary

- **Purge amber**: Replace all `rgba(246,166,35,...)` and `#F6A623` in PCS internal notes with white-opacity equivalents
- **Notes section**: `#1a1a24` bg, `rgba(255,255,255,0.09)` border, `0.12` top border
- **Vis chips**: White-opacity colors, active state `rgba(255,255,255,0.7/0.3/0.05)`
- **Note textarea/button**: All white-opacity, no amber
- **Chip filtering**: Clicking a chip now filters displayed notes by that visibility value and reloads
- **Per-chip counts**: `ALL (3) ADMIN (1) SERV (0) CREATIVE (2)` shown on chips
- **Recipient hint**: `id="pcs-note-recipient"` below note input shows "Entire agency will see this" / "Only you will see this" / "Only Chitra will see this" / "Only Pranav will see this"
- Bump all 18 asset versions to `?v=20260329C`

**Zero changes to `render/client.js` or `preview/index.html`.**

## Test plan

- [x] `node --check actions/pcs.js` passes
- [x] Zero non-ASCII in all files
- [x] `npm test` -- 133/133 pass
- [x] Zero `246,166,35` in notes section CSS
- [x] Zero `#111008` or `#F6A623` in notes CSS
- [x] `.pcs-notes-section` background is `#1a1a24`
- [x] `render/client.js` not modified
- [ ] Verify chips filter notes list on click
- [ ] Verify per-chip counts update after fetch
- [ ] Verify recipient label changes with chip selection

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z