### PR TITLE
feat: task assigned_to stored in attachments + rendered in thread

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -699,16 +699,17 @@ window.loadPcsComments = async function(postId) {
     function _parseTask(c) {
       try {
         var _att = typeof c.attachments === 'string' ? JSON.parse(c.attachments) : (c.attachments || []);
-        if (_att && _att.type === 'task') return true;
+        if (_att && _att.type === 'task') return _att;
       } catch(e) {}
-      return false;
+      return null;
     }
 
     function _renderClientThread(threadRows, isEmpty) {
       if (!threadRows.length) return isEmpty;
       return threadRows.map(function(c) {
         var _initial = (c.author||'?').charAt(0).toUpperCase();
-        var _isTask = _parseTask(c);
+        var _taskObj = _parseTask(c);
+        var _isTask = !!_taskObj;
         var _taskPrefix = _isTask
           ? '<span class="pcs-task-check' + (c.resolved ? ' pcs-task-done' : '') +
             '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\')">' +
@@ -741,11 +742,17 @@ window.loadPcsComments = async function(postId) {
         var _vis = (c.visibility||'all').toUpperCase();
         if (_vis === 'SERVICING') _vis = 'SERV';
         var _visTag = '<span class="pcs-vis-tag">' + _vis + '</span>';
-        var _isTask = _parseTask(c);
+        var _taskObj = _parseTask(c);
+        var _isTask = !!_taskObj;
+        var _assignedTo = (_taskObj && _taskObj.assigned_to) ? _taskObj.assigned_to : null;
+        var _assignedLabel = _assignedTo
+          ? '<span class="pcs-task-assignee">@' + esc(_assignedTo) + '</span> '
+          : '';
         var _taskPrefix = _isTask
           ? '<span class="pcs-task-check' + (c.resolved ? ' pcs-task-done' : '') +
             '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\')">' +
             (c.resolved ? '&#x2611;' : '&#x2610;') + '</span> '
+            + _assignedLabel
           : '';
 
         return '<div class="pcs-note-item' +
@@ -1624,7 +1631,9 @@ window._doSubmitComment = async function(opts) {
         mentioned_users: opts.mentioned,
         resolved: false,
         resolved_by: null,
-        attachments: opts.isTask ? JSON.stringify({type:'task'}) : '[]'
+        attachments: opts.isTask
+          ? JSON.stringify({type:'task', assigned_to: (opts.mentioned && opts.mentioned[0]) || null})
+          : '[]'
       })
     });
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329N">
+ <link rel="stylesheet" href="styles.css?v=20260329O">
 
 </head>
 <body>
@@ -1027,24 +1027,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329N" defer></script>
-<script src="02-session.js?v=20260329N" defer></script>
-<script src="utils.js?v=20260329N" defer></script>
-<script src="03-auth.js?v=20260329N" defer></script>
-<script src="05-api.js?v=20260329N" defer></script>
-<script src="10-ui.js?v=20260329N" defer></script>
+<script src="01-config.js?v=20260329O" defer></script>
+<script src="02-session.js?v=20260329O" defer></script>
+<script src="utils.js?v=20260329O" defer></script>
+<script src="03-auth.js?v=20260329O" defer></script>
+<script src="05-api.js?v=20260329O" defer></script>
+<script src="10-ui.js?v=20260329O" defer></script>
 
-<script src="06-post-create.js?v=20260329N" defer></script>
-<script defer src="render/dashboard.js?v=20260329N"></script>
-<script defer src="render/client.js?v=20260329N"></script>
-<script defer src="render/pipeline.js?v=20260329N"></script>
-<script defer src="render/brief.js?v=20260329N"></script>
-<script defer src="actions/pcs.js?v=20260329N"></script>
-<script src="07-post-load.js?v=20260329N" defer></script>
-<script src="08-post-actions.js?v=20260329N" defer></script>
-<script src="09-library.js?v=20260329N" defer></script>
-<script src="09-approval.js?v=20260329N" defer></script>
-<script src="04-router.js?v=20260329N" defer></script>
+<script src="06-post-create.js?v=20260329O" defer></script>
+<script defer src="render/dashboard.js?v=20260329O"></script>
+<script defer src="render/client.js?v=20260329O"></script>
+<script defer src="render/pipeline.js?v=20260329O"></script>
+<script defer src="render/brief.js?v=20260329O"></script>
+<script defer src="actions/pcs.js?v=20260329O"></script>
+<script src="07-post-load.js?v=20260329O" defer></script>
+<script src="08-post-actions.js?v=20260329O" defer></script>
+<script src="09-library.js?v=20260329O" defer></script>
+<script src="09-approval.js?v=20260329O" defer></script>
+<script src="04-router.js?v=20260329O" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6124,6 +6124,11 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   border-color: rgba(62,207,142,0.5);
   color: #3ECF8E;
 }
+.pcs-task-assignee {
+  color: #9b87f5;
+  font-weight: 500;
+  margin-right: 4px;
+}
 
 /* MENTION / TASK ASSIGN DROPUPS */
 #pcs-mention-dropup,


### PR DESCRIPTION
## Summary

- **attachments now includes assigned_to**: `{type:'task', assigned_to: 'Pranav'}` stored when task created via + TASK
- **_parseTask returns object**: Returns the full attachments object (or null) instead of boolean, so callers can read `assigned_to`
- **Assignee rendered in thread**: Task comments in notes show `@Pranav` purple label next to checkbox
- **Client thread updated**: `_renderClientThread` also uses new `_parseTask` return type (boolean coerced via `!!`)
- **CSS**: Added `.pcs-task-assignee` with purple `#9b87f5` color
- Bump all 18 versions to `?v=20260329O`

## Test plan

- [x] `node --check actions/pcs.js` passes
- [x] Zero non-ASCII in all files
- [x] `npm test` -- 133/133 pass
- [ ] Verify task created via + TASK stores assigned_to in attachments
- [ ] Verify @Name renders purple next to checkbox in note thread

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z