### PR TITLE
fix: Pass 3 pipeline error handling + test file mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
-19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401i
+19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401j
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -208,6 +208,18 @@ tests/timestamp.test.js
 tests/utils.test.js
 
 E2E: tests/e2e/client-feed.spec.js, pcs.spec.js, smoke.spec.js
+
+TEST FILE MAPPING (run targeted tests during development):
+  render/client.js      → npx vitest run tests/client-comment.test.js
+  actions/pcs.js        → npx vitest run tests/pcs.test.js (future)
+  render/pipeline.js    → npx vitest run tests/pipeline.test.js (future)
+  render/dashboard.js   → npx vitest run tests/dashboard.test.js (future)
+  render/brief.js       → npx vitest run tests/brief.test.js (future)
+  00-appstate.js        → npx vitest run tests/appstate-posts.test.js
+  03-auth.js            → npx vitest run tests/role.test.js
+  10-ui.js              → npx vitest run tests/notifications.test.js
+  utils.js              → npx vitest run tests/utils.test.js
+  Full suite before push: npx vitest run
 
 AppState mock pattern for new test files:
 window.AppState = {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401i">
+ <link rel="stylesheet" href="styles.css?v=20260401j">
 
 </head>
 <body>
@@ -1078,26 +1078,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401i"></script>
-<script src="00-appstate-compat.js?v=20260401i"></script>
-<script src="01-config.js?v=20260401i" defer></script>
-<script src="02-session.js?v=20260401i" defer></script>
-<script src="utils.js?v=20260401i" defer></script>
-<script src="03-auth.js?v=20260401i" defer></script>
-<script src="05-api.js?v=20260401i" defer></script>
-<script src="10-ui.js?v=20260401i" defer></script>
+<script src="00-appstate.js?v=20260401j"></script>
+<script src="00-appstate-compat.js?v=20260401j"></script>
+<script src="01-config.js?v=20260401j" defer></script>
+<script src="02-session.js?v=20260401j" defer></script>
+<script src="utils.js?v=20260401j" defer></script>
+<script src="03-auth.js?v=20260401j" defer></script>
+<script src="05-api.js?v=20260401j" defer></script>
+<script src="10-ui.js?v=20260401j" defer></script>
 
-<script src="06-post-create.js?v=20260401i" defer></script>
-<script defer src="render/dashboard.js?v=20260401i"></script>
-<script defer src="render/client.js?v=20260401i"></script>
-<script defer src="render/pipeline.js?v=20260401i"></script>
-<script defer src="render/brief.js?v=20260401i"></script>
-<script defer src="actions/pcs.js?v=20260401i"></script>
-<script src="07-post-load.js?v=20260401i" defer></script>
-<script src="08-post-actions.js?v=20260401i" defer></script>
-<script src="09-library.js?v=20260401i" defer></script>
-<script src="09-approval.js?v=20260401i" defer></script>
-<script src="04-router.js?v=20260401i" defer></script>
+<script src="06-post-create.js?v=20260401j" defer></script>
+<script defer src="render/dashboard.js?v=20260401j"></script>
+<script defer src="render/client.js?v=20260401j"></script>
+<script defer src="render/pipeline.js?v=20260401j"></script>
+<script defer src="render/brief.js?v=20260401j"></script>
+<script defer src="actions/pcs.js?v=20260401j"></script>
+<script src="07-post-load.js?v=20260401j" defer></script>
+<script src="08-post-actions.js?v=20260401j" defer></script>
+<script src="09-library.js?v=20260401j" defer></script>
+<script src="09-approval.js?v=20260401j" defer></script>
+<script src="04-router.js?v=20260401j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/pipeline.js
+++ b/render/pipeline.js
@@ -640,13 +640,14 @@ window.executeBatchAction = async function(targetStage) {
 
   } catch (err) {
     console.error('Batch action error:', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'execute-batch-action');
     showToast('Batch update failed - try again', 'error');
   }
 }
 
 // -- renderPipeline/narrative --
 window.renderPipeline = function() {
-  try { _renderPipelineInner(); } catch(e) { console.error('[PCS] renderPipeline crash:', e); }
+  try { _renderPipelineInner(); } catch(e) { console.error('[PCS] renderPipeline crash:', e); window.logError && window.logError(e && e.message, e && e.stack, 'render-pipeline'); var _p = document.getElementById('pipeline-view'); if (_p) _p.innerHTML = '<div style="color:#FF4B4B;padding:24px;font-family:DM Sans,sans-serif">Something went wrong. Please refresh.</div>'; }
   updatePipelineCritical(window.AppState.posts.all);
   updatePipelineStageBar(window.AppState.posts.all);
   updatePipelineNarrative(window.AppState.posts.all);


### PR DESCRIPTION
## Summary
- **renderPipeline() catch**: added `window.logError` + fallback HTML so pipeline crash logs to DB and shows user message instead of blank screen
- **executeBatchAction() catch**: added `window.logError` so batch failures get recorded in error_log table
- Bumped all 20 `?v=` tags to `20260401j`
- Added TEST FILE MAPPING to CLAUDE.md Section 8 for targeted test runs during dev

## Changes
| File | Change |
|------|--------|
| `render/pipeline.js` | 2 catch blocks: added logError + fallback HTML |
| `index.html` | 20 `?v=` bumped to `20260401j` |
| `CLAUDE.md` | Section 3 version + Section 8 test file mapping |

## Test plan
- [x] `npx vitest run` — 289/289 passing, 0 failing
- [ ] After merge: Purge Cloudflare cache
- [ ] Hard refresh → trigger a pipeline render error → verify error_log row + fallback HTML
- [ ] Trigger batch action failure → verify error_log row + toast

https://claude.ai/code/session_018L3YR2jxCFyhyv2RQqjQpC