### PR TITLE
test: comprehensive notification test suite (67 tests)

### DIFF
--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -2,7 +2,23 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-// Notification routing logic — pure logic, no API calls.
+// Load source files for static analysis
+var uiSrc = readFileSync(resolve(__dirname, '..', '10-ui.js'), 'utf8');
+var actionsSrc = readFileSync(resolve(__dirname, '..', '08-post-actions.js'), 'utf8');
+var sessionSrc = readFileSync(resolve(__dirname, '..', '02-session.js'), 'utf8');
+var pcsSrc = '';
+try { pcsSrc = readFileSync(resolve(__dirname, '..', 'actions', 'pcs.js'), 'utf8'); } catch(e) {}
+
+// Extract _stageLabel from 08-post-actions.js
+function loadStageLabel() {
+  var match = actionsSrc.match(/function _stageLabel\(stage\)\s*\{[\s\S]*?\n\}/);
+  if (!match) throw new Error('Could not find _stageLabel function');
+  var fn = new Function(match[0] + '\n return _stageLabel;');
+  return fn();
+}
+var _stageLabel = loadStageLabel();
+
+// Notification routing logic -- pure logic, no API calls
 function getNotifTargets(actorRole) {
   var r = (actorRole || '').toLowerCase();
   if (r === 'client')                          return ['Servicing', 'Admin'];
@@ -12,109 +28,513 @@ function getNotifTargets(actorRole) {
   return [];
 }
 
-// Extract _stageLabel from 08-post-actions.js
-const actionsSrc = readFileSync(resolve(__dirname, '..', '08-post-actions.js'), 'utf8');
 
-function loadStageLabel() {
-  const match = actionsSrc.match(/function _stageLabel\(stage\)\s*\{[\s\S]*?\n\}/);
-  if (!match) throw new Error('Could not find _stageLabel function');
-  const fn = new Function(match[0] + '\n return _stageLabel;');
-  return fn();
-}
+// =========================================================
+// GROUP 1: Self-notification filtering (source analysis)
+// =========================================================
+describe('Self-notification filtering', function() {
 
-const _stageLabel = loadStageLabel();
-
-// Notification routing
-describe('getNotifTargets', () => {
-  it("'Client' actor -> targets include 'Servicing'", () => {
-    expect(getNotifTargets('Client')).toContain('Servicing');
+  it('updateNotifBadge builds URL with actor=neq filter', function() {
+    // The updateNotifBadge function must append actor=neq to exclude self
+    var match = uiSrc.match(/function updateNotifBadge\(\)[\s\S]*?\.catch/);
+    expect(match).not.toBeNull();
+    var body = match[0];
+    expect(body).toContain('actor=neq.');
   });
 
-  it("'Client' actor -> targets include 'Admin'", () => {
-    expect(getNotifTargets('Client')).toContain('Admin');
+  it('loadNotifications builds URL with actor=neq filter', function() {
+    var match = uiSrc.match(/function loadNotifications\(\)[\s\S]*?catch\(e\)/);
+    expect(match).not.toBeNull();
+    var body = match[0];
+    expect(body).toContain('actor=neq.');
   });
 
-  it("'Client' actor -> targets NOT include 'Client'", () => {
-    expect(getNotifTargets('Client')).not.toContain('Client');
+  it('self-filter uses AppState.user.name as primary source in updateNotifBadge', function() {
+    var match = uiSrc.match(/function updateNotifBadge\(\)[\s\S]*?\.catch/);
+    var body = match[0];
+    // AppState.user.name must come BEFORE window.currentUserName
+    var appStateIdx = body.indexOf('AppState.user.name');
+    var windowIdx = body.indexOf('window.currentUserName');
+    expect(appStateIdx).toBeGreaterThan(-1);
+    expect(windowIdx).toBeGreaterThan(-1);
+    expect(appStateIdx).toBeLessThan(windowIdx);
   });
 
-  it("'Creative' actor -> targets include 'Servicing'", () => {
-    expect(getNotifTargets('Creative')).toContain('Servicing');
+  it('self-filter uses AppState.user.name as primary source in loadNotifications', function() {
+    var match = uiSrc.match(/function loadNotifications\(\)[\s\S]*?catch\(e\)/);
+    var body = match[0];
+    var appStateIdx = body.indexOf('AppState.user.name');
+    var windowIdx = body.indexOf('window.currentUserName');
+    expect(appStateIdx).toBeGreaterThan(-1);
+    expect(windowIdx).toBeGreaterThan(-1);
+    expect(appStateIdx).toBeLessThan(windowIdx);
   });
 
-  it("'Creative' actor -> targets include 'Admin'", () => {
-    expect(getNotifTargets('Creative')).toContain('Admin');
+  it('self-filter is conditional -- empty actor skips the filter', function() {
+    // Must have an if check before appending actor=neq
+    var match = uiSrc.match(/function updateNotifBadge\(\)[\s\S]*?\.catch/);
+    var body = match[0];
+    expect(body).toMatch(/if\s*\(\s*_badgeActor\s*\)/);
   });
 
-  it("'Pranav' actor -> same as Creative", () => {
-    expect(getNotifTargets('Pranav')).toEqual(getNotifTargets('Creative'));
-  });
-
-  it("'Servicing' actor -> targets include 'Admin'", () => {
-    expect(getNotifTargets('Servicing')).toContain('Admin');
-  });
-
-  it("'Servicing' actor -> targets include 'Client'", () => {
-    expect(getNotifTargets('Servicing')).toContain('Client');
-  });
-
-  it("'Chitra' actor -> same as Servicing", () => {
-    expect(getNotifTargets('Chitra')).toEqual(getNotifTargets('Servicing'));
-  });
-
-  it("'Admin' actor -> targets include 'Client'", () => {
-    expect(getNotifTargets('Admin')).toContain('Client');
-  });
-
-  it("'Admin' actor -> targets include 'Servicing'", () => {
-    expect(getNotifTargets('Admin')).toContain('Servicing');
-  });
-
-  it("'Admin' actor -> targets NOT include 'Admin'", () => {
-    expect(getNotifTargets('Admin')).not.toContain('Admin');
-  });
-
-  it('no role doubles up (actor never notifies themselves)', () => {
-    const roles = ['Admin', 'Servicing', 'Creative', 'Pranav', 'Chitra', 'Client'];
-    for (const role of roles) {
-      const targets = getNotifTargets(role);
-      expect(targets).not.toContain(role);
-    }
-  });
 });
 
-// _stageLabel
-describe('_stageLabel', () => {
-  it("'brief' -> 'Brief'", () => {
+
+// =========================================================
+// GROUP 2: Badge system (source analysis)
+// =========================================================
+describe('Notification badge', function() {
+
+  it('updateNotifBadge queries with AppState.user.effectiveRole', function() {
+    var match = uiSrc.match(/function updateNotifBadge\(\)[\s\S]*?\.catch/);
+    var body = match[0];
+    expect(body).toContain('AppState.user.effectiveRole');
+  });
+
+  it('updateNotifBadge updates all 5 badge element IDs', function() {
+    var match = uiSrc.match(/function updateNotifBadge\(\)[\s\S]*?\.catch/);
+    var body = match[0];
+    var expectedIds = [
+      'notif-bell-badge',
+      'notif-pipeline-badge',
+      'notif-lib-badge',
+      'notif-ins-badge',
+      'notif-client-badge'
+    ];
+    expectedIds.forEach(function(id) {
+      expect(body).toContain(id);
+    });
+  });
+
+  it('badge shows 9+ for counts above 9', function() {
+    var match = uiSrc.match(/function updateNotifBadge\(\)[\s\S]*?\.catch/);
+    var body = match[0];
+    expect(body).toContain("'9+'");
+  });
+
+  it('periodic badge refresh interval is set on AppState.timers', function() {
+    expect(uiSrc).toContain('AppState.timers.notifBadgeTimer');
+    expect(uiSrc).toMatch(/setInterval\(function\(\)\s*\{[\s\S]*?updateNotifBadge/);
+  });
+
+  it('periodic badge refresh interval is 60 seconds', function() {
+    var match = uiSrc.match(/AppState\.timers\.notifBadgeTimer\s*=\s*setInterval\([\s\S]*?,\s*(\d+)\)/);
+    expect(match).not.toBeNull();
+    expect(parseInt(match[1])).toBe(60000);
+  });
+
+});
+
+
+// =========================================================
+// GROUP 3: Comment notifications (source analysis)
+// =========================================================
+describe('Comment notifications', function() {
+
+  // Check actions/pcs.js (main moved submitPcsComment there)
+  var commentSrc = pcsSrc || actionsSrc;
+
+  it('comment notification uses type:comment', function() {
+    expect(commentSrc).toMatch(/type:\s*['"]comment['"]/);
+  });
+
+  it('comment notification includes actor field', function() {
+    // Find the notification insert block in comment handler
+    var match = commentSrc.match(/type:\s*['"]comment['"][\s\S]{0,200}/);
+    expect(match).not.toBeNull();
+    // Look nearby for actor field
+    var nearbyBlock = commentSrc.substring(
+      commentSrc.indexOf("type: 'comment'") - 200,
+      commentSrc.indexOf("type: 'comment'") + 300
+    );
+    expect(nearbyBlock).toContain('actor:');
+  });
+
+  it('comment notification actor uses AppState.user.name', function() {
+    var idx = commentSrc.indexOf("type: 'comment'");
+    if (idx === -1) idx = commentSrc.indexOf('type: "comment"');
+    var nearbyBlock = commentSrc.substring(idx - 200, idx + 300);
+    expect(nearbyBlock).toContain('AppState.user.name');
+  });
+
+  it('Client comments notify Servicing and Admin', function() {
+    var targets = getNotifTargets('Client');
+    expect(targets).toContain('Servicing');
+    expect(targets).toContain('Admin');
+    expect(targets).not.toContain('Client');
+  });
+
+  it('Servicing comments notify Admin and Client', function() {
+    var targets = getNotifTargets('Servicing');
+    expect(targets).toContain('Admin');
+    expect(targets).toContain('Client');
+    expect(targets).not.toContain('Servicing');
+  });
+
+  it('Admin comments notify Client and Servicing', function() {
+    var targets = getNotifTargets('Admin');
+    expect(targets).toContain('Client');
+    expect(targets).toContain('Servicing');
+    expect(targets).not.toContain('Admin');
+  });
+
+  it('Creative comments notify Servicing and Admin', function() {
+    var targets = getNotifTargets('Creative');
+    expect(targets).toContain('Servicing');
+    expect(targets).toContain('Admin');
+  });
+
+});
+
+
+// =========================================================
+// GROUP 4: Client request notification
+// =========================================================
+describe('Client request notification', function() {
+
+  it('client request sends new_request notification to Servicing', function() {
+    expect(actionsSrc).toContain("type: 'new_request'");
+    expect(actionsSrc).toContain("user_role: 'Servicing'");
+  });
+
+  it('client request notification includes actor field', function() {
+    var idx = actionsSrc.indexOf("'new_request'");
+    var block = actionsSrc.substring(idx - 100, idx + 300);
+    expect(block).toContain('actor:');
+  });
+
+  it('client request notification uses AppState.user.name', function() {
+    var idx = actionsSrc.indexOf("'new_request'");
+    var block = actionsSrc.substring(idx - 200, idx + 300);
+    expect(block).toContain('AppState.user.name');
+  });
+
+  it('client request notification includes read:false', function() {
+    var idx = actionsSrc.indexOf("'new_request'");
+    var block = actionsSrc.substring(idx - 50, idx + 300);
+    expect(block).toContain('read: false');
+  });
+
+  it('client request notification targets ONLY Servicing (not Admin -- DB trigger handles Admin)', function() {
+    // Find the new_request block and verify it targets only Servicing
+    var idx = actionsSrc.indexOf("type: 'new_request'");
+    var block = actionsSrc.substring(idx - 200, idx + 50);
+    expect(block).toContain("user_role: 'Servicing'");
+    // Verify there is no forEach loop targeting multiple roles for this insert
+    expect(block).not.toContain('.forEach');
+  });
+
+});
+
+
+// =========================================================
+// GROUP 5: Mark as read (source analysis)
+// =========================================================
+describe('Mark as read', function() {
+
+  it('markNotifRead sends PATCH with read:true', function() {
+    var match = uiSrc.match(/function markNotifRead\(id\)[\s\S]*?catch/);
+    expect(match).not.toBeNull();
+    var body = match[0];
+    expect(body).toContain("method: 'PATCH'");
+    expect(body).toContain('read: true');
+  });
+
+  it('markNotifRead uses id=eq. filter in URL', function() {
+    var match = uiSrc.match(/function markNotifRead\(id\)[\s\S]*?catch/);
+    var body = match[0];
+    expect(body).toContain('id=eq.');
+  });
+
+  it('markNotifRead updates _notifData optimistically before API call', function() {
+    var match = uiSrc.match(/function markNotifRead\(id\)[\s\S]*?catch/);
+    var body = match[0];
+    // _notifData.map must come BEFORE apiFetch
+    var mapIdx = body.indexOf('_notifData = _notifData.map');
+    var apiIdx = body.indexOf('apiFetch');
+    expect(mapIdx).toBeGreaterThan(-1);
+    expect(apiIdx).toBeGreaterThan(-1);
+    expect(mapIdx).toBeLessThan(apiIdx);
+  });
+
+  it('markNotifRead calls updateNotifBadge', function() {
+    var match = uiSrc.match(/function markNotifRead\(id\)[\s\S]*?catch/);
+    var body = match[0];
+    expect(body).toContain('updateNotifBadge()');
+  });
+
+  it('markAllNotificationsRead patches all unread for current role', function() {
+    var match = uiSrc.match(/function markAllNotificationsRead\(\)[\s\S]*?catch\(e\)/);
+    expect(match).not.toBeNull();
+    var body = match[0];
+    expect(body).toContain('read=eq.false');
+    expect(body).toContain('user_role=eq.');
+    expect(body).toContain("method: 'PATCH'");
+  });
+
+  it('markAllNotificationsRead hides all 5 badge elements', function() {
+    var match = uiSrc.match(/function markAllNotificationsRead\(\)[\s\S]*?catch\(e\)/);
+    var body = match[0];
+    expect(body).toContain('notif-bell-badge');
+    expect(body).toContain('notif-pipeline-badge');
+    expect(body).toContain('notif-lib-badge');
+    expect(body).toContain('notif-ins-badge');
+    expect(body).toContain('notif-client-badge');
+    expect(body).toContain("display = 'none'");
+  });
+
+});
+
+
+// =========================================================
+// GROUP 6: Card tap mark-as-read
+// =========================================================
+describe('Notification card tap', function() {
+
+  it('notification cards render with data-notif-id attribute', function() {
+    // renderNotifications must include data-notif-id in the HTML template
+    expect(uiSrc).toContain('data-notif-id');
+    // Specifically in the notif-item div
+    var match = uiSrc.match(/class="notif-item[\s\S]{0,200}data-notif-id/);
+    expect(match).not.toBeNull();
+  });
+
+  it('card tap handler reads data-notif-id and calls markNotifRead', function() {
+    // The delegated click handler for .notif-post-card-tap must read notif-id
+    var match = uiSrc.match(/notif-post-card-tap[\s\S]{0,800}markNotifRead/);
+    expect(match).not.toBeNull();
+  });
+
+  it('card tap handler reads notif-id from closest parent if not on card itself', function() {
+    // The delegated handler uses closest to walk up to the notif-item with the id
+    expect(uiSrc).toContain("closest('[data-notif-id]')");
+  });
+
+});
+
+
+// =========================================================
+// GROUP 7: No duplicate stage notifications from JS
+// =========================================================
+describe('No duplicate stage-change notifications from JS', function() {
+
+  it('quickStage does NOT insert notifications', function() {
+    var match = actionsSrc.match(/function quickStage\([\s\S]*?\n\}/);
+    expect(match).not.toBeNull();
+    var body = match[0];
+    // Must NOT contain a POST to /notifications
+    var hasNotifPost = body.includes("'/notifications'") &&
+      body.includes("method: 'POST'");
+    expect(hasNotifPost).toBe(false);
+  });
+
+  it('clientApprove does NOT insert notifications', function() {
+    var match = actionsSrc.match(/function clientApprove\([\s\S]*?\n\}/);
+    if (!match) return; // function may not exist in this file
+    var body = match[0];
+    var hasNotifPost = body.includes("'/notifications'") &&
+      body.includes("method: 'POST'");
+    expect(hasNotifPost).toBe(false);
+  });
+
+  it('publishPost / _confirmPublish does NOT insert notifications', function() {
+    // Look for the publish function
+    var match = actionsSrc.match(/function _confirmPublish\([\s\S]*?\n\}/);
+    if (!match) return; // function may not exist
+    var body = match[0];
+    var hasNotifPost = body.includes("'/notifications'") &&
+      body.includes("method: 'POST'");
+    expect(hasNotifPost).toBe(false);
+  });
+
+  it('08-post-actions.js has exactly 1 notification POST (new_request only)', function() {
+    var matches = actionsSrc.match(/apiFetch\('\/notifications',\s*\{[\s\S]*?method:\s*'POST'/g);
+    // Should be exactly 1 -- the client request notification
+    expect(matches).not.toBeNull();
+    expect(matches.length).toBe(1);
+  });
+
+  it('07-post-load.js has zero notification POSTs', function() {
+    var postLoadSrc = readFileSync(resolve(__dirname, '..', '07-post-load.js'), 'utf8');
+    var matches = postLoadSrc.match(/apiFetch\('\/notifications',\s*\{[\s\S]*?method:\s*'POST'/g);
+    expect(matches).toBeNull();
+  });
+
+});
+
+
+// =========================================================
+// GROUP 8: Dead code stays dead
+// =========================================================
+describe('Dead code removed', function() {
+
+  it('openNotifItem function does not exist in 10-ui.js', function() {
+    expect(uiSrc).not.toMatch(/function openNotifItem\s*\(/);
+    expect(uiSrc).not.toContain('window.openNotifItem');
+  });
+
+  it('handleNotifAction function does not exist in 10-ui.js', function() {
+    expect(uiSrc).not.toMatch(/function handleNotifAction\s*\(/);
+    expect(uiSrc).not.toContain('window.handleNotifAction');
+  });
+
+  it('async submitPcsComment v1 does not exist in 08-post-actions.js', function() {
+    expect(actionsSrc).not.toMatch(/async\s+function\s+submitPcsComment\s*\(/);
+  });
+
+  it('window._unreadCount does not exist in 02-session.js', function() {
+    expect(sessionSrc).not.toContain('window._unreadCount');
+  });
+
+  it('no stage_change type notification inserts remain in 08-post-actions.js', function() {
+    // The only notification insert should be new_request
+    var stageChangeNotifs = actionsSrc.match(/type:\s*['"]stage_change['"]/g);
+    expect(stageChangeNotifs).toBeNull();
+  });
+
+  it('no awaiting_approval type notification inserts remain in 08-post-actions.js', function() {
+    var matches = actionsSrc.match(/type:\s*['"]awaiting_approval['"]/g);
+    expect(matches).toBeNull();
+  });
+
+  it('no published type notification inserts remain in 08-post-actions.js', function() {
+    var matches = actionsSrc.match(/type:\s*['"]published['"]/g);
+    expect(matches).toBeNull();
+  });
+
+});
+
+
+// =========================================================
+// GROUP 9: Role-based query correctness
+// =========================================================
+describe('Role-based notification queries', function() {
+
+  it('loadNotifications uses AppState.user.effectiveRole for role filter', function() {
+    var match = uiSrc.match(/function loadNotifications\(\)[\s\S]*?catch\(e\)/);
+    var body = match[0];
+    expect(body).toContain('AppState.user.effectiveRole');
+    expect(body).toContain('user_role=eq.');
+  });
+
+  it('updateNotifBadge uses AppState.user.effectiveRole for role filter', function() {
+    var match = uiSrc.match(/function updateNotifBadge\(\)[\s\S]*?\.catch/);
+    var body = match[0];
+    expect(body).toContain('AppState.user.effectiveRole');
+    expect(body).toContain('user_role=eq.');
+  });
+
+  it('loadNotifications falls back to AppState.user.role when effectiveRole empty', function() {
+    var match = uiSrc.match(/function loadNotifications\(\)[\s\S]*?catch\(e\)/);
+    var body = match[0];
+    expect(body).toContain('AppState.user.role');
+  });
+
+  it('role is lowercased before query', function() {
+    var match = uiSrc.match(/function loadNotifications\(\)[\s\S]*?catch\(e\)/);
+    var body = match[0];
+    expect(body).toContain('.toLowerCase()');
+  });
+
+});
+
+
+// =========================================================
+// GROUP 10: _stageLabel (preserved from original tests)
+// =========================================================
+describe('_stageLabel', function() {
+
+  it("'brief' -> 'Brief'", function() {
     expect(_stageLabel('brief')).toBe('Brief');
   });
 
-  it("'brief_done' -> 'Closed Brief'", () => {
+  it("'brief_done' -> 'Closed Brief'", function() {
     expect(_stageLabel('brief_done')).toBe('Closed Brief');
   });
 
-  it("'in_production' -> 'In Production'", () => {
+  it("'in_production' -> 'In Production'", function() {
     expect(_stageLabel('in_production')).toBe('In Production');
   });
 
-  it("'awaiting_approval' -> 'Awaiting Approval'", () => {
+  it("'awaiting_approval' -> 'Awaiting Approval'", function() {
     expect(_stageLabel('awaiting_approval')).toBe('Awaiting Approval');
   });
 
-  it("'awaiting_brand_input' -> 'Awaiting Input'", () => {
+  it("'awaiting_brand_input' -> 'Awaiting Input'", function() {
     expect(_stageLabel('awaiting_brand_input')).toBe('Awaiting Input');
   });
 
-  it("'published' -> 'Published'", () => {
+  it("'published' -> 'Published'", function() {
     expect(_stageLabel('published')).toBe('Published');
   });
 
-  it("'unknown_stage' -> 'unknown_stage' (passthrough)", () => {
+  it("'unknown_stage' -> 'unknown_stage' (passthrough)", function() {
     expect(_stageLabel('unknown_stage')).toBe('unknown_stage');
   });
 
-  it('null/undefined -> safe empty-ish return', () => {
+  it('null/undefined -> safe empty-ish return', function() {
     expect(_stageLabel(null)).toBeFalsy();
     expect(_stageLabel(undefined)).toBeFalsy();
   });
+
+});
+
+
+// =========================================================
+// GROUP 11: Notification routing (preserved from original)
+// =========================================================
+describe('getNotifTargets', function() {
+
+  it("'Client' actor -> targets include 'Servicing'", function() {
+    expect(getNotifTargets('Client')).toContain('Servicing');
+  });
+
+  it("'Client' actor -> targets include 'Admin'", function() {
+    expect(getNotifTargets('Client')).toContain('Admin');
+  });
+
+  it("'Client' actor -> targets NOT include 'Client'", function() {
+    expect(getNotifTargets('Client')).not.toContain('Client');
+  });
+
+  it("'Creative' actor -> targets include 'Servicing'", function() {
+    expect(getNotifTargets('Creative')).toContain('Servicing');
+  });
+
+  it("'Pranav' actor -> same as Creative", function() {
+    expect(getNotifTargets('Pranav')).toEqual(getNotifTargets('Creative'));
+  });
+
+  it("'Servicing' actor -> targets include 'Admin'", function() {
+    expect(getNotifTargets('Servicing')).toContain('Admin');
+  });
+
+  it("'Servicing' actor -> targets include 'Client'", function() {
+    expect(getNotifTargets('Servicing')).toContain('Client');
+  });
+
+  it("'Chitra' actor -> same as Servicing", function() {
+    expect(getNotifTargets('Chitra')).toEqual(getNotifTargets('Servicing'));
+  });
+
+  it("'Admin' actor -> targets include 'Client'", function() {
+    expect(getNotifTargets('Admin')).toContain('Client');
+  });
+
+  it("'Admin' actor -> targets include 'Servicing'", function() {
+    expect(getNotifTargets('Admin')).toContain('Servicing');
+  });
+
+  it("'Admin' actor -> targets NOT include 'Admin'", function() {
+    expect(getNotifTargets('Admin')).not.toContain('Admin');
+  });
+
+  it('no role doubles up (actor never notifies themselves)', function() {
+    var roles = ['Admin', 'Servicing', 'Creative', 'Pranav', 'Chitra', 'Client'];
+    for (var i = 0; i < roles.length; i++) {
+      var targets = getNotifTargets(roles[i]);
+      expect(targets).not.toContain(roles[i]);
+    }
+  });
+
 });


### PR DESCRIPTION
- Self-notification filtering (actor=neq, AppState.user.name priority)
- Badge system (5 elements, effectiveRole, 9+ cap, 60s refresh)
- Comment notifications (type:comment, actor field, role routing)
- Client request notification (new_request, Servicing-only)
- Mark as read (PATCH, optimistic update, badge refresh)
- Card tap mark-as-read (data-notif-id, delegated handler)
- No duplicate stage notifications from JS (DB trigger handles)
- Dead code verification (openNotifItem, handleNotifAction, v1 gone)
- Role-based query correctness (effectiveRole, lowercase, fallback)
- _stageLabel + getNotifTargets (preserved from original)

https://claude.ai/code/session_013FdSRdatY567mokDLmy4xh