### PR TITLE
polish: CTO-approved semantic purple wash on internal notes, elevated client comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329I">
+ <link rel="stylesheet" href="styles.css?v=20260329J">
 
 </head>
 <body>
@@ -1026,24 +1026,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329I" defer></script>
-<script src="02-session.js?v=20260329I" defer></script>
-<script src="utils.js?v=20260329I" defer></script>
-<script src="03-auth.js?v=20260329I" defer></script>
-<script src="05-api.js?v=20260329I" defer></script>
-<script src="10-ui.js?v=20260329I" defer></script>
+<script src="01-config.js?v=20260329J" defer></script>
+<script src="02-session.js?v=20260329J" defer></script>
+<script src="utils.js?v=20260329J" defer></script>
+<script src="03-auth.js?v=20260329J" defer></script>
+<script src="05-api.js?v=20260329J" defer></script>
+<script src="10-ui.js?v=20260329J" defer></script>
 
-<script src="06-post-create.js?v=20260329I" defer></script>
-<script defer src="render/dashboard.js?v=20260329I"></script>
-<script defer src="render/client.js?v=20260329I"></script>
-<script defer src="render/pipeline.js?v=20260329I"></script>
-<script defer src="render/brief.js?v=20260329I"></script>
-<script defer src="actions/pcs.js?v=20260329I"></script>
-<script src="07-post-load.js?v=20260329I" defer></script>
-<script src="08-post-actions.js?v=20260329I" defer></script>
-<script src="09-library.js?v=20260329I" defer></script>
-<script src="09-approval.js?v=20260329I" defer></script>
-<script src="04-router.js?v=20260329I" defer></script>
+<script src="06-post-create.js?v=20260329J" defer></script>
+<script defer src="render/dashboard.js?v=20260329J"></script>
+<script defer src="render/client.js?v=20260329J"></script>
+<script defer src="render/pipeline.js?v=20260329J"></script>
+<script defer src="render/brief.js?v=20260329J"></script>
+<script defer src="actions/pcs.js?v=20260329J"></script>
+<script src="07-post-load.js?v=20260329J" defer></script>
+<script src="08-post-actions.js?v=20260329J" defer></script>
+<script src="09-library.js?v=20260329J" defer></script>
+<script src="09-approval.js?v=20260329J" defer></script>
+<script src="04-router.js?v=20260329J" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5688,8 +5688,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* CLIENT COMMENTS SECTION */
 .client-comments-section {
-  background: #1c1c26;
-  border: 1px solid rgba(255,255,255,0.06);
+  background: #222230;
+  border: 1px solid rgba(255,255,255,0.12);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
   margin-bottom: 3px;
 }
@@ -5719,27 +5719,27 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .client-input-zone {
   border-top: 1px solid rgba(255,255,255,0.05);
   padding: 10px 16px 12px;
-  background: #1c1c26;
+  background: #222230;
   display: flex;
   gap: 8px;
   align-items: flex-end;
 }
 .client-input-zone .pcs-textarea {
-  background: rgba(0,0,0,0.2);
-  border: 1px solid rgba(255,255,255,0.05);
+  background: rgba(0,0,0,0.25);
+  border: 1px solid rgba(255,255,255,0.08);
 }
 
 /* INTERNAL NOTES SECTION */
 .pcs-notes-section {
-  background: #111116;
-  border: 1px solid rgba(255,255,255,0.03);
-  border-top: 1px solid rgba(255,255,255,0.06);
+  background: #181124;
+  border: 1px solid rgba(168,114,255,0.15);
+  border-top: 2px solid rgba(168,114,255,0.2);
   margin-top: 8px;
 }
 .pcs-notes-header {
   padding: 12px 16px 10px;
   border-bottom: 1px solid rgba(255,255,255,0.06);
-  background: transparent;
+  background: rgba(168,114,255,0.04);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -5749,7 +5749,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-family: var(--mono);
   font-size: 9px;
   letter-spacing: 0.15em;
-  color: rgba(255,255,255,0.55);
+  color: rgba(200,170,255,0.7);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -5757,7 +5757,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-lock-icon {
   font-family: var(--mono);
   font-size: 7px;
-  color: rgba(255,255,255,0.18);
+  color: rgba(168,114,255,0.5);
   letter-spacing: 0.08em;
 }
 .pcs-notes-list {
@@ -5770,7 +5770,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .notes-input-zone {
   border-top: 1px solid rgba(255,255,255,0.05);
   padding: 10px 16px 12px;
-  background: #111116;
+  background: #181124;
   display: flex;
   gap: 8px;
   align-items: flex-end;
@@ -5799,7 +5799,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   gap: 10px;
   padding: 10px 16px;
   position: relative;
-  border-bottom: 1px solid rgba(255,255,255,0.03);
+  border-bottom: 1px solid rgba(168,114,255,0.06);
 }
 .pcs-note-item:last-child { border-bottom: none; }
 .pcs-unread-dot {
@@ -5864,8 +5864,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-vis-tag {
   font-family: var(--mono);
   font-size: 7px;
-  color: rgba(255,255,255,0.25);
-  border: 1px dotted rgba(255,255,255,0.12);
+  color: rgba(168,114,255,0.45);
+  border: 1px dotted rgba(168,114,255,0.2);
   padding: 1px 4px;
   margin-left: auto;
   flex-shrink: 0;
@@ -5874,9 +5874,9 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-mention-badge {
   font-family: var(--mono);
   font-size: 7px;
-  color: #9b87f5;
-  background: rgba(155,135,245,0.08);
-  border: 1px solid rgba(155,135,245,0.2);
+  color: #c7a3ff;
+  background: rgba(168,114,255,0.1);
+  border: 1px solid rgba(168,114,255,0.25);
   padding: 1px 4px;
 }
 .pcs-comment-text {
@@ -5926,8 +5926,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .pcs-textarea::placeholder { color: rgba(255,255,255,0.18); }
 .pcs-note-textarea {
-  background: rgba(255,255,255,0.03);
-  border: 1px solid rgba(255,255,255,0.05);
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(168,114,255,0.2);
   caret-color: rgba(255,255,255,0.6);
 }
 .pcs-note-textarea:focus {
@@ -5958,12 +5958,12 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   border-color: rgba(200,168,75,0.4);
 }
 .pcs-note-btn {
-  border-color: rgba(255,255,255,0.1);
-  color: rgba(255,255,255,0.22);
+  border-color: rgba(168,114,255,0.2);
+  color: rgba(168,114,255,0.4);
 }
 .pcs-note-btn.active {
-  color: rgba(255,255,255,0.7);
-  border-color: rgba(255,255,255,0.35);
+  color: #c7a3ff;
+  border-color: rgba(168,114,255,0.45);
 }
 
 /* VIS CHIPS */
@@ -5976,17 +5976,17 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-size: 7px;
   letter-spacing: 0.06em;
   padding: 3px 7px;
-  border: 1px dotted rgba(255,255,255,0.08);
-  color: rgba(255,255,255,0.18);
+  border: 1px dotted rgba(168,114,255,0.15);
+  color: rgba(168,114,255,0.35);
   cursor: pointer;
   user-select: none;
   -webkit-user-select: none;
   transition: all 0.15s;
 }
 .pcs-vis-chip.active {
-  color: rgba(255,255,255,0.65);
-  border-color: rgba(255,255,255,0.25);
-  background: rgba(255,255,255,0.04);
+  background: rgba(168,114,255,0.12);
+  color: #c7a3ff;
+  border-color: rgba(168,114,255,0.35);
 }
 
 /* COUNT BADGES */
@@ -5998,8 +5998,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-family: var(--mono);
 }
 .pcs-notes-count-badge {
-  background: rgba(255,255,255,0.06);
-  color: rgba(255,255,255,0.3);
+  background: rgba(168,114,255,0.1);
+  color: rgba(200,170,255,0.6);
   font-size: 8px;
   padding: 1px 5px;
   font-family: var(--mono);


### PR DESCRIPTION
## Summary

- **Client comments elevated**: `#222230` bg, `0.12` border, textarea `rgba(0,0,0,0.25)` with `0.08` border
- **Internal notes purple wash**: `#181124` bg, `rgba(168,114,255,0.15)` border, `2px 0.2` top border
- **Purple accents throughout notes**: header `0.04`, label `rgba(200,170,255,0.7)`, lock `0.5`, vis-chips `0.15/0.35`, active `#c7a3ff`
- **Note items**: purple `0.06` border-bottom, vis-tag purple, mention badge `#c7a3ff`
- **Note buttons**: purple `0.2/0.4`, active `#c7a3ff/0.45`
- **Task button**: green `#3ECF8E` unchanged (semantic color preserved)
- Zero `!important` added. Bump all 18 versions to `?v=20260329J`

**Zero changes to `render/client.js`, `preview/index.html`, or any JS files.**

## Test plan

- [x] Zero non-ASCII in styles.css
- [x] `npm test` -- 133/133 pass
- [x] `.pcs-notes-section` bg is `#181124`
- [x] `.client-comments-section` bg is `#222230`
- [x] Zero new `!important`
- [x] `render/client.js` not modified

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z