### PR TITLE
feat: Phase 3 error handling — logError, toast, catch fixes

### DIFF
--- a/00-appstate.js
+++ b/00-appstate.js
@@ -62,3 +62,44 @@ window.AppState = window.AppState || {
   }
 
 };
+
+// -- Global error logging to Supabase error_log table --
+window.logError = function(message, stack, action) {
+  var _s = document.querySelector('script[src*="?v="]');
+  var _version = _s ? _s.src.split('?v=')[1] : 'unknown';
+  var _payload = {
+    error_message: String(message || 'Unknown error').slice(0, 500),
+    error_stack:   String(stack || '').slice(0, 2000),
+    user_email:    (window.AppState && window.AppState.user.email) || 'unknown',
+    user_role:     (window.AppState && window.AppState.user.effectiveRole) || 'unknown',
+    page:          window.location.pathname || '/',
+    action:        String(action || 'uncaught'),
+    app_version:   _version
+  };
+  var _url = (window.SUPABASE_URL || '') + '/rest/v1/error_log';
+  var _key = window.SUPABASE_KEY || '';
+  fetch(_url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'apikey': _key,
+      'Authorization': 'Bearer ' + _key
+    },
+    body: JSON.stringify(_payload)
+  }).catch(function(){});
+  window._showErrorToast && window._showErrorToast();
+};
+
+window.onerror = function(message, source, lineno, colno, error) {
+  var _stack = error ? (error.stack || '') : (source + ':' + lineno);
+  window.logError(message, _stack, 'window.onerror');
+  return false;
+};
+
+window.onunhandledrejection = function(event) {
+  var _msg = event.reason ?
+    (event.reason.message || String(event.reason))
+    : 'Unhandled promise rejection';
+  var _stack = event.reason ? (event.reason.stack || '') : '';
+  window.logError(_msg, _stack, 'unhandledrejection');
+};

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -191,7 +191,7 @@ async function loadPosts() {
           p._commentCount = counts[p.post_id] || 0;
         });
         scheduleRender();
-      }).catch(function(){});
+      }).catch(function(err){ console.error('[07-post-load] activity-log', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'activity-log-post'); });
     showToast(`${window.AppState.posts.all.length} posts loaded`, 'success');
   } catch (err) {
     console.error('loadPosts:', err);

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -306,7 +306,7 @@ async function submitClientRequest() {
         actor: window.AppState.user.name || window.currentUserName || 'Client',
         read: false
       })
-    }).catch(function(){});
+    }).catch(function(err){ console.error('[post-actions] notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'notification-post'); });
     const topicEl = document.getElementById('req-topic');
     if (topicEl) topicEl.value = '';
     var nameResetEl = document.getElementById('req-name');
@@ -440,6 +440,7 @@ function _confirmPublish(postId) {
     loadPosts();
   }).catch(function(err) {
     console.error('Publish failed:', err);
+    window.logError && window.logError(err&&err.message, err&&err.stack, 'publish-post');
     showToast('Publish failed - try again', 'error');
     if (btn) { btn.textContent = 'Publish'; btn.disabled = false; }
   });

--- a/10-ui.js
+++ b/10-ui.js
@@ -17,6 +17,30 @@ function hideErrorBanner() {
   document.getElementById('error-banner')?.classList.add('hidden');
 }
 
+window._showErrorToast = function() {
+  if (document.getElementById('sorted-error-toast')) return;
+  var _t = document.createElement('div');
+  _t.id = 'sorted-error-toast';
+  _t.style.cssText = [
+    'position:fixed', 'bottom:80px', 'left:50%',
+    'transform:translateX(-50%)',
+    'background:#1a0a0a', 'border:1px solid #FF4B4B',
+    'color:#E8E8E8', 'font-family:DM Sans,sans-serif',
+    'font-size:13px', 'padding:10px 16px', 'z-index:99999',
+    'max-width:320px', 'width:90%', 'text-align:center',
+    'border-radius:0'
+  ].join(';');
+  _t.textContent = 'Something went wrong — our team has been notified.';
+  document.body.appendChild(_t);
+  setTimeout(function() {
+    _t.style.transition = 'opacity 0.4s';
+    _t.style.opacity = '0';
+    setTimeout(function() {
+      _t.parentNode && _t.parentNode.removeChild(_t);
+    }, 400);
+  }, 4000);
+};
+
 // -- Safe render --------------------------------
 function safeRender() {
   try { renderAll(); } catch (err) { console.error('renderAll error:', err); }
@@ -583,7 +607,7 @@ function updateNotifBadge() {
       el.textContent = countStr;
       el.style.display = show ? 'flex' : 'none';
     });
-  }).catch(function() {});
+  }).catch(function(err){ console.error('[10-ui] updateNotifBadge', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'update-notif-badge'); });
 }
 
 // -- PCS Activity toggle -----------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
-19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401f
+19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401h
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -188,8 +188,8 @@ Single file: npx vitest run tests/filename.test.js
 E2E: npx playwright test
 
 Current (verified 2026-04-01):
-Unit test files: 12
-Unit tests:      269 passing, 0 failing
+Unit test files: 13
+Unit tests:      279 passing, 0 failing
 E2E specs:       3
 
 Files:
@@ -199,6 +199,7 @@ tests/client-comment.test.js
 tests/comments-separation.test.js
 tests/config.test.js
 tests/dom-sanity.test.js
+tests/error-handling.test.js
 tests/normalise.test.js
 tests/notifications.test.js
 tests/postlookup.test.js
@@ -251,10 +252,18 @@ Pages branch:   main-/-root
 1. AppState.ui.modalOpen guards render — do not bypass
 1. 15-second poll interval, 50-minute token refresh
 1. Client DB role takes absolute priority over pcs_role_preview
-1. Silent .catch(function(){}) is a bug — always log errors
-1. Vitest must pass 269/269 before every push
+1. Silent .catch(function(){}) is a bug — always use window.logError
+1. Vitest must pass 279/279 before every push
 
 ## SECTION 11 — GLOBAL FUNCTIONS
+
+00-appstate.js:
+window.logError             — log error to Supabase error_log table
+window.onerror              — global error handler → logError
+window.onunhandledrejection — global promise rejection handler → logError
+
+10-ui.js:
+window._showErrorToast      — show transient error toast to user
 
 03-auth.js:
 window.sendMagicLink        — send OTP email to user
@@ -343,7 +352,7 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
 Ph0 Safety            — DONE
 Ph1 File Architecture — DONE (render/ + actions/ extracted)
 Ph2 AppState          — DONE (all globals migrated)
-Ph3 Error Handling    — IN PROGRESS (error_log table created in Supabase)
+Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed)
 Ph4 Event Delegation  — PENDING
 Ph5 Optimistic UI     — IN PROGRESS (client comments done)
 Ph6 PWA               — PENDING

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -628,6 +628,7 @@ window._saveLiUrlInline = function(postId) {
     loadPosts();
   }).catch(function(err) {
     console.error('LinkedIn save failed:', err);
+    window.logError && window.logError(err&&err.message, err&&err.stack, 'linkedin-save');
     showToast('Save failed - try again', 'error');
     if (btn) {
       btn.textContent = 'Save';
@@ -682,7 +683,7 @@ window.loadPcsComments = async function(postId) {
           method: 'PATCH',
           headers: {'Prefer': 'return=minimal'},
           body: JSON.stringify({ read: true })
-        }).catch(function(){});
+        }).catch(function(err){ console.error('[pcs] notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'pcs-notification'); });
       });
     }
 
@@ -2015,7 +2016,7 @@ window._doSubmitComment = async function(opts) {
           message: opts.author + ' commented on ' + opts.title,
           actor: (window.AppState.user.name || window.currentUserName || 'Unknown')
         })
-      }).catch(function(){});
+      }).catch(function(err){ console.error('[pcs] notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'pcs-notification-2'); });
     });
 
     if (opts.mentioned && opts.mentioned.length > 0) {
@@ -2082,6 +2083,7 @@ window.toggleTaskResolve = function(commentId, postId) {
     loadPcsComments(postId);
   }).catch(function(e) {
     console.error('toggleTaskResolve failed:', e);
+    window.logError && window.logError(e&&e.message, e&&e.stack, 'toggle-task-resolve');
   });
 };
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401f">
+ <link rel="stylesheet" href="styles.css?v=20260401h">
 
 </head>
 <body>
@@ -1078,26 +1078,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401f"></script>
-<script src="00-appstate-compat.js?v=20260401f"></script>
-<script src="01-config.js?v=20260401f" defer></script>
-<script src="02-session.js?v=20260401f" defer></script>
-<script src="utils.js?v=20260401f" defer></script>
-<script src="03-auth.js?v=20260401f" defer></script>
-<script src="05-api.js?v=20260401f" defer></script>
-<script src="10-ui.js?v=20260401f" defer></script>
+<script src="00-appstate.js?v=20260401h"></script>
+<script src="00-appstate-compat.js?v=20260401h"></script>
+<script src="01-config.js?v=20260401h" defer></script>
+<script src="02-session.js?v=20260401h" defer></script>
+<script src="utils.js?v=20260401h" defer></script>
+<script src="03-auth.js?v=20260401h" defer></script>
+<script src="05-api.js?v=20260401h" defer></script>
+<script src="10-ui.js?v=20260401h" defer></script>
 
-<script src="06-post-create.js?v=20260401f" defer></script>
-<script defer src="render/dashboard.js?v=20260401f"></script>
-<script defer src="render/client.js?v=20260401f"></script>
-<script defer src="render/pipeline.js?v=20260401f"></script>
-<script defer src="render/brief.js?v=20260401f"></script>
-<script defer src="actions/pcs.js?v=20260401f"></script>
-<script src="07-post-load.js?v=20260401f" defer></script>
-<script src="08-post-actions.js?v=20260401f" defer></script>
-<script src="09-library.js?v=20260401f" defer></script>
-<script src="09-approval.js?v=20260401f" defer></script>
-<script src="04-router.js?v=20260401f" defer></script>
+<script src="06-post-create.js?v=20260401h" defer></script>
+<script defer src="render/dashboard.js?v=20260401h"></script>
+<script defer src="render/client.js?v=20260401h"></script>
+<script defer src="render/pipeline.js?v=20260401h"></script>
+<script defer src="render/brief.js?v=20260401h"></script>
+<script defer src="actions/pcs.js?v=20260401h"></script>
+<script src="07-post-load.js?v=20260401h" defer></script>
+<script src="08-post-actions.js?v=20260401h" defer></script>
+<script src="09-library.js?v=20260401h" defer></script>
+<script src="09-approval.js?v=20260401h" defer></script>
+<script src="04-router.js?v=20260401h" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1001,7 +1001,7 @@ console.log('LOADED:', 'render/client.js');
           post_id: realPostId,
           message: authorName + ' commented on ' + postTitle
         })
-      }).catch(function () {});
+      }).catch(function(err){ console.error('[client] comment patch', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'comment-patch'); });
       window.apiFetch('/notifications', {
         method: 'POST',
         body: JSON.stringify({
@@ -1010,7 +1010,7 @@ console.log('LOADED:', 'render/client.js');
           post_id: realPostId,
           message: authorName + ' commented on ' + postTitle
         })
-      }).catch(function () {});
+      }).catch(function(err){ console.error('[client] notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-notification'); });
       var _ROSTER = [
         { name: 'Shubham', role: 'Admin' },
         { name: 'Pranav', role: 'Creative' },
@@ -1030,7 +1030,7 @@ console.log('LOADED:', 'render/client.js');
             message: authorName + ' mentioned you on "' + postTitle + '"',
             actor: window.AppState.user.email || ''
           })
-        }).catch(function(err) { console.error('[mention notif]', err); });
+        }).catch(function(err) { console.error('[mention notif]', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-mention-notif'); });
       });
     }).catch(function () {
       if (typeof window.showToast === 'function') {

--- a/tests/error-handling.test.js
+++ b/tests/error-handling.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('Phase 3 — Error Handling', function() {
+
+  beforeEach(function() {
+    window.AppState = {
+      user: { name: 'Test', email: 'test@test.com',
+        role: 'Admin', effectiveRole: 'Admin', previewRole: null },
+      posts: { all: [], cached: [], loaded: false,
+        setAll: function(p) { window.AppState.posts.all = p; } },
+      pcs: { open: false, postId: null, activeMenu: null },
+      ui: { modalOpen: false, unreadCount: 0 },
+      timers: {}
+    };
+    window.SUPABASE_URL = 'https://test.supabase.co';
+    window.SUPABASE_KEY = 'test-key';
+    window.fetch = vi.fn(function() {
+      return Promise.resolve({ ok: true });
+    });
+    // Clean up any toast from previous test
+    var existing = document.getElementById('sorted-error-toast');
+    if (existing) existing.parentNode.removeChild(existing);
+  });
+
+  // Load the actual source
+  var appstateSrc = require('fs').readFileSync(
+    require('path').join(__dirname, '..', '00-appstate.js'), 'utf8');
+  eval(appstateSrc);
+
+  var uiSrc = require('fs').readFileSync(
+    require('path').join(__dirname, '..', '10-ui.js'), 'utf8');
+
+  it('1. window.logError exists after 00-appstate.js loads', function() {
+    expect(typeof window.logError).toBe('function');
+  });
+
+  it('2. window.logError calls fetch with URL containing error_log', function() {
+    window.logError('test error', 'stack trace', 'test-action');
+    expect(window.fetch).toHaveBeenCalledTimes(1);
+    var callArgs = window.fetch.mock.calls[0];
+    expect(callArgs[0]).toContain('error_log');
+  });
+
+  it('3. payload includes user_email from AppState.user.email', function() {
+    window.logError('test', '', 'test');
+    var body = JSON.parse(window.fetch.mock.calls[0][1].body);
+    expect(body.user_email).toBe('test@test.com');
+  });
+
+  it('4. payload includes user_role from AppState.user.effectiveRole', function() {
+    window.logError('test', '', 'test');
+    var body = JSON.parse(window.fetch.mock.calls[0][1].body);
+    expect(body.user_role).toBe('Admin');
+  });
+
+  it('5. payload includes app_version string (not empty)', function() {
+    window.logError('test', '', 'test');
+    var body = JSON.parse(window.fetch.mock.calls[0][1].body);
+    expect(body.app_version).toBeTruthy();
+    expect(typeof body.app_version).toBe('string');
+  });
+
+  it('6. payload includes page from window.location.pathname', function() {
+    window.logError('test', '', 'test');
+    var body = JSON.parse(window.fetch.mock.calls[0][1].body);
+    expect(body.page).toBe(window.location.pathname);
+  });
+
+  it('7. payload includes action parameter passed to logError', function() {
+    window.logError('test', '', 'my-custom-action');
+    var body = JSON.parse(window.fetch.mock.calls[0][1].body);
+    expect(body.action).toBe('my-custom-action');
+  });
+
+  it('8. fetch failure inside logError does not throw', function() {
+    window.fetch = vi.fn(function() {
+      return Promise.reject(new Error('network down'));
+    });
+    expect(function() {
+      window.logError('test', '', 'test');
+    }).not.toThrow();
+  });
+
+  it('9. window._showErrorToast creates #sorted-error-toast in DOM', function() {
+    // Eval the _showErrorToast function from 10-ui.js
+    var match = uiSrc.match(/window\._showErrorToast\s*=\s*function[\s\S]*?;\s*\n\s*\};/);
+    expect(match).not.toBeNull();
+    eval(match[0]);
+    window._showErrorToast();
+    var toast = document.getElementById('sorted-error-toast');
+    expect(toast).not.toBeNull();
+    expect(toast.textContent).toContain('Something went wrong');
+  });
+
+  it('10. calling _showErrorToast twice only creates one toast in DOM', function() {
+    var match = uiSrc.match(/window\._showErrorToast\s*=\s*function[\s\S]*?;\s*\n\s*\};/);
+    eval(match[0]);
+    window._showErrorToast();
+    window._showErrorToast();
+    var toasts = document.querySelectorAll('#sorted-error-toast');
+    expect(toasts.length).toBe(1);
+  });
+
+});


### PR DESCRIPTION
- Add window.logError() to 00-appstate.js: logs errors to Supabase error_log table
- Add window.onerror + window.onunhandledrejection global handlers
- Add window._showErrorToast() to 10-ui.js: transient user-facing error toast
- Fix 8 silent .catch(function(){}) blocks with console.error + logError
- Add logError to 4 console.error-only catch blocks for DB logging
- Add 10 TDD tests in tests/error-handling.test.js (279/279 passing)
- Bump ?v= to 20260401h across all 20 tags in index.html
- Update CLAUDE.md: Ph3 DONE, test count 279, new globals documented

https://claude.ai/code/session_018L3YR2jxCFyhyv2RQqjQpC