### PR TITLE
fix: Pass 6 post-load error handling + fix duplicate function overwrite of Pass 5 fixes

### DIFF
--- a/05-api.js
+++ b/05-api.js
@@ -146,5 +146,6 @@ async function logActivity({ post_id, actor, actor_role, action }) {
     });
   } catch (err) {
     console.warn('logActivity failed:', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'log-activity');
   }
 }

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -199,6 +199,7 @@ async function loadPosts() {
     showToast(`${window.AppState.posts.all.length} posts loaded`, 'success');
   } catch (err) {
     console.error('loadPosts:', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'load-posts');
     if (window.AppState.posts.cached.length) {
       if (!_commitPostsResult(reqId, 'cache')) return;
       window.AppState.posts.setAll(
@@ -249,7 +250,7 @@ async function loadPostsForClient() {
             });
           });
         }
-      } catch (_) { /* comments fetch failed - render without them */ }
+      } catch (e) { console.error('[post-load] client comments fetch failed', e); window.logError && window.logError(e && e.message, e && e.stack, 'client-comments-fetch'); }
     }
 
     data = data.filter(function(p) {
@@ -310,6 +311,7 @@ function startRealtime() {
       }
     } catch (e) {
       console.warn('realtime poll failed:', e.message);
+      window.logError && window.logError(e && e.message, e && e.stack, 'realtime-poll');
     }
   }, 15000);
 
@@ -318,9 +320,14 @@ function startRealtime() {
   if (!window.AppState.timers.tokenRefresh) {
     window.AppState.timers.tokenRefresh = setInterval(async () => {
       if (!localStorage.getItem('sb_refresh_token')) return;
-      const newToken = await refreshSession();
-      if (!newToken) {
-        console.warn('Background token refresh failed  -  user may need to re-login');
+      try {
+        const newToken = await refreshSession();
+        if (!newToken) {
+          console.warn('Background token refresh failed  -  user may need to re-login');
+        }
+      } catch (e) {
+        console.error('[post-load] token refresh failed', e);
+        window.logError && window.logError(e && e.message, e && e.stack, 'token-refresh');
       }
     }, 50 * 60 * 1000); // 50 minutes
   }
@@ -337,7 +344,7 @@ async function loadTasks() {
   try {
     const data = await apiFetch('/tasks?order=created_at.desc&limit=50');
     allTasks = Array.isArray(data) ? data : [];
-  } catch { allTasks = []; }
+  } catch (e) { console.error('[post-load] loadTasks failed', e); window.logError && window.logError(e && e.message, e && e.stack, 'load-tasks'); allTasks = []; }
   renderTaskBanner();
   renderAdminTaskPanel();
 }
@@ -358,7 +365,7 @@ async function assignTask() {
     document.getElementById('atask-assignee').value = '';
     showToast('Task assigned OK', 'success');
     await loadTasks();
-  } catch { showToast('Failed - try again', 'error'); }
+  } catch (e) { console.error('[post-load] assignTask failed', e); window.logError && window.logError(e && e.message, e && e.stack, 'assign-task'); showToast('Failed - try again', 'error'); }
 }
 
 async function markTaskDone(id) {
@@ -393,10 +400,12 @@ async function markTaskDone(id) {
         console.log('[Task\u2192Scoreboard] Synced');
       } catch (err) {
         console.error('[Task\u2192Scoreboard] Sync failed:', err);
+        window.logError && window.logError(err && err.message, err && err.stack, 'task-scoreboard-sync');
       }
     }, 600);
   } catch (err) {
     console.error('[Task] Failed:', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'mark-task-done');
     showToast('Failed - try again', 'error');
     // Rollback
     if (el) el.classList.remove('task-done');
@@ -497,7 +506,7 @@ async function deleteTask(id) {
   try {
     await apiFetch(`/tasks?id=eq.${id}`, { method: 'DELETE' });
     await loadTasks();
-  } catch { showToast('Failed - try again', 'error'); }
+  } catch (e) { console.error('[post-load] deleteTask failed', e); window.logError && window.logError(e && e.message, e && e.stack, 'delete-task'); showToast('Failed - try again', 'error'); }
 }
 
 function renderAll() {
@@ -514,7 +523,7 @@ function renderAll() {
     return;
   }
   if (window.AppState.ui.modalOpen) return;
-  const run = (name, fn) => { try { fn(); } catch(e) { console.error('renderAll:' + name, e); } };
+  const run = (name, fn) => { try { fn(); } catch(e) { console.error('renderAll:' + name, e); window.logError && window.logError(e && e.message, e && e.stack, 'render-all-' + name); } };
 
   // Always render: lightweight stats & role visibility
   run('updateStats',        updateStats);
@@ -1154,6 +1163,7 @@ function renderScoreboard() {
 
   } catch (err) {
     console.error('[Scoreboard] Render error', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'render-scoreboard');
   }
 }
 
@@ -1322,7 +1332,7 @@ async function toggleDashTask(row, taskId) {
         method: 'PATCH',
         body: JSON.stringify({ done: cb.classList.contains('done') })
       });
-    } catch(e) { console.warn('Task toggle failed:', e); }
+    } catch(e) { console.error('[dashboard] task toggle failed', e); window.logError && window.logError(e && e.message, e && e.stack, 'toggle-dash-task'); }
   }
 }
 
@@ -1625,7 +1635,7 @@ function _buildDoThisNowItems(role) {
 
 function renderDashboard() {
   if ((window.AppState.user.effectiveRole || '').toLowerCase() === 'client') return;
-  try { _renderDashboardInner(); } catch(e) { console.error('[PCS] renderDashboard crash:', e); }
+  try { _renderDashboardInner(); } catch(e) { console.error('[PCS] renderDashboard crash:', e); window.logError && window.logError(e && e.message, e && e.stack, 'render-dashboard'); var _d = document.getElementById('dashboard-view'); if (_d) _d.innerHTML = '<div style="color:#FF4B4B;padding:24px;font-family:DM Sans,sans-serif">Something went wrong. Please refresh.</div>'; }
 }
 function _renderDashboardInner() {
   var el = document.getElementById('pcs-dashboard');
@@ -1769,7 +1779,8 @@ async function _updateStreakLines() {
       }
     }
   } catch (e) {
-    console.warn('Streak update failed:', e);
+    console.error('[dashboard] streak update failed', e);
+    window.logError && window.logError(e && e.message, e && e.stack, 'update-streak-lines');
   }
 }
 
@@ -2415,7 +2426,7 @@ function _renderFilteredTasks() {
 }
 
 function renderTasks() {
-  try { _renderTasksInner(); } catch(e) { console.error('[PCS] renderTasks crash:', e); }
+  try { _renderTasksInner(); } catch(e) { console.error('[PCS] renderTasks crash:', e); window.logError && window.logError(e && e.message, e && e.stack, 'render-tasks'); var _t = document.getElementById('tasks-container'); if (_t) _t.innerHTML = '<div style="color:#FF4B4B;padding:24px;font-family:DM Sans,sans-serif">Something went wrong. Please refresh.</div>'; }
 }
 function _renderTasksInner() {
   renderTaskStageChips();

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
-19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401o
+19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401p
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -364,7 +364,7 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
 Ph0 Safety            — DONE
 Ph1 File Architecture — DONE (render/ + actions/ extracted)
 Ph2 AppState          — DONE (all globals migrated)
-Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast, Pass 5 dashboard — 4 fixes + 1 post-load fix)
+Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast, Pass 5 dashboard — 4 fixes + 1 post-load fix, Pass 6 post-load — 12 fixes + 4 duplicate function overwrites fixed)
 Ph4 Event Delegation  — PENDING
 Ph5 Optimistic UI     — IN PROGRESS (client comments done)
 Ph6 PWA               — PENDING

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401o">
+ <link rel="stylesheet" href="styles.css?v=20260401p">
 
 </head>
 <body>
@@ -1078,26 +1078,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401o"></script>
-<script src="00-appstate-compat.js?v=20260401o"></script>
-<script src="01-config.js?v=20260401o" defer></script>
-<script src="02-session.js?v=20260401o" defer></script>
-<script src="utils.js?v=20260401o" defer></script>
-<script src="03-auth.js?v=20260401o" defer></script>
-<script src="05-api.js?v=20260401o" defer></script>
-<script src="10-ui.js?v=20260401o" defer></script>
+<script src="00-appstate.js?v=20260401p"></script>
+<script src="00-appstate-compat.js?v=20260401p"></script>
+<script src="01-config.js?v=20260401p" defer></script>
+<script src="02-session.js?v=20260401p" defer></script>
+<script src="utils.js?v=20260401p" defer></script>
+<script src="03-auth.js?v=20260401p" defer></script>
+<script src="05-api.js?v=20260401p" defer></script>
+<script src="10-ui.js?v=20260401p" defer></script>
 
-<script src="06-post-create.js?v=20260401o" defer></script>
-<script defer src="render/dashboard.js?v=20260401o"></script>
-<script defer src="render/client.js?v=20260401o"></script>
-<script defer src="render/pipeline.js?v=20260401o"></script>
-<script defer src="render/brief.js?v=20260401o"></script>
-<script defer src="actions/pcs.js?v=20260401o"></script>
-<script src="07-post-load.js?v=20260401o" defer></script>
-<script src="08-post-actions.js?v=20260401o" defer></script>
-<script src="09-library.js?v=20260401o" defer></script>
-<script src="09-approval.js?v=20260401o" defer></script>
-<script src="04-router.js?v=20260401o" defer></script>
+<script src="06-post-create.js?v=20260401p" defer></script>
+<script defer src="render/dashboard.js?v=20260401p"></script>
+<script defer src="render/client.js?v=20260401p"></script>
+<script defer src="render/pipeline.js?v=20260401p"></script>
+<script defer src="render/brief.js?v=20260401p"></script>
+<script defer src="actions/pcs.js?v=20260401p"></script>
+<script src="07-post-load.js?v=20260401p" defer></script>
+<script src="08-post-actions.js?v=20260401p" defer></script>
+<script src="09-library.js?v=20260401p" defer></script>
+<script src="09-approval.js?v=20260401p" defer></script>
+<script src="04-router.js?v=20260401p" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- **CRITICAL**: 07-post-load.js contained duplicate copies of `renderScoreboard`, `toggleDashTask`, `renderDashboard`, `_updateStreakLines` that loaded AFTER render/dashboard.js and **overwrote the Pass 5 logError fixes**. All 4 now have matching fixes.
- `loadPosts()` catch: added logError
- `startRealtime()` poll catch: added logError
- `startRealtime()` token refresh: wrapped in try/catch + logError
- `loadTasks()` catch: added console.error + logError
- `assignTask()` catch: added console.error + logError
- `markTaskDone()` outer + inner catch: added logError
- `deleteTask()` catch: added console.error + logError
- `renderAll()` run() catch: added logError
- `renderTasks()` catch: added logError + fallback HTML
- `loadPostsForClient()` inner comments catch: added console.error + logError
- `logActivity()` catch in 05-api.js: added logError
- Bumped `?v=` to `20260401p` (20 tags)
- Updated CLAUDE.md Section 3 + Section 13

## Test plan
- [x] `npx vitest run` — 297/297 passing, 0 failing
- [ ] Purge Cloudflare cache after merge
- [ ] Hard refresh all devices before testing
- [ ] Verify error_log table receives entries on post-load failures

https://claude.ai/code/session_018L3YR2jxCFyhyv2RQqjQpC