### PR TITLE
fix: Pass 5 dashboard error handling — 5 fixes

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -12,7 +12,11 @@ async function _fetchActivityLogs() {
       '&order=created_at.desc&limit=500'
     );
     window._activityLogs = Array.isArray(data) ? data : [];
-  } catch(e) { window._activityLogs = []; }
+  } catch(e) {
+    console.error('[post-load] fetchActivityLogs failed', e);
+    window.logError && window.logError(e && e.message, e && e.stack, 'fetch-activity-logs');
+    window._activityLogs = [];
+  }
 }
 
 function isPostStale(p) {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
-19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401n
+19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401o
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -364,7 +364,7 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
 Ph0 Safety            — DONE
 Ph1 File Architecture — DONE (render/ + actions/ extracted)
 Ph2 AppState          — DONE (all globals migrated)
-Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast)
+Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast, Pass 5 dashboard — 4 fixes + 1 post-load fix)
 Ph4 Event Delegation  — PENDING
 Ph5 Optimistic UI     — IN PROGRESS (client comments done)
 Ph6 PWA               — PENDING

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401n">
+ <link rel="stylesheet" href="styles.css?v=20260401o">
 
 </head>
 <body>
@@ -1078,26 +1078,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401n"></script>
-<script src="00-appstate-compat.js?v=20260401n"></script>
-<script src="01-config.js?v=20260401n" defer></script>
-<script src="02-session.js?v=20260401n" defer></script>
-<script src="utils.js?v=20260401n" defer></script>
-<script src="03-auth.js?v=20260401n" defer></script>
-<script src="05-api.js?v=20260401n" defer></script>
-<script src="10-ui.js?v=20260401n" defer></script>
+<script src="00-appstate.js?v=20260401o"></script>
+<script src="00-appstate-compat.js?v=20260401o"></script>
+<script src="01-config.js?v=20260401o" defer></script>
+<script src="02-session.js?v=20260401o" defer></script>
+<script src="utils.js?v=20260401o" defer></script>
+<script src="03-auth.js?v=20260401o" defer></script>
+<script src="05-api.js?v=20260401o" defer></script>
+<script src="10-ui.js?v=20260401o" defer></script>
 
-<script src="06-post-create.js?v=20260401n" defer></script>
-<script defer src="render/dashboard.js?v=20260401n"></script>
-<script defer src="render/client.js?v=20260401n"></script>
-<script defer src="render/pipeline.js?v=20260401n"></script>
-<script defer src="render/brief.js?v=20260401n"></script>
-<script defer src="actions/pcs.js?v=20260401n"></script>
-<script src="07-post-load.js?v=20260401n" defer></script>
-<script src="08-post-actions.js?v=20260401n" defer></script>
-<script src="09-library.js?v=20260401n" defer></script>
-<script src="09-approval.js?v=20260401n" defer></script>
-<script src="04-router.js?v=20260401n" defer></script>
+<script src="06-post-create.js?v=20260401o" defer></script>
+<script defer src="render/dashboard.js?v=20260401o"></script>
+<script defer src="render/client.js?v=20260401o"></script>
+<script defer src="render/pipeline.js?v=20260401o"></script>
+<script defer src="render/brief.js?v=20260401o"></script>
+<script defer src="actions/pcs.js?v=20260401o"></script>
+<script src="07-post-load.js?v=20260401o" defer></script>
+<script src="08-post-actions.js?v=20260401o" defer></script>
+<script src="09-library.js?v=20260401o" defer></script>
+<script src="09-approval.js?v=20260401o" defer></script>
+<script src="04-router.js?v=20260401o" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/dashboard.js
+++ b/render/dashboard.js
@@ -440,6 +440,7 @@ window.renderScoreboard = function() {
 
   } catch (err) {
     console.error('[Scoreboard] Render error', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'render-scoreboard');
   }
 }
 
@@ -608,7 +609,7 @@ window.toggleDashTask = async function(row, taskId) {
         method: 'PATCH',
         body: JSON.stringify({ done: cb.classList.contains('done') })
       });
-    } catch(e) { console.warn('Task toggle failed:', e); }
+    } catch(e) { console.error('[dashboard] task toggle failed', e); window.logError && window.logError(e && e.message, e && e.stack, 'toggle-dash-task'); }
   }
 }
 
@@ -904,7 +905,7 @@ window._buildDoThisNowItems = function(role) {
 
 window.renderDashboard = function() {
   if ((window.AppState.user.effectiveRole || '').toLowerCase() === 'client') return;
-  try { _renderDashboardInner(); } catch(e) { console.error('[PCS] renderDashboard crash:', e); }
+  try { _renderDashboardInner(); } catch(e) { console.error('[PCS] renderDashboard crash:', e); window.logError && window.logError(e && e.message, e && e.stack, 'render-dashboard'); var _d = document.getElementById('dashboard-view'); if (_d) _d.innerHTML = '<div style="color:#FF4B4B;padding:24px;font-family:DM Sans,sans-serif">Something went wrong. Please refresh.</div>'; }
 }
 window._renderDashboardInner = function() {
   var el = document.getElementById('pcs-dashboard');
@@ -1048,7 +1049,8 @@ async function _updateStreakLines() {
       }
     }
   } catch (e) {
-    console.warn('Streak update failed:', e);
+    console.error('[dashboard] streak update failed', e);
+    window.logError && window.logError(e && e.message, e && e.stack, 'update-streak-lines');
   }
 }
 


### PR DESCRIPTION
- renderDashboard() catch: added logError + fallback HTML
- renderScoreboard() catch: added logError
- toggleDashTask() catch: upgraded console.warn to console.error + logError
- _updateStreakLines() catch: upgraded console.warn to console.error + logError
- _fetchActivityLogs() catch (07-post-load.js): added console.error + logError
- Bumped ?v= to 20260401o (20 tags)
- Updated CLAUDE.md Section 3 + Section 13

https://claude.ai/code/session_018L3YR2jxCFyhyv2RQqjQpC