### PR TITLE
feat: three-dot menus, paperclip icon, client feed image attach

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -195,11 +195,10 @@ window._renderPCS = function(postId) {
       'Photos <span style="color:' + (imgs.length ? '#777' : '#333') + ';">' +
       imgs.length + '</span></div>' +
       ((canEdit || canEditCreative) ?
-        '<button onclick="_pcsAddPhotos(\'' + esc(id) + '\')" ' +
-        'style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
-        'letter-spacing:0.1em;text-transform:uppercase;color:#F6A623;' +
-        'background:transparent;border:1px solid rgba(246,166,35,0.3);' +
-        'padding:4px 10px;cursor:pointer;">+ Add More</button>'
+        '<button onclick="window._pcsPhotoMenu(\'' + esc(id) + '\')" ' +
+        'style="font-family:\'IBM Plex Mono\',monospace;font-size:11px;' +
+        'color:#F6A623;background:transparent;border:1px dotted ' +
+        'rgba(246,166,35,0.3);padding:4px 10px;cursor:pointer;">...</button>'
         : '') +
       '</div>' +
       (imgs.length > 0 ?
@@ -325,11 +324,11 @@ window._renderPCS = function(postId) {
       'justify-content:space-between;">' +
       '<span>Copy / Caption</span>' +
       ((canEdit || canEditCreative) ?
-        '<button onclick="_startCaptionEdit(\'' + esc(id) + '\')" ' +
+        '<button onclick="window._pcsCaptionMenu(\'' + esc(id) + '\')" ' +
         'id="pcs-caption-edit-btn" ' +
-        'style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
-        'letter-spacing:0.1em;text-transform:uppercase;color:#F6A623;' +
-        'background:transparent;border:none;cursor:pointer;">Edit</button>'
+        'style="font-family:\'IBM Plex Mono\',monospace;font-size:11px;' +
+        'color:#F6A623;background:transparent;border:1px dotted ' +
+        'rgba(246,166,35,0.3);padding:4px 10px;cursor:pointer;">...</button>'
         : '') +
       '</div>' +
       (post.caption ?
@@ -1337,6 +1336,208 @@ window._pcsRemovePhoto = async function(postId, idx) {
   }
 }
 
+window._pcsPhotoMenu = function(postId) {
+  var existing = document.getElementById('pcs-photo-menu-drop');
+  if (existing) { existing.remove(); return; }
+  var btn = document.querySelector(
+    '[onclick*="_pcsPhotoMenu"]'
+  );
+  if (!btn) return;
+  var menu = document.createElement('div');
+  menu.id = 'pcs-photo-menu-drop';
+  menu.style.cssText = 'position:absolute;right:18px;' +
+    'background:#1a1a26;border:1px solid rgba(255,255,255,0.12);' +
+    'z-index:200;min-width:140px;';
+  var post = (window.allPosts||[]).find(function(p) {
+    return p.post_id === postId;
+  });
+  var imgs = (post && post.images) ? post.images : [];
+  menu.innerHTML =
+    '<div class="pcs-menu-item" onclick="window._pcsAddPhotos(\'' +
+      postId + '\');document.getElementById(\'pcs-photo-menu-drop\').remove();">' +
+      '+ Add More</div>' +
+    '<div class="pcs-menu-item" onclick="window._pcsSaveAllPhotos(\'' +
+      postId + '\');document.getElementById(\'pcs-photo-menu-drop\').remove();">' +
+      'Save All</div>' +
+    '<div class="pcs-menu-item pcs-menu-item-danger" ' +
+      'onclick="window._pcsConfirmRemoveAll(\'' + postId + '\');' +
+      'document.getElementById(\'pcs-photo-menu-drop\').remove();">' +
+      'Remove All</div>';
+  var section = document.getElementById('pcs-photo-section');
+  if (section) section.style.position = 'relative';
+  if (section) section.appendChild(menu);
+  setTimeout(function() {
+    document.addEventListener('click', function _dismiss(e) {
+      var m = document.getElementById('pcs-photo-menu-drop');
+      if (m && !m.contains(e.target)) {
+        m.remove();
+        document.removeEventListener('click', _dismiss);
+      }
+    });
+  }, 10);
+};
+
+window._pcsSaveAllPhotos = function(postId) {
+  var post = (window.allPosts||[]).find(function(p) {
+    return p.post_id === postId;
+  });
+  var imgs = (post && post.images) ? post.images : [];
+  imgs.forEach(function(img, i) {
+    var url = typeof img === 'string' ? img : (img.url || img);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = 'image-' + (i+1) + '.jpg';
+    a.target = '_blank';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  });
+};
+
+window._pcsConfirmRemoveAll = function(postId) {
+  _removePcsConfirm();
+  var overlay = document.createElement('div');
+  overlay.className = 'pcs-confirm-overlay';
+  overlay.addEventListener('click', function(e) {
+    if (e.target === overlay) _removePcsConfirm();
+  });
+  var post = (window.allPosts||[]).find(function(p) {
+    return p.post_id === postId;
+  });
+  var count = (post && post.images) ? post.images.length : 0;
+  overlay.innerHTML =
+    '<div class="pcs-confirm-sheet">' +
+    '<div class="pcs-confirm-msg">Remove all ' + count +
+      ' photos from this post? This cannot be undone.</div>' +
+    '<div class="pcs-confirm-btns">' +
+    '<button class="pcs-confirm-cancel" ' +
+      'onclick="_removePcsConfirm()">CANCEL</button>' +
+    '<button class="pcs-confirm-delete" ' +
+      'onclick="window._pcsDoRemoveAll(\'' + postId + '\')">REMOVE ALL</button>' +
+    '</div></div>';
+  document.body.appendChild(overlay);
+};
+
+window._pcsDoRemoveAll = async function(postId) {
+  _removePcsConfirm();
+  try {
+    await apiFetch('/posts?post_id=eq.' + postId, {
+      method: 'PATCH',
+      body: JSON.stringify({ images: [] })
+    });
+    var idx = (window.allPosts||[]).findIndex(function(p) {
+      return p.post_id === postId;
+    });
+    if (idx > -1) window.allPosts[idx].images = [];
+    openPCS(postId, '');
+  } catch(e) {
+    showToast('Failed to remove photos.', 'error');
+  }
+};
+
+window._pcsCaptionMenu = function(postId) {
+  var existing = document.getElementById('pcs-caption-menu-drop');
+  if (existing) { existing.remove(); return; }
+  var menu = document.createElement('div');
+  menu.id = 'pcs-caption-menu-drop';
+  menu.style.cssText = 'position:absolute;right:18px;' +
+    'background:#1a1a26;border:1px solid rgba(255,255,255,0.12);' +
+    'z-index:200;min-width:140px;';
+  menu.innerHTML =
+    '<div class="pcs-menu-item" onclick="window._pcsCopyCaption(\'' +
+      postId + '\');document.getElementById(\'pcs-caption-menu-drop\').remove();">' +
+      'Copy</div>' +
+    '<div class="pcs-menu-item" onclick="_startCaptionEdit(\'' +
+      postId + '\');document.getElementById(\'pcs-caption-menu-drop\').remove();">' +
+      'Edit</div>' +
+    '<div class="pcs-menu-item pcs-menu-item-danger" ' +
+      'onclick="window._pcsConfirmReplace(\'' + postId + '\');' +
+      'document.getElementById(\'pcs-caption-menu-drop\').remove();">' +
+      'Replace</div>';
+  var section = document.getElementById('pcs-caption-section');
+  if (section) section.style.position = 'relative';
+  if (section) section.appendChild(menu);
+  setTimeout(function() {
+    document.addEventListener('click', function _dismiss(e) {
+      var m = document.getElementById('pcs-caption-menu-drop');
+      if (m && !m.contains(e.target)) {
+        m.remove();
+        document.removeEventListener('click', _dismiss);
+      }
+    });
+  }, 10);
+};
+
+window._pcsCopyCaption = function(postId) {
+  var el = document.getElementById('pcs-caption-text');
+  var text = el ? (el.dataset.raw || el.textContent || '') : '';
+  if (navigator.clipboard) {
+    navigator.clipboard.writeText(text).then(function() {
+      showToast('Caption copied.', 'success');
+    });
+  } else {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand('copy');
+    document.body.removeChild(ta);
+    showToast('Caption copied.', 'success');
+  }
+};
+
+window._pcsConfirmReplace = function(postId) {
+  _removePcsConfirm();
+  var overlay = document.createElement('div');
+  overlay.className = 'pcs-confirm-overlay';
+  overlay.addEventListener('click', function(e) {
+    if (e.target === overlay) _removePcsConfirm();
+  });
+  overlay.innerHTML =
+    '<div class="pcs-confirm-sheet">' +
+    '<div class="pcs-confirm-msg">This will clear the entire ' +
+      'caption. Paste your new copy to replace it.</div>' +
+    '<div class="pcs-confirm-btns">' +
+    '<button class="pcs-confirm-cancel" ' +
+      'onclick="_removePcsConfirm()">CANCEL</button>' +
+    '<button class="pcs-confirm-stage" ' +
+      'onclick="window._pcsDoReplace(\'' + postId + '\')">REPLACE</button>' +
+    '</div></div>';
+  document.body.appendChild(overlay);
+};
+
+window._pcsDoReplace = function(postId) {
+  _removePcsConfirm();
+  var textEl = document.getElementById('pcs-caption-text');
+  var editBtn = document.getElementById('pcs-caption-edit-btn');
+  if (!textEl) return;
+  if (textEl) textEl.style.display = 'none';
+  if (editBtn) editBtn.style.display = 'none';
+  var ta = document.createElement('textarea');
+  ta.id = 'pcs-caption-textarea';
+  ta.value = '';
+  ta.placeholder = 'Paste new caption here...';
+  ta.style.cssText = 'width:100%;min-height:80px;background:rgba(255,255,255,0.04);' +
+    'border:1px solid rgba(246,166,35,0.3);color:#E8E8E8;' +
+    'font-family:\'DM Sans\',sans-serif;font-size:13px;' +
+    'padding:8px;resize:vertical;';
+  var btnRow = document.createElement('div');
+  btnRow.id = 'pcs-caption-btnrow';
+  btnRow.style.cssText = 'display:flex;gap:8px;margin-top:6px;';
+  btnRow.innerHTML =
+    '<button onclick="_saveCaptionEdit(\'' + postId + '\')" ' +
+      'style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
+      'color:#3ECF8E;border:1px dotted rgba(62,207,142,0.4);' +
+      'background:transparent;padding:6px 12px;cursor:pointer;">SAVE</button>' +
+    '<button onclick="_cancelCaptionEdit()" ' +
+      'style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
+      'color:#8E8E93;border:1px dotted rgba(255,255,255,0.15);' +
+      'background:transparent;padding:6px 12px;cursor:pointer;">CANCEL</button>';
+  textEl.parentNode.insertBefore(ta, textEl.nextSibling);
+  textEl.parentNode.insertBefore(btnRow, ta.nextSibling);
+  ta.focus();
+};
+
 window._pcsOpenLightbox = function(postId, idx) {
   var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
   window._pcsLbImages = (post && Array.isArray(post.images)) ? post.images : [];
@@ -1919,7 +2120,7 @@ window._pcsHandleCommentImg = async function(zone) {
       window._pcsNoteImgs.push(url);
     }
 
-    if (btn) { btn.textContent = '\uD83D\uDCF7'; btn.disabled = false; }
+    if (btn) { btn.textContent = '\uD83D\uDCCC'; btn.disabled = false; }
 
     _pcsRenderImgPreviews(zone);
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329U">
+ <link rel="stylesheet" href="styles.css?v=20260329V">
 
 </head>
 <body>
@@ -913,7 +913,7 @@
           <div class="client-input-zone">
             <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..." oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-client');var t=document.getElementById('pcs-task-btn-client');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
             <input type="file" id="pcs-client-img-input" accept="image/*" style="display:none" onchange="window._pcsHandleCommentImg('client')">
-            <button class="pcs-img-btn" onclick="document.getElementById('pcs-client-img-input').click()">&#128247;</button>
+            <button class="pcs-img-btn" onclick="document.getElementById('pcs-client-img-input').click()">&#128204;</button>
             <div style="display:flex;gap:6px;flex-shrink:0;">
               <button id="pcs-send-btn-client" class="pcs-send-btn" style="min-width:72px" onclick="window.submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all',false)">SEND &#x2192;</button>
               <button id="pcs-task-btn-client" class="pcs-send-btn pcs-task-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all',true)">+ TASK</button>
@@ -938,7 +938,7 @@
           <div class="notes-input-zone">
             <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add note... @mention" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');var t=document.getElementById('pcs-task-btn-note');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
             <input type="file" id="pcs-note-img-input" accept="image/*" style="display:none" onchange="window._pcsHandleCommentImg('note')">
-            <button class="pcs-img-btn" onclick="document.getElementById('pcs-note-img-input').click()">&#128247;</button>
+            <button class="pcs-img-btn" onclick="document.getElementById('pcs-note-img-input').click()">&#128204;</button>
             <div style="display:flex;gap:6px;flex-shrink:0;">
               <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all',false)">NOTE</button>
               <button id="pcs-task-btn-note" class="pcs-send-btn pcs-note-btn pcs-task-btn" style="min-width:72px" onclick="window._showTaskAssign('pcs-note-input','pcs-task-btn-note')">+ TASK</button>
@@ -1033,24 +1033,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329U" defer></script>
-<script src="02-session.js?v=20260329U" defer></script>
-<script src="utils.js?v=20260329U" defer></script>
-<script src="03-auth.js?v=20260329U" defer></script>
-<script src="05-api.js?v=20260329U" defer></script>
-<script src="10-ui.js?v=20260329U" defer></script>
+<script src="01-config.js?v=20260329V" defer></script>
+<script src="02-session.js?v=20260329V" defer></script>
+<script src="utils.js?v=20260329V" defer></script>
+<script src="03-auth.js?v=20260329V" defer></script>
+<script src="05-api.js?v=20260329V" defer></script>
+<script src="10-ui.js?v=20260329V" defer></script>
 
-<script src="06-post-create.js?v=20260329U" defer></script>
-<script defer src="render/dashboard.js?v=20260329U"></script>
-<script defer src="render/client.js?v=20260329U"></script>
-<script defer src="render/pipeline.js?v=20260329U"></script>
-<script defer src="render/brief.js?v=20260329U"></script>
-<script defer src="actions/pcs.js?v=20260329U"></script>
-<script src="07-post-load.js?v=20260329U" defer></script>
-<script src="08-post-actions.js?v=20260329U" defer></script>
-<script src="09-library.js?v=20260329U" defer></script>
-<script src="09-approval.js?v=20260329U" defer></script>
-<script src="04-router.js?v=20260329U" defer></script>
+<script src="06-post-create.js?v=20260329V" defer></script>
+<script defer src="render/dashboard.js?v=20260329V"></script>
+<script defer src="render/client.js?v=20260329V"></script>
+<script defer src="render/pipeline.js?v=20260329V"></script>
+<script defer src="render/brief.js?v=20260329V"></script>
+<script defer src="actions/pcs.js?v=20260329V"></script>
+<script src="07-post-load.js?v=20260329V" defer></script>
+<script src="08-post-actions.js?v=20260329V" defer></script>
+<script src="09-library.js?v=20260329V" defer></script>
+<script src="09-approval.js?v=20260329V" defer></script>
+<script src="04-router.js?v=20260329V" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -606,6 +606,8 @@
       '<div style="width:28px;height:28px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;background:rgba(255,255,255,0.06);">' + ICON_PERSON + '</div>' +
       '<div style="flex:1;display:flex;align-items:center;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.06);border-radius:20px;padding:0 4px 0 14px;">' +
         '<input id="comment-input-' + pid + '" type="text" placeholder="' + _esc(placeholder) + '" style="flex:1;background:transparent;border:none;outline:none;font-family:\'DM Sans\',sans-serif;font-size:13px;color:#ccc;padding:7px 0;" data-post-id="' + pid + '">' +
+        '<input type="file" id="client-feed-img-input-' + pid + '" accept="image/*" style="display:none" onchange="window._clientFeedHandleImg(\'' + pid + '\')">' +
+        '<button class="pcs-img-btn" style="font-size:13px;" onclick="document.getElementById(\'client-feed-img-input-' + pid + '\').click()">&#128204;</button>' +
         '<button data-action="submitComment" data-id="' + pid + '" style="background:none;border:none;color:#555;cursor:pointer;padding:4px;flex-shrink:0;">' + ICON_SEND + '</button>' +
       '</div>' +
     '</div>';
@@ -776,6 +778,20 @@
     if (m) m.remove();
   }
 
+  window._clientFeedHandleImg = async function(postId) {
+    var input = document.getElementById('client-feed-img-input-' + postId);
+    if (!input || !input.files || !input.files[0]) return;
+    var file = input.files[0];
+    input.value = '';
+    try {
+      var url = await uploadPostAsset(file, postId + '-comment');
+      window._clientFeedPendingImg = url;
+      showToast('Image ready. Add a message and send.', 'success');
+    } catch(e) {
+      showToast('Image upload failed.', 'error');
+    }
+  };
+
   function _handleSubmitComment(postId, root) {
     var input = document.getElementById('comment-input-' + postId);
     if (!input) return;
@@ -822,14 +838,21 @@
 
     if (typeof window.apiFetch !== 'function') return;
 
+    var _pendingImg = window._clientFeedPendingImg || null;
+    window._clientFeedPendingImg = null;
+    var _commentBody = {
+      post_id: realPostId,
+      author: authorName,
+      author_role: 'Client',
+      message: message
+    };
+    if (_pendingImg) {
+      _commentBody.attachments = JSON.stringify({type:'images', urls:[_pendingImg]});
+    }
+
     window.apiFetch('/post_comments', {
       method: 'POST',
-      body: JSON.stringify({
-        post_id: realPostId,
-        author: authorName,
-        author_role: 'Client',
-        message: message
-      })
+      body: JSON.stringify(_commentBody)
     }).then(function () {
       window.apiFetch('/notifications', {
         method: 'POST',

--- a/styles.css
+++ b/styles.css
@@ -6240,3 +6240,26 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   border: 1px solid rgba(255,255,255,0.12);
   cursor: pointer;
 }
+
+.pcs-menu-item {
+  padding: 10px 14px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  color: #E8E8E8;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  letter-spacing: 0.04em;
+}
+
+.pcs-menu-item:last-child {
+  border-bottom: none;
+}
+
+.pcs-menu-item:hover,
+.pcs-menu-item:active {
+  background: rgba(255,255,255,0.06);
+}
+
+.pcs-menu-item-danger {
+  color: #FF4B4B;
+}


### PR DESCRIPTION
## Summary
- Replaced "+ Add More" button in Photos header with three-dot menu (Add More / Save All / Remove All with confirmation)
- Replaced "Edit" button in Caption header with three-dot menu (Copy / Edit / Replace with confirmation)
- Changed camera emoji to paperclip (&#128204;) on both PCS comment image buttons
- Added paperclip image attach button to client feed comment input rows
- Added `_clientFeedHandleImg` handler with pending image support in `_handleSubmitComment`
- Added `.pcs-menu-item` / `.pcs-menu-item-danger` CSS classes for dropdown menus
- Version bump `?v=20260329U` to `?v=20260329V`

## Files changed
- `actions/pcs.js` — new functions: `_pcsPhotoMenu`, `_pcsSaveAllPhotos`, `_pcsConfirmRemoveAll`, `_pcsDoRemoveAll`, `_pcsCaptionMenu`, `_pcsCopyCaption`, `_pcsConfirmReplace`, `_pcsDoReplace`; replaced photo/caption header buttons
- `render/client.js` — added `_clientFeedHandleImg`, paperclip button in `_commentInputHtml`, image attachment in `_handleSubmitComment`
- `index.html` — camera to paperclip swap, version bump
- `styles.css` — menu item styles

## Test plan
- [x] 133 Vitest tests pass
- [x] Zero non-ASCII characters in all modified files
- [ ] Manual: PCS Photos three-dot menu — Add More, Save All, Remove All (with confirm)
- [ ] Manual: PCS Caption three-dot menu — Copy, Edit, Replace (with confirm)
- [ ] Manual: Paperclip icon visible in PCS comment zones
- [ ] Manual: Paperclip icon visible in client feed comment input
- [ ] Manual: Client feed image attach uploads and sends with comment

https://claude.ai/code/session_017QEVFyqD2evb8ZFxw4nvFS