### PR TITLE
style: replace opacity text colors with solid grays for OLED legibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329O">
+ <link rel="stylesheet" href="styles.css?v=20260329P">
 
 </head>
 <body>
@@ -1027,24 +1027,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329O" defer></script>
-<script src="02-session.js?v=20260329O" defer></script>
-<script src="utils.js?v=20260329O" defer></script>
-<script src="03-auth.js?v=20260329O" defer></script>
-<script src="05-api.js?v=20260329O" defer></script>
-<script src="10-ui.js?v=20260329O" defer></script>
+<script src="01-config.js?v=20260329P" defer></script>
+<script src="02-session.js?v=20260329P" defer></script>
+<script src="utils.js?v=20260329P" defer></script>
+<script src="03-auth.js?v=20260329P" defer></script>
+<script src="05-api.js?v=20260329P" defer></script>
+<script src="10-ui.js?v=20260329P" defer></script>
 
-<script src="06-post-create.js?v=20260329O" defer></script>
-<script defer src="render/dashboard.js?v=20260329O"></script>
-<script defer src="render/client.js?v=20260329O"></script>
-<script defer src="render/pipeline.js?v=20260329O"></script>
-<script defer src="render/brief.js?v=20260329O"></script>
-<script defer src="actions/pcs.js?v=20260329O"></script>
-<script src="07-post-load.js?v=20260329O" defer></script>
-<script src="08-post-actions.js?v=20260329O" defer></script>
-<script src="09-library.js?v=20260329O" defer></script>
-<script src="09-approval.js?v=20260329O" defer></script>
-<script src="04-router.js?v=20260329O" defer></script>
+<script src="06-post-create.js?v=20260329P" defer></script>
+<script defer src="render/dashboard.js?v=20260329P"></script>
+<script defer src="render/client.js?v=20260329P"></script>
+<script defer src="render/pipeline.js?v=20260329P"></script>
+<script defer src="render/brief.js?v=20260329P"></script>
+<script defer src="actions/pcs.js?v=20260329P"></script>
+<script src="07-post-load.js?v=20260329P" defer></script>
+<script src="08-post-actions.js?v=20260329P" defer></script>
+<script src="09-library.js?v=20260329P" defer></script>
+<script src="09-approval.js?v=20260329P" defer></script>
+<script src="04-router.js?v=20260329P" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5705,7 +5705,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-family: var(--mono);
   font-size: 9px;
   letter-spacing: 0.15em;
-  color: rgba(255,255,255,0.55);
+  color: #AEAEB2;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -5713,7 +5713,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .client-sublabel {
   font-family: var(--mono);
   font-size: 7px;
-  color: rgba(255,255,255,0.35);
+  color: #8E8E93;
   letter-spacing: 0.08em;
 }
 .client-input-zone {
@@ -5765,7 +5765,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   background: transparent;
 }
 .pcs-notes-section .pcs-comment-text {
-  color: rgba(255,255,255,0.7);
+  color: #E8E8E8;
 }
 .notes-input-zone {
   border-top: 1px solid rgba(255,255,255,0.05);
@@ -5780,7 +5780,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   width: 100%;
   font-family: var(--mono);
   font-size: 8px;
-  color: rgba(255,255,255,0.25);
+  color: #8E8E93;
   letter-spacing: 0.04em;
   margin-top: -4px;
 }
@@ -5854,12 +5854,12 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-comment-author {
   font-size: 11px;
   font-weight: 600;
-  color: rgba(255,255,255,0.75);
+  color: #E8E8E8;
 }
 .pcs-comment-time {
   font-family: var(--mono);
   font-size: 7px;
-  color: rgba(255,255,255,0.2);
+  color: #AEAEB2;
 }
 .pcs-vis-tag {
   font-family: var(--mono);
@@ -5881,7 +5881,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .pcs-comment-text {
   font-size: 13px;
-  color: rgba(255,255,255,0.6);
+  color: #E8E8E8;
   line-height: 1.5;
   white-space: pre-wrap;
   word-break: break-word;
@@ -5898,7 +5898,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-empty-text {
   font-family: var(--mono);
   font-size: 8px;
-  color: rgba(255,255,255,0.2);
+  color: #8E8E93;
   letter-spacing: 0.08em;
   line-height: 1.7;
 }
@@ -5908,7 +5908,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   flex: 1;
   background: rgba(255,255,255,0.03);
   border: 1px solid rgba(255,255,255,0.07);
-  color: rgba(255,255,255,0.8);
+  color: #E8E8E8;
   font-family: var(--sans);
   font-size: 13px;
   padding: 8px 10px;
@@ -5924,7 +5924,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   border-color: rgba(200,168,75,0.35);
   background: rgba(255,255,255,0.05);
 }
-.pcs-textarea::placeholder { color: rgba(255,255,255,0.18); }
+.pcs-textarea::placeholder { color: #8E8E93; }
 .pcs-note-textarea {
   background: rgba(255,255,255,0.04);
   border: 1px solid rgba(168,114,255,0.2);
@@ -5935,7 +5935,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   background: rgba(255,255,255,0.05);
 }
 .pcs-note-textarea::placeholder {
-  color: rgba(255,255,255,0.15);
+  color: #8E8E93;
 }
 
 /* SEND BUTTONS */
@@ -5992,7 +5992,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 /* COUNT BADGES */
 .pcs-count-badge {
   background: rgba(255,255,255,0.06);
-  color: rgba(255,255,255,0.3);
+  color: #AEAEB2;
   font-size: 8px;
   padding: 1px 5px;
   font-family: var(--mono);
@@ -6026,13 +6026,13 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-confirm-title {
   font-family: var(--mono);
   font-size: 9px;
-  color: rgba(255,255,255,0.35);
+  color: #AEAEB2;
   letter-spacing: 0.15em;
   margin-bottom: 14px;
 }
 .pcs-confirm-preview {
   font-size: 13px;
-  color: rgba(255,255,255,0.4);
+  color: #E8E8E8;
   font-style: italic;
   line-height: 1.5;
   padding: 10px 12px;
@@ -6043,7 +6043,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-confirm-warn1 {
   font-family: var(--mono);
   font-size: 9px;
-  color: rgba(255,255,255,0.4);
+  color: #AEAEB2;
   letter-spacing: 0.08em;
   margin-bottom: 4px;
 }
@@ -6062,7 +6062,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-confirm-cancel {
   font-family: var(--mono);
   font-size: 9px;
-  color: rgba(255,255,255,0.25);
+  color: #8E8E93;
   border: 1px dotted rgba(255,255,255,0.1);
   background: none;
   padding: 12px;
@@ -6088,7 +6088,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-resolved-summary {
   font-family: var(--mono);
   font-size: 8px;
-  color: rgba(255,255,255,0.2);
+  color: #8E8E93;
   letter-spacing: 0.06em;
   cursor: pointer;
   padding: 4px 0;
@@ -6100,7 +6100,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   cursor: pointer;
   font-size: 14px;
   margin-right: 4px;
-  color: rgba(255,255,255,0.4);
+  color: #AEAEB2;
   user-select: none;
   -webkit-user-select: none;
 }
@@ -6163,5 +6163,5 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-size: 10px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.28);
+  color: #8E8E93;
 }


### PR DESCRIPTION
## Summary

Replace 19 `rgba(255,255,255,0.*)` text colors in PCS comment section with solid hex grays for OLED legibility:

| Tier | Hex | Used for |
|------|-----|----------|
| Primary | `#E8E8E8` | Comment text, author names, textarea input, confirm preview, notes text |
| Secondary | `#AEAEB2` | Labels, timestamps, count badges, confirm title/warn, task checks |
| Tertiary | `#8E8E93` | Sublabels, placeholders, empty states, resolved summaries, cancel button, mention roles, recipient hint |

19 color values changed. No borders, backgrounds, layout, fonts, or buttons modified.

## Test plan

- [x] Zero non-ASCII
- [x] `npm test` -- 133/133 pass

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z