### PR TITLE
style: PCS dual-zone temperature split - client cool, internal warm

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329J">
+ <link rel="stylesheet" href="styles.css?v=20260329K">
 
 </head>
 <body>
@@ -1026,24 +1026,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329J" defer></script>
-<script src="02-session.js?v=20260329J" defer></script>
-<script src="utils.js?v=20260329J" defer></script>
-<script src="03-auth.js?v=20260329J" defer></script>
-<script src="05-api.js?v=20260329J" defer></script>
-<script src="10-ui.js?v=20260329J" defer></script>
+<script src="01-config.js?v=20260329K" defer></script>
+<script src="02-session.js?v=20260329K" defer></script>
+<script src="utils.js?v=20260329K" defer></script>
+<script src="03-auth.js?v=20260329K" defer></script>
+<script src="05-api.js?v=20260329K" defer></script>
+<script src="10-ui.js?v=20260329K" defer></script>
 
-<script src="06-post-create.js?v=20260329J" defer></script>
-<script defer src="render/dashboard.js?v=20260329J"></script>
-<script defer src="render/client.js?v=20260329J"></script>
-<script defer src="render/pipeline.js?v=20260329J"></script>
-<script defer src="render/brief.js?v=20260329J"></script>
-<script defer src="actions/pcs.js?v=20260329J"></script>
-<script src="07-post-load.js?v=20260329J" defer></script>
-<script src="08-post-actions.js?v=20260329J" defer></script>
-<script src="09-library.js?v=20260329J" defer></script>
-<script src="09-approval.js?v=20260329J" defer></script>
-<script src="04-router.js?v=20260329J" defer></script>
+<script src="06-post-create.js?v=20260329K" defer></script>
+<script defer src="render/dashboard.js?v=20260329K"></script>
+<script defer src="render/client.js?v=20260329K"></script>
+<script defer src="render/pipeline.js?v=20260329K"></script>
+<script defer src="render/brief.js?v=20260329K"></script>
+<script defer src="actions/pcs.js?v=20260329K"></script>
+<script src="07-post-load.js?v=20260329K" defer></script>
+<script src="08-post-actions.js?v=20260329K" defer></script>
+<script src="09-library.js?v=20260329K" defer></script>
+<script src="09-approval.js?v=20260329K" defer></script>
+<script src="04-router.js?v=20260329K" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5688,7 +5688,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* CLIENT COMMENTS SECTION */
 .client-comments-section {
-  background: #222230;
+  background: #191924;
   border: 1px solid rgba(255,255,255,0.12);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
   margin-bottom: 3px;
@@ -5719,7 +5719,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .client-input-zone {
   border-top: 1px solid rgba(255,255,255,0.05);
   padding: 10px 16px 12px;
-  background: #222230;
+  background: #191924;
   display: flex;
   gap: 8px;
   align-items: flex-end;
@@ -5731,7 +5731,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* INTERNAL NOTES SECTION */
 .pcs-notes-section {
-  background: #181124;
+  background: #16130A;
   border: 1px solid rgba(168,114,255,0.15);
   border-top: 2px solid rgba(168,114,255,0.2);
   margin-top: 8px;
@@ -5770,7 +5770,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .notes-input-zone {
   border-top: 1px solid rgba(255,255,255,0.05);
   padding: 10px 16px 12px;
-  background: #181124;
+  background: #16130A;
   display: flex;
   gap: 8px;
   align-items: flex-end;


### PR DESCRIPTION
## Summary

- **Client Comments zone**: `#222230` -> `#191924` (cool blue-gray)
- **Internal Notes zone**: `#181124` -> `#16130A` (warm amber-tinted dark)
- 4 hex values changed across 4 CSS rules, nothing else touched
- Bump all 18 asset versions to `?v=20260329K`

## Changed rules

| Rule | Property | Old | New |
|------|----------|-----|-----|
| `.client-comments-section` | background | `#222230` | `#191924` |
| `.client-input-zone` | background | `#222230` | `#191924` |
| `.pcs-notes-section` | background | `#181124` | `#16130A` |
| `.notes-input-zone` | background | `#181124` | `#16130A` |

## Test plan

- [x] Zero non-ASCII in styles.css
- [x] `npm test` -- 133/133 pass
- [x] Zero remaining `#222230` or `#181124` in styles.css
- [x] `render/client.js` and `preview/index.html` not modified

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z