### PR TITLE
fix: task dropup positioning + shorten note placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329R">
+ <link rel="stylesheet" href="styles.css?v=20260329S">
 
 </head>
 <body>
@@ -932,7 +932,7 @@
           <div id="pcs-notes-list" class="pcs-notes-list"></div>
           <div id="pcs-mention-dropup" style="display:none;"></div>
           <div class="notes-input-zone">
-            <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add internal note... @mention to notify" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');var t=document.getElementById('pcs-task-btn-note');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
+            <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add note... @mention" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');var t=document.getElementById('pcs-task-btn-note');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
             <div style="display:flex;gap:6px;flex-shrink:0;">
               <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all',false)">NOTE</button>
               <button id="pcs-task-btn-note" class="pcs-send-btn pcs-note-btn pcs-task-btn" style="min-width:72px" onclick="window._showTaskAssign('pcs-note-input','pcs-task-btn-note')">+ TASK</button>
@@ -1027,24 +1027,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329R" defer></script>
-<script src="02-session.js?v=20260329R" defer></script>
-<script src="utils.js?v=20260329R" defer></script>
-<script src="03-auth.js?v=20260329R" defer></script>
-<script src="05-api.js?v=20260329R" defer></script>
-<script src="10-ui.js?v=20260329R" defer></script>
+<script src="01-config.js?v=20260329S" defer></script>
+<script src="02-session.js?v=20260329S" defer></script>
+<script src="utils.js?v=20260329S" defer></script>
+<script src="03-auth.js?v=20260329S" defer></script>
+<script src="05-api.js?v=20260329S" defer></script>
+<script src="10-ui.js?v=20260329S" defer></script>
 
-<script src="06-post-create.js?v=20260329R" defer></script>
-<script defer src="render/dashboard.js?v=20260329R"></script>
-<script defer src="render/client.js?v=20260329R"></script>
-<script defer src="render/pipeline.js?v=20260329R"></script>
-<script defer src="render/brief.js?v=20260329R"></script>
-<script defer src="actions/pcs.js?v=20260329R"></script>
-<script src="07-post-load.js?v=20260329R" defer></script>
-<script src="08-post-actions.js?v=20260329R" defer></script>
-<script src="09-library.js?v=20260329R" defer></script>
-<script src="09-approval.js?v=20260329R" defer></script>
-<script src="04-router.js?v=20260329R" defer></script>
+<script src="06-post-create.js?v=20260329S" defer></script>
+<script defer src="render/dashboard.js?v=20260329S"></script>
+<script defer src="render/client.js?v=20260329S"></script>
+<script defer src="render/pipeline.js?v=20260329S"></script>
+<script defer src="render/brief.js?v=20260329S"></script>
+<script defer src="actions/pcs.js?v=20260329S"></script>
+<script src="07-post-load.js?v=20260329S" defer></script>
+<script src="08-post-actions.js?v=20260329S" defer></script>
+<script src="09-library.js?v=20260329S" defer></script>
+<script src="09-approval.js?v=20260329S" defer></script>
+<script src="04-router.js?v=20260329S" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5772,6 +5772,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   color: #E8E8E8;
 }
 .notes-input-zone {
+  position: relative;
   border-top: 1px solid rgba(255,255,255,0.05);
   padding: 10px 16px 12px;
   background: #191924;
@@ -6135,13 +6136,22 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 /* MENTION / TASK ASSIGN DROPUPS */
-#pcs-mention-dropup,
-#pcs-task-assign-dropup {
+#pcs-mention-dropup {
   background: #1a1a2e;
   border: 1px solid rgba(155,135,245,0.25);
   position: relative;
   z-index: 10;
   width: 100%;
+  margin-bottom: 4px;
+}
+#pcs-task-assign-dropup {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  width: 100%;
+  z-index: 100;
+  background: #1a1a2e;
+  border: 1px solid rgba(155,135,245,0.25);
   margin-bottom: 4px;
 }
 .pcs-mention-item {


### PR DESCRIPTION
## Summary

- `#pcs-task-assign-dropup`: Split from shared rule, now `position:absolute; bottom:100%; z-index:100` so it pops up above the input zone
- `.notes-input-zone`: Added `position:relative` as positioning context for the dropup
- Note textarea placeholder shortened: `"Add note... @mention"`
- Bump all 18 versions to `?v=20260329S`

## Test plan

- [x] Zero non-ASCII
- [x] `npm test` -- 133/133 pass

https://claude.ai/code/session_01UZp8dG486G52QMPqH2nt4Z