### PR TITLE
fix: fire mention notifications with correct role mapping

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -2003,10 +2003,6 @@ window._doSubmitComment = async function(opts) {
       _targets = ['Servicing'];
     } else if (opts.visibility === 'creative') {
       _targets = ['Creative'];
-    } else {
-      if (opts.mentioned && opts.mentioned.length) {
-        _targets = opts.mentioned;
-      }
     }
 
     _targets.forEach(function(role) {
@@ -2021,6 +2017,29 @@ window._doSubmitComment = async function(opts) {
         })
       }).catch(function(){});
     });
+
+    if (opts.mentioned && opts.mentioned.length > 0) {
+      opts.mentioned.forEach(function(name) {
+        var _member = _AGENCY_MEMBERS.find(function(m) {
+          return m.name.toLowerCase() === name.toLowerCase();
+        });
+        if (!_member) return;
+        if (_targets.indexOf(_member.role) !== -1) return;
+        var _mentionMsg = opts.isInternal
+          ? opts.author + ' mentioned you in a note on "' + opts.title + '"'
+          : opts.author + ' mentioned you on "' + opts.title + '"';
+        apiFetch('/notifications', {
+          method: 'POST',
+          body: JSON.stringify({
+            user_role: _member.role,
+            post_id: opts.postId,
+            type: 'mention',
+            message: _mentionMsg,
+            actor: (window.AppState.user.name || window.currentUserName || 'Unknown')
+          })
+        }).catch(function(){});
+      });
+    }
 
     var _mentionContacts = await _lookupMentionEmails(opts.mentioned);
     window._lastMentionContacts = _mentionContacts;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260331N">
+ <link rel="stylesheet" href="styles.css?v=20260401a">
 
 </head>
 <body>
@@ -1078,26 +1078,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260331N"></script>
-<script src="00-appstate-compat.js?v=20260331N"></script>
-<script src="01-config.js?v=20260331N" defer></script>
-<script src="02-session.js?v=20260331N" defer></script>
-<script src="utils.js?v=20260331N" defer></script>
-<script src="03-auth.js?v=20260331N" defer></script>
-<script src="05-api.js?v=20260331N" defer></script>
-<script src="10-ui.js?v=20260331N" defer></script>
+<script src="00-appstate.js?v=20260401a"></script>
+<script src="00-appstate-compat.js?v=20260401a"></script>
+<script src="01-config.js?v=20260401a" defer></script>
+<script src="02-session.js?v=20260401a" defer></script>
+<script src="utils.js?v=20260401a" defer></script>
+<script src="03-auth.js?v=20260401a" defer></script>
+<script src="05-api.js?v=20260401a" defer></script>
+<script src="10-ui.js?v=20260401a" defer></script>
 
-<script src="06-post-create.js?v=20260331N" defer></script>
-<script defer src="render/dashboard.js?v=20260331N"></script>
-<script defer src="render/client.js?v=20260331N"></script>
-<script defer src="render/pipeline.js?v=20260331N"></script>
-<script defer src="render/brief.js?v=20260331N"></script>
-<script defer src="actions/pcs.js?v=20260331N"></script>
-<script src="07-post-load.js?v=20260331N" defer></script>
-<script src="08-post-actions.js?v=20260331N" defer></script>
-<script src="09-library.js?v=20260331N" defer></script>
-<script src="09-approval.js?v=20260331N" defer></script>
-<script src="04-router.js?v=20260331N" defer></script>
+<script src="06-post-create.js?v=20260401a" defer></script>
+<script defer src="render/dashboard.js?v=20260401a"></script>
+<script defer src="render/client.js?v=20260401a"></script>
+<script defer src="render/pipeline.js?v=20260401a"></script>
+<script defer src="render/brief.js?v=20260401a"></script>
+<script defer src="actions/pcs.js?v=20260401a"></script>
+<script src="07-post-load.js?v=20260401a" defer></script>
+<script src="08-post-actions.js?v=20260401a" defer></script>
+<script src="09-library.js?v=20260401a" defer></script>
+<script src="09-approval.js?v=20260401a" defer></script>
+<script src="04-router.js?v=20260401a" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -538,3 +538,102 @@ describe('getNotifTargets', function() {
   });
 
 });
+
+
+// =========================================================
+// GROUP 12: @mention notification system
+// =========================================================
+
+// Extract _AGENCY_MEMBERS from pcs.js for test use
+var _TEST_AGENCY_MEMBERS = [
+  { name: 'Shubham', role: 'Admin' },
+  { name: 'Pranav', role: 'Creative' },
+  { name: 'Chitra', role: 'Servicing' }
+];
+
+// Pure logic: resolve mention name to role (mirrors production code)
+function _resolveMentionRole(name) {
+  var found = _TEST_AGENCY_MEMBERS.find(function(m) {
+    return m.name.toLowerCase() === (name || '').toLowerCase();
+  });
+  return found ? found.role : null;
+}
+
+describe('@mention notification routing', function() {
+
+  it('@Pranav resolves to role Creative', function() {
+    expect(_resolveMentionRole('Pranav')).toBe('Creative');
+  });
+
+  it('@Shubham resolves to role Admin', function() {
+    expect(_resolveMentionRole('Shubham')).toBe('Admin');
+  });
+
+  it('@Chitra resolves to role Servicing', function() {
+    expect(_resolveMentionRole('Chitra')).toBe('Servicing');
+  });
+
+  it('@UnknownPerson resolves to null (skipped)', function() {
+    expect(_resolveMentionRole('UnknownPerson')).toBeNull();
+  });
+
+  it('case insensitive resolution works', function() {
+    expect(_resolveMentionRole('pranav')).toBe('Creative');
+    expect(_resolveMentionRole('CHITRA')).toBe('Servicing');
+  });
+
+});
+
+describe('@mention notifications in _doSubmitComment (source analysis)', function() {
+
+  it('pcs.js contains a mention notification loop after comment notifications', function() {
+    expect(pcsSrc).toContain("type: 'mention'");
+  });
+
+  it('mention notification maps name to role via _AGENCY_MEMBERS', function() {
+    var idx = pcsSrc.indexOf("type: 'mention'");
+    var mentionBlock = pcsSrc.substring(Math.max(0, idx - 800), idx + 200);
+    expect(mentionBlock).toContain('_AGENCY_MEMBERS');
+  });
+
+  it('mention notification skips names not in _AGENCY_MEMBERS', function() {
+    var mentionBlock = pcsSrc.substring(
+      pcsSrc.indexOf("type: 'mention'") - 500,
+      pcsSrc.indexOf("type: 'mention'") + 200
+    );
+    expect(mentionBlock).toMatch(/if\s*\(\s*!|continue/);
+  });
+
+  it('mention notification skips roles already in _targets to avoid doubles', function() {
+    var mentionBlock = pcsSrc.substring(
+      pcsSrc.indexOf("type: 'mention'") - 500,
+      pcsSrc.indexOf("type: 'mention'") + 200
+    );
+    expect(mentionBlock).toContain('_targets');
+    expect(mentionBlock).toMatch(/indexOf|includes/);
+  });
+
+  it('mention notification only runs when opts.mentioned has entries', function() {
+    var idx = pcsSrc.indexOf("type: 'mention'");
+    var mentionBlock = pcsSrc.substring(Math.max(0, idx - 800), idx + 200);
+    expect(mentionBlock).toMatch(/opts\.mentioned[\s\S]*?length/);
+  });
+
+  it('the old buggy fallback (targets = opts.mentioned) is removed', function() {
+    var targetBlock = pcsSrc.match(
+      /var _targets = \[\];[\s\S]*?_targets\.forEach/
+    );
+    expect(targetBlock).not.toBeNull();
+    var body = targetBlock[0];
+    expect(body).not.toContain('_targets = opts.mentioned');
+  });
+
+  it('mention message differs for internal notes vs client comments', function() {
+    var mentionBlock = pcsSrc.substring(
+      pcsSrc.indexOf("type: 'mention'") - 500,
+      pcsSrc.indexOf("type: 'mention'") + 300
+    );
+    expect(mentionBlock).toMatch(/isInternal|internal/i);
+  });
+
+});


### PR DESCRIPTION
## Summary
- **Remove buggy fallback** — the `else` branch in `_doSubmitComment()` was setting `_targets = opts.mentioned`, putting NAME strings (e.g. `'Pranav'`) into `user_role`. Deleted entirely.
- **Add dedicated mention notification loop** — after the existing comment notification loop, a new block maps each `@name` to a role via `_AGENCY_MEMBERS`, skips unknown names, skips roles already in `_targets` (no double notifications), and inserts `type:'mention'` notifications
- **Message varies by context** — internal notes: "X mentioned you in a note on Y", client comments: "X mentioned you on Y"
- **12 new tests** — pure routing logic tests + source analysis tests verifying the mention loop structure

## Files changed (3)
- `actions/pcs.js` — removed buggy fallback, added mention notification loop
- `tests/notifications.test.js` — 12 new mention tests (79 total in file)
- `index.html` — version bump to `?v=20260401a`

## How it works
```
@Pranav in a note
  -> _AGENCY_MEMBERS.find('Pranav') -> role: 'Creative'
  -> 'Creative' not already in _targets? -> fire notification
  -> type: 'mention', user_role: 'Creative'
  -> message: 'Shubham mentioned you in a note on "Post Title"'

@UnknownPerson in a note
  -> _AGENCY_MEMBERS.find('UnknownPerson') -> null
  -> skipped, no notification
```

## Test plan
- [x] 222/222 tests pass (11 test files)
- [x] 20/20 version strings at `?v=20260401a`
- [x] `node --check actions/pcs.js` passes
- [ ] Verify @Pranav in a note fires mention notification to Creative
- [ ] Verify @Chitra in a servicing-visibility note doesn't double-notify

https://claude.ai/code/session_013FdSRdatY567mokDLmy4xh