### PR TITLE
fix: caption edit and replace button styling

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1574,7 +1574,8 @@ window._pcsDoReplace = function(postId) {
     '<button onclick="_cancelCaptionEdit()" ' +
       'style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
       'color:#8E8E93;border:1px dotted rgba(255,255,255,0.15);' +
-      'background:transparent;padding:6px 12px;cursor:pointer;">CANCEL</button>';
+      'background:transparent;padding:6px 12px;cursor:pointer;' +
+      'margin-left:6px;">CANCEL</button>';
   textEl.parentNode.insertBefore(ta, textEl.nextSibling);
   textEl.parentNode.insertBefore(btnRow, ta.nextSibling);
   ta.focus();
@@ -1692,15 +1693,14 @@ window._startCaptionEdit = function(postId) {
   btnRow.style.cssText = 'display:flex;gap:8px;margin-top:8px;';
   btnRow.innerHTML =
     '<button onclick="_saveCaptionEdit(\'' + postId + '\')" ' +
-    'style="flex:1;font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
-    'letter-spacing:0.1em;text-transform:uppercase;color:#3ECF8E;' +
-    'background:transparent;border:1px solid rgba(62,207,142,0.3);' +
-    'padding:9px 0;cursor:pointer;">Save</button>' +
+    'style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
+    'color:#3ECF8E;border:1px dotted rgba(62,207,142,0.4);' +
+    'background:transparent;padding:6px 12px;cursor:pointer;">SAVE</button>' +
     '<button onclick="_cancelCaptionEdit()" ' +
-    'style="flex:1;font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
-    'letter-spacing:0.1em;text-transform:uppercase;color:#555;' +
-    'background:transparent;border:1px solid rgba(255,255,255,0.07);' +
-    'padding:9px 0;cursor:pointer;">Cancel</button>';
+    'style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
+    'color:#8E8E93;border:1px dotted rgba(255,255,255,0.15);' +
+    'background:transparent;padding:6px 12px;cursor:pointer;' +
+    'margin-left:6px;">CANCEL</button>';
   ta.parentNode.insertBefore(btnRow, ta.nextSibling);
   ta.focus();
 }

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260329Y">
+ <link rel="stylesheet" href="styles.css?v=20260329Z">
 
 </head>
 <body>
@@ -1041,24 +1041,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260329Y" defer></script>
-<script src="02-session.js?v=20260329Y" defer></script>
-<script src="utils.js?v=20260329Y" defer></script>
-<script src="03-auth.js?v=20260329Y" defer></script>
-<script src="05-api.js?v=20260329Y" defer></script>
-<script src="10-ui.js?v=20260329Y" defer></script>
+<script src="01-config.js?v=20260329Z" defer></script>
+<script src="02-session.js?v=20260329Z" defer></script>
+<script src="utils.js?v=20260329Z" defer></script>
+<script src="03-auth.js?v=20260329Z" defer></script>
+<script src="05-api.js?v=20260329Z" defer></script>
+<script src="10-ui.js?v=20260329Z" defer></script>
 
-<script src="06-post-create.js?v=20260329Y" defer></script>
-<script defer src="render/dashboard.js?v=20260329Y"></script>
-<script defer src="render/client.js?v=20260329Y"></script>
-<script defer src="render/pipeline.js?v=20260329Y"></script>
-<script defer src="render/brief.js?v=20260329Y"></script>
-<script defer src="actions/pcs.js?v=20260329Y"></script>
-<script src="07-post-load.js?v=20260329Y" defer></script>
-<script src="08-post-actions.js?v=20260329Y" defer></script>
-<script src="09-library.js?v=20260329Y" defer></script>
-<script src="09-approval.js?v=20260329Y" defer></script>
-<script src="04-router.js?v=20260329Y" defer></script>
+<script src="06-post-create.js?v=20260329Z" defer></script>
+<script defer src="render/dashboard.js?v=20260329Z"></script>
+<script defer src="render/client.js?v=20260329Z"></script>
+<script defer src="render/pipeline.js?v=20260329Z"></script>
+<script defer src="render/brief.js?v=20260329Z"></script>
+<script defer src="actions/pcs.js?v=20260329Z"></script>
+<script src="07-post-load.js?v=20260329Z" defer></script>
+<script src="08-post-actions.js?v=20260329Z" defer></script>
+<script src="09-library.js?v=20260329Z" defer></script>
+<script src="09-approval.js?v=20260329Z" defer></script>
+<script src="04-router.js?v=20260329Z" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Unified SAVE/CANCEL button styling in both `_startCaptionEdit` and `_pcsDoReplace` to consistent IBM Plex Mono 9px, dotted borders, 6px 12px padding
- Added `margin-left:6px` to CANCEL buttons for spacing
- Version bump `?v=20260329Y` to `?v=20260329Z`

## Test plan
- [x] 133 Vitest tests pass
- [x] Zero non-ASCII characters
- [ ] Manual: Caption Edit (via ... menu > Edit) shows SAVE/CANCEL buttons that work
- [ ] Manual: Caption Replace (via ... menu > Replace) shows SAVE/CANCEL buttons that work

https://claude.ai/code/session_017QEVFyqD2evb8ZFxw4nvFS