### PR TITLE
fix: SEND button silent failure - try/catch + null guard

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1514,6 +1514,7 @@ window._sharePostOnWhatsApp = function(postId) {
 };
 
 window.submitPcsComment = async function(postId, message, visibility, isTask) {
+  try {
   isTask = isTask || false;
   visibility = visibility || 'all';
 
@@ -1545,6 +1546,12 @@ window.submitPcsComment = async function(postId, message, visibility, isTask) {
       isTask: isTask
     };
     var confirmEl = document.getElementById('pcs-comment-confirm');
+    if (!confirmEl) {
+      await window._doSubmitComment({ postId:_realPostId, message:message,
+        visibility:visibility, mentioned:_mentioned, author:_author,
+        role:_role, title:_title, isTask:isTask });
+      return;
+    }
     var previewEl = document.getElementById('pcs-comment-confirm-preview');
     if (confirmEl && previewEl) {
       previewEl.textContent = '"' + message + '"';
@@ -1563,6 +1570,10 @@ window.submitPcsComment = async function(postId, message, visibility, isTask) {
     title: _title,
     isTask: isTask
   });
+  } catch(e) {
+    console.error('submitPcsComment failed:', e);
+    showToast('Failed to send. Try again.', 'error');
+  }
 };
 
 async function _lookupMentionEmails(names) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329K">
+ <link rel="stylesheet" href="styles.css?v=20260329L">
 
 </head>
 <body>
@@ -912,7 +912,7 @@
           <div class="client-input-zone">
             <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..." oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-client');var t=document.getElementById('pcs-task-btn-client');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
             <div style="display:flex;gap:6px;flex-shrink:0;">
-              <button id="pcs-send-btn-client" class="pcs-send-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all',false)">SEND &#x2192;</button>
+              <button id="pcs-send-btn-client" class="pcs-send-btn" style="min-width:72px" onclick="window.submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all',false)">SEND &#x2192;</button>
               <button id="pcs-task-btn-client" class="pcs-send-btn pcs-task-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all',true)">+ TASK</button>
             </div>
           </div>
@@ -1026,24 +1026,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329K" defer></script>
-<script src="02-session.js?v=20260329K" defer></script>
-<script src="utils.js?v=20260329K" defer></script>
-<script src="03-auth.js?v=20260329K" defer></script>
-<script src="05-api.js?v=20260329K" defer></script>
-<script src="10-ui.js?v=20260329K" defer></script>
+<script src="01-config.js?v=20260329L" defer></script>
+<script src="02-session.js?v=20260329L" defer></script>
+<script src="utils.js?v=20260329L" defer></script>
+<script src="03-auth.js?v=20260329L" defer></script>
+<script src="05-api.js?v=20260329L" defer></script>
+<script src="10-ui.js?v=20260329L" defer></script>
 
-<script src="06-post-create.js?v=20260329K" defer></script>
-<script defer src="render/dashboard.js?v=20260329K"></script>
-<script defer src="render/client.js?v=20260329K"></script>
-<script defer src="render/pipeline.js?v=20260329K"></script>
-<script defer src="render/brief.js?v=20260329K"></script>
-<script defer src="actions/pcs.js?v=20260329K"></script>
-<script src="07-post-load.js?v=20260329K" defer></script>
-<script src="08-post-actions.js?v=20260329K" defer></script>
-<script src="09-library.js?v=20260329K" defer></script>
-<script src="09-approval.js?v=20260329K" defer></script>
-<script src="04-router.js?v=20260329K" defer></script>
+<script src="06-post-create.js?v=20260329L" defer></script>
+<script defer src="render/dashboard.js?v=20260329L"></script>
+<script defer src="render/client.js?v=20260329L"></script>
+<script defer src="render/pipeline.js?v=20260329L"></script>
+<script defer src="render/brief.js?v=20260329L"></script>
+<script defer src="actions/pcs.js?v=20260329L"></script>
+<script src="07-post-load.js?v=20260329L" defer></script>
+<script src="08-post-actions.js?v=20260329L" defer></script>
+<script src="09-library.js?v=20260329L" defer></script>
+<script src="09-approval.js?v=20260329L" defer></script>
+<script src="04-router.js?v=20260329L" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- Wrap entire `submitPcsComment` body in try/catch with `showToast` + `console.error` on failure
- Add null guard: if `#pcs-comment-confirm` element is missing, skip confirmation dialog and send directly via `_doSubmitComment`
- Change SEND button onclick from `submitPcsComment(...)` to `window.submitPcsComment(...)` for explicit global scope
- Bump all 18 asset versions to `?v=20260329L`

## Test plan

- [x] `node --check actions/pcs.js` passes
- [x] Zero non-ASCII
- [x] `npm test` -- 133/133 pass

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z