### PR TITLE
fix: internal notes blue reduction, notification routing, gap removal

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1552,6 +1552,12 @@ window._doSubmitComment = async function(opts) {
       } else {
         _targets = ['Client'];
       }
+    } else if (opts.visibility === 'admin') {
+      _targets = ['Admin'];
+    } else if (opts.visibility === 'servicing') {
+      _targets = ['Servicing'];
+    } else if (opts.visibility === 'creative') {
+      _targets = ['Creative'];
     } else {
       if (opts.mentioned && opts.mentioned.length) {
         _targets = opts.mentioned;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329C">
+ <link rel="stylesheet" href="styles.css?v=20260329D">
 
 </head>
 <body>
@@ -918,7 +918,7 @@
         <!-- SECTION 2: INTERNAL NOTES (agency only) -->
         <div id="pcs-notes-section" class="pcs-notes-section" style="display:none;">
           <div class="pcs-notes-header">
-            <div class="pcs-notes-label">INTERNAL NOTES <span class="pcs-lock-icon">&#128274;</span> <span id="pcs-notes-count" class="pcs-notes-count-badge" style="display:none;">0</span></div>
+            <div class="pcs-notes-label">INTERNAL NOTES <span class="pcs-lock-icon">PRIVATE</span> <span id="pcs-notes-count" class="pcs-notes-count-badge" style="display:none;">0</span></div>
             <div class="pcs-vis-selector" id="pcs-vis-selector">
               <div class="pcs-vis-chip active" data-vis="all" onclick="setPcsVisibility(this,'all')">ALL</div>
               <div class="pcs-vis-chip" data-vis="admin" onclick="setPcsVisibility(this,'admin')">ADMIN</div>
@@ -926,7 +926,7 @@
               <div class="pcs-vis-chip" data-vis="creative" onclick="setPcsVisibility(this,'creative')">CREATIVE</div>
             </div>
           </div>
-          <div id="pcs-notes-list" class="pcs-notes-list" style="min-height:60px;"></div>
+          <div id="pcs-notes-list" class="pcs-notes-list"></div>
           <div class="notes-input-zone">
             <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');if(b){b.classList.toggle('active',!!this.value.trim())}"></textarea>
             <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all')">NOTE</button>
@@ -1020,24 +1020,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329C" defer></script>
-<script src="02-session.js?v=20260329C" defer></script>
-<script src="utils.js?v=20260329C" defer></script>
-<script src="03-auth.js?v=20260329C" defer></script>
-<script src="05-api.js?v=20260329C" defer></script>
-<script src="10-ui.js?v=20260329C" defer></script>
+<script src="01-config.js?v=20260329D" defer></script>
+<script src="02-session.js?v=20260329D" defer></script>
+<script src="utils.js?v=20260329D" defer></script>
+<script src="03-auth.js?v=20260329D" defer></script>
+<script src="05-api.js?v=20260329D" defer></script>
+<script src="10-ui.js?v=20260329D" defer></script>
 
-<script src="06-post-create.js?v=20260329C" defer></script>
-<script defer src="render/dashboard.js?v=20260329C"></script>
-<script defer src="render/client.js?v=20260329C"></script>
-<script defer src="render/pipeline.js?v=20260329C"></script>
-<script defer src="render/brief.js?v=20260329C"></script>
-<script defer src="actions/pcs.js?v=20260329C"></script>
-<script src="07-post-load.js?v=20260329C" defer></script>
-<script src="08-post-actions.js?v=20260329C" defer></script>
-<script src="09-library.js?v=20260329C" defer></script>
-<script src="09-approval.js?v=20260329C" defer></script>
-<script src="04-router.js?v=20260329C" defer></script>
+<script src="06-post-create.js?v=20260329D" defer></script>
+<script defer src="render/dashboard.js?v=20260329D"></script>
+<script defer src="render/client.js?v=20260329D"></script>
+<script defer src="render/pipeline.js?v=20260329D"></script>
+<script defer src="render/brief.js?v=20260329D"></script>
+<script defer src="actions/pcs.js?v=20260329D"></script>
+<script src="07-post-load.js?v=20260329D" defer></script>
+<script src="08-post-actions.js?v=20260329D" defer></script>
+<script src="09-library.js?v=20260329D" defer></script>
+<script src="09-approval.js?v=20260329D" defer></script>
+<script src="04-router.js?v=20260329D" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5698,7 +5698,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 /* CLIENT COMMENTS SECTION */
 .client-comments-section {
   background: #0d0d12;
-  border: 1px solid rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.06);
   margin-bottom: 3px;
 }
 .client-section-header {
@@ -5734,9 +5734,9 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* INTERNAL NOTES SECTION */
 .pcs-notes-section {
-  background: #1a1a24;
+  background: #181820;
   border: 1px solid rgba(255,255,255,0.09);
-  border-top: 2px solid rgba(255,255,255,0.12);
+  border-top: 1px solid rgba(255,255,255,0.08);
   margin-bottom: 3px;
 }
 .pcs-notes-header {
@@ -5758,18 +5758,19 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   gap: 6px;
 }
 .pcs-lock-icon {
-  font-size: 10px;
-  color: rgba(255,255,255,0.25);
+  font-family: var(--mono);
+  font-size: 7px;
+  color: rgba(255,255,255,0.2);
+  letter-spacing: 0.08em;
 }
 .pcs-notes-list {
   padding: 4px 0;
   background: transparent;
-  min-height: 60px;
 }
 .notes-input-zone {
   border-top: 1px solid rgba(255,255,255,0.05);
   padding: 10px 16px 12px;
-  background: #1a1a24;
+  background: #181820;
   display: flex;
   gap: 8px;
   align-items: flex-end;


### PR DESCRIPTION
## Summary

- **Blue reduction**: `.pcs-notes-section` and `.notes-input-zone` background `#1a1a24` -> `#181820`
- **Client border**: `.client-comments-section` border `0.07` -> `0.06`
- **Section separator**: `border-top` from `2px 0.12` to `1px 0.08`
- **Lock icon**: Replace emoji with `PRIVATE` text label (mono 7px, white 0.2)
- **Gap removal**: Remove `min-height:60px` from `pcs-notes-list`
- **Notification routing**: Admin/servicing/creative notes now notify their respective role instead of only @mentioned users
- Bump all 18 asset versions to `?v=20260329D`

**Zero changes to `render/client.js` or `preview/index.html`.**

## Test plan

- [x] `node --check actions/pcs.js` passes
- [x] Zero non-ASCII in all files
- [x] `npm test` -- 133/133 pass
- [x] Zero `#1a1a24` in styles.css
- [x] `.pcs-notes-section` background is `#181820`
- [x] 4 `data-vis` attributes in index.html
- [x] `render/client.js` not modified

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z