### PR TITLE
fix: show awaiting_approval and awaiting_brand_input posts in Pranav pipeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260330H">
+ <link rel="stylesheet" href="styles.css?v=20260330I">
 
 </head>
 <body>
@@ -1041,24 +1041,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260330H" defer></script>
-<script src="02-session.js?v=20260330H" defer></script>
-<script src="utils.js?v=20260330H" defer></script>
-<script src="03-auth.js?v=20260330H" defer></script>
-<script src="05-api.js?v=20260330H" defer></script>
-<script src="10-ui.js?v=20260330H" defer></script>
+<script src="01-config.js?v=20260330I" defer></script>
+<script src="02-session.js?v=20260330I" defer></script>
+<script src="utils.js?v=20260330I" defer></script>
+<script src="03-auth.js?v=20260330I" defer></script>
+<script src="05-api.js?v=20260330I" defer></script>
+<script src="10-ui.js?v=20260330I" defer></script>
 
-<script src="06-post-create.js?v=20260330H" defer></script>
-<script defer src="render/dashboard.js?v=20260330H"></script>
-<script defer src="render/client.js?v=20260330H"></script>
-<script defer src="render/pipeline.js?v=20260330H"></script>
-<script defer src="render/brief.js?v=20260330H"></script>
-<script defer src="actions/pcs.js?v=20260330H"></script>
-<script src="07-post-load.js?v=20260330H" defer></script>
-<script src="08-post-actions.js?v=20260330H" defer></script>
-<script src="09-library.js?v=20260330H" defer></script>
-<script src="09-approval.js?v=20260330H" defer></script>
-<script src="04-router.js?v=20260330H" defer></script>
+<script src="06-post-create.js?v=20260330I" defer></script>
+<script defer src="render/dashboard.js?v=20260330I"></script>
+<script defer src="render/client.js?v=20260330I"></script>
+<script defer src="render/pipeline.js?v=20260330I"></script>
+<script defer src="render/brief.js?v=20260330I"></script>
+<script defer src="actions/pcs.js?v=20260330I"></script>
+<script src="07-post-load.js?v=20260330I" defer></script>
+<script src="08-post-actions.js?v=20260330I" defer></script>
+<script src="09-library.js?v=20260330I" defer></script>
+<script src="09-approval.js?v=20260330I" defer></script>
+<script src="04-router.js?v=20260330I" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/pipeline.js
+++ b/render/pipeline.js
@@ -902,6 +902,8 @@ window._renderPipelineInner = function() {
       if (stage === 'brief') return isMine;
       if (stage === 'in_production') return isMine;
       if (stage === 'ready') return isMine;
+      if (stage === 'awaiting_approval') return true;
+      if (stage === 'awaiting_brand_input') return true;
       return false;
     });
   }


### PR DESCRIPTION
## Summary
- Creative/Pranav pipeline filter now includes `awaiting_approval` and `awaiting_brand_input` stages (visible regardless of owner)
- Previously these stages returned `false`, hiding all approval-stage posts from Pranav's pipeline view
- Bumped all 18 version strings to `?v=20260330I`

## Test plan
- [x] `node --check render/pipeline.js` passes
- [x] `npm test` — 133/133 tests pass

https://claude.ai/code/session_017pUfggqcCwUiZ68yz1Spd5