### PR TITLE
fix: remove stale comments column from client request form

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -20,13 +20,12 @@ location: document.getElementById('new-post-location')?.value || '',
 owner:    document.getElementById('new-post-owner')?.value    || '',
 stage:    document.getElementById('new-post-stage')?.value    || '',
 date:     document.getElementById('new-post-date')?.value     || '',
-comments: document.getElementById('new-post-comments')?.value || '',
 postLink: document.getElementById('new-post-link')?.value     || '',
 format:   document.getElementById('new-post-format')?.value   || '',
 savedAt:  Date.now(),
 };
 
-if (draft.title || draft.comments) {
+if (draft.title) {
 localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
 showDraftStatus('Draft saved');
 }
@@ -44,7 +43,7 @@ localStorage.removeItem(DRAFT_KEY);
 return false;
 }
 
-if (!d.title && !d.comments) return false;
+if (!d.title) return false;
 
 const _el = id => document.getElementById(id);
 if (_el('new-post-title'))    _el('new-post-title').value    = d.title    || '';
@@ -53,7 +52,7 @@ if (_el('new-post-location')) _el('new-post-location').value = d.location || '';
 if (_el('new-post-owner'))    _el('new-post-owner').value    = d.owner    || '';
 if (_el('new-post-stage'))    _el('new-post-stage').value    = d.stage    || 'in_production';
 if (_el('new-post-date'))     _el('new-post-date').value     = d.date     || '';
-if (_el('new-post-comments')) _el('new-post-comments').value = d.comments || '';
+
 if (_el('new-post-link'))     _el('new-post-link').value     = d.postLink || '';
 if (_el('new-post-format'))   _el('new-post-format').value   = d.format   || '';
 
@@ -130,7 +129,7 @@ if (createBtn) createBtn.onclick = function() { submitNewPost(); };
   var el = document.getElementById(id);
   if (el) el.onchange = saveDraftDebounced;
 });
-['new-post-link','new-post-comments'].forEach(function(id) {
+['new-post-link'].forEach(function(id) {
   var el = document.getElementById(id);
   if (el) el.oninput = saveDraftDebounced;
 });
@@ -148,7 +147,7 @@ const hasDraft = loadDraft();
 
 if (!hasDraft) {
 
-['new-post-title','new-post-comments','new-post-link'].forEach(id => {
+['new-post-title','new-post-link'].forEach(id => {
 const el = document.getElementById(id);
 if (el) el.value = '';
 });

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -82,7 +82,6 @@ function openAdminEdit(postId) {
   const aePillar = _ae('ae-pillar');    if (aePillar) aePillar.value = post.contentPillar || '';
   const aeLoc    = _ae('ae-location');  if (aeLoc) aeLoc.value = post.location || '';
   const aeDate   = _ae('ae-date');      if (aeDate) aeDate.value = post.targetDate || '';
-  const aeComm   = _ae('ae-comments');  if (aeComm) aeComm.value = post.comments || '';
   const aeLink   = _ae('ae-postlink');  if (aeLink) aeLink.value = post.postLink || post.linkedinUrl || '';
   const sel = _ae('ae-stage');
   if (sel) sel.innerHTML = PIPELINE_ORDER.map(s => `<option value="${s}" ${post.stage===s?'selected':''}>${s}</option>`).join('');
@@ -116,7 +115,6 @@ async function saveAdminEdit() {
   const location = _ae('ae-location')?.value || '';
   const stage    = _ae('ae-stage')?.value || '';
   const date     = _ae('ae-date')?.value || '';
-  const comments = (_ae('ae-comments')?.value || '').trim();
   const postLink = (_ae('ae-postlink')?.value || '').trim();
   if (!title) {
     console.warn('[saveAdminEdit] BLOCKED: title empty');
@@ -125,7 +123,7 @@ async function saveAdminEdit() {
   }
   const btn = _ae('ae-save-btn');
   if (btn) btn.disabled = true;
-  const _payload = { title, owner: owner||null, content_pillar: sanitizePillar(pillar)||null, location: location||null, stage: toDbStage(stage)||null, target_date: date||null, comments: comments||null, updated_at: new Date().toISOString() };
+  const _payload = { title, owner: owner||null, content_pillar: sanitizePillar(pillar)||null, location: location||null, stage: toDbStage(stage)||null, target_date: date||null, updated_at: new Date().toISOString() };
   // Defensive: remove any invalid field names that must never reach DB
   delete _payload.post_link;
   delete _payload.linkedin_url;
@@ -258,7 +256,7 @@ async function submitClientRequest() {
       title:       reqName.trim() || fallbackTitle,
       stage:       'brief',
       owner:       'Chitra',
-      comments:    brief,
+      client_feedback: brief,
       target_date: reqDate,
       created_at:  new Date().toISOString(),
       updated_at:  new Date().toISOString(),
@@ -268,7 +266,7 @@ async function submitClientRequest() {
       '#req-overlay button[style*="rgb(200, 168, 75)"]'
     );
     if (selectedChip) {
-      payload.comments = (payload.comments || '') +
+      payload.client_feedback = (payload.client_feedback || '') +
         ' [Type: ' + selectedChip.textContent.trim() + ']';
     }
     // Read urgency
@@ -276,7 +274,7 @@ async function submitClientRequest() {
     var isUrgent = urgentBtn &&
       urgentBtn.style.color === 'rgb(255, 75, 75)';
     if (isUrgent) {
-      payload.comments = '[URGENT] ' + (payload.comments || '');
+      payload.client_feedback = '[URGENT] ' + (payload.client_feedback || '');
     }
     var imageUrls = [];
     if (files.length) {
@@ -362,7 +360,7 @@ async function flagIssue(postId) {
   try {
     await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
       method: 'PATCH',
-      body: JSON.stringify({ comments: `! ${msg}`, updated_at: new Date().toISOString() }),
+      body: JSON.stringify({ client_feedback: `! ${msg}`, updated_at: new Date().toISOString() }),
     });
     await logActivity({ post_id: postId, actor: window.AppState.user.role, actor_role: window.AppState.user.role, action: `Issue flagged: ${msg.substring(0,80)}` });
     showToast('Issue flagged  -  team has been notified', 'success');
@@ -584,7 +582,6 @@ async function updatePost(postId, field, value) {
     targetDate:    'target_date',
     postLink:      'canva_link',
     linkedinUrl:   'linkedin_link',
-    comments:      'comments',
   }[field] || field;
 
   // Guard: reject any legacy/invalid field names before they reach DB

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
-19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401r
+19 script tags total. Version format: ?v=YYYYMMDDx. Current: ?v=20260401s
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401r">
+ <link rel="stylesheet" href="styles.css?v=20260401s">
 
 </head>
 <body>
@@ -1078,26 +1078,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401r"></script>
-<script src="00-appstate-compat.js?v=20260401r"></script>
-<script src="01-config.js?v=20260401r" defer></script>
-<script src="02-session.js?v=20260401r" defer></script>
-<script src="utils.js?v=20260401r" defer></script>
-<script src="03-auth.js?v=20260401r" defer></script>
-<script src="05-api.js?v=20260401r" defer></script>
-<script src="10-ui.js?v=20260401r" defer></script>
+<script src="00-appstate.js?v=20260401s"></script>
+<script src="00-appstate-compat.js?v=20260401s"></script>
+<script src="01-config.js?v=20260401s" defer></script>
+<script src="02-session.js?v=20260401s" defer></script>
+<script src="utils.js?v=20260401s" defer></script>
+<script src="03-auth.js?v=20260401s" defer></script>
+<script src="05-api.js?v=20260401s" defer></script>
+<script src="10-ui.js?v=20260401s" defer></script>
 
-<script src="06-post-create.js?v=20260401r" defer></script>
-<script defer src="render/dashboard.js?v=20260401r"></script>
-<script defer src="render/client.js?v=20260401r"></script>
-<script defer src="render/pipeline.js?v=20260401r"></script>
-<script defer src="render/brief.js?v=20260401r"></script>
-<script defer src="actions/pcs.js?v=20260401r"></script>
-<script src="07-post-load.js?v=20260401r" defer></script>
-<script src="08-post-actions.js?v=20260401r" defer></script>
-<script src="09-library.js?v=20260401r" defer></script>
-<script src="09-approval.js?v=20260401r" defer></script>
-<script src="04-router.js?v=20260401r" defer></script>
+<script src="06-post-create.js?v=20260401s" defer></script>
+<script defer src="render/dashboard.js?v=20260401s"></script>
+<script defer src="render/client.js?v=20260401s"></script>
+<script defer src="render/pipeline.js?v=20260401s"></script>
+<script defer src="render/brief.js?v=20260401s"></script>
+<script defer src="actions/pcs.js?v=20260401s"></script>
+<script src="07-post-load.js?v=20260401s" defer></script>
+<script src="08-post-actions.js?v=20260401s" defer></script>
+<script src="09-library.js?v=20260401s" defer></script>
+<script src="09-approval.js?v=20260401s" defer></script>
+<script src="04-router.js?v=20260401s" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- `submitClientRequest()` was failing with: `Could not find the 'comments' column of 'posts' in the schema cache`
- Same root cause as #614 — `comments` column removed from posts table
- **08-post-actions.js**: Remapped `comments` → `client_feedback` in submitClientRequest (3 refs), saveAdminEdit (removed), flagIssue (remapped), field mapping (removed)
- **06-post-create.js**: Cleaned up 6 remaining draft save/restore references to `comments` that PR #614 missed
- Zero `comments` references remain in either file
- Bumped `?v=` to `20260401s` (20 tags)

## Test plan
- [x] `npx vitest run` — 297/297 passing, 0 failing
- [ ] Submit a client request and verify it saves
- [ ] Admin edit a post and verify it saves
- [ ] Flag an issue on a post and verify it saves
- [ ] Purge Cloudflare cache after merge

https://claude.ai/code/session_018L3YR2jxCFyhyv2RQqjQpC