### PR TITLE
fix: client session token refresh — prevent logout loop for Manisha

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -241,6 +241,14 @@ function activateRole(role) {
     if (loginOv) loginOv.classList.add('hidden');
     document.getElementById('client-view')?.classList.add('active');
     if (typeof loadPostsForClient === 'function') loadPostsForClient();
+    if (!window._clientTokenTimer) {
+      window._clientTokenTimer = setInterval(async function() {
+        var newToken = await refreshSession();
+        if (!newToken) {
+          console.warn('Client token refresh failed');
+        }
+      }, 50 * 60 * 1000);
+    }
     return;
   }
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260330I">
+ <link rel="stylesheet" href="styles.css?v=20260330J">
 
 </head>
 <body>
@@ -1041,24 +1041,24 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260330I" defer></script>
-<script src="02-session.js?v=20260330I" defer></script>
-<script src="utils.js?v=20260330I" defer></script>
-<script src="03-auth.js?v=20260330I" defer></script>
-<script src="05-api.js?v=20260330I" defer></script>
-<script src="10-ui.js?v=20260330I" defer></script>
+<script src="01-config.js?v=20260330J" defer></script>
+<script src="02-session.js?v=20260330J" defer></script>
+<script src="utils.js?v=20260330J" defer></script>
+<script src="03-auth.js?v=20260330J" defer></script>
+<script src="05-api.js?v=20260330J" defer></script>
+<script src="10-ui.js?v=20260330J" defer></script>
 
-<script src="06-post-create.js?v=20260330I" defer></script>
-<script defer src="render/dashboard.js?v=20260330I"></script>
-<script defer src="render/client.js?v=20260330I"></script>
-<script defer src="render/pipeline.js?v=20260330I"></script>
-<script defer src="render/brief.js?v=20260330I"></script>
-<script defer src="actions/pcs.js?v=20260330I"></script>
-<script src="07-post-load.js?v=20260330I" defer></script>
-<script src="08-post-actions.js?v=20260330I" defer></script>
-<script src="09-library.js?v=20260330I" defer></script>
-<script src="09-approval.js?v=20260330I" defer></script>
-<script src="04-router.js?v=20260330I" defer></script>
+<script src="06-post-create.js?v=20260330J" defer></script>
+<script defer src="render/dashboard.js?v=20260330J"></script>
+<script defer src="render/client.js?v=20260330J"></script>
+<script defer src="render/pipeline.js?v=20260330J"></script>
+<script defer src="render/brief.js?v=20260330J"></script>
+<script defer src="actions/pcs.js?v=20260330J"></script>
+<script src="07-post-load.js?v=20260330J" defer></script>
+<script src="08-post-actions.js?v=20260330J" defer></script>
+<script src="09-library.js?v=20260330J" defer></script>
+<script src="09-approval.js?v=20260330J" defer></script>
+<script src="04-router.js?v=20260330J" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- **Added proactive token refresh timer for Client role sessions** in `03-auth.js`. The `activateRole()` Client branch previously returned before `startRealtime()` was called, so Client sessions never got the 50-minute background token refresh. This caused tokens to expire silently, leading to a logout loop for client users (Manisha).
- **Bumped all 18 cache-bust `?v=` strings** (17 scripts + 1 CSS) in `index.html` from `20260330H` to `20260330J`.

## Test plan

- [x] 133 tests pass (`npm test`)
- [ ] Verify Client role login persists beyond 60 minutes without forced logout
- [ ] Verify `window._clientTokenTimer` is set after Client login (browser console)
- [ ] Verify non-client roles are unaffected (Admin/Servicing/Creative still use `startRealtime()` path)

https://claude.ai/code/session_01Vw5AWyvuhtGPBvwnMvcEbn