### PR TITLE
feat: image attachments in comment threads

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -15,6 +15,8 @@ window._pcsCloseTimer = null;
 window._pcsEditingTarget = null;
 window._pcsLbImages = [];
 window._pcsLbIdx = 0;
+window._pcsClientImgs = [];
+window._pcsNoteImgs = [];
 window._modalOpen = window._modalOpen || false;
 
 window.openPCS = function(postId, listKey) {
@@ -715,6 +717,24 @@ window.loadPcsComments = async function(postId) {
             '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\')">' +
             (c.resolved ? '&#x2611;' : '&#x2610;') + '</span> '
           : '';
+        var _att = (function() {
+          try {
+            return typeof c.attachments === 'string'
+              ? JSON.parse(c.attachments)
+              : c.attachments;
+          } catch(e) { return null; }
+        })();
+        var _imgHtml = '';
+        if (_att && _att.type === 'images' && _att.urls) {
+          _imgHtml = '<div class="pcs-comment-imgs">' +
+            _att.urls.map(function(u) {
+              return '<img src="' + esc(u) + '" class="pcs-comment-img-thumb" ' +
+                'onclick="window._pcsOpenLightbox(\'' + esc(postId) + '\',[' +
+                _att.urls.map(function(x){ return '\'' + esc(x) + '\''; }).join(',') +
+                '],' + _att.urls.indexOf(u) + ')">';
+            }).join('') +
+          '</div>';
+        }
         return '<div class="pcs-comment-item">' +
           (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
           '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>' +
@@ -726,6 +746,7 @@ window.loadPcsComments = async function(postId) {
             '<div class="pcs-comment-text' + (_isTask ? ' pcs-task-text' : '') +
             ((_isTask && c.resolved) ? ' pcs-task-done' : '') + '">' +
             _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
+            _imgHtml +
           '</div>' +
         '</div>';
       }).join('');
@@ -755,6 +776,24 @@ window.loadPcsComments = async function(postId) {
             + _assignedLabel
           : '';
 
+        var _att = (function() {
+          try {
+            return typeof c.attachments === 'string'
+              ? JSON.parse(c.attachments)
+              : c.attachments;
+          } catch(e) { return null; }
+        })();
+        var _imgHtml = '';
+        if (_att && _att.type === 'images' && _att.urls) {
+          _imgHtml = '<div class="pcs-comment-imgs">' +
+            _att.urls.map(function(u) {
+              return '<img src="' + esc(u) + '" class="pcs-comment-img-thumb" ' +
+                'onclick="window._pcsOpenLightbox(\'' + esc(postId) + '\',[' +
+                _att.urls.map(function(x){ return '\'' + esc(x) + '\''; }).join(',') +
+                '],' + _att.urls.indexOf(u) + ')">';
+            }).join('') +
+          '</div>';
+        }
         return '<div class="pcs-note-item' +
           (c.resolved ? ' pcs-resolved' : '') + '">' +
           (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
@@ -769,6 +808,7 @@ window.loadPcsComments = async function(postId) {
             '<div class="pcs-comment-text' + (_isTask ? ' pcs-task-text' : '') +
             ((_isTask && c.resolved) ? ' pcs-task-done' : '') + '">' +
             _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
+            _imgHtml +
           '</div>' +
         '</div>';
       }).join('');
@@ -1545,6 +1585,15 @@ window.submitPcsComment = async function(postId, message, visibility, isTask) {
     return m.slice(1);
   });
 
+  var _imgs = (visibility === 'all' && !isTask)
+    ? window._pcsClientImgs.slice()
+    : window._pcsNoteImgs.slice();
+
+  window._pcsClientImgs = [];
+  window._pcsNoteImgs = [];
+  _pcsRenderImgPreviews('client');
+  _pcsRenderImgPreviews('note');
+
   if (visibility === 'all' && _roleLower !== 'client') {
     window._pendingComment = {
       postId: _realPostId,
@@ -1554,13 +1603,14 @@ window.submitPcsComment = async function(postId, message, visibility, isTask) {
       author: _author,
       role: _role,
       title: _title,
-      isTask: isTask
+      isTask: isTask,
+      images: _imgs
     };
     var confirmEl = document.getElementById('pcs-comment-confirm');
     if (!confirmEl) {
       await window._doSubmitComment({ postId:_realPostId, message:message,
         visibility:visibility, mentioned:_mentioned, author:_author,
-        role:_role, title:_title, isTask:isTask });
+        role:_role, title:_title, isTask:isTask, images:_imgs });
       return;
     }
     var previewEl = document.getElementById('pcs-comment-confirm-preview');
@@ -1579,7 +1629,8 @@ window.submitPcsComment = async function(postId, message, visibility, isTask) {
     author: _author,
     role: _role,
     title: _title,
-    isTask: isTask
+    isTask: isTask,
+    images: _imgs
   });
   } catch(e) {
     console.error('submitPcsComment failed:', e);
@@ -1633,7 +1684,9 @@ window._doSubmitComment = async function(opts) {
         resolved_by: null,
         attachments: opts.isTask
           ? JSON.stringify({type:'task', assigned_to: (opts.mentioned && opts.mentioned[0]) || null})
-          : '[]'
+          : (opts.images && opts.images.length
+              ? JSON.stringify({type:'images', urls: opts.images})
+              : '[]')
       })
     });
 
@@ -1836,5 +1889,70 @@ window.submitPcsTask = function(inputId, taskBtnId) {
   var message = input ? input.value.trim() : '';
   if (!message) return;
   window.submitPcsComment(postIdEl.value, message, 'all', true);
+};
+
+window._pcsHandleCommentImg = async function(zone) {
+  var inputId = zone === 'client'
+    ? 'pcs-client-img-input'
+    : 'pcs-note-img-input';
+  var input = document.getElementById(inputId);
+  if (!input || !input.files || !input.files[0]) return;
+  var file = input.files[0];
+  input.value = '';
+
+  var postIdEl = document.getElementById('pcs-post-id');
+  var postId = postIdEl ? postIdEl.value : 'comment';
+
+  try {
+    var btn = document.querySelector(
+      zone === 'client'
+        ? '#pcs-client-img-input + .pcs-img-btn'
+        : '#pcs-note-img-input + .pcs-img-btn'
+    );
+    if (btn) { btn.textContent = '...'; btn.disabled = true; }
+
+    var url = await uploadPostAsset(file, postId + '-comment');
+
+    if (zone === 'client') {
+      window._pcsClientImgs.push(url);
+    } else {
+      window._pcsNoteImgs.push(url);
+    }
+
+    if (btn) { btn.textContent = '\uD83D\uDCF7'; btn.disabled = false; }
+
+    _pcsRenderImgPreviews(zone);
+
+  } catch(e) {
+    console.error('Comment img upload failed:', e);
+    showToast('Image upload failed. Try again.', 'error');
+  }
+};
+
+window._pcsRenderImgPreviews = function(zone) {
+  var imgs = zone === 'client'
+    ? window._pcsClientImgs
+    : window._pcsNoteImgs;
+  var containerId = zone === 'client'
+    ? 'pcs-client-img-previews'
+    : 'pcs-note-img-previews';
+  var el = document.getElementById(containerId);
+  if (!el) return;
+  el.innerHTML = imgs.map(function(url, i) {
+    return '<div class="pcs-img-preview-wrap">' +
+      '<img src="' + esc(url) + '" class="pcs-img-preview">' +
+      '<span class="pcs-img-remove" onclick="window._pcsRemoveCommentImg(\'' +
+        zone + '\',' + i + ')">x</span>' +
+      '</div>';
+  }).join('');
+};
+
+window._pcsRemoveCommentImg = function(zone, idx) {
+  if (zone === 'client') {
+    window._pcsClientImgs.splice(idx, 1);
+  } else {
+    window._pcsNoteImgs.splice(idx, 1);
+  }
+  _pcsRenderImgPreviews(zone);
 };
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329S">
+ <link rel="stylesheet" href="styles.css?v=20260329T">
 
 </head>
 <body>
@@ -909,8 +909,11 @@
             <div class="client-sublabel">CLIENT + AGENCY</div>
           </div>
           <div id="pcs-comments-list" class="pcs-thread-list" style="min-height:60px;"></div>
+          <div id="pcs-client-img-previews" class="pcs-img-previews"></div>
           <div class="client-input-zone">
             <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..." oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-client');var t=document.getElementById('pcs-task-btn-client');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
+            <input type="file" id="pcs-client-img-input" accept="image/*" style="display:none" onchange="window._pcsHandleCommentImg('client')">
+            <button class="pcs-img-btn" onclick="document.getElementById('pcs-client-img-input').click()">&#128247;</button>
             <div style="display:flex;gap:6px;flex-shrink:0;">
               <button id="pcs-send-btn-client" class="pcs-send-btn" style="min-width:72px" onclick="window.submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all',false)">SEND &#x2192;</button>
               <button id="pcs-task-btn-client" class="pcs-send-btn pcs-task-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all',true)">+ TASK</button>
@@ -931,8 +934,11 @@
           </div>
           <div id="pcs-notes-list" class="pcs-notes-list"></div>
           <div id="pcs-mention-dropup" style="display:none;"></div>
+          <div id="pcs-note-img-previews" class="pcs-img-previews"></div>
           <div class="notes-input-zone">
             <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add note... @mention" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');var t=document.getElementById('pcs-task-btn-note');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
+            <input type="file" id="pcs-note-img-input" accept="image/*" style="display:none" onchange="window._pcsHandleCommentImg('note')">
+            <button class="pcs-img-btn" onclick="document.getElementById('pcs-note-img-input').click()">&#128247;</button>
             <div style="display:flex;gap:6px;flex-shrink:0;">
               <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all',false)">NOTE</button>
               <button id="pcs-task-btn-note" class="pcs-send-btn pcs-note-btn pcs-task-btn" style="min-width:72px" onclick="window._showTaskAssign('pcs-note-input','pcs-task-btn-note')">+ TASK</button>
@@ -1027,24 +1033,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329S" defer></script>
-<script src="02-session.js?v=20260329S" defer></script>
-<script src="utils.js?v=20260329S" defer></script>
-<script src="03-auth.js?v=20260329S" defer></script>
-<script src="05-api.js?v=20260329S" defer></script>
-<script src="10-ui.js?v=20260329S" defer></script>
+<script src="01-config.js?v=20260329T" defer></script>
+<script src="02-session.js?v=20260329T" defer></script>
+<script src="utils.js?v=20260329T" defer></script>
+<script src="03-auth.js?v=20260329T" defer></script>
+<script src="05-api.js?v=20260329T" defer></script>
+<script src="10-ui.js?v=20260329T" defer></script>
 
-<script src="06-post-create.js?v=20260329S" defer></script>
-<script defer src="render/dashboard.js?v=20260329S"></script>
-<script defer src="render/client.js?v=20260329S"></script>
-<script defer src="render/pipeline.js?v=20260329S"></script>
-<script defer src="render/brief.js?v=20260329S"></script>
-<script defer src="actions/pcs.js?v=20260329S"></script>
-<script src="07-post-load.js?v=20260329S" defer></script>
-<script src="08-post-actions.js?v=20260329S" defer></script>
-<script src="09-library.js?v=20260329S" defer></script>
-<script src="09-approval.js?v=20260329S" defer></script>
-<script src="04-router.js?v=20260329S" defer></script>
+<script src="06-post-create.js?v=20260329T" defer></script>
+<script defer src="render/dashboard.js?v=20260329T"></script>
+<script defer src="render/client.js?v=20260329T"></script>
+<script defer src="render/pipeline.js?v=20260329T"></script>
+<script defer src="render/brief.js?v=20260329T"></script>
+<script defer src="actions/pcs.js?v=20260329T"></script>
+<script src="07-post-load.js?v=20260329T" defer></script>
+<script src="08-post-actions.js?v=20260329T" defer></script>
+<script src="09-library.js?v=20260329T" defer></script>
+<script src="09-approval.js?v=20260329T" defer></script>
+<script src="04-router.js?v=20260329T" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6179,3 +6179,64 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   text-transform: uppercase;
   color: #8E8E93;
 }
+
+.pcs-img-btn {
+  border: 1px dotted rgba(255,255,255,0.18);
+  padding: 7px 8px;
+  font-size: 13px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(255,255,255,0.5);
+  flex-shrink: 0;
+}
+
+.pcs-img-previews {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 14px 6px;
+}
+
+.pcs-img-preview-wrap {
+  position: relative;
+  width: 56px;
+  height: 56px;
+}
+
+.pcs-img-preview {
+  width: 56px;
+  height: 56px;
+  object-fit: cover;
+  border: 1px solid rgba(255,255,255,0.12);
+}
+
+.pcs-img-remove {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #FF4B4B;
+  color: white;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 8px;
+  cursor: pointer;
+}
+
+.pcs-comment-imgs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.pcs-comment-img-thumb {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border: 1px solid rgba(255,255,255,0.12);
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Added image attachment support (upload via R2) to both Client Comments and Internal Notes input zones in the PCS modal
- Paperclip button triggers file picker; uploaded images show as removable thumbnails before send
- Stored images render as clickable thumbnails in comment threads with lightbox support
- Version bump `?v=20260329S` → `?v=20260329T` across all 18 asset references

## Files changed
- `index.html` — file inputs, paperclip buttons, preview containers, version bump
- `actions/pcs.js` — `_pcsHandleCommentImg`, `_pcsRenderImgPreviews`, `_pcsRemoveCommentImg`, modified `_doSubmitComment`/`submitPcsComment`/`_renderClientThread`/`_renderNoteThread`
- `styles.css` — 7 new classes for image UI

## Test plan
- [x] 133 Vitest tests pass
- [x] Zero non-ASCII characters in modified files
- [ ] Manual: open PCS, attach image in client comment, verify upload + preview + send
- [ ] Manual: open PCS, attach image in internal note, verify upload + preview + send
- [ ] Manual: verify image thumbnails render in saved comment threads

https://claude.ai/code/session_017QEVFyqD2evb8ZFxw4nvFS