### PR TITLE
fix: save all opens images directly — bypass CORS blob fetch

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -1927,6 +1927,22 @@ async function _pcsHandlePhotoInput(postId, input) {
 }
 window._pcsHandlePhotoInput = _pcsHandlePhotoInput;
 
+window._pcsSaveAllPhotos = function(postId) {
+  var post = (window.allPosts||[]).find(function(p) {
+    return p.post_id === postId;
+  });
+  var imgs = (post && post.images) ? post.images : [];
+  if (!imgs.length) {
+    showToast('No images to save.', 'error');
+    return;
+  }
+  imgs.forEach(function(img) {
+    var url = typeof img === 'string' ? img : (img.url || img);
+    window.open(url, '_blank');
+  });
+  showToast('Opening ' + imgs.length + ' images. Long press each to save.', 'success');
+};
+
 async function _pcsRemovePhoto(postId, idx) {
   var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
   if (!post) return;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260327j">
+ <link rel="stylesheet" href="styles.css?v=20260330A">
 
 </head>
 <body>
@@ -974,23 +974,23 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260327j" defer></script>
-<script src="02-session.js?v=20260327j" defer></script>
-<script src="utils.js?v=20260327j" defer></script>
-<script src="03-auth.js?v=20260327j" defer></script>
-<script src="05-api.js?v=20260327j" defer></script>
-<script src="10-ui.js?v=20260327j" defer></script>
+<script src="01-config.js?v=20260330A" defer></script>
+<script src="02-session.js?v=20260330A" defer></script>
+<script src="utils.js?v=20260330A" defer></script>
+<script src="03-auth.js?v=20260330A" defer></script>
+<script src="05-api.js?v=20260330A" defer></script>
+<script src="10-ui.js?v=20260330A" defer></script>
 
-<script src="06-post-create.js?v=20260327j" defer></script>
-<script defer src="render/dashboard.js?v=20260327j"></script>
-<script defer src="render/client.js?v=20260327j"></script>
-<script defer src="render/pipeline.js?v=20260327j"></script>
-<script defer src="render/brief.js?v=20260327j"></script>
-<script src="07-post-load.js?v=20260327j" defer></script>
-<script src="08-post-actions.js?v=20260327j" defer></script>
-<script src="09-library.js?v=20260327j" defer></script>
-<script src="09-approval.js?v=20260327j" defer></script>
-<script src="04-router.js?v=20260327j" defer></script>
+<script src="06-post-create.js?v=20260330A" defer></script>
+<script defer src="render/dashboard.js?v=20260330A"></script>
+<script defer src="render/client.js?v=20260330A"></script>
+<script defer src="render/pipeline.js?v=20260330A"></script>
+<script defer src="render/brief.js?v=20260330A"></script>
+<script src="07-post-load.js?v=20260330A" defer></script>
+<script src="08-post-actions.js?v=20260330A" defer></script>
+<script src="09-library.js?v=20260330A" defer></script>
+<script src="09-approval.js?v=20260330A" defer></script>
+<script src="04-router.js?v=20260330A" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Added `_pcsSaveAllPhotos()` function that opens each image URL directly in a new tab, bypassing CORS blob fetch issues
- Users can long-press each opened image to save on mobile
- Bumped all 17 version strings to `?v=20260330A`

## Test plan
- [x] `node --check 08-post-actions.js` passes
- [x] `npm test` — 133/133 tests pass

https://claude.ai/code/session_017pUfggqcCwUiZ68yz1Spd5