### PR TITLE
style: internal notes bg matches client comments #191924

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329Q">
+ <link rel="stylesheet" href="styles.css?v=20260329R">
 
 </head>
 <body>
@@ -1027,24 +1027,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329Q" defer></script>
-<script src="02-session.js?v=20260329Q" defer></script>
-<script src="utils.js?v=20260329Q" defer></script>
-<script src="03-auth.js?v=20260329Q" defer></script>
-<script src="05-api.js?v=20260329Q" defer></script>
-<script src="10-ui.js?v=20260329Q" defer></script>
+<script src="01-config.js?v=20260329R" defer></script>
+<script src="02-session.js?v=20260329R" defer></script>
+<script src="utils.js?v=20260329R" defer></script>
+<script src="03-auth.js?v=20260329R" defer></script>
+<script src="05-api.js?v=20260329R" defer></script>
+<script src="10-ui.js?v=20260329R" defer></script>
 
-<script src="06-post-create.js?v=20260329Q" defer></script>
-<script defer src="render/dashboard.js?v=20260329Q"></script>
-<script defer src="render/client.js?v=20260329Q"></script>
-<script defer src="render/pipeline.js?v=20260329Q"></script>
-<script defer src="render/brief.js?v=20260329Q"></script>
-<script defer src="actions/pcs.js?v=20260329Q"></script>
-<script src="07-post-load.js?v=20260329Q" defer></script>
-<script src="08-post-actions.js?v=20260329Q" defer></script>
-<script src="09-library.js?v=20260329Q" defer></script>
-<script src="09-approval.js?v=20260329Q" defer></script>
-<script src="04-router.js?v=20260329Q" defer></script>
+<script src="06-post-create.js?v=20260329R" defer></script>
+<script defer src="render/dashboard.js?v=20260329R"></script>
+<script defer src="render/client.js?v=20260329R"></script>
+<script defer src="render/pipeline.js?v=20260329R"></script>
+<script defer src="render/brief.js?v=20260329R"></script>
+<script defer src="actions/pcs.js?v=20260329R"></script>
+<script src="07-post-load.js?v=20260329R" defer></script>
+<script src="08-post-actions.js?v=20260329R" defer></script>
+<script src="09-library.js?v=20260329R" defer></script>
+<script src="09-approval.js?v=20260329R" defer></script>
+<script src="04-router.js?v=20260329R" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5735,7 +5735,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* INTERNAL NOTES SECTION */
 .pcs-notes-section {
-  background: #16130A;
+  background: #191924;
   border: 1px solid rgba(168,114,255,0.15);
   border-top: 2px solid rgba(168,114,255,0.2);
   margin-top: 8px;
@@ -5774,7 +5774,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .notes-input-zone {
   border-top: 1px solid rgba(255,255,255,0.05);
   padding: 10px 16px 12px;
-  background: #16130A;
+  background: #191924;
   display: flex;
   gap: 8px;
   align-items: flex-end;


### PR DESCRIPTION
## Summary

- `.pcs-notes-section` background: `#16130A` -> `#191924`
- `.notes-input-zone` background: `#16130A` -> `#191924`
- Both zones now share the same `#191924` base background
- Bump all 18 versions to `?v=20260329R`

2 values changed. Nothing else.

## Test plan

- [x] `npm test` -- 133/133 pass
- [x] Zero `#16130A` remaining in styles.css

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z