### PR TITLE
fix: client view error handling pass 2 — 289 tests

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -259,6 +259,7 @@ async function loadPostsForClient() {
     hideErrorBanner();
     renderClientView();
   } catch (err) {
+    window.logError && window.logError(err && err.message, err && err.stack, 'load-posts-client');
     if (window.AppState.posts.cached.length) {
       if (!_commitPostsResult(reqId, 'cache')) return;
       window.AppState.posts.setAll(

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -191,7 +191,7 @@ async function clientApprove(postId, btn) {
     }
     setStage(post, 'scheduled', 'clientApprove');
     setTimeout(() => loadPostsForClient(), 1200);
-  } catch { if (btn) btn.disabled = false; showToast('Failed  -  try again', 'error'); }
+  } catch (err) { if (btn) btn.disabled = false; showToast('Failed  -  try again', 'error'); window.logError && window.logError(err && err.message, err && err.stack, 'client-approve'); }
 }
 
 async function clientAcknowledge(postId) {
@@ -341,8 +341,13 @@ async function submitClientRequest() {
     setTimeout(() => loadPostsForClient(), 800);
   } catch (err) {
     console.error('[REQUEST] API FAILED:', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'submit-client-request');
     showToast('Failed - try again', 'error');
-    if (btn) btn.disabled = false;
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = '-- SEND REQUEST';
+      btn.style.opacity = '1';
+    }
   }
 }
 

--- a/10-ui.js
+++ b/10-ui.js
@@ -257,6 +257,7 @@ async function loadNotifications() {
     updateNotifBadge();
   } catch(e) {
     console.error('loadNotifications error:', e);
+    window.logError && window.logError(e && e.message, e && e.stack, 'load-notifications');
   }
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
-19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401h
+19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401i
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -189,7 +189,7 @@ E2E: npx playwright test
 
 Current (verified 2026-04-01):
 Unit test files: 13
-Unit tests:      279 passing, 0 failing
+Unit tests:      289 passing, 0 failing
 E2E specs:       3
 
 Files:
@@ -253,7 +253,7 @@ Pages branch:   main-/-root
 1. 15-second poll interval, 50-minute token refresh
 1. Client DB role takes absolute priority over pcs_role_preview
 1. Silent .catch(function(){}) is a bug — always use window.logError
-1. Vitest must pass 279/279 before every push
+1. Vitest must pass 289/289 before every push
 
 ## SECTION 11 — GLOBAL FUNCTIONS
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401h">
+ <link rel="stylesheet" href="styles.css?v=20260401i">
 
 </head>
 <body>
@@ -1078,26 +1078,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401h"></script>
-<script src="00-appstate-compat.js?v=20260401h"></script>
-<script src="01-config.js?v=20260401h" defer></script>
-<script src="02-session.js?v=20260401h" defer></script>
-<script src="utils.js?v=20260401h" defer></script>
-<script src="03-auth.js?v=20260401h" defer></script>
-<script src="05-api.js?v=20260401h" defer></script>
-<script src="10-ui.js?v=20260401h" defer></script>
+<script src="00-appstate.js?v=20260401i"></script>
+<script src="00-appstate-compat.js?v=20260401i"></script>
+<script src="01-config.js?v=20260401i" defer></script>
+<script src="02-session.js?v=20260401i" defer></script>
+<script src="utils.js?v=20260401i" defer></script>
+<script src="03-auth.js?v=20260401i" defer></script>
+<script src="05-api.js?v=20260401i" defer></script>
+<script src="10-ui.js?v=20260401i" defer></script>
 
-<script src="06-post-create.js?v=20260401h" defer></script>
-<script defer src="render/dashboard.js?v=20260401h"></script>
-<script defer src="render/client.js?v=20260401h"></script>
-<script defer src="render/pipeline.js?v=20260401h"></script>
-<script defer src="render/brief.js?v=20260401h"></script>
-<script defer src="actions/pcs.js?v=20260401h"></script>
-<script src="07-post-load.js?v=20260401h" defer></script>
-<script src="08-post-actions.js?v=20260401h" defer></script>
-<script src="09-library.js?v=20260401h" defer></script>
-<script src="09-approval.js?v=20260401h" defer></script>
-<script src="04-router.js?v=20260401h" defer></script>
+<script src="06-post-create.js?v=20260401i" defer></script>
+<script defer src="render/dashboard.js?v=20260401i"></script>
+<script defer src="render/client.js?v=20260401i"></script>
+<script defer src="render/pipeline.js?v=20260401i"></script>
+<script defer src="render/brief.js?v=20260401i"></script>
+<script defer src="actions/pcs.js?v=20260401i"></script>
+<script src="07-post-load.js?v=20260401i" defer></script>
+<script src="08-post-actions.js?v=20260401i" defer></script>
+<script src="09-library.js?v=20260401i" defer></script>
+<script src="09-approval.js?v=20260401i" defer></script>
+<script src="04-router.js?v=20260401i" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -875,6 +875,7 @@ console.log('LOADED:', 'render/client.js');
         _clientRenderImgPreview(postId);
       } catch(e) {
         showToast('Image upload failed.', 'error');
+        window.logError && window.logError(e && e.message, e && e.stack, 'client-img-upload');
       }
     }
     if ((window._clientFeedPendingImgs[postId] || []).length > 0) {
@@ -1032,10 +1033,11 @@ console.log('LOADED:', 'render/client.js');
           })
         }).catch(function(err) { console.error('[mention notif]', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-mention-notif'); });
       });
-    }).catch(function () {
+    }).catch(function (err) {
       if (typeof window.showToast === 'function') {
         window.showToast('Failed to send comment', 'error');
       }
+      window.logError && window.logError(err && err.message, err && err.stack, 'submit-comment');
       input.value = savedValue;
       if (listEl && listEl.lastChild) {
         listEl.removeChild(listEl.lastChild);
@@ -1464,6 +1466,7 @@ console.log('LOADED:', 'render/client.js');
     var cv = document.getElementById('client-view');
     if (!cv) return;
 
+    try {
     _ensurePulseStyle();
     _ensureReqOverlay();
     cv.style.display = 'block';
@@ -1535,6 +1538,11 @@ console.log('LOADED:', 'render/client.js');
     if (lbEl && !lbEl.dataset.clickWired) {
       _wireEvents(lbEl);
       lbEl.dataset.clickWired = '1';
+    }
+    } catch(err) {
+      console.error('[client] renderClientView crashed', err);
+      window.logError && window.logError(err && err.message, err && err.stack, 'render-client-view');
+      if (cv) cv.innerHTML = '<div style="color:#FF4B4B;padding:24px;font-family:DM Sans,sans-serif">Something went wrong. Please refresh.</div>';
     }
   };
 
@@ -1816,6 +1824,13 @@ window._reqAddPhotos = function(input) {
         // Re-enable send if name + brief filled
         _reqValidate();
       }
+    };
+    reader.onerror = function() {
+      console.error('[client] FileReader failed');
+      window.logError && window.logError('FileReader error', '', 'req-add-photos');
+      if (typeof showToast === 'function') showToast('Failed to load photo — try again', 'error');
+      loaded++;
+      if (loaded === total) _reqValidate();
     };
     reader.readAsDataURL(file);
   });

--- a/tests/client-comment.test.js
+++ b/tests/client-comment.test.js
@@ -4,6 +4,9 @@ import { resolve } from 'path';
 
 // Load source for static analysis
 var clientSrc = readFileSync(resolve(__dirname, '..', 'render', 'client.js'), 'utf8');
+var actionsSrc = readFileSync(resolve(__dirname, '..', '08-post-actions.js'), 'utf8');
+var uiSrc = readFileSync(resolve(__dirname, '..', '10-ui.js'), 'utf8');
+var postLoadSrc = readFileSync(resolve(__dirname, '..', '07-post-load.js'), 'utf8');
 
 // =========================================================
 // SETUP — mirrors tests/appstate-posts.test.js
@@ -455,5 +458,84 @@ describe('comment notifications', function() {
     var thenIdx = fnBody.indexOf('.then(function');
     var notifIdx = fnBody.indexOf("'/notifications'");
     expect(thenIdx).toBeLessThan(notifIdx);
+  });
+});
+
+
+// =========================================================
+// GROUP 7 — Error handling pass 2
+// =========================================================
+describe('error handling pass 2', function() {
+
+  it('48. _handleSubmitComment outer catch calls window.logError', function() {
+    var outerCatch = clientSrc.match(/\}\)\.catch\(function\s*\([^)]*\)\s*\{[\s\S]*?Failed to send comment[\s\S]*?\}\);/);
+    expect(outerCatch).toBeTruthy();
+    expect(outerCatch[0]).toContain('logError');
+  });
+
+  it('49. clientApprove() catch calls window.logError', function() {
+    var match = actionsSrc.match(/function clientApprove[\s\S]*?\n\}/);
+    expect(match).toBeTruthy();
+    var body = match[0];
+    expect(body).toContain('logError');
+  });
+
+  it('50. submitClientRequest() catch calls window.logError', function() {
+    var match = actionsSrc.match(/function submitClientRequest[\s\S]*?\n\}/);
+    expect(match).toBeTruthy();
+    var body = match[0];
+    expect(body).toContain('logError');
+  });
+
+  it('51. loadPostsForClient() catch calls window.logError', function() {
+    var match = postLoadSrc.match(/function loadPostsForClient[\s\S]*?\n\}/);
+    expect(match).toBeTruthy();
+    var body = match[0];
+    expect(body).toContain('logError');
+  });
+
+  it('52. loadNotifications() catch calls window.logError', function() {
+    var match = uiSrc.match(/function loadNotifications[\s\S]*?catch\(e\)[\s\S]*?\}/);
+    expect(match).toBeTruthy();
+    var body = match[0];
+    expect(body).toContain('logError');
+  });
+
+  it('53. _clientFeedHandleImg() catch calls window.logError', function() {
+    var match = clientSrc.match(/window\._clientFeedHandleImg\s*=\s*async\s*function[\s\S]*?\n  \};/);
+    expect(match).toBeTruthy();
+    var body = match[0];
+    expect(body).toContain('logError');
+  });
+
+  it('54. submitClientRequest() resets button text to original on failure', function() {
+    var match = actionsSrc.match(/function submitClientRequest[\s\S]*?\n\}/);
+    expect(match).toBeTruthy();
+    var catchBlock = match[0].match(/catch\s*\(err\)[\s\S]*?\}/);
+    expect(catchBlock).toBeTruthy();
+    expect(catchBlock[0]).toMatch(/SEND REQUEST/);
+  });
+
+  it('55. renderClientView() wrapped in try/catch', function() {
+    var match = clientSrc.match(/window\.renderClientView\s*=\s*function\s*\(\)\s*\{[\s\S]*?\n  \};/);
+    expect(match).toBeTruthy();
+    var body = match[0];
+    expect(body).toContain('try {');
+    expect(body).toContain('catch');
+  });
+
+  it('56. renderClientView() catch calls window.logError', function() {
+    var match = clientSrc.match(/window\.renderClientView\s*=\s*function\s*\(\)\s*\{[\s\S]*?\n  \};/);
+    expect(match).toBeTruthy();
+    var body = match[0];
+    expect(body).toContain('logError');
+    expect(body).toContain('render-client-view');
+  });
+
+  it('57. _reqAddPhotos FileReader has onerror handler', function() {
+    var match = clientSrc.match(/window\._reqAddPhotos\s*=\s*function[\s\S]*?reader\.readAsDataURL/);
+    expect(match).toBeTruthy();
+    var body = match[0];
+    expect(body).toContain('reader.onerror');
   });
 });


### PR DESCRIPTION
## Summary
- Add `logError` to 6 catch blocks missing DB logging: submit-comment, client-approve, submit-client-request, load-posts-client, load-notifications, client-img-upload
- Wrap `renderClientView()` in try/catch with `logError` + fallback HTML (prevents blank page on crash)
- Fix `submitClientRequest()` button stuck as 'Sending...' on failure — now resets to '-- SEND REQUEST'
- Add `FileReader.onerror` handler in `_reqAddPhotos` (photo upload failure was silent)
- 10 new TDD tests in `tests/client-comment.test.js` (tests 48-57)

## Files changed
- `render/client.js` — logError in submit-comment + img-upload catches, renderClientView try/catch, FileReader onerror
- `08-post-actions.js` — logError in clientApprove + submitClientRequest catches, button text reset
- `10-ui.js` — logError in loadNotifications catch
- `07-post-load.js` — logError in loadPostsForClient catch
- `index.html` — bump ?v=20260401i (all 20 tags)
- `CLAUDE.md` — test count 289, ?v= 20260401i
- `tests/client-comment.test.js` — 10 new tests

## Test plan
- [x] 289/289 vitest passing (279 existing + 10 new)
- [ ] Purge Cloudflare after merge
- [ ] Hard refresh all devices
- [ ] Submit a comment as client → verify error_log row on network failure
- [ ] Submit a request → simulate failure → verify button resets to '-- SEND REQUEST'
- [ ] Force renderClientView crash → verify fallback HTML shown

https://claude.ai/code/session_018L3YR2jxCFyhyv2RQqjQpC