### PR TITLE
feat: task system, mention highlights, lock emoji fix, input alignment

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -674,10 +674,29 @@ window.loadPcsComments = async function(postId) {
       return 'pcs-avatar av-admin';
     }
 
+    function _highlightMentions(text) {
+      return text.replace(/@([a-zA-Z0-9_]+)/g,
+        '<span style="color:#9b87f5;background:rgba(155,135,245,0.1);padding:0 3px;font-weight:500;">@$1</span>');
+    }
+
+    function _parseTask(c) {
+      try {
+        var _att = typeof c.attachments === 'string' ? JSON.parse(c.attachments) : (c.attachments || []);
+        if (_att && _att.type === 'task') return true;
+      } catch(e) {}
+      return false;
+    }
+
     function _renderClientThread(threadRows, isEmpty) {
       if (!threadRows.length) return isEmpty;
       return threadRows.map(function(c) {
         var _initial = (c.author||'?').charAt(0).toUpperCase();
+        var _isTask = _parseTask(c);
+        var _taskPrefix = _isTask
+          ? '<span class="pcs-task-check' + (c.resolved ? ' pcs-task-done' : '') +
+            '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\')">' +
+            (c.resolved ? '&#x2611;' : '&#x2610;') + '</span> '
+          : '';
         return '<div class="pcs-comment-item">' +
           (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
           '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>' +
@@ -686,7 +705,9 @@ window.loadPcsComments = async function(postId) {
               '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
               '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
             '</div>' +
-            '<div class="pcs-comment-text">' + esc(c.message) + '</div>' +
+            '<div class="pcs-comment-text' + (_isTask ? ' pcs-task-text' : '') +
+            ((_isTask && c.resolved) ? ' pcs-task-done' : '') + '">' +
+            _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
           '</div>' +
         '</div>';
       }).join('');
@@ -703,6 +724,12 @@ window.loadPcsComments = async function(postId) {
         var _vis = (c.visibility||'all').toUpperCase();
         if (_vis === 'SERVICING') _vis = 'SERV';
         var _visTag = '<span class="pcs-vis-tag">' + _vis + '</span>';
+        var _isTask = _parseTask(c);
+        var _taskPrefix = _isTask
+          ? '<span class="pcs-task-check' + (c.resolved ? ' pcs-task-done' : '') +
+            '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\')">' +
+            (c.resolved ? '&#x2611;' : '&#x2610;') + '</span> '
+          : '';
 
         return '<div class="pcs-note-item' +
           (c.resolved ? ' pcs-resolved' : '') + '">' +
@@ -715,7 +742,9 @@ window.loadPcsComments = async function(postId) {
               _mentionBadge +
               _visTag +
             '</div>' +
-            '<div class="pcs-comment-text">' + esc(c.message) + '</div>' +
+            '<div class="pcs-comment-text' + (_isTask ? ' pcs-task-text' : '') +
+            ((_isTask && c.resolved) ? ' pcs-task-done' : '') + '">' +
+            _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
           '</div>' +
         '</div>';
       }).join('');
@@ -749,7 +778,7 @@ window.loadPcsComments = async function(postId) {
 
       var emptyNotes =
         '<div class="pcs-empty-thread">' +
-        '<div class="pcs-empty-icon">&#x1F512;</div>' +
+        '<div class="pcs-empty-icon" style="font-family:var(--mono);font-size:9px;letter-spacing:0.12em;color:rgba(255,255,255,0.15);opacity:1;">PRIVATE</div>' +
         '<div class="pcs-empty-text">No internal notes yet.</div></div>';
 
       var notesHtml = _renderNoteThread(activeRows, emptyNotes);
@@ -1471,7 +1500,8 @@ window._sharePostOnWhatsApp = function(postId) {
     + encodeURIComponent(message);
 };
 
-window.submitPcsComment = async function(postId, message, visibility) {
+window.submitPcsComment = async function(postId, message, visibility, isTask) {
+  isTask = isTask || false;
   visibility = visibility || 'all';
 
   if (!postId || !message || !(message = message.trim())) return;
@@ -1498,7 +1528,8 @@ window.submitPcsComment = async function(postId, message, visibility) {
       mentioned: _mentioned,
       author: _author,
       role: _role,
-      title: _title
+      title: _title,
+      isTask: isTask
     };
     var confirmEl = document.getElementById('pcs-comment-confirm');
     var previewEl = document.getElementById('pcs-comment-confirm-preview');
@@ -1516,7 +1547,8 @@ window.submitPcsComment = async function(postId, message, visibility) {
     mentioned: _mentioned,
     author: _author,
     role: _role,
-    title: _title
+    title: _title,
+    isTask: isTask
   });
 };
 
@@ -1534,7 +1566,10 @@ window._doSubmitComment = async function(opts) {
         author_role: _normalRole,
         message: opts.message,
         visibility: opts.visibility,
-        mentioned_users: opts.mentioned
+        mentioned_users: opts.mentioned,
+        resolved: false,
+        resolved_by: null,
+        attachments: opts.isTask ? JSON.stringify({type:'task'}) : '[]'
       })
     });
 
@@ -1595,5 +1630,20 @@ window._doSubmitComment = async function(opts) {
     console.error('_doSubmitComment failed:', e);
     showToast('Failed to send. Try again.', 'error');
   }
+};
+
+window.toggleTaskResolve = function(commentId, postId) {
+  apiFetch('/post_comments?id=eq.' + commentId, {
+    method: 'PATCH',
+    headers: {'Prefer': 'return=minimal'},
+    body: JSON.stringify({
+      resolved: true,
+      resolved_by: window.currentUserName || 'Admin'
+    })
+  }).then(function() {
+    loadPcsComments(postId);
+  }).catch(function(e) {
+    console.error('toggleTaskResolve failed:', e);
+  });
 };
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329G">
+ <link rel="stylesheet" href="styles.css?v=20260329H">
 
 </head>
 <body>
@@ -910,8 +910,11 @@
           </div>
           <div id="pcs-comments-list" class="pcs-thread-list" style="min-height:60px;"></div>
           <div class="client-input-zone">
-            <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..." oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-client');if(b){b.classList.toggle('active',!!this.value.trim())}"></textarea>
-            <button id="pcs-send-btn-client" class="pcs-send-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all')">SEND &#x2192;</button>
+            <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..." oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-client');var t=document.getElementById('pcs-task-btn-client');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
+            <div style="display:flex;gap:6px;flex-shrink:0;">
+              <button id="pcs-send-btn-client" class="pcs-send-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all',false)">SEND &#x2192;</button>
+              <button id="pcs-task-btn-client" class="pcs-send-btn pcs-task-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all',true)">+ TASK</button>
+            </div>
           </div>
         </div>
 
@@ -929,7 +932,7 @@
           <div id="pcs-notes-list" class="pcs-notes-list"></div>
           <div class="notes-input-zone">
             <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');if(b){b.classList.toggle('active',!!this.value.trim())}"></textarea>
-            <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all')">NOTE</button>
+            <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all')">NOTE</button>
             <div id="pcs-note-recipient" class="pcs-note-recipient">Entire agency will see this</div>
           </div>
         </div>
@@ -1020,24 +1023,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329G" defer></script>
-<script src="02-session.js?v=20260329G" defer></script>
-<script src="utils.js?v=20260329G" defer></script>
-<script src="03-auth.js?v=20260329G" defer></script>
-<script src="05-api.js?v=20260329G" defer></script>
-<script src="10-ui.js?v=20260329G" defer></script>
+<script src="01-config.js?v=20260329H" defer></script>
+<script src="02-session.js?v=20260329H" defer></script>
+<script src="utils.js?v=20260329H" defer></script>
+<script src="03-auth.js?v=20260329H" defer></script>
+<script src="05-api.js?v=20260329H" defer></script>
+<script src="10-ui.js?v=20260329H" defer></script>
 
-<script src="06-post-create.js?v=20260329G" defer></script>
-<script defer src="render/dashboard.js?v=20260329G"></script>
-<script defer src="render/client.js?v=20260329G"></script>
-<script defer src="render/pipeline.js?v=20260329G"></script>
-<script defer src="render/brief.js?v=20260329G"></script>
-<script defer src="actions/pcs.js?v=20260329G"></script>
-<script src="07-post-load.js?v=20260329G" defer></script>
-<script src="08-post-actions.js?v=20260329G" defer></script>
-<script src="09-library.js?v=20260329G" defer></script>
-<script src="09-approval.js?v=20260329G" defer></script>
-<script src="04-router.js?v=20260329G" defer></script>
+<script src="06-post-create.js?v=20260329H" defer></script>
+<script defer src="render/dashboard.js?v=20260329H"></script>
+<script defer src="render/client.js?v=20260329H"></script>
+<script defer src="render/pipeline.js?v=20260329H"></script>
+<script defer src="render/brief.js?v=20260329H"></script>
+<script defer src="actions/pcs.js?v=20260329H"></script>
+<script src="07-post-load.js?v=20260329H" defer></script>
+<script src="08-post-actions.js?v=20260329H" defer></script>
+<script src="09-library.js?v=20260329H" defer></script>
+<script src="09-approval.js?v=20260329H" defer></script>
+<script src="04-router.js?v=20260329H" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6104,3 +6104,33 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   padding: 4px 0;
   list-style: none;
 }
+
+/* TASK COMMENTS */
+.pcs-task-check {
+  cursor: pointer;
+  font-size: 14px;
+  margin-right: 4px;
+  color: rgba(255,255,255,0.4);
+  user-select: none;
+  -webkit-user-select: none;
+}
+.pcs-task-check.pcs-task-done {
+  color: #3ECF8E;
+}
+.pcs-task-text {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+}
+.pcs-task-text.pcs-task-done {
+  text-decoration: line-through;
+  opacity: 0.5;
+}
+.pcs-task-btn {
+  border-color: rgba(62,207,142,0.2);
+  color: rgba(62,207,142,0.35);
+}
+.pcs-task-btn.active {
+  border-color: rgba(62,207,142,0.5);
+  color: #3ECF8E;
+}


### PR DESCRIPTION
## Summary

- **Lock emoji fix**: Replace `&#x1F512;` in notes empty state with `PRIVATE` mono text (no golden tinge)
- **Task system**: New `+ TASK` button alongside SEND in client comments. Tasks store `{type:'task'}` in `attachments` jsonb. Render with checkbox prefix. Click checkbox to mark resolved via `PATCH /post_comments?id=eq.{id}`
- **Mention highlights**: `@Pranav` renders as purple highlighted text in both client and note threads via `_highlightMentions()`
- **Input alignment**: Both send buttons get `min-width:72px` so textareas have identical available width
- **New functions**: `toggleTaskResolve()`, `_highlightMentions()`, `_parseTask()`
- **submitPcsComment**: Now accepts 4th param `isTask`, passes through to `_doSubmitComment`
- **POST body**: Includes `resolved`, `resolved_by`, `attachments` fields
- **CSS**: `.pcs-task-check`, `.pcs-task-text`, `.pcs-task-done`, `.pcs-task-btn` with green accent
- Bump all 18 versions to `?v=20260329H`

**Zero changes to `render/client.js` or `preview/index.html`.**

## Test plan

- [x] `node --check actions/pcs.js` passes
- [x] Zero non-ASCII in all files
- [x] `npm test` -- 133/133 pass
- [x] Zero `1F512` in actions/pcs.js
- [x] `+ TASK` button in index.html
- [x] `toggleTaskResolve` and `_highlightMentions` exist in actions/pcs.js
- [x] `render/client.js` not modified
- [ ] Verify task checkbox renders and toggles resolved on click
- [ ] Verify @mentions render purple in both threads
- [ ] Verify SEND and TASK buttons both highlight on input

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z