### PR TITLE
redesign: PCS final implementation — approved design v11

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260401w
+Version format: ?v=YYYYMMDDx. Current: ?v=20260401y
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -325,7 +325,7 @@ window._closeBriefConfirm, window._closeBrief,
 window._reopenBrief, window._createPostFromBrief
 
 actions/pcs.js:
-window._pcsLbImages, window._pcsLbIdx, window._pcsActiveTab,
+window._pcsLbImages, window._pcsLbIdx, window._pcsActiveTab, window._pcsDateChange,
 window.openPCS, window.closePCS, window.forcePCSReset,
 window._renderPCS, window._pcsTabSwitch, window._pcsChipDrop,
 window._updateSubtitle, window._pcsTitleEdit,

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -155,8 +155,6 @@ window._renderPCS = function(postId) {
   var stageLC     = post.stage || '';
   console.log('[PCS] _renderPCS READING:', id, 'stage=' + post.stage, 'stageLC=' + stageLC, Date.now());
   var isPublished = stageLC === 'published';
-  var canvaUrl    = post.postLink || '';
-  var linkedinUrl = post.linkedinUrl || '';
   var _pcsRole = (window.AppState.user.effectiveRole || '').toLowerCase();
   var _isPranavPCS = _pcsRole === 'creative' ||
     _pcsRole === 'pranav' ||
@@ -165,119 +163,97 @@ window._renderPCS = function(postId) {
   var canEditCreative = _isPranavPCS;
   var dateValue   = post.targetDate || '';
   var isAdmin = _pcsRole === 'admin';
+  var canManage = canEdit || canEditCreative;
 
-  // 3. Title
-  var elTitle = document.getElementById('pcs-topbar-title');
-  if (elTitle) {
-    elTitle.textContent = title;
-    if (canEdit) {
-      elTitle.classList.add('pcs-title--editable');
-      elTitle.onclick = function() { _pcsTitleEdit(elTitle, id); };
-    } else {
-      elTitle.classList.remove('pcs-title--editable');
-      elTitle.onclick = null;
-    }
-  }
-
-  // 4. Stage pill + overdue pill in topbar right
+  // a) Stage pill + overdue pill in topbar right
   var topbarRight = document.getElementById('pcs-topbar-right');
   if (topbarRight) {
     var _stageLabel = (typeof STAGE_DISPLAY !== 'undefined' && STAGE_DISPLAY[stageLC]) || stageLC || 'Unknown';
-    var _stageColor = '#AEAEB2';
-    if (stageLC === 'in_production' || stageLC === 'awaiting_brand_input') _stageColor = '#F6A623';
-    else if (stageLC === 'ready') _stageColor = '#3ECF8E';
-    else if (stageLC === 'awaiting_approval') _stageColor = '#FF4B4B';
-    else if (stageLC === 'scheduled') _stageColor = '#22D3EE';
-    else if (stageLC === 'published') _stageColor = '#8E8E93';
-    else if (stageLC === 'parked') _stageColor = '#F6A623';
-    else if (stageLC === 'rejected') _stageColor = '#FF4B4B';
-    var _pillHtml = '<span class="pcs-stage-pill' + (isAdmin ? ' editable pcs-chip--interactive' : '') + '" style="color:' + _stageColor + ';border-color:' + _stageColor + ';"' +
+    var _pillHtml = '<span class="pcs-stage-pill" id="pcs-stage-pill"' +
       (isAdmin ? ' onclick="window._pcsChipDrop(this,\'stage\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(_stageLabel) + '</span>';
-    // Overdue pill
+      '>' + esc(_stageLabel) +
+      (isAdmin ? ' <span class="pcs-pill-arr">&#x25BE;</span>' : '') +
+      '</span>';
     var _noOverdue = ['published','parked','rejected'];
     if (_noOverdue.indexOf(stageLC) === -1 && dateValue) {
       var _td = typeof parseDate === 'function' ? parseDate(dateValue) : null;
       var _now = new Date(); _now.setHours(0,0,0,0);
       if (_td && _td < _now) {
-        _pillHtml += ' <span class="pc-overdue-badge">Overdue</span>';
+        _pillHtml += '<span class="pcs-od-pill" id="pcs-od-pill"><span class="pcs-od-dot"></span>Overdue</span>';
       }
     }
     topbarRight.innerHTML = _pillHtml;
   }
 
-  // 7. Photo grid
-  var elDesign = document.getElementById('pcs-action-btn-wrap');
+  // b) Photo section
   var imgs = Array.isArray(post.images) ? post.images : [];
-  var showPhotoSection = (canEdit || canEditCreative) || imgs.length > 0;
-  if (elDesign) {
-    elDesign.innerHTML = showPhotoSection
-      ? _buildPhotoGrid(imgs, canEdit, canEditCreative, isAdmin, id)
-      : '';
+  var photoHeader = document.getElementById('pcs-photo-header-row');
+  var photoLabel = document.getElementById('pcs-photo-label');
+  var photoMenuBtn = document.getElementById('pcs-photo-menu-btn');
+  var photoGridWrap = document.getElementById('pcs-photo-grid-wrap');
+  if (photoHeader) photoHeader.style.display = (canManage || imgs.length > 0) ? 'flex' : 'none';
+  if (photoLabel) photoLabel.textContent = 'PHOTOS \u00B7 ' + imgs.length;
+  if (photoMenuBtn) {
+    photoMenuBtn.onclick = function(ev) { window._pcsPhotoMenu(id, ev); };
+    photoMenuBtn.style.display = canManage ? '' : 'none';
+  }
+  if (photoGridWrap) photoGridWrap.innerHTML = _buildPhotoGrid(imgs, canEdit, canEditCreative, isAdmin, id);
+
+  // c) Title
+  var elTitle = document.getElementById('pcs-topbar-title');
+  if (elTitle) {
+    elTitle.textContent = title;
+    if (canEdit) {
+      elTitle.style.cursor = 'text';
+      elTitle.onclick = function() { _pcsTitleEdit(elTitle, id); };
+    } else {
+      elTitle.style.cursor = '';
+      elTitle.onclick = null;
+    }
   }
 
-  // 8. Meta chips
-  var chipsEl = document.getElementById('pcs-meta-chips');
-  if (chipsEl) chipsEl.innerHTML = _buildMetaChips(post, canEdit, canEditCreative, id);
+  // d) Meta chips
+  var chipsEl = document.getElementById('pcs-chips-row');
+  if (chipsEl) chipsEl.innerHTML = _buildChipsRow(post, canEdit, canEditCreative, id);
 
-  // 9. Caption + LinkedIn into pcs-fields, advance rendered inline, then WA
+  // e) Caption + LinkedIn into pcs-fields
   var elFields = document.getElementById('pcs-fields');
   var captionHtml = _buildCaptionHtml(post, canEdit, canEditCreative, id);
   var liHtml = _buildLinkedInHtml(post, id, stageLC);
-  var waHtml = _buildWAHtml(post, id, postId, stageLC);
   if (elFields) {
     elFields.innerHTML = captionHtml + liHtml +
       '<input type="hidden" id="pcs-post-id" value="' + esc(id) + '">';
   }
 
-  // 10. Stage advance button (renders into static pc-advance-block, which is between fields and WA)
-  _renderAdvanceButton(stageLC);
-
-  // 10b. WA button goes into a container after advance block
+  // f) WA button
+  var waHtml = _buildWAHtml(post, id, postId, stageLC);
   var waContainer = document.getElementById('pcs-wa-container');
   if (waContainer) waContainer.innerHTML = waHtml;
 
-  // 11. Activity count
-  _renderActivityCount(id);
-
-  // 12. Hide activity trigger
-  var actTrigger = document.getElementById('pc-activity-trigger');
-  if (actTrigger) actTrigger.style.display = 'none';
-
-  // 13. Load activity async
-  var elActivity = document.getElementById('pcs-activity-body');
-  if (elActivity) {
-    if (elActivity.dataset.loadedFor !== id) {
-      elActivity.dataset.loadedFor = id;
-      elActivity.innerHTML = '<div class="pcs-activity-loading">Loading...</div>';
-      _loadPCSActivity(id, elActivity);
-    }
-  }
-
-  // 14. Show comments section container
+  // g) Show comments section (compatibility)
   var commSection = document.getElementById('pcs-comments-section');
   if (commSection) commSection.style.display = 'block';
 
-  // 15. Load comments
+  // h) Load comments
   var _pcsPostIdEl = document.getElementById('pcs-post-id');
   var _pcsPostId = _pcsPostIdEl ? _pcsPostIdEl.value : id;
   if (typeof loadPcsComments === 'function') {
     loadPcsComments(_pcsPostId);
   }
 
-  // 16. Hide Internal tab for clients
+  // i) Hide Internal tab for clients
   var internalTab = document.querySelector('[data-tab="internal"]');
   if (internalTab) internalTab.style.display = _pcsRole === 'client' ? 'none' : '';
 
-  // 17. Notes section role guard
+  // j) Notes section role guard
   var notesSection = document.getElementById('pcs-notes-section');
   if (notesSection) notesSection.style.display = _pcsRole === 'client' ? 'none' : '';
 
-  // 18. Default to caption tab
+  // k) Default to caption tab
   window._pcsActiveTab = 'caption';
   _pcsTabSwitch('caption');
 
-  // 19. Mention dropup
+  // l) Mention dropup
   if (typeof window._initMentionDropup === 'function') {
     window._initMentionDropup();
   }
@@ -309,130 +285,96 @@ function _buildPhotoGrid(imgs, canEdit, canEditCreative, isAdmin, id) {
   var canManage = canEdit || canEditCreative;
   var count = imgs.length;
 
-  var headerHtml =
-    '<div class="pcs-photo-header">' +
-    '<div class="pcs-photo-label">Photos <span style="color:' +
-    (count ? '#E8E8E8' : '#8E8E93') + ';">' + count + '</span></div>' +
-    (canManage ?
-      '<button onclick="window._pcsPhotoMenu(\'' + esc(id) + '\',event)" ' +
-      'style="color:#8E8E93;background:transparent;border:none;' +
-      'padding:8px 12px;cursor:pointer;font-family:\'IBM Plex Mono\',monospace;' +
-      'font-size:13px;height:36px;letter-spacing:0.2em;">...</button>' : '') +
-    '</div>';
-
-  function _cell(idx, extraStyle, overlayHtml) {
-    return '<div class="pcs-photo-grid-cell" onclick="window._pcsOpenLightbox(\'' + esc(id) + '\',' + idx + ')"' +
-      (extraStyle ? ' style="' + extraStyle + '"' : '') + '>' +
-      '<img src="' + esc(imgs[idx]) + '">' +
-      (isAdmin ? '<button class="pcs-photo-x" onclick="event.stopPropagation();window._pcsRemovePhoto(\'' + esc(id) + '\',' + idx + ')">x</button>' : '') +
+  function _cell(idx, heroClass, overlayHtml) {
+    return '<div class="pcs-pcell' + (heroClass ? ' hero' : '') + '" onclick="window._pcsOpenLightbox(\'' + esc(id) + '\',' + idx + ')">' +
+      '<img src="' + esc(imgs[idx]) + '" onerror="this.style.display=\'none\'">' +
+      (isAdmin ? '<button class="pcs-photo-x" onclick="event.stopPropagation();window._pcsRemovePhoto(\'' + esc(id) + '\',' + idx + ')">&#x2715;</button>' : '') +
       (overlayHtml || '') +
       '</div>';
   }
 
   var gridHtml = '';
 
-  if (count === 0 && canManage) {
-    // Empty upload box
-    gridHtml = '<div class="pcs-photo-empty" onclick="window._pcsAddPhotos(\'' + esc(id) + '\')">' +
-      '<div style="font-size:20px;color:rgba(246,166,35,0.3);">+</div>' +
-      '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;letter-spacing:0.12em;text-transform:uppercase;color:#F6A623;">Upload Photos</div>' +
-      '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;color:#333;letter-spacing:0.06em;">JPG / PNG -- stored in Supabase, original quality</div>' +
-      '</div>';
-
+  if (count === 0) {
+    if (canManage) {
+      gridHtml = '<div class="pcs-photo-empty" onclick="window._pcsAddPhotos(\'' + esc(id) + '\')">' +
+        '<div style="font-size:22px;color:rgba(246,166,35,.3)">+</div>' +
+        '<div style="font-family:\'Courier New\',monospace;font-size:8px;letter-spacing:.1em;text-transform:uppercase;color:#F6A623">Upload Photos</div>' +
+        '<div style="font-family:\'Courier New\',monospace;font-size:7px;color:#333;letter-spacing:.06em">JPG / PNG</div>' +
+        '</div>';
+    }
   } else if (count === 1) {
-    // Single full-width image
-    gridHtml = '<div class="pcs-photo-grid pcs-photo-grid--single">' + _cell(0) + '</div>';
-
+    gridHtml = '<div class="pcs-pg-1">' +
+      '<img src="' + esc(imgs[0]) + '" onclick="window._pcsOpenLightbox(\'' + esc(id) + '\',0)" onerror="this.style.display=\'none\'">' +
+      (isAdmin ? '<button class="pcs-photo-x" onclick="event.stopPropagation();window._pcsRemovePhoto(\'' + esc(id) + '\',0)">&#x2715;</button>' : '') +
+      '</div>';
   } else if (count === 2) {
-    // Two equal columns
-    gridHtml = '<div class="pcs-photo-grid pcs-photo-grid--two">' + _cell(0) + _cell(1) + '</div>';
-
+    gridHtml = '<div class="pcs-pg-2">' + _cell(0) + _cell(1) + '</div>';
   } else if (count === 3) {
-    // LinkedIn 62/38 — hero left, 2 stacked right
-    gridHtml = '<div class="pcs-photo-grid pcs-photo-grid--three">' +
-      '<div class="pcs-photo-grid-hero" onclick="window._pcsOpenLightbox(\'' + esc(id) + '\',0)">' +
-      '<img src="' + esc(imgs[0]) + '">' +
-      (isAdmin ? '<button class="pcs-photo-x" onclick="event.stopPropagation();window._pcsRemovePhoto(\'' + esc(id) + '\',0)">x</button>' : '') +
-      '</div>' +
-      _cell(1) + _cell(2) +
-      '</div>';
-
+    gridHtml = '<div class="pcs-pg-3">' + _cell(0, true) + _cell(1) + _cell(2) + '</div>';
   } else if (count === 4) {
-    // 2x2 grid
-    gridHtml = '<div class="pcs-photo-grid pcs-photo-grid--four">' +
-      _cell(0) + _cell(1) + _cell(2) + _cell(3) +
-      '</div>';
-
-  } else if (count >= 5) {
-    // LinkedIn 62/38 with +N overlay on bottom-right
+    gridHtml = '<div class="pcs-pg-4">' + _cell(0) + _cell(1) + _cell(2) + _cell(3) + '</div>';
+  } else {
     var extra = count - 3;
-    var overlayHtml = '<div class="pcs-photo-grid-more">' +
-      '<div class="pcs-photo-grid-more-num">+' + extra + '</div>' +
-      '<div class="pcs-photo-grid-more-lbl">more</div></div>';
-    gridHtml = '<div class="pcs-photo-grid pcs-photo-grid--three">' +
-      '<div class="pcs-photo-grid-hero" onclick="window._pcsOpenLightbox(\'' + esc(id) + '\',0)">' +
-      '<img src="' + esc(imgs[0]) + '">' +
-      (isAdmin ? '<button class="pcs-photo-x" onclick="event.stopPropagation();window._pcsRemovePhoto(\'' + esc(id) + '\',0)">x</button>' : '') +
-      '</div>' +
-      _cell(1) +
-      _cell(2, 'position:relative;', overlayHtml) +
-      '</div>';
+    var ov = '<div class="pcs-more-ov"><div class="pcs-more-n">+' + extra + '</div><div class="pcs-more-l">more</div></div>';
+    gridHtml = '<div class="pcs-pg-5">' + _cell(0, true) + _cell(1) + _cell(2, false, ov) + '</div>';
   }
 
   var inputHtml = canManage
-    ? '<input type="file" id="pcs-photo-input" accept="image/*" multiple style="display:none;" onchange="window._pcsHandlePhotoInput(\'' + esc(id) + '\',this)">'
+    ? '<input type="file" id="pcs-photo-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandlePhotoInput(\'' + esc(id) + '\',this)">'
     : '';
 
-  return '<div id="pcs-photo-section" class="pcs-photo-linkedin">' + headerHtml + gridHtml + inputHtml + '</div>';
+  return gridHtml + inputHtml;
 }
 
-// -- Meta chips builder (stage is in topbar, not here) --
-function _buildMetaChips(post, canEdit, canEditCreative, id) {
+// -- Chips row builder (stage in topbar, not here) --
+function _buildChipsRow(post, canEdit, canEditCreative, id) {
   var stageLC = post.stage || '';
   var canManage = canEdit || canEditCreative;
+  var arr = canManage ? ' <span class="pcs-chip-arr">&#x25BE;</span>' : '';
   var chips = [];
 
   // Format chip
   if (post.format) {
-    chips.push('<div class="pcs-chip' + (canManage ? ' pcs-chip--interactive' : '') + '" ' +
-      (canManage ? 'onclick="window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(post.format) + '</div>');
+    chips.push('<button class="pcs-chip pcs-chip--dim"' +
+      (canManage ? ' onclick="window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')"' : '') +
+      '>' + esc(post.format) + arr + '</button>');
   } else if (canManage) {
-    chips.push('<div class="pcs-chip pcs-chip--empty pcs-chip--interactive" onclick="window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')">+ Format</div>');
+    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')">+ Format' + arr + '</button>');
   }
 
-  // Pillar chip
+  // Pillar chip — skip if null and no edit
   if (post.contentPillar) {
     var pillarVal = typeof formatPillarDisplay === 'function' ? formatPillarDisplay(post.contentPillar) : post.contentPillar;
-    chips.push('<div class="pcs-chip' + (canManage ? ' pcs-chip--interactive' : '') + '" ' +
-      (canManage ? 'onclick="window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(pillarVal) + '</div>');
+    chips.push('<button class="pcs-chip pcs-chip--dim"' +
+      (canManage ? ' onclick="window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')"' : '') +
+      '>' + esc(pillarVal) + arr + '</button>');
   } else if (canManage) {
-    chips.push('<div class="pcs-chip pcs-chip--empty pcs-chip--interactive" onclick="window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')">+ Pillar</div>');
+    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')">+ Pillar' + arr + '</button>');
   }
 
-  // Location chip
+  // Location chip — skip if null and no edit
   if (post.location) {
-    chips.push('<div class="pcs-chip' + (canManage ? ' pcs-chip--interactive' : '') + '" ' +
-      (canManage ? 'onclick="window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(post.location) + '</div>');
+    chips.push('<button class="pcs-chip pcs-chip--dim"' +
+      (canManage ? ' onclick="window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')"' : '') +
+      '>' + esc(post.location) + arr + '</button>');
   } else if (canManage) {
-    chips.push('<div class="pcs-chip pcs-chip--empty pcs-chip--interactive" onclick="window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')">+ Location</div>');
+    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')">+ Location' + arr + '</button>');
   }
 
-  // Owner chip — skip if empty
+  // Owner chip
   if (post.owner) {
-    var ownerColor = '';
+    var ownerColor = ' pcs-chip--dim';
     var ownerLC = (post.owner || '').toLowerCase();
-    if (ownerLC === 'chitra') ownerColor = ' chip-cyan';
-    else if (ownerLC === 'pranav') ownerColor = ' chip-purple';
-    else if (ownerLC === 'client') ownerColor = ' chip-amber';
-    chips.push('<div class="pcs-chip' + ownerColor + (canEdit ? ' pcs-chip--interactive' : '') + '" ' +
-      (canEdit ? 'onclick="window._pcsChipDrop(this,\'owner\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(typeof formatOwner === 'function' ? formatOwner(post.owner) : post.owner) + '</div>');
+    if (ownerLC === 'chitra' || ownerLC === 'pranav') ownerColor = ' pcs-chip--cyan';
+    else if (ownerLC === 'client') ownerColor = ' pcs-chip--amber';
+    var ownerArr = canEdit ? ' <span class="pcs-chip-arr">&#x25BE;</span>' : '';
+    chips.push('<button class="pcs-chip' + ownerColor + '"' +
+      (canEdit ? ' onclick="window._pcsChipDrop(this,\'owner\',\'' + esc(id) + '\')"' : '') +
+      '>' + esc(typeof formatOwner === 'function' ? formatOwner(post.owner) : post.owner) + ownerArr + '</button>');
   }
 
-  // Date chip — skip if empty
+  // Date chip
   var dateValue = post.targetDate || '';
   if (dateValue) {
     var dateDisplay = '';
@@ -443,15 +385,16 @@ function _buildMetaChips(post, canEdit, canEditCreative, id) {
       }
     } catch(e) {}
     if (dateDisplay) {
-      var dateColor = '';
+      var dateColor = ' pcs-chip--dim';
       if (stageLC !== 'published' && stageLC !== 'parked' && stageLC !== 'rejected') {
         var _td = typeof parseDate === 'function' ? parseDate(dateValue) : new Date(dateValue);
         var _now = new Date(); _now.setHours(0,0,0,0);
-        if (_td && _td < _now) dateColor = ' chip-red';
+        if (_td && _td < _now) dateColor = ' pcs-chip--red';
       }
-      chips.push('<div class="pcs-chip' + dateColor + (canEdit ? ' pcs-chip--interactive' : '') + '" ' +
-        (canEdit ? 'onclick="window._pcsChipDrop(this,\'date\',\'' + esc(id) + '\')"' : '') +
-        '>' + esc(dateDisplay) + '</div>');
+      var dateArr = canEdit ? ' <span class="pcs-chip-arr">&#x25BE;</span>' : '';
+      chips.push('<button class="pcs-chip' + dateColor + '"' +
+        (canEdit ? ' onclick="window._pcsChipDrop(this,\'date\',\'' + esc(id) + '\')"' : '') +
+        '>' + esc(dateDisplay) + dateArr + '</button>');
     }
   }
 
@@ -468,21 +411,20 @@ window._pcsChipDrop = function(chipEl, field, postId) {
 
   var post = typeof getPostById === 'function' ? getPostById(postId) : null;
 
-  // DATE: use hidden native date picker
+  // DATE: inline date input in dropdown
   if (field === 'date') {
-    var dateInput = document.createElement('input');
-    dateInput.type = 'date';
-    dateInput.value = post ? (post.targetDate || '') : '';
-    dateInput.style.cssText = 'position:fixed;top:-100px;left:-100px;opacity:0;pointer-events:none;';
-    document.body.appendChild(dateInput);
-    dateInput.onchange = function() {
-      if (typeof updatePost === 'function') updatePost(postId, 'targetDate', dateInput.value);
-      dateInput.remove();
-      if (typeof openPCS === 'function') openPCS(postId, '');
-    };
-    dateInput.onblur = function() { setTimeout(function() { if (dateInput.parentNode) dateInput.remove(); }, 200); };
-    // showPicker() supported in modern browsers, click() as fallback
-    try { dateInput.showPicker(); } catch(e) { dateInput.click(); }
+    var rect = chipEl.getBoundingClientRect();
+    var drop = document.createElement('div');
+    drop.className = 'pcs-chip-drop';
+    drop.style.cssText = 'position:fixed;top:' + (rect.bottom + 4) + 'px;left:' + rect.left + 'px;z-index:9700;';
+    drop.innerHTML = '<div style="padding:12px 16px;background:#141420">' +
+      '<input type="date" value="' + esc(post ? (post.targetDate || '') : '') + '" ' +
+      'style="width:100%;padding:10px 12px;background:#0f0f1a;border:1px solid #1c1c26;color:#fff;font-size:14px;outline:none;color-scheme:dark;font-family:inherit" ' +
+      'onchange="window._pcsDateChange(\'' + esc(postId) + '\',this.value)"/></div>';
+    document.body.appendChild(drop);
+    window.AppState.pcs.activeMenu = drop;
+    var dateInp = drop.querySelector('input');
+    if (dateInp) dateInp.focus();
     return;
   }
 
@@ -545,6 +487,16 @@ window._pcsChipDrop = function(chipEl, field, postId) {
 
   document.body.appendChild(drop);
   window.AppState.pcs.activeMenu = drop;
+}
+
+// -- Date change from inline date picker --
+window._pcsDateChange = function(postId, dateValue) {
+  if (window.AppState.pcs.activeMenu) {
+    window.AppState.pcs.activeMenu.remove();
+    window.AppState.pcs.activeMenu = null;
+  }
+  if (typeof updatePost === 'function') updatePost(postId, 'targetDate', dateValue);
+  if (typeof openPCS === 'function') openPCS(postId, '');
 }
 
 // -- Caption section builder --
@@ -1348,7 +1300,7 @@ window.pcsSaveAttach = async function(postId) {
     var _attachCanEdit = _attachRole !== 'client' && !_attachIsPranav;
     var _attachCanEditCreative = _attachIsPranav;
     var _attachIsAdmin = _attachRole === 'admin';
-    var _attachWrap = document.getElementById('pcs-action-btn-wrap');
+    var _attachWrap = document.getElementById('pcs-photo-grid-wrap');
     if (_attachWrap) {
       _attachWrap.innerHTML = _buildPhotoGrid(_attachImgs, _attachCanEdit, _attachCanEditCreative, _attachIsAdmin, postId);
     }

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401w">
+ <link rel="stylesheet" href="styles.css?v=20260401y">
 
 </head>
 <body>
@@ -861,117 +861,111 @@
 <div id="pcs-overlay" onclick="if(event.target===this)closePCS()">
   <div id="pcs-screen" class="pc-sheet">
 
-    <!-- Topbar: X left, stage pill right -->
+    <!-- Topbar: X left, stage+overdue pills right -->
     <div class="pc-topbar">
       <button class="pc-icon-btn" onclick="closePCS()" aria-label="Close">
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
       </button>
-      <div id="pcs-topbar-right" class="pcs-topbar-right"></div>
+      <div id="pcs-topbar-right" style="display:flex;align-items:center;gap:6px"></div>
     </div>
 
     <!-- Scrollable content -->
     <div class="pc-scroll-body" id="pcs-scroll">
-      <!-- Photo grid -->
-      <div class="pcs-body-section" id="pcs-action-btn-wrap"></div>
-      <!-- Title block -->
-      <div class="pc-title-block" id="pcs-title-block">
-        <div class="pc-title" id="pcs-topbar-title"></div>
+
+      <!-- Photo section -->
+      <div class="pcs-photo-header" id="pcs-photo-header-row" style="display:none">
+        <span class="pcs-photo-label" id="pcs-photo-label">PHOTOS · 0</span>
+        <button class="pcs-photo-menu-btn" id="pcs-photo-menu-btn">···</button>
       </div>
+      <div id="pcs-photo-grid-wrap"></div>
+
+      <!-- Title -->
+      <div id="pcs-topbar-title"></div>
+
       <!-- Meta chips row -->
-      <div id="pcs-meta-chips" class="pcs-meta-chips"></div>
+      <div id="pcs-chips-row" class="pcs-chips-row"></div>
+
       <!-- Tab bar -->
       <div id="pcs-tab-bar" class="pcs-tab-bar">
         <button class="pcs-tab active" data-tab="caption" onclick="window._pcsTabSwitch('caption')">Caption</button>
-        <button class="pcs-tab" data-tab="client" onclick="window._pcsTabSwitch('client')">Client <span id="pcs-tab-client-count" class="pcs-tab-count"></span></button>
-        <button class="pcs-tab" data-tab="internal" onclick="window._pcsTabSwitch('internal')">Internal <span id="pcs-tab-notes-count" class="pcs-tab-count"></span></button>
+        <button class="pcs-tab" data-tab="client" onclick="window._pcsTabSwitch('client')">Client <span id="pcs-tab-client-count" style="opacity:.6"></span></button>
+        <button class="pcs-tab" data-tab="internal" onclick="window._pcsTabSwitch('internal')">Internal <span id="pcs-tab-notes-count" style="opacity:.6"></span></button>
       </div>
+
       <!-- Tab pane: Caption -->
-      <div id="pcs-pane-caption" class="pcs-tab-pane">
-        <div class="pcs-body-section" id="pcs-fields"></div>
-        <!-- Stage advance button -->
-        <div class="pc-advance-block" id="pc-advance-block" style="display:none">
-          <button class="pc-advance-btn" id="pc-advance-btn">
-            <span class="pc-advance-arrow">&rarr;</span>
-            <span class="pc-advance-label" id="pc-advance-label">Move to Next</span>
-          </button>
-        </div>
-        <!-- WhatsApp share (below advance) -->
+      <div id="pcs-pane-caption" class="pcs-tab-pane" style="flex:1;display:flex;flex-direction:column">
+        <div style="flex:1;overflow-y:auto" id="pcs-fields"></div>
         <div id="pcs-wa-container"></div>
       </div>
-      <!-- Activity (hidden) -->
-      <div class="pc-activity-row" id="pc-activity-trigger" style="display:none" onclick="togglePCSActivity()">
-        <div class="pc-act-arrow">&rarr;</div>
-        <div class="pc-act-lbl">Activity</div>
-        <div class="pc-act-count" id="pc-activity-count"></div>
-      </div>
-      <div class="pcs-activity-body" id="pcs-activity-body" style="display:none"></div>
-      <!-- Comments / Notes container -->
-      <div id="pcs-comments-section" style="display:none;">
 
-        <!-- Tab pane: CLIENT COMMENTS -->
-        <div id="pcs-pane-client" class="pcs-tab-pane" style="display:none">
+      <!-- Tab pane: Client -->
+      <div id="pcs-pane-client" class="pcs-tab-pane" style="display:none;flex:1;display:none;flex-direction:column">
         <span id="pcs-comments-count" style="display:none">0</span>
-        <div class="client-comments-section">
-          <div id="pcs-comments-list" class="pcs-thread-list" style="min-height:60px;"></div>
-          <div style="padding:8px 14px 12px;background:#08080c;border-top:1px solid #14141e">
-            <div id="pcs-client-reply-indicator" class="pcs-reply-indicator-bar" style="display:none"><span></span><span onclick="window._pcsClearReply('client')" class="pcs-reply-cancel">x</span></div>
-            <div id="pcs-client-img-previews" class="pcs-img-previews"></div>
-            <div style="display:flex;align-items:center;gap:8px;background:#0f0f1a;border:1px solid #1c1c28;padding:5px 5px 5px 13px;border-radius:22px;margin-bottom:6px">
-              <button style="width:30px;height:30px;border-radius:50%;background:#1c1c28;border:none;color:#52525c;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0" onclick="document.getElementById('pcs-client-img-input').click()">+</button>
-              <textarea id="pcs-comment-input" placeholder="Reply to client..." rows="1" style="flex:1;background:none;border:none;font-size:14px;color:#F0F0F2;outline:none;resize:none;max-height:100px;overflow-y:auto;font-family:-apple-system,sans-serif;line-height:1.4;padding:4px 0" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.4'"></textarea>
-              <button id="pcs-send-btn-client" style="width:30px;height:30px;border-radius:50%;background:#C8A84B;border:none;color:#000;font-size:15px;cursor:pointer;flex-shrink:0;display:flex;align-items:center;justify-content:center;opacity:0.4" onclick="window.submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',false)">&#x2191;</button>
-            </div>
-            <div style="font-family:'Courier New',monospace;font-size:6px;color:#1c1c2c;letter-spacing:.06em;text-transform:uppercase;padding-left:3px">Client + Agency · Visible to all</div>
-            <input type="file" id="pcs-client-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg('client')">
-            <button id="pcs-task-btn-client" style="display:none" onclick="window.submitPcsComment&&submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',true,false)"></button>
+        <div id="pcs-comments-list" style="flex:1;overflow-y:auto;min-height:60px;-webkit-overflow-scrolling:touch"></div>
+        <!-- Pill input bar -->
+        <div class="pcs-ibar-wrap client">
+          <div id="pcs-client-reply-indicator" class="pcs-reply-indicator-bar" style="display:none"><span></span><span onclick="window._pcsClearReply('client')" class="pcs-reply-cancel">x</span></div>
+          <div id="pcs-client-img-previews" class="pcs-img-previews"></div>
+          <div class="pcs-ibar-pill">
+            <button class="pcs-ibar-plus" onclick="var i=document.getElementById('pcs-client-img-input');if(i)i.click()">+</button>
+            <textarea id="pcs-comment-input" class="pcs-ibar-input" placeholder="Reply to client..." rows="1" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.4'"></textarea>
+            <button id="pcs-send-btn-client" class="pcs-ibar-send" style="opacity:0.4" onclick="window.submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',false)">&#x2191;</button>
           </div>
+          <div class="pcs-ibar-hint">Client + Agency · Visible to all</div>
+          <input type="file" id="pcs-client-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg('client')">
+          <button id="pcs-task-btn-client" style="display:none" onclick="window.submitPcsComment&&submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',true,false)"></button>
         </div>
-        </div>
-
-        <!-- Tab pane: INTERNAL NOTES (agency only) -->
-        <div id="pcs-pane-internal" class="pcs-tab-pane" style="display:none">
-        <span id="pcs-notes-count" class="pcs-notes-count-badge" style="display:none">0</span>
-        <div id="pcs-notes-section" class="pcs-notes-section">
-          <div class="pcs-vis-selector" id="pcs-vis-selector" style="padding:8px 14px 4px;display:flex;gap:6px;overflow-x:auto;">
-            <div class="pcs-vis-chip active" data-vis="all" onclick="setPcsVisibility(this,'all')">ALL</div>
-            <div class="pcs-vis-chip" data-vis="admin" onclick="setPcsVisibility(this,'admin')">ADMIN</div>
-            <div class="pcs-vis-chip" data-vis="servicing" onclick="setPcsVisibility(this,'servicing')">SERV</div>
-            <div class="pcs-vis-chip" data-vis="creative" onclick="setPcsVisibility(this,'creative')">CREATIVE</div>
-          </div>
-          <div id="pcs-notes-list" class="pcs-notes-list"></div>
-          <div style="padding:8px 14px 12px;background:#090807;border-top:1px solid #151208">
-            <div id="pcs-note-reply-indicator" class="pcs-reply-indicator-bar" style="display:none"><span></span><span onclick="window._pcsClearReply('note')" class="pcs-reply-cancel">x</span></div>
-            <div id="pcs-note-img-previews" class="pcs-img-previews"></div>
-            <div id="pcs-mention-dropup" style="display:none"></div>
-            <div style="display:flex;align-items:center;gap:8px;background:#100e04;border:1px solid #26200a;padding:5px 5px 5px 13px;border-radius:22px;margin-bottom:6px">
-              <button style="width:30px;height:30px;border-radius:50%;background:#1e1a06;border:none;color:#52525c;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0" onclick="document.getElementById('pcs-note-img-input').click()">+</button>
-              <textarea id="pcs-note-input" placeholder="Add note... @mention" rows="1" style="flex:1;background:none;border:none;font-size:14px;color:#F0F0F2;outline:none;resize:none;max-height:100px;overflow-y:auto;font-family:-apple-system,sans-serif;line-height:1.4;padding:4px 0" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.4'"></textarea>
-              <button id="pcs-send-btn-note" style="width:30px;height:30px;border-radius:50%;background:#F6A623;border:none;color:#000;font-size:15px;cursor:pointer;flex-shrink:0;display:flex;align-items:center;justify-content:center;opacity:0.4" onclick="submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-note-input')?document.getElementById('pcs-note-input').value:'',window._pcsNoteVisibility||'all',false,true)">&#x2191;</button>
-            </div>
-            <div style="font-family:'Courier New',monospace;font-size:6px;color:#1c1c2c;letter-spacing:.06em;text-transform:uppercase;padding-left:3px">Agency only · Visibility set above</div>
-            <input type="file" id="pcs-note-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg('note')">
-            <button id="pcs-task-btn-note" style="display:none" onclick="window._showTaskAssign&&_showTaskAssign('pcs-note-input','pcs-task-btn-note')"></button>
-          </div>
-        </div>
-        </div>
-
-        <!-- CONFIRMATION DIALOG -->
-        <div id="pcs-comment-confirm" class="pcs-confirm-overlay" style="display:none;">
-          <div class="pcs-confirm-sheet">
-            <div class="pcs-confirm-title">SEND TO CLIENT?</div>
-            <div id="pcs-comment-confirm-preview" class="pcs-confirm-preview"></div>
-            <div class="pcs-confirm-warn1">Client will see this.</div>
-            <div class="pcs-confirm-warn2">This cannot be unsaid.</div>
-            <div class="pcs-confirm-btns">
-              <button class="pcs-confirm-cancel" onclick="document.getElementById('pcs-comment-confirm').style.display='none';window._pendingComment=null;">CANCEL</button>
-              <button class="pcs-confirm-send" onclick="document.getElementById('pcs-comment-confirm').style.display='none';if(window._pendingComment){window._doSubmitComment(window._pendingComment);window._pendingComment=null;}">SEND &#x2192;</button>
-            </div>
-          </div>
-        </div>
-
       </div>
-    </div>
 
+      <!-- Tab pane: Internal -->
+      <div id="pcs-pane-internal" class="pcs-tab-pane" style="display:none;flex:1;display:none;flex-direction:column">
+        <span id="pcs-notes-count" style="display:none">0</span>
+        <div id="pcs-vis-selector" style="flex-shrink:0;display:flex;gap:4px;padding:8px 16px;border-bottom:1px solid #0f0f16">
+          <div class="pcs-vis-chip active" data-vis="all" onclick="setPcsVisibility(this,'all')">ALL</div>
+          <div class="pcs-vis-chip" data-vis="admin" onclick="setPcsVisibility(this,'admin')">ADMIN</div>
+          <div class="pcs-vis-chip" data-vis="servicing" onclick="setPcsVisibility(this,'servicing')">SERV</div>
+          <div class="pcs-vis-chip" data-vis="creative" onclick="setPcsVisibility(this,'creative')">CREATIVE</div>
+        </div>
+        <div id="pcs-notes-section" class="pcs-notes-section" style="flex:1;display:flex;flex-direction:column">
+          <div id="pcs-notes-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch"></div>
+        </div>
+        <!-- Pill input bar -->
+        <div class="pcs-ibar-wrap notes">
+          <div id="pcs-note-reply-indicator" class="pcs-reply-indicator-bar" style="display:none"><span></span><span onclick="window._pcsClearReply('note')" class="pcs-reply-cancel">x</span></div>
+          <div id="pcs-note-img-previews" class="pcs-img-previews"></div>
+          <div id="pcs-mention-dropup" style="display:none"></div>
+          <div class="pcs-ibar-pill">
+            <button class="pcs-ibar-plus" onclick="var i=document.getElementById('pcs-note-img-input');if(i)i.click()">+</button>
+            <textarea id="pcs-note-input" class="pcs-ibar-input" placeholder="Add note... @mention" rows="1" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.4'"></textarea>
+            <button id="pcs-send-btn-note" class="pcs-ibar-send" style="opacity:0.4" onclick="submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-note-input')?document.getElementById('pcs-note-input').value:'',window._pcsNoteVisibility||'all',false,true)">&#x2191;</button>
+          </div>
+          <div class="pcs-ibar-hint">Agency only · Visibility set above</div>
+          <input type="file" id="pcs-note-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg('note')">
+          <button id="pcs-task-btn-note" style="display:none" onclick="window._showTaskAssign&&_showTaskAssign('pcs-note-input','pcs-task-btn-note')"></button>
+        </div>
+      </div>
+
+      <!-- Comments container (holds panes + confirm) -->
+      <div id="pcs-comments-section" style="display:none"></div>
+
+      <!-- CONFIRMATION DIALOG -->
+      <div id="pcs-comment-confirm" class="pcs-confirm-overlay" style="display:none;">
+        <div class="pcs-confirm-sheet">
+          <div class="pcs-confirm-title">SEND TO CLIENT?</div>
+          <div id="pcs-comment-confirm-preview" class="pcs-confirm-preview"></div>
+          <div class="pcs-confirm-warn1">Client will see this.</div>
+          <div class="pcs-confirm-warn2">This cannot be unsaid.</div>
+          <div class="pcs-confirm-btns">
+            <button class="pcs-confirm-cancel" onclick="document.getElementById('pcs-comment-confirm').style.display='none';window._pendingComment=null;">CANCEL</button>
+            <button class="pcs-confirm-send" onclick="document.getElementById('pcs-comment-confirm').style.display='none';if(window._pendingComment){window._doSubmitComment(window._pendingComment);window._pendingComment=null;}">SEND &#x2192;</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Hidden activity (kept for compatibility) -->
+      <div id="pcs-activity-body" style="display:none"></div>
+
+    </div>
   </div>
 </div>
 
@@ -1078,26 +1072,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401w"></script>
-<script src="00-appstate-compat.js?v=20260401w"></script>
-<script src="01-config.js?v=20260401w" defer></script>
-<script src="02-session.js?v=20260401w" defer></script>
-<script src="utils.js?v=20260401w" defer></script>
-<script src="03-auth.js?v=20260401w" defer></script>
-<script src="05-api.js?v=20260401w" defer></script>
-<script src="10-ui.js?v=20260401w" defer></script>
+<script src="00-appstate.js?v=20260401y"></script>
+<script src="00-appstate-compat.js?v=20260401y"></script>
+<script src="01-config.js?v=20260401y" defer></script>
+<script src="02-session.js?v=20260401y" defer></script>
+<script src="utils.js?v=20260401y" defer></script>
+<script src="03-auth.js?v=20260401y" defer></script>
+<script src="05-api.js?v=20260401y" defer></script>
+<script src="10-ui.js?v=20260401y" defer></script>
 
-<script src="06-post-create.js?v=20260401w" defer></script>
-<script defer src="render/dashboard.js?v=20260401w"></script>
-<script defer src="render/client.js?v=20260401w"></script>
-<script defer src="render/pipeline.js?v=20260401w"></script>
-<script defer src="render/brief.js?v=20260401w"></script>
-<script defer src="actions/pcs.js?v=20260401w"></script>
-<script src="07-post-load.js?v=20260401w" defer></script>
-<script src="08-post-actions.js?v=20260401w" defer></script>
-<script src="09-library.js?v=20260401w" defer></script>
-<script src="09-approval.js?v=20260401w" defer></script>
-<script src="04-router.js?v=20260401w" defer></script>
+<script src="06-post-create.js?v=20260401y" defer></script>
+<script defer src="render/dashboard.js?v=20260401y"></script>
+<script defer src="render/client.js?v=20260401y"></script>
+<script defer src="render/pipeline.js?v=20260401y"></script>
+<script defer src="render/brief.js?v=20260401y"></script>
+<script defer src="actions/pcs.js?v=20260401y"></script>
+<script src="07-post-load.js?v=20260401y" defer></script>
+<script src="08-post-actions.js?v=20260401y" defer></script>
+<script src="09-library.js?v=20260401y" defer></script>
+<script src="09-approval.js?v=20260401y" defer></script>
+<script src="04-router.js?v=20260401y" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6348,398 +6348,244 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   color: #636366;
 }
 
+
 /* ===============================================
-   PCS Redesign v2 — LinkedIn photos, meta chips, tabs
+   PCS v2 Design — approved v11
    =============================================== */
 
-/* -- Tab bar -- */
+/* Topbar pills */
+.pcs-stage-pill {
+  padding: 4px 10px;
+  font-family: 'Courier New', monospace; font-size: 8px;
+  letter-spacing: .07em; text-transform: uppercase;
+  background: rgba(246,166,35,.1);
+  border: 1px solid rgba(246,166,35,.4);
+  color: #F6A623; cursor: pointer;
+  display: flex; align-items: center; gap: 4px;
+}
+.pcs-stage-pill .pcs-pill-arr { font-size: 8px; opacity: .5; }
+.pcs-od-pill {
+  padding: 4px 9px;
+  font-family: 'Courier New', monospace; font-size: 8px;
+  letter-spacing: .06em; text-transform: uppercase;
+  background: rgba(255,75,75,.08);
+  border: 1px solid rgba(255,75,75,.35);
+  color: #FF4B4B;
+  display: flex; align-items: center; gap: 4px;
+}
+.pcs-od-dot {
+  width: 4px; height: 4px; border-radius: 50%;
+  background: #FF4B4B;
+  animation: pcs-blink 1.5s infinite;
+}
+@keyframes pcs-blink { 0%,100%{opacity:1} 50%{opacity:.2} }
+
+/* Photo header */
+.pcs-photo-header {
+  display: flex; align-items: center;
+  justify-content: space-between;
+  padding: 5px 16px 3px;
+}
+.pcs-photo-label {
+  font-family: 'Courier New', monospace; font-size: 8px;
+  color: #52525c; letter-spacing: .07em; text-transform: uppercase;
+}
+.pcs-photo-menu-btn {
+  background: none; border: none; color: #52525c;
+  font-size: 14px; letter-spacing: .15em; cursor: pointer;
+  padding: 2px 6px;
+}
+
+/* Photo grids */
+.pcs-pg-1 { width:100%; height:260px; overflow:hidden; cursor:pointer; position:relative; }
+.pcs-pg-1 img { width:100%; height:100%; object-fit:cover; display:block; }
+.pcs-pg-2 { display:grid; grid-template-columns:1fr 1fr; gap:2px; height:220px; }
+.pcs-pg-3, .pcs-pg-5 { display:grid; grid-template-columns:62% 38%; grid-template-rows:1fr 1fr; gap:2px; height:220px; }
+.pcs-pg-4 { display:grid; grid-template-columns:1fr 1fr; grid-template-rows:1fr 1fr; gap:2px; height:240px; }
+.pcs-pcell { position:relative; overflow:hidden; cursor:pointer; background:#111; flex-shrink:0; }
+.pcs-pcell.hero { grid-row:span 2; }
+.pcs-pcell img { width:100%; height:100%; object-fit:cover; display:block; }
+.pcs-photo-x {
+  position:absolute; top:6px; left:6px;
+  width:22px; height:22px; border-radius:50%;
+  background:rgba(0,0,0,.78); border:none;
+  color:rgba(255,255,255,.85); font-size:10px;
+  cursor:pointer; display:flex; align-items:center;
+  justify-content:center; z-index:5;
+}
+.pcs-more-ov {
+  position:absolute; inset:0; background:rgba(0,0,0,.62);
+  display:flex; flex-direction:column;
+  align-items:center; justify-content:center; gap:3px;
+}
+.pcs-more-n { font-size:26px; font-weight:300; color:#fff; line-height:1; }
+.pcs-more-l {
+  font-family:'Courier New',monospace; font-size:7px;
+  color:rgba(255,255,255,.6); letter-spacing:.08em; text-transform:uppercase;
+}
+.pcs-photo-empty {
+  padding: 28px 16px;
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
+  cursor: pointer; border-bottom: 1px solid #0f0f16;
+}
+
+/* Title */
+#pcs-topbar-title {
+  font-size: 26px !important;
+  font-weight: 700 !important;
+  letter-spacing: -0.03em !important;
+  line-height: 1.1 !important;
+  color: #FFFFFF !important;
+  padding: 11px 16px 7px !important;
+}
+
+/* Chips row */
+.pcs-chips-row {
+  display: flex; gap: 5px;
+  padding: 6px 16px 8px;
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  scrollbar-width: none; flex-wrap: nowrap;
+  border-bottom: 1px solid #0f0f16;
+}
+.pcs-chips-row::-webkit-scrollbar { display: none; }
+.pcs-chip {
+  display: flex; align-items: center; gap: 4px;
+  padding: 6px 12px; flex-shrink: 0; white-space: nowrap;
+  font-size: 12px; font-weight: 600; cursor: pointer;
+  background: linear-gradient(180deg,#1c1c28 0%,#10101a 100%);
+  border-top: 1px solid #28283a;
+  border-right: 1px solid #16162a;
+  border-bottom: 1px solid #0c0c18;
+  border-left: 1px solid #28283a;
+  box-shadow: 0 2px 6px rgba(0,0,0,.6),
+    inset 0 1px 0 rgba(255,255,255,.04),
+    inset 0 -1px 0 rgba(0,0,0,.3);
+  transition: transform .1s, box-shadow .1s;
+}
+.pcs-chip:active { transform: translateY(1px); box-shadow: 0 1px 3px rgba(0,0,0,.6); }
+.pcs-chip .pcs-chip-arr { font-size: 8px; opacity: .4; margin-left: 2px; }
+.pcs-chip--cyan  { color: #22D3EE; }
+.pcs-chip--red   { color: #FF4B4B; }
+.pcs-chip--amber { color: #F6A623; }
+.pcs-chip--dim   { color: #AEAEB2; }
+.pcs-chip--empty {
+  color: #52525c; font-weight: 400;
+  border-style: dashed; background: transparent; box-shadow: none;
+}
+.pcs-chip--static { cursor: default; }
+
+/* Tab bar */
 .pcs-tab-bar {
   display: flex;
-  width: 100%;
-  border-bottom: 1px solid #1a1a2a;
-  padding: 0 20px;
-  gap: 0;
+  border-bottom: 1px solid #0f0f16;
   flex-shrink: 0;
 }
 .pcs-tab {
-  flex: 1;
-  padding: 11px 0 9px;
-  font-family: var(--mono);
-  font-size: 10px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: #6e6e80;
-  background: transparent;
-  border: none;
+  flex: 1; padding: 11px 8px;
+  font-family: 'Courier New', monospace;
+  font-size: 8px; letter-spacing: .07em; text-transform: uppercase;
+  background: none; border: none; cursor: pointer;
+  color: #6e6e80; text-align: center;
   border-bottom: 2px solid transparent;
-  cursor: pointer;
-  text-align: center;
-  transition: color 0.15s;
+  transition: color .15s, border-color .15s;
 }
-.pcs-tab.active {
-  color: #F0F0F2;
-  border-bottom-color: #F0F0F2;
-}
-.pcs-tab.amber {
-  color: #F6A623;
-  border-bottom-color: #F6A623;
-}
-.pcs-tab-count {
-  font-size: 9px;
-  color: inherit;
-  opacity: 0.7;
-}
-.pcs-tab-pane {
-  /* panes shown/hidden via JS display toggle */
-}
+.pcs-tab.active { color: #F0F0F2; border-bottom-color: #F0F0F2; }
+.pcs-tab.amber.active { color: #F6A623; border-bottom-color: #F6A623; }
 
-/* -- Meta chips row -- */
-.pcs-meta-chips {
-  display: flex;
-  gap: 6px;
-  padding: 10px 20px;
-  overflow-x: auto;
-  scrollbar-width: none;
+/* WA button */
+.pcs-wa-btn {
+  width: 100%; padding: 14px 0;
+  background: linear-gradient(180deg,rgba(62,207,142,.1) 0%,rgba(62,207,142,.04) 100%);
+  border-top: 1px solid rgba(62,207,142,.35);
+  border-right: 1px solid rgba(62,207,142,.2);
+  border-bottom: 1px solid rgba(62,207,142,.12);
+  border-left: 1px solid rgba(62,207,142,.2);
+  box-shadow: 0 2px 6px rgba(0,0,0,.5), inset 0 1px 0 rgba(62,207,142,.08);
+  color: #3ECF8E; font-family: 'Courier New', monospace;
+  font-size: 9px; letter-spacing: .08em; text-transform: uppercase;
+  cursor: pointer; display: flex; align-items: center;
+  justify-content: center; gap: 8px;
+  transition: transform .1s, box-shadow .1s;
+}
+.pcs-wa-btn:active { transform: translateY(1px); box-shadow: 0 1px 3px rgba(0,0,0,.5); }
+
+/* Pill input bar */
+.pcs-ibar-wrap {
   flex-shrink: 0;
+  padding: 8px 14px 14px;
+  border-top: 1px solid;
 }
-.pcs-meta-chips::-webkit-scrollbar { display: none; }
-.pcs-meta-chips:empty { display: none; }
-
-.pcs-chip {
+.pcs-ibar-wrap.client {
+  background: #08080c; border-top-color: #141420;
+}
+.pcs-ibar-wrap.notes {
+  background: #090808; border-top-color: #151208;
+}
+.pcs-ibar-pill {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 6px 6px 14px;
+  border-radius: 24px; border: 1px solid;
+  margin-bottom: 6px;
+}
+.pcs-ibar-wrap.client .pcs-ibar-pill {
+  background: #0f0f1a; border-color: #1c1c28;
+}
+.pcs-ibar-wrap.notes .pcs-ibar-pill {
+  background: #100e04; border-color: #26200a;
+}
+.pcs-ibar-plus {
+  width: 32px; height: 32px; border-radius: 50%;
+  border: none; color: #fff; font-size: 20px; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0; line-height: 1;
+  box-shadow: 0 2px 4px rgba(0,0,0,.4), inset 0 1px 0 rgba(255,255,255,.1);
+}
+.pcs-ibar-wrap.client .pcs-ibar-plus {
+  background: linear-gradient(180deg,#2a2a3a,#1a1a28);
+}
+.pcs-ibar-wrap.notes .pcs-ibar-plus {
+  background: linear-gradient(180deg,#2a2208,#1a1408);
+}
+.pcs-ibar-input {
+  flex: 1; background: none; border: none;
+  font-size: 14px; color: #F0F0F2; outline: none;
+  font-family: -apple-system, sans-serif;
+  line-height: 1.4; padding: 4px 0;
+  resize: none; max-height: 100px; overflow-y: auto;
+}
+.pcs-ibar-input::placeholder { color: #1e1e2e; }
+.pcs-ibar-send {
+  width: 32px; height: 32px; border-radius: 50%;
+  border: none; color: #000; font-size: 15px; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
   flex-shrink: 0;
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 600;
-  padding: 5px 11px;
-  color: #AEAEB2;
-  background: linear-gradient(180deg, #1c1c28 0%, #10101a 100%);
-  border-width: 1px;
-  border-style: solid;
-  border-color: #28283a #16162a #0c0c18 #28283a;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,255,255,0.04);
-  cursor: pointer;
-  position: relative;
-  white-space: nowrap;
-  user-select: none;
-  -webkit-user-select: none;
+  box-shadow: 0 2px 6px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,255,255,.2);
+  transition: transform .1s, box-shadow .1s;
 }
-.pcs-chip:active {
-  transform: translateY(1px);
-  box-shadow: 0 1px 3px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.02);
+.pcs-ibar-send:active { transform: translateY(1px); }
+.pcs-ibar-wrap.client .pcs-ibar-send {
+  background: linear-gradient(180deg,#d4b050,#b8922e);
 }
-.pcs-chip.chip-cyan { color: #22D3EE; }
-.pcs-chip.chip-purple { color: #9b87f5; }
-.pcs-chip.chip-amber { color: #F6A623; }
-.pcs-chip.chip-red { color: #FF4B4B; }
-.pcs-chip.chip-green { color: #3ECF8E; }
-
-/* Empty placeholder chip */
-.pcs-chip--empty {
-  color: #3a3a4a;
-  border-style: dashed;
-  font-weight: 400;
+.pcs-ibar-wrap.notes .pcs-ibar-send {
+  background: linear-gradient(180deg,#fdb030,#e09218);
+}
+.pcs-ibar-hint {
+  font-family: 'Courier New', monospace; font-size: 7px;
+  color: #1c1c2c; letter-spacing: .06em;
+  text-transform: uppercase; padding-left: 4px;
 }
 
-/* Interactive chip affordance — ▾ indicator */
-.pcs-chip--interactive {
-  cursor: pointer;
-}
-.pcs-chip--interactive::after {
-  content: '\25BE';
-  font-size: 8px;
-  color: rgba(255,255,255,0.2);
-  margin-left: 4px;
-}
-/* Stage pill also gets the ▾ */
-.pcs-stage-pill.pcs-chip--interactive::after {
-  content: '\25BE';
-  font-size: 8px;
-  color: rgba(255,255,255,0.2);
-  margin-left: 4px;
-}
-.pcs-chip.chip-muted { color: #8E8E93; }
-
-/* Stage pill */
-.pcs-stage-pill {
-  display: inline-block;
-  font-family: var(--mono);
-  font-size: 9px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  padding: 3px 10px;
-  border: 1px solid;
-  cursor: default;
-}
-.pcs-stage-pill.editable { cursor: pointer; }
-
-/* Chip dropdown (body-appended, position set by JS) */
+/* Chip dropdown */
 .pcs-chip-drop {
-  background: #1e1e26;
-  border: 1px solid #2a2a36;
-  min-width: 120px;
-  max-height: 240px;
-  overflow-y: auto;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.6);
+  background: #1e1e26; border: 1px solid #2a2a36;
+  min-width: 120px; max-height: 240px; overflow-y: auto;
+  box-shadow: 0 8px 24px rgba(0,0,0,.6);
 }
 .pcs-chip-drop-item {
   padding: 9px 14px;
-  font-family: var(--mono);
-  font-size: 11px;
-  color: #AEAEB2;
-  cursor: pointer;
-  border-bottom: 1px solid #1a1a2a;
+  font-family: 'Courier New', monospace; font-size: 11px;
+  color: #AEAEB2; cursor: pointer; border-bottom: 1px solid #1a1a2a;
 }
 .pcs-chip-drop-item:last-child { border-bottom: none; }
-.pcs-chip-drop-item:hover,
-.pcs-chip-drop-item:active {
-  background: rgba(255,255,255,0.06);
-  color: #E8E8E8;
-}
-.pcs-chip-drop-item.selected {
-  color: #F6A623;
-}
-
-/* -- LinkedIn-style photo grid -- */
-.pcs-photo-linkedin {
-  position: relative;
-  border-bottom: 1px solid #1a1a2a;
-  flex-shrink: 0;
-}
-.pcs-photo-grid {
-  display: grid;
-  gap: 2px;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-/* Single image — full width */
-.pcs-photo-grid--single {
-  grid-template-columns: 1fr;
-  height: 280px;
-  min-height: 280px;
-}
-/* Two images — equal columns */
-.pcs-photo-grid--two {
-  grid-template-columns: 1fr 1fr;
-  height: 220px;
-  min-height: 220px;
-}
-/* Three or 5+ images — LinkedIn 62/38 layout */
-.pcs-photo-grid--three {
-  grid-template-columns: 62% 38%;
-  grid-template-rows: 1fr 1fr;
-  height: 220px;
-  min-height: 220px;
-}
-/* Four images — 2x2 grid */
-.pcs-photo-grid--four {
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
-  height: 240px;
-  min-height: 240px;
-}
-.pcs-photo-grid-hero {
-  grid-row: span 2;
-  position: relative;
-  overflow: hidden;
-  cursor: pointer;
-  background: #1a1a1a;
-}
-.pcs-photo-grid-cell {
-  position: relative;
-  overflow: hidden;
-  cursor: pointer;
-  background: #1a1a1a;
-}
-.pcs-photo-grid-hero img,
-.pcs-photo-grid-cell img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-.pcs-photo-grid-more {
-  position: absolute;
-  inset: 0;
-  background: rgba(0,0,0,0.6);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
-.pcs-photo-grid-more-num {
-  font-family: 'DM Sans', sans-serif;
-  font-size: 24px;
-  font-weight: 700;
-  color: #FFFFFF;
-}
-.pcs-photo-grid-more-lbl {
-  font-family: var(--mono);
-  font-size: 8px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #AEAEB2;
-}
-/* FIX 8: Consistent X delete button across all photo cells */
-.pcs-photo-x {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: rgba(0,0,0,0.75);
-  border: none;
-  color: rgba(255,255,255,0.8);
-  font-size: 9px;
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  z-index: 5;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
-}
-/* Legacy alias */
-.pcs-photo-del {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: rgba(0,0,0,0.75);
-  border: none;
-  color: rgba(255,255,255,0.8);
-  font-size: 9px;
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  z-index: 5;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
-}
-.pcs-photo-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 7px 18px;
-  border-bottom: 1px solid #1a1a2a;
-}
-.pcs-photo-label {
-  font-family: var(--mono);
-  font-size: 7px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: #AEAEB2;
-}
-.pcs-photo-empty {
-  margin: 10px 18px 12px;
-  border: 1px dashed #222232;
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-}
-
-/* -- 3D WhatsApp button -- */
-.pcs-wa-btn {
-  width: 100%;
-  font-family: var(--mono);
-  font-size: 8px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: #25D366;
-  background: linear-gradient(180deg, rgba(62,207,142,0.1) 0%, rgba(62,207,142,0.04) 100%);
-  border-width: 1px;
-  border-style: solid;
-  border-color: rgba(62,207,142,0.35) rgba(62,207,142,0.2) rgba(62,207,142,0.12) rgba(62,207,142,0.2);
-  box-shadow: 0 2px 6px rgba(0,0,0,0.5), inset 0 1px 0 rgba(62,207,142,0.08);
-  padding: 11px 0;
-  cursor: pointer;
-  transition: transform 0.1s, box-shadow 0.1s;
-}
-.pcs-wa-btn:active {
-  transform: translateY(1px);
-  box-shadow: 0 1px 2px rgba(0,0,0,0.3), inset 0 1px 0 rgba(62,207,142,0.04);
-}
-
-/* -- Input pill bar (comment/note inputs) -- */
-.pcs-ibar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  background: #111118;
-  border: 1px solid #222232;
-  border-radius: 22px;
-  margin: 8px 14px 12px;
-}
-.pcs-ibar .pcs-textarea {
-  flex: 1;
-  border: none;
-  background: transparent;
-  font-size: 13px;
-  color: #E8E8E8;
-  padding: 4px 0;
-  min-height: auto;
-  resize: none;
-}
-.pcs-ibar .pcs-textarea:focus {
-  border: none;
-  outline: none;
-}
-.pcs-ibar-send {
-  flex-shrink: 0;
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background: #C8A84B;
-  border: none;
-  color: #080808;
-  font-size: 14px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.pcs-ibar-send.amber {
-  background: #F6A623;
-}
-.pcs-ibar-hint {
-  font-family: var(--mono);
-  font-size: 7px;
-  letter-spacing: 0.08em;
-  color: #444;
-  text-align: center;
-  padding: 0 14px 8px;
-}
-
-/* -- Visibility chips at top of internal pane -- */
-.pcs-vis-top {
-  display: flex;
-  gap: 6px;
-  padding: 10px 14px 6px;
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-.pcs-vis-top::-webkit-scrollbar { display: none; }
-
-/* -- Topbar right (stage pill + overdue) -- */
-.pcs-topbar-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-/* -- Title redesign -- */
-.pc-title-block {
-  padding: 8px 14px 6px;
-}
-.pc-title-block .pc-title {
-  font-size: 20px;
-  font-weight: 700;
-  letter-spacing: -0.025em;
-  margin-bottom: 0;
-}
+.pcs-chip-drop-item:hover, .pcs-chip-drop-item:active { background: rgba(255,255,255,.06); color: #E8E8E8; }
+.pcs-chip-drop-item.selected { color: #F6A623; }


### PR DESCRIPTION
## Summary

Complete rewrite of PCS overlay to match approved v11 design. All three files rewritten: HTML skeleton, CSS design system, JS render functions.

### HTML skeleton
- **Topbar**: X close left, stage pill + animated overdue pill right
- **Photo section**: PHOTOS · N header + ··· menu button + grid wrap (JS fills)
- **Title**: 26px bold, -0.03em tracking, editable on tap
- **Meta chips**: scrollable row with 3D gradient chips + ▾ arrows
- **Tab bar**: Caption | Client | Internal (amber active)
- **Client pane**: thread list + pill input bar (gold gradient `↑` send)
- **Internal pane**: vis chips top + thread list + pill input bar (amber gradient `↑` send)
- **Removed**: `#pcs-subtitle`, `#pcs-progress-wrap`, `#pc-advance-block`, old ATTACH/SEND/NOTE/TASK button rows, "CLIENT COMMENTS" / "INTERNAL NOTES" headers

### CSS
- `.pcs-stage-pill` + `.pcs-od-pill` with `@keyframes pcs-blink` animated red dot
- `.pcs-pg-1` through `.pcs-pg-5` photo grid variants + `.pcs-pcell.hero`
- `.pcs-chip` 3D gradient + `.pcs-chip--empty` dashed placeholder
- `.pcs-ibar-*` pill input bar with gradient send buttons
- `.pcs-wa-btn` 3D WhatsApp treatment

### JS
- `_renderPCS` rewired to new skeleton IDs (`pcs-photo-grid-wrap`, `pcs-chips-row`, etc)
- `_buildPhotoGrid` uses `.pcs-pg-*` + `.pcs-pcell` classes
- `_buildChipsRow` (replaces `_buildMetaChips`) with `<button>` elements + `▾` arrows
- `_pcsChipDrop` date field now shows inline date input in dropdown
- `_pcsDateChange` new handler for date picker
- `pcsSaveAttach` targets `#pcs-photo-grid-wrap` (not old `#pcs-action-btn-wrap`)

### All IDs preserved
`pcs-comment-input`, `pcs-send-btn-client`, `pcs-task-btn-client`, `pcs-client-img-input`, `pcs-client-img-previews`, `pcs-client-reply-indicator`, `pcs-note-input`, `pcs-send-btn-note`, `pcs-task-btn-note`, `pcs-note-img-input`, `pcs-note-img-previews`, `pcs-note-reply-indicator`, `pcs-mention-dropup`, `pcs-comments-list`, `pcs-notes-list`, `pcs-vis-selector`, `pcs-lightbox`, `pcs-comment-confirm`

## Test plan
- [x] `npx vitest run` — 297/297 passing, 0 failing
- [ ] Hard refresh srtd.io after Cloudflare purge
- [ ] Verify topbar: X left, stage pill right, overdue pill with blinking dot
- [ ] Verify photo grid: 0/1/2/3/4/5+ responsive layouts
- [ ] Verify title: 26px bold, editable on tap (Admin/Servicing)
- [ ] Verify meta chips: Format/Pillar/Location/Owner/Date with ▾ arrows, dropdowns work
- [ ] Verify empty chips show "+ Format" / "+ Pillar" / "+ Location"
- [ ] Verify tab switching: Caption / Client / Internal
- [ ] Verify pill input bars: gold send (client), amber send (internal)
- [ ] Verify WA 3D button in caption tab
- [ ] Test on iPhone Safari (mobile bottom sheet)

https://claude.ai/code/session_016Yb1akXfJKAMRbkBoXifkr