### PR TITLE
fix: remove stale comments column from new post payload

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -227,7 +227,6 @@ const pillar   = _s('new-post-pillar')?.value || '';
 const location = _s('new-post-location')?.value || '';
 const stage    = _s('new-post-stage')?.value || '';
 const date     = _s('new-post-date')?.value || '';
-const comments = (_s('new-post-comments')?.value || '').trim();
 const postLink = (_s('new-post-link')?.value || '').trim();
 var captionVal = (_s('new-post-caption')?.value || '').trim();
 
@@ -257,7 +256,6 @@ content_pillar: sanitizePillar(pillar) || null,
 location: location || null,
 stage: 'in_production',
 target_date: date || null,
-comments: comments || null,
 };
 if (captionVal) payload.caption = captionVal;
 // Defensive: remove any invalid field names that must never reach DB

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
-19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401q
+19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401r
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -97,7 +97,7 @@ PostgREST eq. is CASE-SENSITIVE — always capitalize roles.
 (‘Creative’ not ‘creative’, ‘Admin’ not ‘admin’)
 
 posts: post_id(PK), title, stage, owner, content_pillar,
-location, target_date, linkedin_link, comments, canva_link,
+location, target_date, linkedin_link, canva_link,
 status_changed_at, format, caption, images(jsonb), client_feedback
 
 post_comments: id, post_id, author, author_role, message,

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401q">
+ <link rel="stylesheet" href="styles.css?v=20260401r">
 
 </head>
 <body>
@@ -1078,26 +1078,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401q"></script>
-<script src="00-appstate-compat.js?v=20260401q"></script>
-<script src="01-config.js?v=20260401q" defer></script>
-<script src="02-session.js?v=20260401q" defer></script>
-<script src="utils.js?v=20260401q" defer></script>
-<script src="03-auth.js?v=20260401q" defer></script>
-<script src="05-api.js?v=20260401q" defer></script>
-<script src="10-ui.js?v=20260401q" defer></script>
+<script src="00-appstate.js?v=20260401r"></script>
+<script src="00-appstate-compat.js?v=20260401r"></script>
+<script src="01-config.js?v=20260401r" defer></script>
+<script src="02-session.js?v=20260401r" defer></script>
+<script src="utils.js?v=20260401r" defer></script>
+<script src="03-auth.js?v=20260401r" defer></script>
+<script src="05-api.js?v=20260401r" defer></script>
+<script src="10-ui.js?v=20260401r" defer></script>
 
-<script src="06-post-create.js?v=20260401q" defer></script>
-<script defer src="render/dashboard.js?v=20260401q"></script>
-<script defer src="render/client.js?v=20260401q"></script>
-<script defer src="render/pipeline.js?v=20260401q"></script>
-<script defer src="render/brief.js?v=20260401q"></script>
-<script defer src="actions/pcs.js?v=20260401q"></script>
-<script src="07-post-load.js?v=20260401q" defer></script>
-<script src="08-post-actions.js?v=20260401q" defer></script>
-<script src="09-library.js?v=20260401q" defer></script>
-<script src="09-approval.js?v=20260401q" defer></script>
-<script src="04-router.js?v=20260401q" defer></script>
+<script src="06-post-create.js?v=20260401r" defer></script>
+<script defer src="render/dashboard.js?v=20260401r"></script>
+<script defer src="render/client.js?v=20260401r"></script>
+<script defer src="render/pipeline.js?v=20260401r"></script>
+<script defer src="render/brief.js?v=20260401r"></script>
+<script defer src="actions/pcs.js?v=20260401r"></script>
+<script src="07-post-load.js?v=20260401r" defer></script>
+<script src="08-post-actions.js?v=20260401r" defer></script>
+<script src="09-library.js?v=20260401r" defer></script>
+<script src="09-approval.js?v=20260401r" defer></script>
+<script src="04-router.js?v=20260401r" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- New post creation was failing with: `Could not find the 'comments' column of 'posts' in the schema cache`
- The `comments` column was removed from the `posts` table when comments moved to `post_comments` and `internal_notes` tables
- Removed `comments` variable read and `comments` field from the `submitNewPost()` payload in `06-post-create.js`
- Updated CLAUDE.md Section 5 schema to remove `comments` from posts table
- Bumped `?v=` to `20260401r` (20 tags)

## Test plan
- [x] `npx vitest run` — 297/297 passing, 0 failing
- [ ] Create a new post and verify it saves successfully
- [ ] Purge Cloudflare cache after merge

https://claude.ai/code/session_018L3YR2jxCFyhyv2RQqjQpC