### PR TITLE
fix: save all downloads via R2 Worker with proper Content-Disposition

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1443,7 +1443,7 @@ window._pcsPhotoMenu = function(postId) {
   }, 10);
 };
 
-window._pcsSaveAllPhotos = function(postId) {
+window._pcsSaveAllPhotos = async function(postId) {
   var post = (window.allPosts||[]).find(function(p) {
     return p.post_id === postId;
   });
@@ -1452,11 +1452,21 @@ window._pcsSaveAllPhotos = function(postId) {
     showToast('No images to save.', 'error');
     return;
   }
-  imgs.forEach(function(img) {
-    var url = typeof img === 'string' ? img : (img.url || img);
-    window.open(url, '_blank');
-  });
-  showToast('Opening ' + imgs.length + ' images. Long press each to save.', 'success');
+  showToast('Downloading ' + imgs.length + ' images...', 'success');
+  var R2_BASE = 'https://pub-6a2a4aa8073d454ab9aeee69ef841635.r2.dev/';
+  var WORKER = 'https://srtd-r2-upload.ksg-kumarshubhamgune.workers.dev/download?key=';
+  for (var i = 0; i < imgs.length; i++) {
+    var url = typeof imgs[i] === 'string' ? imgs[i] : (imgs[i].url || imgs[i]);
+    var key = url.replace(R2_BASE, '');
+    var downloadUrl = WORKER + encodeURIComponent(key);
+    var a = document.createElement('a');
+    a.href = downloadUrl;
+    a.download = 'image-' + (i + 1) + '.jpg';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    await new Promise(function(resolve) { setTimeout(resolve, 300); });
+  }
 };
 
 window._pcsCaptionMenu = function(postId) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260330A">
+ <link rel="stylesheet" href="styles.css?v=20260330B">
 
 </head>
 <body>
@@ -1041,24 +1041,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260330A" defer></script>
-<script src="02-session.js?v=20260330A" defer></script>
-<script src="utils.js?v=20260330A" defer></script>
-<script src="03-auth.js?v=20260330A" defer></script>
-<script src="05-api.js?v=20260330A" defer></script>
-<script src="10-ui.js?v=20260330A" defer></script>
+<script src="01-config.js?v=20260330B" defer></script>
+<script src="02-session.js?v=20260330B" defer></script>
+<script src="utils.js?v=20260330B" defer></script>
+<script src="03-auth.js?v=20260330B" defer></script>
+<script src="05-api.js?v=20260330B" defer></script>
+<script src="10-ui.js?v=20260330B" defer></script>
 
-<script src="06-post-create.js?v=20260330A" defer></script>
-<script defer src="render/dashboard.js?v=20260330A"></script>
-<script defer src="render/client.js?v=20260330A"></script>
-<script defer src="render/pipeline.js?v=20260330A"></script>
-<script defer src="render/brief.js?v=20260330A"></script>
-<script defer src="actions/pcs.js?v=20260330A"></script>
-<script src="07-post-load.js?v=20260330A" defer></script>
-<script src="08-post-actions.js?v=20260330A" defer></script>
-<script src="09-library.js?v=20260330A" defer></script>
-<script src="09-approval.js?v=20260330A" defer></script>
-<script src="04-router.js?v=20260330A" defer></script>
+<script src="06-post-create.js?v=20260330B" defer></script>
+<script defer src="render/dashboard.js?v=20260330B"></script>
+<script defer src="render/client.js?v=20260330B"></script>
+<script defer src="render/pipeline.js?v=20260330B"></script>
+<script defer src="render/brief.js?v=20260330B"></script>
+<script defer src="actions/pcs.js?v=20260330B"></script>
+<script src="07-post-load.js?v=20260330B" defer></script>
+<script src="08-post-actions.js?v=20260330B" defer></script>
+<script src="09-library.js?v=20260330B" defer></script>
+<script src="09-approval.js?v=20260330B" defer></script>
+<script src="04-router.js?v=20260330B" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Replaced `_pcsSaveAllPhotos` in `actions/pcs.js` to use R2 Worker download endpoint with proper `Content-Disposition` header
- Strips R2 base URL to extract the key, constructs worker download URL, triggers `<a>` click with `download` attribute
- 300ms delay between downloads to avoid browser throttling
- Bumped all 18 version strings to `?v=20260330B`

## Test plan
- [x] `node --check actions/pcs.js` passes
- [x] `npm test` — 133/133 tests pass
- [x] Zero non-ASCII characters

https://claude.ai/code/session_017pUfggqcCwUiZ68yz1Spd5