### PR TITLE
fix: paperclip icon, neutral dots, confirm timing, blob download

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -191,14 +191,14 @@ window._renderPCS = function(postId) {
       '<div style="display:flex;align-items:center;justify-content:space-between;' +
       'padding:7px 18px;border-bottom:1px solid rgba(255,255,255,0.07);">' +
       '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
-      'letter-spacing:0.14em;text-transform:uppercase;color:#555;">' +
-      'Photos <span style="color:' + (imgs.length ? '#777' : '#333') + ';">' +
+      'letter-spacing:0.14em;text-transform:uppercase;color:#AEAEB2;">' +
+      'Photos <span style="color:' + (imgs.length ? '#E8E8E8' : '#8E8E93') + ';">' +
       imgs.length + '</span></div>' +
       ((canEdit || canEditCreative) ?
         '<button onclick="window._pcsPhotoMenu(\'' + esc(id) + '\')" ' +
-        'style="font-family:\'IBM Plex Mono\',monospace;font-size:11px;' +
-        'color:#F6A623;background:transparent;border:1px dotted ' +
-        'rgba(246,166,35,0.3);padding:4px 10px;cursor:pointer;">...</button>'
+        'style="color:#AEAEB2;background:transparent;border:1px dotted ' +
+        'rgba(255,255,255,0.2);padding:4px 10px;cursor:pointer;' +
+        'font-family:\'IBM Plex Mono\',monospace;font-size:11px;">...</button>'
         : '') +
       '</div>' +
       (imgs.length > 0 ?
@@ -326,9 +326,9 @@ window._renderPCS = function(postId) {
       ((canEdit || canEditCreative) ?
         '<button onclick="window._pcsCaptionMenu(\'' + esc(id) + '\')" ' +
         'id="pcs-caption-edit-btn" ' +
-        'style="font-family:\'IBM Plex Mono\',monospace;font-size:11px;' +
-        'color:#F6A623;background:transparent;border:1px dotted ' +
-        'rgba(246,166,35,0.3);padding:4px 10px;cursor:pointer;">...</button>'
+        'style="color:#AEAEB2;background:transparent;border:1px dotted ' +
+        'rgba(255,255,255,0.2);padding:4px 10px;cursor:pointer;' +
+        'font-family:\'IBM Plex Mono\',monospace;font-size:11px;">...</button>'
         : '') +
       '</div>' +
       (post.caption ?
@@ -1358,11 +1358,7 @@ window._pcsPhotoMenu = function(postId) {
       '+ Add More</div>' +
     '<div class="pcs-menu-item" onclick="window._pcsSaveAllPhotos(\'' +
       postId + '\');document.getElementById(\'pcs-photo-menu-drop\').remove();">' +
-      'Save All</div>' +
-    '<div class="pcs-menu-item pcs-menu-item-danger" ' +
-      'onclick="window._pcsConfirmRemoveAll(\'' + postId + '\');' +
-      'document.getElementById(\'pcs-photo-menu-drop\').remove();">' +
-      'Remove All</div>';
+      'Save All</div>';
   var section = document.getElementById('pcs-photo-section');
   if (section) section.style.position = 'relative';
   if (section) section.appendChild(menu);
@@ -1377,61 +1373,33 @@ window._pcsPhotoMenu = function(postId) {
   }, 10);
 };
 
-window._pcsSaveAllPhotos = function(postId) {
+window._pcsSaveAllPhotos = async function(postId) {
   var post = (window.allPosts||[]).find(function(p) {
     return p.post_id === postId;
   });
   var imgs = (post && post.images) ? post.images : [];
-  imgs.forEach(function(img, i) {
-    var url = typeof img === 'string' ? img : (img.url || img);
-    var a = document.createElement('a');
-    a.href = url;
-    a.download = 'image-' + (i+1) + '.jpg';
-    a.target = '_blank';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-  });
-};
-
-window._pcsConfirmRemoveAll = function(postId) {
-  _removePcsConfirm();
-  var overlay = document.createElement('div');
-  overlay.className = 'pcs-confirm-overlay';
-  overlay.addEventListener('click', function(e) {
-    if (e.target === overlay) _removePcsConfirm();
-  });
-  var post = (window.allPosts||[]).find(function(p) {
-    return p.post_id === postId;
-  });
-  var count = (post && post.images) ? post.images.length : 0;
-  overlay.innerHTML =
-    '<div class="pcs-confirm-sheet">' +
-    '<div class="pcs-confirm-msg">Remove all ' + count +
-      ' photos from this post? This cannot be undone.</div>' +
-    '<div class="pcs-confirm-btns">' +
-    '<button class="pcs-confirm-cancel" ' +
-      'onclick="_removePcsConfirm()">CANCEL</button>' +
-    '<button class="pcs-confirm-delete" ' +
-      'onclick="window._pcsDoRemoveAll(\'' + postId + '\')">REMOVE ALL</button>' +
-    '</div></div>';
-  document.body.appendChild(overlay);
-};
-
-window._pcsDoRemoveAll = async function(postId) {
-  _removePcsConfirm();
-  try {
-    await apiFetch('/posts?post_id=eq.' + postId, {
-      method: 'PATCH',
-      body: JSON.stringify({ images: [] })
-    });
-    var idx = (window.allPosts||[]).findIndex(function(p) {
-      return p.post_id === postId;
-    });
-    if (idx > -1) window.allPosts[idx].images = [];
-    openPCS(postId, '');
-  } catch(e) {
-    showToast('Failed to remove photos.', 'error');
+  if (!imgs.length) {
+    showToast('No images to save.', 'error');
+    return;
+  }
+  showToast('Saving ' + imgs.length + ' images...', 'success');
+  for (var i = 0; i < imgs.length; i++) {
+    try {
+      var url = typeof imgs[i] === 'string'
+        ? imgs[i] : (imgs[i].url || imgs[i]);
+      var res = await fetch(url);
+      var blob = await res.blob();
+      var objUrl = URL.createObjectURL(blob);
+      var a = document.createElement('a');
+      a.href = objUrl;
+      a.download = 'image-' + (i+1) + '.jpg';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      setTimeout(function(){ URL.revokeObjectURL(objUrl); }, 1000);
+    } catch(e) {
+      console.error('Save image failed:', e);
+    }
   }
 };
 
@@ -1451,8 +1419,7 @@ window._pcsCaptionMenu = function(postId) {
       postId + '\');document.getElementById(\'pcs-caption-menu-drop\').remove();">' +
       'Edit</div>' +
     '<div class="pcs-menu-item pcs-menu-item-danger" ' +
-      'onclick="window._pcsConfirmReplace(\'' + postId + '\');' +
-      'document.getElementById(\'pcs-caption-menu-drop\').remove();">' +
+      'onclick="var m=document.getElementById(\'pcs-caption-menu-drop\');if(m)m.remove();setTimeout(function(){window._pcsConfirmReplace(\'' + postId + '\');},50);">' +
       'Replace</div>';
   var section = document.getElementById('pcs-caption-section');
   if (section) section.style.position = 'relative';
@@ -2120,7 +2087,7 @@ window._pcsHandleCommentImg = async function(zone) {
       window._pcsNoteImgs.push(url);
     }
 
-    if (btn) { btn.textContent = '\uD83D\uDCCC'; btn.disabled = false; }
+    if (btn) { btn.textContent = '\uD83D\uDCCE'; btn.disabled = false; }
 
     _pcsRenderImgPreviews(zone);
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329V">
+ <link rel="stylesheet" href="styles.css?v=20260329W">
 
 </head>
 <body>
@@ -913,7 +913,7 @@
           <div class="client-input-zone">
             <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..." oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-client');var t=document.getElementById('pcs-task-btn-client');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
             <input type="file" id="pcs-client-img-input" accept="image/*" style="display:none" onchange="window._pcsHandleCommentImg('client')">
-            <button class="pcs-img-btn" onclick="document.getElementById('pcs-client-img-input').click()">&#128204;</button>
+            <button class="pcs-img-btn" onclick="document.getElementById('pcs-client-img-input').click()">&#128206;</button>
             <div style="display:flex;gap:6px;flex-shrink:0;">
               <button id="pcs-send-btn-client" class="pcs-send-btn" style="min-width:72px" onclick="window.submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all',false)">SEND &#x2192;</button>
               <button id="pcs-task-btn-client" class="pcs-send-btn pcs-task-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-comment-input').value,'all',true)">+ TASK</button>
@@ -938,7 +938,7 @@
           <div class="notes-input-zone">
             <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add note... @mention" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');var t=document.getElementById('pcs-task-btn-note');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
             <input type="file" id="pcs-note-img-input" accept="image/*" style="display:none" onchange="window._pcsHandleCommentImg('note')">
-            <button class="pcs-img-btn" onclick="document.getElementById('pcs-note-img-input').click()">&#128204;</button>
+            <button class="pcs-img-btn" onclick="document.getElementById('pcs-note-img-input').click()">&#128206;</button>
             <div style="display:flex;gap:6px;flex-shrink:0;">
               <button id="pcs-send-btn-note" class="pcs-send-btn pcs-note-btn" style="min-width:72px" onclick="submitPcsComment(document.getElementById('pcs-post-id').value,document.getElementById('pcs-note-input').value,window._pcsNoteVisibility||'all',false)">NOTE</button>
               <button id="pcs-task-btn-note" class="pcs-send-btn pcs-note-btn pcs-task-btn" style="min-width:72px" onclick="window._showTaskAssign('pcs-note-input','pcs-task-btn-note')">+ TASK</button>
@@ -1033,24 +1033,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329V" defer></script>
-<script src="02-session.js?v=20260329V" defer></script>
-<script src="utils.js?v=20260329V" defer></script>
-<script src="03-auth.js?v=20260329V" defer></script>
-<script src="05-api.js?v=20260329V" defer></script>
-<script src="10-ui.js?v=20260329V" defer></script>
+<script src="01-config.js?v=20260329W" defer></script>
+<script src="02-session.js?v=20260329W" defer></script>
+<script src="utils.js?v=20260329W" defer></script>
+<script src="03-auth.js?v=20260329W" defer></script>
+<script src="05-api.js?v=20260329W" defer></script>
+<script src="10-ui.js?v=20260329W" defer></script>
 
-<script src="06-post-create.js?v=20260329V" defer></script>
-<script defer src="render/dashboard.js?v=20260329V"></script>
-<script defer src="render/client.js?v=20260329V"></script>
-<script defer src="render/pipeline.js?v=20260329V"></script>
-<script defer src="render/brief.js?v=20260329V"></script>
-<script defer src="actions/pcs.js?v=20260329V"></script>
-<script src="07-post-load.js?v=20260329V" defer></script>
-<script src="08-post-actions.js?v=20260329V" defer></script>
-<script src="09-library.js?v=20260329V" defer></script>
-<script src="09-approval.js?v=20260329V" defer></script>
-<script src="04-router.js?v=20260329V" defer></script>
+<script src="06-post-create.js?v=20260329W" defer></script>
+<script defer src="render/dashboard.js?v=20260329W"></script>
+<script defer src="render/client.js?v=20260329W"></script>
+<script defer src="render/pipeline.js?v=20260329W"></script>
+<script defer src="render/brief.js?v=20260329W"></script>
+<script defer src="actions/pcs.js?v=20260329W"></script>
+<script src="07-post-load.js?v=20260329W" defer></script>
+<script src="08-post-actions.js?v=20260329W" defer></script>
+<script src="09-library.js?v=20260329W" defer></script>
+<script src="09-approval.js?v=20260329W" defer></script>
+<script src="04-router.js?v=20260329W" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Fixed paperclip icon: `&#128204;` (pushpin) to `&#128206;` (paperclip) in index.html, `\uD83D\uDCCC` to `\uD83D\uDCCE` in pcs.js
- Changed `...` button styling from gold (#F6A623) to neutral gray (#AEAEB2) on both Photos and Caption zones
- Brightened Photos header label from #555 to #AEAEB2, count from #777/#333 to #E8E8E8/#8E8E93
- Fixed Replace confirm dialog being killed by menu dismiss listener — now uses setTimeout(50ms) to defer
- Removed "Remove All" from photos menu and deleted `_pcsConfirmRemoveAll` / `_pcsDoRemoveAll`
- Replaced `_pcsSaveAllPhotos` with blob-fetch approach for reliable cross-origin downloads
- Version bump `?v=20260329V` to `?v=20260329W`

## Test plan
- [x] 133 Vitest tests pass
- [x] Zero non-ASCII characters
- [ ] Manual: verify paperclip icon renders correctly in PCS comment zones
- [ ] Manual: verify `...` buttons are neutral gray, not gold
- [ ] Manual: Caption menu Replace opens confirm dialog (not killed by dismiss)
- [ ] Manual: Photos menu Save All triggers blob downloads

https://claude.ai/code/session_017QEVFyqD2evb8ZFxw4nvFS