### PR TITLE
fix: call _restoreAgencyNav on non-client role activation

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -266,6 +266,10 @@ function activateRole(role) {
     document.getElementById('client-view')?.classList.add('active');
     loadPostsForClient();
   } else {
+    if (typeof window._restoreAgencyNav === 'function') {
+      window._restoreAgencyNav();
+    }
+    document.body.classList.remove('client-mode');
     document.getElementById('dashboard-view')?.classList.add('active');
     const lbl = document.getElementById('topbar-role-label');
     if (lbl) lbl.textContent = effectiveRole;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260330K">
+ <link rel="stylesheet" href="styles.css?v=20260331E">
 
 </head>
 <body>
@@ -974,24 +974,24 @@ window.currentRole     = window.currentRole || 'Admin';
 window.allTasks        = window.allTasks    || [];
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="01-config.js?v=20260330K" defer></script>
-<script src="02-session.js?v=20260330K" defer></script>
-<script src="utils.js?v=20260330K" defer></script>
-<script src="03-auth.js?v=20260330K" defer></script>
-<script src="05-api.js?v=20260330K" defer></script>
-<script src="10-ui.js?v=20260330K" defer></script>
+<script src="01-config.js?v=20260331E" defer></script>
+<script src="02-session.js?v=20260331E" defer></script>
+<script src="utils.js?v=20260331E" defer></script>
+<script src="03-auth.js?v=20260331E" defer></script>
+<script src="05-api.js?v=20260331E" defer></script>
+<script src="10-ui.js?v=20260331E" defer></script>
 
-<script src="06-post-create.js?v=20260330K" defer></script>
-<script defer src="render/dashboard.js?v=20260330K"></script>
-<script defer src="render/client.js?v=20260330K"></script>
-<script defer src="render/pipeline.js?v=20260330K"></script>
-<script defer src="render/brief.js?v=20260330K"></script>
-<script defer src="actions/pcs.js?v=20260330K"></script>
-<script src="07-post-load.js?v=20260330K" defer></script>
-<script src="08-post-actions.js?v=20260330K" defer></script>
-<script src="09-library.js?v=20260330K" defer></script>
-<script src="09-approval.js?v=20260330K" defer></script>
-<script src="04-router.js?v=20260330K" defer></script>
+<script src="06-post-create.js?v=20260331E" defer></script>
+<script defer src="render/dashboard.js?v=20260331E"></script>
+<script defer src="render/client.js?v=20260331E"></script>
+<script defer src="render/pipeline.js?v=20260331E"></script>
+<script defer src="render/brief.js?v=20260331E"></script>
+<script defer src="actions/pcs.js?v=20260331E"></script>
+<script src="07-post-load.js?v=20260331E" defer></script>
+<script src="08-post-actions.js?v=20260331E" defer></script>
+<script src="09-library.js?v=20260331E" defer></script>
+<script src="09-approval.js?v=20260331E" defer></script>
+<script src="04-router.js?v=20260331E" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- Added `_restoreAgencyNav()` call in `activateRole()` non-client branch (line 269-270)
- Added `document.body.classList.remove('client-mode')` to clean up CSS scope
- Both fire before dashboard-view activation, restoring agency bottom nav tabs (Dashboard/Posts/Library/Insights)

**Root cause:** `_setClientNav()` overwrites `#bottom-nav` innerHTML when client view activates, but nothing called `_restoreAgencyNav()` when switching back to agency roles. The function existed but had zero callers.

Version strings: `?v=20260331E` (18 files). 133/133 tests pass. 0 non-ASCII.

## Test plan

- [ ] Login as Client: bottom nav shows Feed/Requests/Alerts
- [ ] Admin previews Client then switches back: bottom nav restores Dashboard/Posts/Library/Insights
- [ ] Pipeline, Library, Insights tabs all clickable after restore
- [ ] body.client-mode class removed on agency activation

https://claude.ai/code/session_01YSpQkL8d9oF2DZYVFKHWTB