### PR TITLE
fix: Pass 7 auth error handling — 6 fixes

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -37,7 +37,10 @@ async function refreshSession() {
         if (data.refresh_token) localStorage.setItem('sb_refresh_token', data.refresh_token);
         return data.access_token;
       }
-    } catch (_) {}
+    } catch (err) {
+      console.error('[auth] refreshSession failed', err);
+      window.logError && window.logError(err && err.message, err && err.stack, 'refresh-session');
+    }
     return null;
   })();
   try {
@@ -98,6 +101,7 @@ window.sendMagicLink = async function sendMagicLink() {
   } catch (err) {
     const errMsg = document.getElementById('login-error');
     if (errMsg) errMsg.textContent = err.message || 'Could not send code. Try again.';
+    window.logError && window.logError(err && err.message, err && err.stack, 'send-magic-link');
     btn.disabled = false;
     btn.textContent = 'Send Code ->';
   }
@@ -137,6 +141,7 @@ window.verifyOTPCode = async function verifyOTPCode() {
     await resolveRoleFromToken(accessToken, email);
   } catch (err) {
     if (errEl) errEl.textContent = err.message || 'Incorrect code - try again.';
+    window.logError && window.logError(err && err.message, err && err.stack, 'verify-otp');
     btn.disabled = false;
     btn.textContent = 'Verify ->';
   }
@@ -165,6 +170,8 @@ async function resolveRoleFromToken(accessToken, email) {
     if (overlay) overlay.classList.add('hidden');
     activateRole(role);
   } catch (err) {
+    console.error('[auth] resolveRoleFromToken failed', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'resolve-role-token');
     const el = document.getElementById('login-code-error');
     if (el) el.textContent = 'Login failed - try again.';
   }
@@ -188,6 +195,8 @@ async function handleMagicLinkToken(accessToken, _retried) {
     localStorage.setItem('sb_access_token', accessToken);
     await resolveRoleFromToken(accessToken, email);
   } catch (err) {
+    console.error('[auth] handleMagicLinkToken failed', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'handle-magic-link');
     showLoginOverlay();
   }
 }
@@ -243,9 +252,15 @@ function activateRole(role) {
     if (typeof loadPostsForClient === 'function') loadPostsForClient();
     if (!window._clientTokenTimer) {
       window._clientTokenTimer = setInterval(async function() {
-        var newToken = await refreshSession();
-        if (!newToken) {
-          console.warn('Client token refresh failed');
+        try {
+          var newToken = await refreshSession();
+          if (!newToken) {
+            console.warn('[auth] client token refresh returned null');
+            window.logError && window.logError('Client token refresh returned null', '', 'client-token-refresh');
+          }
+        } catch(err) {
+          console.error('[auth] client token refresh threw', err);
+          window.logError && window.logError(err && err.message, err && err.stack, 'client-token-refresh');
         }
       }, 50 * 60 * 1000);
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
-19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401p
+19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401q
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -364,7 +364,7 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
 Ph0 Safety            — DONE
 Ph1 File Architecture — DONE (render/ + actions/ extracted)
 Ph2 AppState          — DONE (all globals migrated)
-Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast, Pass 5 dashboard — 4 fixes + 1 post-load fix, Pass 6 post-load — 12 fixes + 4 duplicate function overwrites fixed)
+Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast, Pass 5 dashboard — 4 fixes + 1 post-load fix, Pass 6 post-load — 12 fixes + 4 duplicate function overwrites fixed, Pass 7 auth — 6 fixes incl. silent refreshSession catch)
 Ph4 Event Delegation  — PENDING
 Ph5 Optimistic UI     — IN PROGRESS (client comments done)
 Ph6 PWA               — PENDING

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401p">
+ <link rel="stylesheet" href="styles.css?v=20260401q">
 
 </head>
 <body>
@@ -1078,26 +1078,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401p"></script>
-<script src="00-appstate-compat.js?v=20260401p"></script>
-<script src="01-config.js?v=20260401p" defer></script>
-<script src="02-session.js?v=20260401p" defer></script>
-<script src="utils.js?v=20260401p" defer></script>
-<script src="03-auth.js?v=20260401p" defer></script>
-<script src="05-api.js?v=20260401p" defer></script>
-<script src="10-ui.js?v=20260401p" defer></script>
+<script src="00-appstate.js?v=20260401q"></script>
+<script src="00-appstate-compat.js?v=20260401q"></script>
+<script src="01-config.js?v=20260401q" defer></script>
+<script src="02-session.js?v=20260401q" defer></script>
+<script src="utils.js?v=20260401q" defer></script>
+<script src="03-auth.js?v=20260401q" defer></script>
+<script src="05-api.js?v=20260401q" defer></script>
+<script src="10-ui.js?v=20260401q" defer></script>
 
-<script src="06-post-create.js?v=20260401p" defer></script>
-<script defer src="render/dashboard.js?v=20260401p"></script>
-<script defer src="render/client.js?v=20260401p"></script>
-<script defer src="render/pipeline.js?v=20260401p"></script>
-<script defer src="render/brief.js?v=20260401p"></script>
-<script defer src="actions/pcs.js?v=20260401p"></script>
-<script src="07-post-load.js?v=20260401p" defer></script>
-<script src="08-post-actions.js?v=20260401p" defer></script>
-<script src="09-library.js?v=20260401p" defer></script>
-<script src="09-approval.js?v=20260401p" defer></script>
-<script src="04-router.js?v=20260401p" defer></script>
+<script src="06-post-create.js?v=20260401q" defer></script>
+<script defer src="render/dashboard.js?v=20260401q"></script>
+<script defer src="render/client.js?v=20260401q"></script>
+<script defer src="render/pipeline.js?v=20260401q"></script>
+<script defer src="render/brief.js?v=20260401q"></script>
+<script defer src="actions/pcs.js?v=20260401q"></script>
+<script src="07-post-load.js?v=20260401q" defer></script>
+<script src="08-post-actions.js?v=20260401q" defer></script>
+<script src="09-library.js?v=20260401q" defer></script>
+<script src="09-approval.js?v=20260401q" defer></script>
+<script src="04-router.js?v=20260401q" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- **CRITICAL**: `refreshSession()` had completely silent `catch(_){}` — most-called auth function in codebase. Now logs to error_log.
- `sendMagicLink()` catch: added logError after UI error display
- `verifyOTPCode()` catch: added logError after UI error display
- `resolveRoleFromToken()` catch: added console.error + logError
- `handleMagicLinkToken()` catch: added console.error + logError
- `activateRole()` client token timer: wrapped `refreshSession()` in try/catch + logError
- Bumped `?v=` to `20260401q` (20 tags)
- Updated CLAUDE.md Section 3 + Section 13

## Test plan
- [x] `npx vitest run` — 297/297 passing, 0 failing
- [ ] Purge Cloudflare cache after merge
- [ ] Hard refresh all devices before testing
- [ ] Verify error_log receives entries on auth failures

https://claude.ai/code/session_018L3YR2jxCFyhyv2RQqjQpC