### PR TITLE
fix: PCS chips clickable — stopPropagation + menu guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260401y
+Version format: ?v=YYYYMMDDx. Current: ?v=20260401z
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -24,10 +24,11 @@ window.AppState.pcs.activeMenu = null;
 window.AppState.ui.modalOpen = window.AppState.ui.modalOpen || false;
 
 document.addEventListener('click', function(e) {
-  if (!window.AppState.pcs.activeMenu) return;
+  var menu = window.AppState && window.AppState.pcs && window.AppState.pcs.activeMenu;
+  if (!menu) return;
   if (e.target.closest('.pcs-confirm-overlay')) return;
-  if (!window.AppState.pcs.activeMenu.contains(e.target)) {
-    window.AppState.pcs.activeMenu.remove();
+  if (!menu.contains(e.target)) {
+    menu.remove();
     window.AppState.pcs.activeMenu = null;
   }
 });
@@ -170,7 +171,7 @@ window._renderPCS = function(postId) {
   if (topbarRight) {
     var _stageLabel = (typeof STAGE_DISPLAY !== 'undefined' && STAGE_DISPLAY[stageLC]) || stageLC || 'Unknown';
     var _pillHtml = '<span class="pcs-stage-pill" id="pcs-stage-pill"' +
-      (isAdmin ? ' onclick="window._pcsChipDrop(this,\'stage\',\'' + esc(id) + '\')"' : '') +
+      (isAdmin ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'stage\',\'' + esc(id) + '\')"' : '') +
       '>' + esc(_stageLabel) +
       (isAdmin ? ' <span class="pcs-pill-arr">&#x25BE;</span>' : '') +
       '</span>';
@@ -337,29 +338,29 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
   // Format chip
   if (post.format) {
     chips.push('<button class="pcs-chip pcs-chip--dim"' +
-      (canManage ? ' onclick="window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')"' : '') +
+      (canManage ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')"' : '') +
       '>' + esc(post.format) + arr + '</button>');
   } else if (canManage) {
-    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')">+ Format' + arr + '</button>');
+    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="event.stopPropagation();window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')">+ Format' + arr + '</button>');
   }
 
   // Pillar chip — skip if null and no edit
   if (post.contentPillar) {
     var pillarVal = typeof formatPillarDisplay === 'function' ? formatPillarDisplay(post.contentPillar) : post.contentPillar;
     chips.push('<button class="pcs-chip pcs-chip--dim"' +
-      (canManage ? ' onclick="window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')"' : '') +
+      (canManage ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')"' : '') +
       '>' + esc(pillarVal) + arr + '</button>');
   } else if (canManage) {
-    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')">+ Pillar' + arr + '</button>');
+    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="event.stopPropagation();window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')">+ Pillar' + arr + '</button>');
   }
 
   // Location chip — skip if null and no edit
   if (post.location) {
     chips.push('<button class="pcs-chip pcs-chip--dim"' +
-      (canManage ? ' onclick="window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')"' : '') +
+      (canManage ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')"' : '') +
       '>' + esc(post.location) + arr + '</button>');
   } else if (canManage) {
-    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')">+ Location' + arr + '</button>');
+    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="event.stopPropagation();window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')">+ Location' + arr + '</button>');
   }
 
   // Owner chip
@@ -370,7 +371,7 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
     else if (ownerLC === 'client') ownerColor = ' pcs-chip--amber';
     var ownerArr = canEdit ? ' <span class="pcs-chip-arr">&#x25BE;</span>' : '';
     chips.push('<button class="pcs-chip' + ownerColor + '"' +
-      (canEdit ? ' onclick="window._pcsChipDrop(this,\'owner\',\'' + esc(id) + '\')"' : '') +
+      (canEdit ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'owner\',\'' + esc(id) + '\')"' : '') +
       '>' + esc(typeof formatOwner === 'function' ? formatOwner(post.owner) : post.owner) + ownerArr + '</button>');
   }
 
@@ -393,7 +394,7 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
       }
       var dateArr = canEdit ? ' <span class="pcs-chip-arr">&#x25BE;</span>' : '';
       chips.push('<button class="pcs-chip' + dateColor + '"' +
-        (canEdit ? ' onclick="window._pcsChipDrop(this,\'date\',\'' + esc(id) + '\')"' : '') +
+        (canEdit ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'date\',\'' + esc(id) + '\')"' : '') +
         '>' + esc(dateDisplay) + dateArr + '</button>');
     }
   }

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401y">
+ <link rel="stylesheet" href="styles.css?v=20260401z">
 
 </head>
 <body>
@@ -1072,26 +1072,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401y"></script>
-<script src="00-appstate-compat.js?v=20260401y"></script>
-<script src="01-config.js?v=20260401y" defer></script>
-<script src="02-session.js?v=20260401y" defer></script>
-<script src="utils.js?v=20260401y" defer></script>
-<script src="03-auth.js?v=20260401y" defer></script>
-<script src="05-api.js?v=20260401y" defer></script>
-<script src="10-ui.js?v=20260401y" defer></script>
+<script src="00-appstate.js?v=20260401z"></script>
+<script src="00-appstate-compat.js?v=20260401z"></script>
+<script src="01-config.js?v=20260401z" defer></script>
+<script src="02-session.js?v=20260401z" defer></script>
+<script src="utils.js?v=20260401z" defer></script>
+<script src="03-auth.js?v=20260401z" defer></script>
+<script src="05-api.js?v=20260401z" defer></script>
+<script src="10-ui.js?v=20260401z" defer></script>
 
-<script src="06-post-create.js?v=20260401y" defer></script>
-<script defer src="render/dashboard.js?v=20260401y"></script>
-<script defer src="render/client.js?v=20260401y"></script>
-<script defer src="render/pipeline.js?v=20260401y"></script>
-<script defer src="render/brief.js?v=20260401y"></script>
-<script defer src="actions/pcs.js?v=20260401y"></script>
-<script src="07-post-load.js?v=20260401y" defer></script>
-<script src="08-post-actions.js?v=20260401y" defer></script>
-<script src="09-library.js?v=20260401y" defer></script>
-<script src="09-approval.js?v=20260401y" defer></script>
-<script src="04-router.js?v=20260401y" defer></script>
+<script src="06-post-create.js?v=20260401z" defer></script>
+<script defer src="render/dashboard.js?v=20260401z"></script>
+<script defer src="render/client.js?v=20260401z"></script>
+<script defer src="render/pipeline.js?v=20260401z"></script>
+<script defer src="render/brief.js?v=20260401z"></script>
+<script defer src="actions/pcs.js?v=20260401z"></script>
+<script src="07-post-load.js?v=20260401z" defer></script>
+<script src="08-post-actions.js?v=20260401z" defer></script>
+<script src="09-library.js?v=20260401z" defer></script>
+<script src="09-approval.js?v=20260401z" defer></script>
+<script src="04-router.js?v=20260401z" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Add `event.stopPropagation()` before every `_pcsChipDrop` call in chip onclick handlers (9 occurrences: format, pillar, location, owner, date + empty placeholders + stage pill)
- Harden global document click handler with null-safe `window.AppState && window.AppState.pcs && window.AppState.pcs.activeMenu` access

## Root cause
Chip onclick calls `_pcsChipDrop` which appends dropdown to `document.body` and sets `activeMenu`. The click event then bubbles to the document click handler which checks `!menu.contains(e.target)` — but the chip element is NOT inside the dropdown, so the handler immediately removes the dropdown in the same tick. Dropdown opens and closes instantly.

## Test plan
- [x] `npx vitest run` — 297/297 passing
- [ ] Tap Format chip → dropdown stays open, selecting an item closes it
- [ ] Tap Owner chip → dropdown stays open
- [ ] Tap Date chip → date picker stays open
- [ ] Tap stage pill (Admin) → stage dropdown stays open
- [ ] Tap outside any open dropdown → closes it
- [ ] Tap ··· photo menu → stays open

https://claude.ai/code/session_016Yb1akXfJKAMRbkBoXifkr