### PR TITLE
feat: threaded reply and copy comment on all threads

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -17,6 +17,8 @@ window._pcsLbImages = [];
 window._pcsLbIdx = 0;
 window._pcsClientImgs = [];
 window._pcsNoteImgs = [];
+window._pcsReplyTo = null;
+window._pcsReplyToAuthor = null;
 window._modalOpen = window._modalOpen || false;
 
 window.openPCS = function(postId, listKey) {
@@ -633,6 +635,16 @@ window.loadPcsComments = async function(postId) {
     );
     if (!Array.isArray(rows)) rows = [];
 
+    var _commentMap = {};
+    rows.forEach(function(c) {
+      _commentMap[c.id] = c.author;
+    });
+    rows.forEach(function(c) {
+      if (c.reply_to && _commentMap[c.reply_to]) {
+        c.reply_to_author = _commentMap[c.reply_to];
+      }
+    });
+
     var _unreadIds = rows
       .filter(function(r) { return !r.read; })
       .map(function(r) { return r.id; });
@@ -734,7 +746,8 @@ window.loadPcsComments = async function(postId) {
             }).join('') +
           '</div>';
         }
-        return '<div class="pcs-comment-item">' +
+        return '<div class="pcs-comment-item' +
+          (c.reply_to ? ' pcs-comment-reply' : '') + '">' +
           (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
           '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>' +
           '<div class="pcs-comment-body">' +
@@ -742,10 +755,23 @@ window.loadPcsComments = async function(postId) {
               '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
               '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
             '</div>' +
+            (c.reply_to && c.reply_to_author ?
+              '<div class="pcs-reply-indicator">' +
+              '&#8629; ' + esc(c.reply_to_author) + '</div>'
+              : '') +
             '<div class="pcs-comment-text' + (_isTask ? ' pcs-task-text' : '') +
             ((_isTask && c.resolved) ? ' pcs-task-done' : '') + '">' +
             _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
             _imgHtml +
+            '<div class="pcs-comment-actions">' +
+            '<span class="pcs-comment-action" ' +
+              'onclick="window._pcsSetReply(\'client\',\'' +
+              esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
+              esc(c.message) + '\')">REPLY</span>' +
+            '<span class="pcs-comment-action" ' +
+              'onclick="window._pcsCopyComment(\'' +
+              esc(c.message) + '\')">COPY</span>' +
+            '</div>' +
           '</div>' +
         '</div>';
       }).join('');
@@ -794,6 +820,7 @@ window.loadPcsComments = async function(postId) {
           '</div>';
         }
         return '<div class="pcs-note-item' +
+          (c.reply_to ? ' pcs-comment-reply' : '') +
           (c.resolved ? ' pcs-resolved' : '') + '">' +
           (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
           '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>' +
@@ -804,10 +831,23 @@ window.loadPcsComments = async function(postId) {
               _mentionBadge +
               _visTag +
             '</div>' +
+            (c.reply_to && c.reply_to_author ?
+              '<div class="pcs-reply-indicator">' +
+              '&#8629; ' + esc(c.reply_to_author) + '</div>'
+              : '') +
             '<div class="pcs-comment-text' + (_isTask ? ' pcs-task-text' : '') +
             ((_isTask && c.resolved) ? ' pcs-task-done' : '') + '">' +
             _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
             _imgHtml +
+            '<div class="pcs-comment-actions">' +
+            '<span class="pcs-comment-action" ' +
+              'onclick="window._pcsSetReply(\'note\',\'' +
+              esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
+              esc(c.message) + '\')">REPLY</span>' +
+            '<span class="pcs-comment-action" ' +
+              'onclick="window._pcsCopyComment(\'' +
+              esc(c.message) + '\')">COPY</span>' +
+            '</div>' +
           '</div>' +
         '</div>';
       }).join('');
@@ -1762,6 +1802,13 @@ window.submitPcsComment = async function(postId, message, visibility, isTask) {
   _pcsRenderImgPreviews('client');
   _pcsRenderImgPreviews('note');
 
+  var _replyTo = window._pcsReplyTo || null;
+  var _replyToAuthor = window._pcsReplyToAuthor || null;
+  window._pcsReplyTo = null;
+  window._pcsReplyToAuthor = null;
+  window._pcsClearReply('client');
+  window._pcsClearReply('note');
+
   if (visibility === 'all' && _roleLower !== 'client') {
     window._pendingComment = {
       postId: _realPostId,
@@ -1772,13 +1819,16 @@ window.submitPcsComment = async function(postId, message, visibility, isTask) {
       role: _role,
       title: _title,
       isTask: isTask,
-      images: _imgs
+      images: _imgs,
+      reply_to: _replyTo,
+      reply_to_author: _replyToAuthor
     };
     var confirmEl = document.getElementById('pcs-comment-confirm');
     if (!confirmEl) {
       await window._doSubmitComment({ postId:_realPostId, message:message,
         visibility:visibility, mentioned:_mentioned, author:_author,
-        role:_role, title:_title, isTask:isTask, images:_imgs });
+        role:_role, title:_title, isTask:isTask, images:_imgs,
+        reply_to:_replyTo, reply_to_author:_replyToAuthor });
       return;
     }
     var previewEl = document.getElementById('pcs-comment-confirm-preview');
@@ -1798,7 +1848,9 @@ window.submitPcsComment = async function(postId, message, visibility, isTask) {
     role: _role,
     title: _title,
     isTask: isTask,
-    images: _imgs
+    images: _imgs,
+    reply_to: _replyTo,
+    reply_to_author: _replyToAuthor
   });
   } catch(e) {
     console.error('submitPcsComment failed:', e);
@@ -1848,6 +1900,7 @@ window._doSubmitComment = async function(opts) {
         message: opts.message,
         visibility: opts.visibility,
         mentioned_users: opts.mentioned,
+        reply_to: opts.reply_to || null,
         resolved: false,
         resolved_by: null,
         attachments: opts.isTask
@@ -2122,5 +2175,57 @@ window._pcsRemoveCommentImg = function(zone, idx) {
     window._pcsNoteImgs.splice(idx, 1);
   }
   _pcsRenderImgPreviews(zone);
+};
+
+window._pcsSetReply = function(zone, commentId, author, message) {
+  window._pcsReplyTo = commentId;
+  window._pcsReplyToAuthor = author;
+  var inputId = zone === 'client'
+    ? 'pcs-comment-input'
+    : 'pcs-note-input';
+  var input = document.getElementById(inputId);
+  var indicator = document.getElementById(
+    zone === 'client'
+      ? 'pcs-client-reply-indicator'
+      : 'pcs-note-reply-indicator'
+  );
+  if (indicator) {
+    indicator.textContent = 'Replying to ' + author;
+    indicator.style.display = 'flex';
+  }
+  if (input) {
+    input.focus();
+    input.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+};
+
+window._pcsClearReply = function(zone) {
+  window._pcsReplyTo = null;
+  window._pcsReplyToAuthor = null;
+  var indicator = document.getElementById(
+    zone === 'client'
+      ? 'pcs-client-reply-indicator'
+      : 'pcs-note-reply-indicator'
+  );
+  if (indicator) {
+    indicator.style.display = 'none';
+    indicator.textContent = '';
+  }
+};
+
+window._pcsCopyComment = function(message) {
+  if (navigator.clipboard) {
+    navigator.clipboard.writeText(message).then(function() {
+      showToast('Copied.', 'success');
+    });
+  } else {
+    var ta = document.createElement('textarea');
+    ta.value = message;
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand('copy');
+    document.body.removeChild(ta);
+    showToast('Copied.', 'success');
+  }
 };
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329W">
+ <link rel="stylesheet" href="styles.css?v=20260329X">
 
 </head>
 <body>
@@ -910,6 +910,10 @@
           </div>
           <div id="pcs-comments-list" class="pcs-thread-list" style="min-height:60px;"></div>
           <div id="pcs-client-img-previews" class="pcs-img-previews"></div>
+          <div id="pcs-client-reply-indicator" class="pcs-reply-indicator-bar" style="display:none;">
+            <span></span>
+            <span onclick="window._pcsClearReply('client')" class="pcs-reply-cancel">x</span>
+          </div>
           <div class="client-input-zone">
             <textarea id="pcs-comment-input" class="pcs-textarea" rows="1" placeholder="Reply to client..." oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-client');var t=document.getElementById('pcs-task-btn-client');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
             <input type="file" id="pcs-client-img-input" accept="image/*" style="display:none" onchange="window._pcsHandleCommentImg('client')">
@@ -935,6 +939,10 @@
           <div id="pcs-notes-list" class="pcs-notes-list"></div>
           <div id="pcs-mention-dropup" style="display:none;"></div>
           <div id="pcs-note-img-previews" class="pcs-img-previews"></div>
+          <div id="pcs-note-reply-indicator" class="pcs-reply-indicator-bar" style="display:none;">
+            <span></span>
+            <span onclick="window._pcsClearReply('note')" class="pcs-reply-cancel">x</span>
+          </div>
           <div class="notes-input-zone">
             <textarea id="pcs-note-input" class="pcs-textarea pcs-note-textarea" rows="1" placeholder="Add note... @mention" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var b=document.getElementById('pcs-send-btn-note');var t=document.getElementById('pcs-task-btn-note');var v=!!this.value.trim();if(b)b.classList.toggle('active',v);if(t)t.classList.toggle('active',v)"></textarea>
             <input type="file" id="pcs-note-img-input" accept="image/*" style="display:none" onchange="window._pcsHandleCommentImg('note')">
@@ -1033,24 +1041,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329W" defer></script>
-<script src="02-session.js?v=20260329W" defer></script>
-<script src="utils.js?v=20260329W" defer></script>
-<script src="03-auth.js?v=20260329W" defer></script>
-<script src="05-api.js?v=20260329W" defer></script>
-<script src="10-ui.js?v=20260329W" defer></script>
+<script src="01-config.js?v=20260329X" defer></script>
+<script src="02-session.js?v=20260329X" defer></script>
+<script src="utils.js?v=20260329X" defer></script>
+<script src="03-auth.js?v=20260329X" defer></script>
+<script src="05-api.js?v=20260329X" defer></script>
+<script src="10-ui.js?v=20260329X" defer></script>
 
-<script src="06-post-create.js?v=20260329W" defer></script>
-<script defer src="render/dashboard.js?v=20260329W"></script>
-<script defer src="render/client.js?v=20260329W"></script>
-<script defer src="render/pipeline.js?v=20260329W"></script>
-<script defer src="render/brief.js?v=20260329W"></script>
-<script defer src="actions/pcs.js?v=20260329W"></script>
-<script src="07-post-load.js?v=20260329W" defer></script>
-<script src="08-post-actions.js?v=20260329W" defer></script>
-<script src="09-library.js?v=20260329W" defer></script>
-<script src="09-approval.js?v=20260329W" defer></script>
-<script src="04-router.js?v=20260329W" defer></script>
+<script src="06-post-create.js?v=20260329X" defer></script>
+<script defer src="render/dashboard.js?v=20260329X"></script>
+<script defer src="render/client.js?v=20260329X"></script>
+<script defer src="render/pipeline.js?v=20260329X"></script>
+<script defer src="render/brief.js?v=20260329X"></script>
+<script defer src="actions/pcs.js?v=20260329X"></script>
+<script src="07-post-load.js?v=20260329X" defer></script>
+<script src="08-post-actions.js?v=20260329X" defer></script>
+<script src="09-library.js?v=20260329X" defer></script>
+<script src="09-approval.js?v=20260329X" defer></script>
+<script src="04-router.js?v=20260329X" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -561,6 +561,15 @@
           '<span style="margin-left:auto;font-family:\'IBM Plex Mono\',monospace;font-size:10px;color:#333;">' + ts + '</span>' +
         '</div>' +
         '<div style="font-family:\'DM Sans\',sans-serif;font-size:13px;color:#999;line-height:1.5;margin-top:2px;white-space:pre-wrap;">' + _esc(c.message) + '</div>' +
+        '<div class="pcs-comment-actions">' +
+        '<span class="pcs-comment-action" ' +
+          'onclick="window._clientSetReply(\'' +
+          _esc(c.id || '') + '\',\'' + _esc(c.author || '') + '\',\'' +
+          _esc(c.post_id || '') + '\')">REPLY</span>' +
+        '<span class="pcs-comment-action" ' +
+          'onclick="window._pcsCopyComment(\'' +
+          _esc(c.message || '') + '\')">COPY</span>' +
+        '</div>' +
       '</div>' +
     '</div>';
   }
@@ -602,12 +611,18 @@
     var placeholder = post.stage === 'awaiting_brand_input'
       ? 'Share the information here...'
       : 'Add your thoughts...';
-    return '<div style="display:flex;align-items:center;gap:8px;padding:8px 14px;">' +
+    return '<div id="client-reply-indicator-' + pid + '" ' +
+      'class="pcs-reply-indicator-bar" style="display:none;">' +
+      '<span id="client-reply-text-' + pid + '"></span>' +
+      '<span onclick="window._clientClearReply(\'' + pid + '\')" ' +
+        'class="pcs-reply-cancel">x</span>' +
+    '</div>' +
+    '<div style="display:flex;align-items:center;gap:8px;padding:8px 14px;">' +
       '<div style="width:28px;height:28px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;background:rgba(255,255,255,0.06);">' + ICON_PERSON + '</div>' +
       '<div style="flex:1;display:flex;align-items:center;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.06);border-radius:20px;padding:0 4px 0 14px;">' +
         '<input id="comment-input-' + pid + '" type="text" placeholder="' + _esc(placeholder) + '" style="flex:1;background:transparent;border:none;outline:none;font-family:\'DM Sans\',sans-serif;font-size:13px;color:#ccc;padding:7px 0;" data-post-id="' + pid + '">' +
         '<input type="file" id="client-feed-img-input-' + pid + '" accept="image/*" style="display:none" onchange="window._clientFeedHandleImg(\'' + pid + '\')">' +
-        '<button class="pcs-img-btn" style="font-size:13px;" onclick="document.getElementById(\'client-feed-img-input-' + pid + '\').click()">&#128204;</button>' +
+        '<button class="pcs-img-btn" style="font-size:13px;" onclick="document.getElementById(\'client-feed-img-input-' + pid + '\').click()">&#128206;</button>' +
         '<button data-action="submitComment" data-id="' + pid + '" style="background:none;border:none;color:#555;cursor:pointer;padding:4px;flex-shrink:0;">' + ICON_SEND + '</button>' +
       '</div>' +
     '</div>';
@@ -778,6 +793,29 @@
     if (m) m.remove();
   }
 
+  window._clientSetReply = function(commentId, author, postId) {
+    window._clientReplyTo = window._clientReplyTo || {};
+    window._clientReplyTo[postId] = { id: commentId, author: author };
+    var indicator = document.getElementById(
+      'client-reply-indicator-' + postId
+    );
+    var text = document.getElementById(
+      'client-reply-text-' + postId
+    );
+    if (text) text.textContent = 'Replying to ' + author;
+    if (indicator) indicator.style.display = 'flex';
+    var input = document.getElementById('comment-input-' + postId);
+    if (input) input.focus();
+  };
+
+  window._clientClearReply = function(postId) {
+    if (window._clientReplyTo) delete window._clientReplyTo[postId];
+    var indicator = document.getElementById(
+      'client-reply-indicator-' + postId
+    );
+    if (indicator) indicator.style.display = 'none';
+  };
+
   window._clientFeedHandleImg = async function(postId) {
     var input = document.getElementById('client-feed-img-input-' + postId);
     if (!input || !input.files || !input.files[0]) return;
@@ -838,13 +876,20 @@
 
     if (typeof window.apiFetch !== 'function') return;
 
+    var _replyTo = (window._clientReplyTo &&
+      window._clientReplyTo[postId])
+      ? window._clientReplyTo[postId].id
+      : null;
+    window._clientClearReply(postId);
+
     var _pendingImg = window._clientFeedPendingImg || null;
     window._clientFeedPendingImg = null;
     var _commentBody = {
       post_id: realPostId,
       author: authorName,
       author_role: 'Client',
-      message: message
+      message: message,
+      reply_to: _replyTo || null
     };
     if (_pendingImg) {
       _commentBody.attachments = JSON.stringify({type:'images', urls:[_pendingImg]});

--- a/styles.css
+++ b/styles.css
@@ -6263,3 +6263,58 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-menu-item-danger {
   color: #FF4B4B;
 }
+
+.pcs-comment-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 5px;
+  justify-content: flex-end;
+}
+
+.pcs-comment-action {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #8E8E93;
+  cursor: pointer;
+}
+
+.pcs-comment-action:hover,
+.pcs-comment-action:active {
+  color: #AEAEB2;
+}
+
+.pcs-comment-reply {
+  margin-left: 20px;
+  border-left: 2px solid rgba(255,255,255,0.08);
+  padding-left: 10px;
+}
+
+.pcs-reply-indicator {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #9b87f5;
+  margin-bottom: 2px;
+  letter-spacing: 0.06em;
+}
+
+.pcs-reply-indicator-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 14px;
+  background: rgba(155,135,245,0.08);
+  border-top: 1px solid rgba(155,135,245,0.15);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #9b87f5;
+  letter-spacing: 0.06em;
+}
+
+.pcs-reply-cancel {
+  cursor: pointer;
+  color: #8E8E93;
+  font-size: 11px;
+  padding: 0 4px;
+}


### PR DESCRIPTION
## Summary
- Added REPLY and COPY action buttons on every comment in PCS client thread, PCS note thread, and client feed
- Threaded replies: clicking REPLY sets reply context, shows indicator bar above input, stores `reply_to` in comment POST body
- Reply comments render with left border indent (`.pcs-comment-reply`) and reply indicator showing parent author
- `loadPcsComments` resolves `reply_to_author` from comment map for display
- `_pcsCopyComment` copies comment text to clipboard (shared across PCS and client feed)
- Client feed: `_clientSetReply`/`_clientClearReply` with per-post reply state tracking
- Fixed paperclip entity in render/client.js (`&#128204;` to `&#128206;`)
- Version bump `?v=20260329W` to `?v=20260329X`

## Files changed
- `actions/pcs.js` — reply globals, comment map resolution in `loadPcsComments`, REPLY/COPY actions in both render threads, `reply_to` in submit flow, `_pcsSetReply`/`_pcsClearReply`/`_pcsCopyComment` functions
- `render/client.js` — REPLY/COPY in `_singleCommentHtml`, reply indicator in `_commentInputHtml`, `_clientSetReply`/`_clientClearReply`, `reply_to` in `_handleSubmitComment`, paperclip fix
- `index.html` — reply indicator bar divs for both PCS zones, version bump
- `styles.css` — `.pcs-comment-actions`, `.pcs-comment-action`, `.pcs-comment-reply`, `.pcs-reply-indicator`, `.pcs-reply-indicator-bar`, `.pcs-reply-cancel`

## Test plan
- [x] 133 Vitest tests pass
- [x] Zero non-ASCII characters in all modified files
- [ ] Manual: REPLY on PCS client comment shows indicator, sends with reply_to
- [ ] Manual: REPLY on PCS note shows indicator, sends with reply_to
- [ ] Manual: COPY on any comment copies text to clipboard
- [ ] Manual: Reply comments render with indent + parent author indicator
- [ ] Manual: Client feed REPLY/COPY buttons work

https://claude.ai/code/session_017QEVFyqD2evb8ZFxw4nvFS