### PR TITLE
feat: @mention dropup + task assignment + send loading state

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -428,6 +428,10 @@ window._renderPCS = function(postId) {
     var _r = (window.effectiveRole||'').toLowerCase();
     notesSection.style.display = _r === 'client' ? 'none' : 'block';
   }
+
+  if (typeof window._initMentionDropup === 'function') {
+    window._initMentionDropup();
+  }
 }
 
 // -- Subtitle sync (single source of truth) --------------
@@ -1603,6 +1607,11 @@ window._doSubmitComment = async function(opts) {
     opts.role.slice(1).toLowerCase();
 
   try {
+    var _sendBtn = document.getElementById('pcs-send-btn-client');
+    var _noteBtn = document.getElementById('pcs-send-btn-note');
+    if (_sendBtn) { _sendBtn.textContent = 'SENDING...'; _sendBtn.style.opacity = '0.5'; _sendBtn.disabled = true; }
+    if (_noteBtn) { _noteBtn.textContent = 'SAVING...'; _noteBtn.style.opacity = '0.5'; _noteBtn.disabled = true; }
+
     await apiFetch('/post_comments', {
       method: 'POST',
       body: JSON.stringify({
@@ -1678,6 +1687,11 @@ window._doSubmitComment = async function(opts) {
   } catch(e) {
     console.error('_doSubmitComment failed:', e);
     showToast('Failed to send. Try again.', 'error');
+  } finally {
+    var _sendBtn2 = document.getElementById('pcs-send-btn-client');
+    var _noteBtn2 = document.getElementById('pcs-send-btn-note');
+    if (_sendBtn2) { _sendBtn2.textContent = 'SEND \u2192'; _sendBtn2.style.opacity = ''; _sendBtn2.disabled = false; }
+    if (_noteBtn2) { _noteBtn2.textContent = 'NOTE'; _noteBtn2.style.opacity = ''; _noteBtn2.disabled = false; }
   }
 };
 
@@ -1694,5 +1708,124 @@ window.toggleTaskResolve = function(commentId, postId) {
   }).catch(function(e) {
     console.error('toggleTaskResolve failed:', e);
   });
+};
+
+// -- @mention dropup system --
+var _AGENCY_MEMBERS = [
+  { name: 'Shubham', role: 'Admin' },
+  { name: 'Pranav', role: 'Creative' },
+  { name: 'Chitra', role: 'Servicing' }
+];
+
+function _hideMentionDropup() {
+  var dropup = document.getElementById('pcs-mention-dropup');
+  if (dropup) dropup.style.display = 'none';
+}
+
+window._initMentionDropup = function() {
+  var textarea = document.getElementById('pcs-note-input');
+  if (!textarea) return;
+  var dropup = document.getElementById('pcs-mention-dropup');
+  if (!dropup) return;
+
+  var _currentMentionStart = -1;
+
+  textarea.addEventListener('input', function() {
+    var val = textarea.value;
+    var cursor = textarea.selectionStart;
+    var textBeforeCursor = val.slice(0, cursor);
+    var atIndex = textBeforeCursor.lastIndexOf('@');
+
+    if (atIndex === -1) { _hideMentionDropup(); return; }
+
+    var query = textBeforeCursor.slice(atIndex + 1);
+    if (/\s/.test(query)) { _hideMentionDropup(); return; }
+
+    _currentMentionStart = atIndex;
+    var filtered = _AGENCY_MEMBERS.filter(function(m) {
+      return m.name.toLowerCase().startsWith(query.toLowerCase());
+    });
+
+    if (!filtered.length) { _hideMentionDropup(); return; }
+
+    dropup.innerHTML = filtered.map(function(m) {
+      return '<div class="pcs-mention-item" data-name="' + m.name + '">' +
+        '<span class="pcs-mention-name">@' + m.name + '</span>' +
+        '<span class="pcs-mention-role">' + m.role + '</span>' +
+        '</div>';
+    }).join('');
+
+    dropup.style.display = 'block';
+
+    dropup.querySelectorAll('.pcs-mention-item').forEach(function(item) {
+      item.addEventListener('mousedown', function(e) {
+        e.preventDefault();
+        var name = item.getAttribute('data-name');
+        var before = val.slice(0, _currentMentionStart);
+        var after = val.slice(cursor);
+        textarea.value = before + '@' + name + ' ' + after;
+        textarea.dispatchEvent(new Event('input'));
+        _hideMentionDropup();
+        textarea.focus();
+      });
+    });
+  });
+
+  textarea.addEventListener('blur', function() {
+    setTimeout(_hideMentionDropup, 150);
+  });
+};
+
+// -- Task assignment dropup --
+window._showTaskAssign = function(inputId, taskBtnId) {
+  var existing = document.getElementById('pcs-task-assign-dropup');
+  if (existing) { existing.remove(); return; }
+
+  var btn = document.getElementById(taskBtnId);
+  if (!btn) return;
+
+  var dropup = document.createElement('div');
+  dropup.id = 'pcs-task-assign-dropup';
+  dropup.innerHTML = _AGENCY_MEMBERS.map(function(m) {
+    return '<div class="pcs-mention-item" data-name="' + m.name + '">' +
+      '<span class="pcs-mention-name">@' + m.name + '</span>' +
+      '<span class="pcs-mention-role">' + m.role + '</span>' +
+      '</div>';
+  }).join('');
+
+  btn.parentNode.insertBefore(dropup, btn.parentNode.firstChild);
+
+  dropup.querySelectorAll('.pcs-mention-item').forEach(function(item) {
+    item.addEventListener('mousedown', function(e) {
+      e.preventDefault();
+      var name = item.getAttribute('data-name');
+      var input = document.getElementById(inputId);
+      if (input) {
+        input.value = '@' + name + ' ';
+        input.focus();
+        input.dispatchEvent(new Event('input'));
+      }
+      dropup.remove();
+      window.submitPcsTask(inputId, taskBtnId);
+    });
+  });
+
+  setTimeout(function() {
+    document.addEventListener('click', function _dismiss(e) {
+      if (!dropup.contains(e.target) && e.target.id !== taskBtnId) {
+        dropup.remove();
+        document.removeEventListener('click', _dismiss);
+      }
+    });
+  }, 10);
+};
+
+window.submitPcsTask = function(inputId, taskBtnId) {
+  var postIdEl = document.getElementById('pcs-post-id');
+  if (!postIdEl) return;
+  var input = document.getElementById(inputId);
+  var message = input ? input.value.trim() : '';
+  if (!message) return;
+  window.submitPcsComment(postIdEl.value, message, 'all', true);
 };
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329M">
+ <link rel="stylesheet" href="styles.css?v=20260329N">
 
 </head>
 <body>
@@ -930,11 +930,12 @@
             </div>
           </div>
           <div id="pcs-notes-list" class="pcs-notes-list"></div>
+          <div id="pcs-mention-dropup" style="display:none;"></div>
           <div class="notes-input-zone">
             <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');var t=document.getElementById('pcs-task-btn-note');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
             <div style="display:flex;gap:6px;flex-shrink:0;">
               <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all',false)">NOTE</button>
-              <button id="pcs-task-btn-note" class="pcs-send-btn pcs-note-btn pcs-task-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all',true)">+ TASK</button>
+              <button id="pcs-task-btn-note" class="pcs-send-btn pcs-note-btn pcs-task-btn" style="min-width:72px" onclick="window._showTaskAssign('pcs-note-input','pcs-task-btn-note')">+ TASK</button>
             </div>
             <div id="pcs-note-recipient" class="pcs-note-recipient">Entire agency will see this</div>
           </div>
@@ -1026,24 +1027,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329M" defer></script>
-<script src="02-session.js?v=20260329M" defer></script>
-<script src="utils.js?v=20260329M" defer></script>
-<script src="03-auth.js?v=20260329M" defer></script>
-<script src="05-api.js?v=20260329M" defer></script>
-<script src="10-ui.js?v=20260329M" defer></script>
+<script src="01-config.js?v=20260329N" defer></script>
+<script src="02-session.js?v=20260329N" defer></script>
+<script src="utils.js?v=20260329N" defer></script>
+<script src="03-auth.js?v=20260329N" defer></script>
+<script src="05-api.js?v=20260329N" defer></script>
+<script src="10-ui.js?v=20260329N" defer></script>
 
-<script src="06-post-create.js?v=20260329M" defer></script>
-<script defer src="render/dashboard.js?v=20260329M"></script>
-<script defer src="render/client.js?v=20260329M"></script>
-<script defer src="render/pipeline.js?v=20260329M"></script>
-<script defer src="render/brief.js?v=20260329M"></script>
-<script defer src="actions/pcs.js?v=20260329M"></script>
-<script src="07-post-load.js?v=20260329M" defer></script>
-<script src="08-post-actions.js?v=20260329M" defer></script>
-<script src="09-library.js?v=20260329M" defer></script>
-<script src="09-approval.js?v=20260329M" defer></script>
-<script src="04-router.js?v=20260329M" defer></script>
+<script src="06-post-create.js?v=20260329N" defer></script>
+<script defer src="render/dashboard.js?v=20260329N"></script>
+<script defer src="render/client.js?v=20260329N"></script>
+<script defer src="render/pipeline.js?v=20260329N"></script>
+<script defer src="render/brief.js?v=20260329N"></script>
+<script defer src="actions/pcs.js?v=20260329N"></script>
+<script src="07-post-load.js?v=20260329N" defer></script>
+<script src="08-post-actions.js?v=20260329N" defer></script>
+<script src="09-library.js?v=20260329N" defer></script>
+<script src="09-approval.js?v=20260329N" defer></script>
+<script src="04-router.js?v=20260329N" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6124,3 +6124,39 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   border-color: rgba(62,207,142,0.5);
   color: #3ECF8E;
 }
+
+/* MENTION / TASK ASSIGN DROPUPS */
+#pcs-mention-dropup,
+#pcs-task-assign-dropup {
+  background: #1a1a2e;
+  border: 1px solid rgba(155,135,245,0.25);
+  position: relative;
+  z-index: 10;
+  width: 100%;
+  margin-bottom: 4px;
+}
+.pcs-mention-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.pcs-mention-item:last-child { border-bottom: none; }
+.pcs-mention-item:hover,
+.pcs-mention-item:active {
+  background: rgba(155,135,245,0.1);
+}
+.pcs-mention-name {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px;
+  color: #9b87f5;
+}
+.pcs-mention-role {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.28);
+}


### PR DESCRIPTION
## Summary

- **@mention dropup**: Typing `@` in internal notes textarea shows filtered agency member list (Shubham/Admin, Pranav/Creative, Chitra/Servicing). Clicking inserts `@Name` at cursor.
- **Task assignment dropup**: `+ TASK` button in internal notes shows member picker. Selecting a member prefills `@Name` and auto-submits as task comment.
- **Send loading state**: SEND button shows "SENDING..." and NOTE button shows "SAVING..." with `opacity:0.5` + `disabled` during `_doSubmitComment`. Reset in `finally` block.
- **New functions**: `_initMentionDropup()`, `_hideMentionDropup()`, `_showTaskAssign()`, `submitPcsTask()`
- **New HTML**: `#pcs-mention-dropup` div before notes-input-zone
- **New CSS**: Dropup styling with purple accent (`#1a1a2e` bg, `rgba(155,135,245,0.25)` border)
- Client `+ TASK` button unchanged (no assignment needed on client-facing zone)
- Bump all 18 versions to `?v=20260329N`

## Test plan

- [x] `node --check actions/pcs.js` passes
- [x] Zero non-ASCII in all files
- [x] `npm test` -- 133/133 pass
- [ ] Verify typing `@` in note input shows dropup
- [ ] Verify clicking member inserts `@Name` at cursor
- [ ] Verify `+ TASK` in notes shows assignment picker
- [ ] Verify SEND/NOTE buttons show loading state during submit

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z