### PR TITLE
fix: button tap safe area, duplicate CSS, notes task button, mention lookup, read receipts

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -628,6 +628,19 @@ window.loadPcsComments = async function(postId) {
     );
     if (!Array.isArray(rows)) rows = [];
 
+    var _unreadIds = rows
+      .filter(function(r) { return !r.read; })
+      .map(function(r) { return r.id; });
+    if (_unreadIds.length > 0) {
+      _unreadIds.forEach(function(id) {
+        apiFetch('/post_comments?id=eq.' + id, {
+          method: 'PATCH',
+          headers: {'Prefer': 'return=minimal'},
+          body: JSON.stringify({ read: true })
+        }).catch(function(){});
+      });
+    }
+
     var clientRows = rows.filter(function(c) {
       return c.visibility === 'all' || !c.visibility;
     });
@@ -1552,6 +1565,27 @@ window.submitPcsComment = async function(postId, message, visibility, isTask) {
   });
 };
 
+async function _lookupMentionEmails(names) {
+  if (!names || !names.length) return [];
+  try {
+    var results = [];
+    for (var i = 0; i < names.length; i++) {
+      var rows = await apiFetch(
+        '/user_roles?name=eq.' +
+        encodeURIComponent(names[i]) +
+        '&select=email,name&limit=1'
+      );
+      if (Array.isArray(rows) && rows[0] && rows[0].email) {
+        results.push({ name: rows[0].name, email: rows[0].email });
+      }
+    }
+    return results;
+  } catch(e) {
+    console.error('_lookupMentionEmails failed:', e);
+    return [];
+  }
+}
+
 window._doSubmitComment = async function(opts) {
   var _roleLower = (opts.role||'').toLowerCase();
   var _normalRole = opts.role.charAt(0).toUpperCase() +
@@ -1610,6 +1644,9 @@ window._doSubmitComment = async function(opts) {
         })
       }).catch(function(){});
     });
+
+    var _mentionContacts = await _lookupMentionEmails(opts.mentioned);
+    window._lastMentionContacts = _mentionContacts;
 
     if (typeof loadPcsComments === 'function') {
       loadPcsComments(opts.postId);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329H">
+ <link rel="stylesheet" href="styles.css?v=20260329I">
 
 </head>
 <body>
@@ -931,8 +931,11 @@
           </div>
           <div id="pcs-notes-list" class="pcs-notes-list"></div>
           <div class="notes-input-zone">
-            <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');if(b){b.classList.toggle('active',!!this.value.trim())}"></textarea>
-            <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all')">NOTE</button>
+            <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');var t=document.getElementById('pcs-task-btn-note');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
+            <div style="display:flex;gap:6px;flex-shrink:0;">
+              <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all',false)">NOTE</button>
+              <button id="pcs-task-btn-note" class="pcs-send-btn pcs-note-btn pcs-task-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all',true)">+ TASK</button>
+            </div>
             <div id="pcs-note-recipient" class="pcs-note-recipient">Entire agency will see this</div>
           </div>
         </div>
@@ -1023,24 +1026,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329H" defer></script>
-<script src="02-session.js?v=20260329H" defer></script>
-<script src="utils.js?v=20260329H" defer></script>
-<script src="03-auth.js?v=20260329H" defer></script>
-<script src="05-api.js?v=20260329H" defer></script>
-<script src="10-ui.js?v=20260329H" defer></script>
+<script src="01-config.js?v=20260329I" defer></script>
+<script src="02-session.js?v=20260329I" defer></script>
+<script src="utils.js?v=20260329I" defer></script>
+<script src="03-auth.js?v=20260329I" defer></script>
+<script src="05-api.js?v=20260329I" defer></script>
+<script src="10-ui.js?v=20260329I" defer></script>
 
-<script src="06-post-create.js?v=20260329H" defer></script>
-<script defer src="render/dashboard.js?v=20260329H"></script>
-<script defer src="render/client.js?v=20260329H"></script>
-<script defer src="render/pipeline.js?v=20260329H"></script>
-<script defer src="render/brief.js?v=20260329H"></script>
-<script defer src="actions/pcs.js?v=20260329H"></script>
-<script src="07-post-load.js?v=20260329H" defer></script>
-<script src="08-post-actions.js?v=20260329H" defer></script>
-<script src="09-library.js?v=20260329H" defer></script>
-<script src="09-approval.js?v=20260329H" defer></script>
-<script src="04-router.js?v=20260329H" defer></script>
+<script src="06-post-create.js?v=20260329I" defer></script>
+<script defer src="render/dashboard.js?v=20260329I"></script>
+<script defer src="render/client.js?v=20260329I"></script>
+<script defer src="render/pipeline.js?v=20260329I"></script>
+<script defer src="render/brief.js?v=20260329I"></script>
+<script defer src="actions/pcs.js?v=20260329I"></script>
+<script src="07-post-load.js?v=20260329I" defer></script>
+<script src="08-post-actions.js?v=20260329I" defer></script>
+<script src="09-library.js?v=20260329I" defer></script>
+<script src="09-approval.js?v=20260329I" defer></script>
+<script src="04-router.js?v=20260329I" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -2999,7 +2999,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   flex-direction: column;
   width: var(--pcs-modal-width);
   max-width: var(--pcs-modal-width);
-  height: 92vh;
   color: var(--text-primary);
   background: var(--surface);
   border: 1px solid var(--border);
@@ -3354,16 +3353,6 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 .pcs-activity-empty { font-size: 12px; color: var(--text-tertiary); padding: var(--pcs-space-1) 0; }
 
 /*  Delete confirm  theme-aware  */
-.pcs-confirm-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 9501;
-  background: rgba(0,0,0,0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--pcs-space-5);
-}
 .pcs-confirm-sheet {
   background: var(--surface);
   border: 1px solid var(--border);
@@ -3427,6 +3416,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   overflow-y: auto;
   scrollbar-width: none;
   min-height: 0;
+  padding-bottom: env(safe-area-inset-bottom, 20px);
 }
 .pc-scroll-body::-webkit-scrollbar { display: none; }
 
@@ -5723,7 +5713,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .client-sublabel {
   font-family: var(--mono);
   font-size: 7px;
-  color: rgba(255,255,255,0.28);
+  color: rgba(255,255,255,0.35);
   letter-spacing: 0.08em;
 }
 .client-input-zone {
@@ -5759,7 +5749,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-family: var(--mono);
   font-size: 9px;
   letter-spacing: 0.15em;
-  color: rgba(255,255,255,0.3);
+  color: rgba(255,255,255,0.55);
   display: flex;
   align-items: center;
   gap: 6px;


### PR DESCRIPTION
## Summary

- **Button tap safe area**: Add `padding-bottom:env(safe-area-inset-bottom,20px)` to `.pc-scroll-body` so buttons aren't clipped by mobile home indicator
- **Remove height:92vh**: Removed from `#pcs-screen` main rule (`.pc-sheet` controls height via `max-height:92vh`)
- **Delete duplicate CSS**: Removed first `.pcs-confirm-overlay` rule at line ~3357 (conflicted with second rule at ~6019)
- **Label opacity**: `.client-sublabel` 0.28->0.35, `.pcs-notes-label` 0.3->0.55
- **Notes + TASK button**: Added `+ TASK` button alongside `NOTE` in internal notes input bar, with oninput toggling active on both
- **Mention email lookup**: `_lookupMentionEmails()` resolves @mention names to emails via `/user_roles`, stored in `window._lastMentionContacts`
- **Read receipts**: On PCS open, PATCH `read:true` on all unread `post_comments` (fire-and-forget, non-blocking)
- Bump all 18 versions to `?v=20260329I`

**Zero changes to `render/client.js` or `preview/index.html`.**

## Test plan

- [x] `node --check actions/pcs.js` passes
- [x] Zero non-ASCII in all files
- [x] `npm test` -- 133/133 pass
- [x] Duplicate `.pcs-confirm-overlay` deleted
- [x] `height:92vh` removed from `#pcs-screen` main rule
- [x] `safe-area-inset-bottom` on `.pc-scroll-body`
- [x] `+ TASK` button in both input bars (4 refs in HTML)
- [x] `_lookupMentionEmails` exists (3 refs)
- [x] Read receipt PATCH exists
- [x] `render/client.js` not modified

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z