### PR TITLE
fix: global click listener — migrate _pcsActiveMenu to AppState.pcs.activeMenu

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260331A">
+ <link rel="stylesheet" href="styles.css?v=20260331B">
 
 </head>
 <body>
@@ -1078,26 +1078,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260331A"></script>
-<script src="00-appstate-compat.js?v=20260331A"></script>
-<script src="01-config.js?v=20260331A" defer></script>
-<script src="02-session.js?v=20260331A" defer></script>
-<script src="utils.js?v=20260331A" defer></script>
-<script src="03-auth.js?v=20260331A" defer></script>
-<script src="05-api.js?v=20260331A" defer></script>
-<script src="10-ui.js?v=20260331A" defer></script>
+<script src="00-appstate.js?v=20260331B"></script>
+<script src="00-appstate-compat.js?v=20260331B"></script>
+<script src="01-config.js?v=20260331B" defer></script>
+<script src="02-session.js?v=20260331B" defer></script>
+<script src="utils.js?v=20260331B" defer></script>
+<script src="03-auth.js?v=20260331B" defer></script>
+<script src="05-api.js?v=20260331B" defer></script>
+<script src="10-ui.js?v=20260331B" defer></script>
 
-<script src="06-post-create.js?v=20260331A" defer></script>
-<script defer src="render/dashboard.js?v=20260331A"></script>
-<script defer src="render/client.js?v=20260331A"></script>
-<script defer src="render/pipeline.js?v=20260331A"></script>
-<script defer src="render/brief.js?v=20260331A"></script>
-<script defer src="actions/pcs.js?v=20260331A"></script>
-<script src="07-post-load.js?v=20260331A" defer></script>
-<script src="08-post-actions.js?v=20260331A" defer></script>
-<script src="09-library.js?v=20260331A" defer></script>
-<script src="09-approval.js?v=20260331A" defer></script>
-<script src="04-router.js?v=20260331A" defer></script>
+<script src="06-post-create.js?v=20260331B" defer></script>
+<script defer src="render/dashboard.js?v=20260331B"></script>
+<script defer src="render/client.js?v=20260331B"></script>
+<script defer src="render/pipeline.js?v=20260331B"></script>
+<script defer src="render/brief.js?v=20260331B"></script>
+<script defer src="actions/pcs.js?v=20260331B"></script>
+<script src="07-post-load.js?v=20260331B" defer></script>
+<script src="08-post-actions.js?v=20260331B" defer></script>
+<script src="09-library.js?v=20260331B" defer></script>
+<script src="09-approval.js?v=20260331B" defer></script>
+<script src="04-router.js?v=20260331B" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Migration already complete via rebase — `_pcsActiveMenu` fully replaced with `AppState.pcs.activeMenu` (zero legacy references remain)
- Bumped all 20 version strings to `?v=20260331B`

## Test plan
- [x] `grep -n "_pcsActiveMenu" actions/pcs.js` — zero matches
- [x] `node --check actions/pcs.js` passes
- [x] `npm test` — 152/152 tests pass

https://claude.ai/code/session_017pUfggqcCwUiZ68yz1Spd5