### PR TITLE
fix: PCS final — chat rewrite, chip order, date chip, spacing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260401z
+Version format: ?v=YYYYMMDDx. Current: ?v=20260401aa
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -175,7 +175,7 @@ window._renderPCS = function(postId) {
       '>' + esc(_stageLabel) +
       (isAdmin ? ' <span class="pcs-pill-arr">&#x25BE;</span>' : '') +
       '</span>';
-    var _noOverdue = ['published','parked','rejected'];
+    var _noOverdue = ['published','parked','rejected','scheduled'];
     if (_noOverdue.indexOf(stageLC) === -1 && dateValue) {
       var _td = typeof parseDate === 'function' ? parseDate(dateValue) : null;
       var _now = new Date(); _now.setHours(0,0,0,0);
@@ -329,13 +329,45 @@ function _buildPhotoGrid(imgs, canEdit, canEditCreative, isAdmin, id) {
 }
 
 // -- Chips row builder (stage in topbar, not here) --
+// Order: Owner → Date → Format → Pillar → Location
 function _buildChipsRow(post, canEdit, canEditCreative, id) {
   var stageLC = post.stage || '';
   var canManage = canEdit || canEditCreative;
-  var arr = canManage ? ' <span class="pcs-chip-arr">&#x25BE;</span>' : '';
+  var arr = canManage ? ' <span class="pcs-chip-arr">&#9662;</span>' : '';
   var chips = [];
 
-  // Format chip
+  // 1. Owner chip (always render if present)
+  if (post.owner) {
+    var ownerColor = ' pcs-chip--dim';
+    var ownerLC = (post.owner || '').toLowerCase();
+    if (ownerLC === 'chitra' || ownerLC === 'pranav') ownerColor = ' pcs-chip--cyan';
+    else if (ownerLC === 'client') ownerColor = ' pcs-chip--amber';
+    var ownerArr = canEdit ? ' <span class="pcs-chip-arr">&#9662;</span>' : '';
+    chips.push('<button class="pcs-chip' + ownerColor + '"' +
+      (canEdit ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'owner\',\'' + esc(id) + '\')"' : '') +
+      '>' + esc(typeof formatOwner === 'function' ? formatOwner(post.owner) : post.owner) + ownerArr + '</button>');
+  }
+
+  // 2. Date chip (ALWAYS render — never skip)
+  var rawDate = post.targetDate || post.target_date || null;
+  var dateDisplay = 'Add Date';
+  if (rawDate) {
+    try {
+      var _dp = new Date(rawDate + 'T00:00:00');
+      if (!isNaN(_dp.getTime())) {
+        dateDisplay = _dp.toLocaleDateString('en-IN', { weekday:'short', day:'numeric', month:'short', year:'numeric' });
+      }
+    } catch(e) {}
+  }
+  var terminalStages = ['published','parked','rejected'];
+  var isOverdue = rawDate && terminalStages.indexOf(stageLC) === -1 && new Date(rawDate) < new Date();
+  var dateCls = isOverdue ? ' pcs-chip--red' : rawDate ? ' pcs-chip--dim' : ' pcs-chip--empty';
+  var dateArr = canEdit ? ' <span class="pcs-chip-arr">&#9662;</span>' : '';
+  chips.push('<button class="pcs-chip' + dateCls + '"' +
+    (canEdit ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'date\',\'' + esc(id) + '\')"' : '') +
+    '>' + esc(dateDisplay) + dateArr + '</button>');
+
+  // 3. Format chip
   if (post.format) {
     chips.push('<button class="pcs-chip pcs-chip--dim"' +
       (canManage ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')"' : '') +
@@ -344,7 +376,7 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
     chips.push('<button class="pcs-chip pcs-chip--empty" onclick="event.stopPropagation();window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')">+ Format' + arr + '</button>');
   }
 
-  // Pillar chip — skip if null and no edit
+  // 4. Pillar chip
   if (post.contentPillar) {
     var pillarVal = typeof formatPillarDisplay === 'function' ? formatPillarDisplay(post.contentPillar) : post.contentPillar;
     chips.push('<button class="pcs-chip pcs-chip--dim"' +
@@ -354,49 +386,13 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
     chips.push('<button class="pcs-chip pcs-chip--empty" onclick="event.stopPropagation();window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')">+ Pillar' + arr + '</button>');
   }
 
-  // Location chip — skip if null and no edit
+  // 5. Location chip
   if (post.location) {
     chips.push('<button class="pcs-chip pcs-chip--dim"' +
       (canManage ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')"' : '') +
       '>' + esc(post.location) + arr + '</button>');
   } else if (canManage) {
     chips.push('<button class="pcs-chip pcs-chip--empty" onclick="event.stopPropagation();window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')">+ Location' + arr + '</button>');
-  }
-
-  // Owner chip
-  if (post.owner) {
-    var ownerColor = ' pcs-chip--dim';
-    var ownerLC = (post.owner || '').toLowerCase();
-    if (ownerLC === 'chitra' || ownerLC === 'pranav') ownerColor = ' pcs-chip--cyan';
-    else if (ownerLC === 'client') ownerColor = ' pcs-chip--amber';
-    var ownerArr = canEdit ? ' <span class="pcs-chip-arr">&#x25BE;</span>' : '';
-    chips.push('<button class="pcs-chip' + ownerColor + '"' +
-      (canEdit ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'owner\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(typeof formatOwner === 'function' ? formatOwner(post.owner) : post.owner) + ownerArr + '</button>');
-  }
-
-  // Date chip
-  var dateValue = post.targetDate || '';
-  if (dateValue) {
-    var dateDisplay = '';
-    try {
-      var _dp = new Date(dateValue + 'T00:00:00');
-      if (!isNaN(_dp.getTime())) {
-        dateDisplay = _dp.toLocaleDateString('en-IN', { weekday:'short', day:'numeric', month:'short', year:'numeric' });
-      }
-    } catch(e) {}
-    if (dateDisplay) {
-      var dateColor = ' pcs-chip--dim';
-      if (stageLC !== 'published' && stageLC !== 'parked' && stageLC !== 'rejected') {
-        var _td = typeof parseDate === 'function' ? parseDate(dateValue) : new Date(dateValue);
-        var _now = new Date(); _now.setHours(0,0,0,0);
-        if (_td && _td < _now) dateColor = ' pcs-chip--red';
-      }
-      var dateArr = canEdit ? ' <span class="pcs-chip-arr">&#x25BE;</span>' : '';
-      chips.push('<button class="pcs-chip' + dateColor + '"' +
-        (canEdit ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'date\',\'' + esc(id) + '\')"' : '') +
-        '>' + esc(dateDisplay) + dateArr + '</button>');
-    }
   }
 
   return chips.join('');
@@ -1129,27 +1125,7 @@ window.loadPcsComments = async function(postId) {
         tabNotesCount.textContent = internalRows.length > 0 ? internalRows.length : '';
       }
 
-      // Per-chip counts  dynamic builder
-      var chipsHtml = [
-        {val:'all', label:'ALL'},
-        {val:'admin', label:'ADMIN'},
-        {val:'servicing', label:'SERV'},
-        {val:'creative', label:'CREATIVE'}
-      ].map(function(chip) {
-        var count = internalRows.filter(function(r) {
-          return r.visibility === chip.val ||
-            (!r.visibility && chip.val === 'all');
-        }).length;
-        var isActive = (window._pcsNoteVisibility || 'all') === chip.val;
-        return '<button class="pcs-vis-chip' +
-          (isActive ? ' active' : '') +
-          '" data-vis="' + chip.val + '" ' +
-          'onclick="window._pcsNoteVisibility=\'' + chip.val +
-          '\';loadPcsComments(\'' + postId + '\')">' +
-          chip.label + ' (' + count + ')</button>';
-      }).join('');
-      var chipsContainer = document.getElementById('pcs-vis-selector');
-      if (chipsContainer) chipsContainer.innerHTML = chipsHtml;
+      // Vis chips: keep static HTML, do not rebuild with counts
     }
 
     list.scrollTop = list.scrollHeight;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401z">
+ <link rel="stylesheet" href="styles.css?v=20260401aa">
 
 </head>
 <body>
@@ -893,54 +893,52 @@
       </div>
 
       <!-- Tab pane: Caption -->
-      <div id="pcs-pane-caption" class="pcs-tab-pane" style="flex:1;display:flex;flex-direction:column">
+      <div id="pcs-pane-caption" class="pcs-tab-pane" style="flex:1;display:flex;flex-direction:column;overflow:hidden">
         <div style="flex:1;overflow-y:auto" id="pcs-fields"></div>
         <div id="pcs-wa-container"></div>
       </div>
 
       <!-- Tab pane: Client -->
-      <div id="pcs-pane-client" class="pcs-tab-pane" style="display:none;flex:1;display:none;flex-direction:column">
+      <div id="pcs-pane-client" class="pcs-tab-pane" style="display:none;flex:1;flex-direction:column;overflow:hidden">
         <span id="pcs-comments-count" style="display:none">0</span>
-        <div id="pcs-comments-list" style="flex:1;overflow-y:auto;min-height:60px;-webkit-overflow-scrolling:touch"></div>
-        <!-- Pill input bar -->
-        <div class="pcs-ibar-wrap client">
-          <div id="pcs-client-reply-indicator" class="pcs-reply-indicator-bar" style="display:none"><span></span><span onclick="window._pcsClearReply('client')" class="pcs-reply-cancel">x</span></div>
-          <div id="pcs-client-img-previews" class="pcs-img-previews"></div>
-          <div class="pcs-ibar-pill">
-            <button class="pcs-ibar-plus" onclick="var i=document.getElementById('pcs-client-img-input');if(i)i.click()">+</button>
-            <textarea id="pcs-comment-input" class="pcs-ibar-input" placeholder="Reply to client..." rows="1" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.4'"></textarea>
-            <button id="pcs-send-btn-client" class="pcs-ibar-send" style="opacity:0.4" onclick="window.submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',false)">&#x2191;</button>
+        <div id="pcs-comments-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:12px 16px;scrollbar-width:none;min-height:0"></div>
+        <div style="flex-shrink:0;padding:8px 14px 14px;background:#08080c;border-top:1px solid #141420">
+          <div id="pcs-client-reply-indicator" class="pcs-reply-bar" style="display:none"></div>
+          <div id="pcs-client-img-previews"></div>
+          <div style="display:flex;align-items:center;gap:8px;background:#0f0f1a;border:1px solid #1c1c28;padding:6px 6px 6px 14px;border-radius:24px;margin-bottom:6px">
+            <button style="width:32px;height:32px;border-radius:50%;background:linear-gradient(180deg,#2a2a3a,#1a1a28);border:none;color:#fff;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;box-shadow:0 2px 4px rgba(0,0,0,.4),inset 0 1px 0 rgba(255,255,255,.1)" onclick="var i=document.getElementById('pcs-client-img-input');if(i)i.click()">+</button>
+            <textarea id="pcs-comment-input" placeholder="Reply to client..." rows="1" style="flex:1;background:none;border:none;font-size:14px;color:#F0F0F2;outline:none;resize:none;max-height:100px;overflow-y:auto;font-family:-apple-system,sans-serif;line-height:1.4;padding:4px 0;scrollbar-width:none" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.45'"></textarea>
+            <button id="pcs-send-btn-client" style="width:32px;height:32px;border-radius:50%;background:linear-gradient(180deg,#d4b050,#b8922e);border:none;color:#000;font-size:15px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;opacity:0.45;box-shadow:0 2px 6px rgba(0,0,0,.5),inset 0 1px 0 rgba(255,255,255,.2);transition:transform .1s,box-shadow .1s,opacity .15s" onclick="window.submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',false)">&#x2191;</button>
           </div>
-          <div class="pcs-ibar-hint">Client + Agency · Visible to all</div>
-          <input type="file" id="pcs-client-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg('client')">
+          <div style="font-family:'Courier New',monospace;font-size:7px;color:#1c1c2c;letter-spacing:.06em;text-transform:uppercase;padding-left:4px">Client + Agency · Visible to all</div>
+          <input type="file" id="pcs-client-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg&&_pcsHandleCommentImg('client')">
           <button id="pcs-task-btn-client" style="display:none" onclick="window.submitPcsComment&&submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',true,false)"></button>
         </div>
       </div>
 
       <!-- Tab pane: Internal -->
-      <div id="pcs-pane-internal" class="pcs-tab-pane" style="display:none;flex:1;display:none;flex-direction:column">
+      <div id="pcs-pane-internal" class="pcs-tab-pane" style="display:none;flex:1;flex-direction:column;overflow:hidden">
         <span id="pcs-notes-count" style="display:none">0</span>
-        <div id="pcs-vis-selector" style="flex-shrink:0;display:flex;gap:4px;padding:8px 16px;border-bottom:1px solid #0f0f16">
-          <div class="pcs-vis-chip active" data-vis="all" onclick="setPcsVisibility(this,'all')">ALL</div>
-          <div class="pcs-vis-chip" data-vis="admin" onclick="setPcsVisibility(this,'admin')">ADMIN</div>
-          <div class="pcs-vis-chip" data-vis="servicing" onclick="setPcsVisibility(this,'servicing')">SERV</div>
-          <div class="pcs-vis-chip" data-vis="creative" onclick="setPcsVisibility(this,'creative')">CREATIVE</div>
+        <div id="pcs-vis-selector" style="flex-shrink:0;display:flex;gap:4px;padding:8px 16px;border-bottom:1px solid #0f0f16;background:#09080a">
+          <button class="pcs-vis-chip" data-vis="all" onclick="window.setPcsVisibility&&setPcsVisibility(this,'all')" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid rgba(246,166,35,.35);color:#F6A623;background:rgba(246,166,35,.04);cursor:pointer">ALL</button>
+          <button class="pcs-vis-chip" data-vis="admin" onclick="window.setPcsVisibility&&setPcsVisibility(this,'admin')" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">ADMIN</button>
+          <button class="pcs-vis-chip" data-vis="servicing" onclick="window.setPcsVisibility&&setPcsVisibility(this,'servicing')" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">SERV</button>
+          <button class="pcs-vis-chip" data-vis="creative" onclick="window.setPcsVisibility&&setPcsVisibility(this,'creative')" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">CREATIVE</button>
         </div>
-        <div id="pcs-notes-section" class="pcs-notes-section" style="flex:1;display:flex;flex-direction:column">
-          <div id="pcs-notes-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch"></div>
+        <div id="pcs-notes-section" style="flex:1;display:flex;flex-direction:column;min-height:0">
+          <div id="pcs-notes-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:12px 16px;background:#080806;scrollbar-width:none;min-height:0"></div>
         </div>
-        <!-- Pill input bar -->
-        <div class="pcs-ibar-wrap notes">
-          <div id="pcs-note-reply-indicator" class="pcs-reply-indicator-bar" style="display:none"><span></span><span onclick="window._pcsClearReply('note')" class="pcs-reply-cancel">x</span></div>
-          <div id="pcs-note-img-previews" class="pcs-img-previews"></div>
+        <div style="flex-shrink:0;padding:8px 14px 14px;background:#090808;border-top:1px solid #151208">
+          <div id="pcs-note-reply-indicator" class="pcs-reply-bar" style="display:none"></div>
+          <div id="pcs-note-img-previews"></div>
           <div id="pcs-mention-dropup" style="display:none"></div>
-          <div class="pcs-ibar-pill">
-            <button class="pcs-ibar-plus" onclick="var i=document.getElementById('pcs-note-img-input');if(i)i.click()">+</button>
-            <textarea id="pcs-note-input" class="pcs-ibar-input" placeholder="Add note... @mention" rows="1" oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.4'"></textarea>
-            <button id="pcs-send-btn-note" class="pcs-ibar-send" style="opacity:0.4" onclick="submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-note-input')?document.getElementById('pcs-note-input').value:'',window._pcsNoteVisibility||'all',false,true)">&#x2191;</button>
+          <div style="display:flex;align-items:center;gap:8px;background:#100e04;border:1px solid #26200a;padding:6px 6px 6px 14px;border-radius:24px;margin-bottom:6px">
+            <button style="width:32px;height:32px;border-radius:50%;background:linear-gradient(180deg,#2a2208,#1a1408);border:none;color:#fff;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;box-shadow:0 2px 4px rgba(0,0,0,.4),inset 0 1px 0 rgba(255,255,255,.08)" onclick="var i=document.getElementById('pcs-note-img-input');if(i)i.click()">+</button>
+            <textarea id="pcs-note-input" placeholder="Add note... @mention" rows="1" style="flex:1;background:none;border:none;font-size:14px;color:#F0F0F2;outline:none;resize:none;max-height:100px;overflow-y:auto;font-family:-apple-system,sans-serif;line-height:1.4;padding:4px 0;scrollbar-width:none" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.45'"></textarea>
+            <button id="pcs-send-btn-note" style="width:32px;height:32px;border-radius:50%;background:linear-gradient(180deg,#fdb030,#e09218);border:none;color:#000;font-size:15px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;opacity:0.45;box-shadow:0 2px 6px rgba(0,0,0,.5),inset 0 1px 0 rgba(255,255,255,.2);transition:transform .1s,box-shadow .1s,opacity .15s" onclick="submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-note-input')?document.getElementById('pcs-note-input').value:'',window._pcsNoteVisibility||'all',false,true)">&#x2191;</button>
           </div>
-          <div class="pcs-ibar-hint">Agency only · Visibility set above</div>
-          <input type="file" id="pcs-note-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg('note')">
+          <div style="font-family:'Courier New',monospace;font-size:7px;color:#1c1c2c;letter-spacing:.06em;text-transform:uppercase;padding-left:4px">Agency only · Visibility set above</div>
+          <input type="file" id="pcs-note-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg&&_pcsHandleCommentImg('note')">
           <button id="pcs-task-btn-note" style="display:none" onclick="window._showTaskAssign&&_showTaskAssign('pcs-note-input','pcs-task-btn-note')"></button>
         </div>
       </div>
@@ -1072,26 +1070,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401z"></script>
-<script src="00-appstate-compat.js?v=20260401z"></script>
-<script src="01-config.js?v=20260401z" defer></script>
-<script src="02-session.js?v=20260401z" defer></script>
-<script src="utils.js?v=20260401z" defer></script>
-<script src="03-auth.js?v=20260401z" defer></script>
-<script src="05-api.js?v=20260401z" defer></script>
-<script src="10-ui.js?v=20260401z" defer></script>
+<script src="00-appstate.js?v=20260401aa"></script>
+<script src="00-appstate-compat.js?v=20260401aa"></script>
+<script src="01-config.js?v=20260401aa" defer></script>
+<script src="02-session.js?v=20260401aa" defer></script>
+<script src="utils.js?v=20260401aa" defer></script>
+<script src="03-auth.js?v=20260401aa" defer></script>
+<script src="05-api.js?v=20260401aa" defer></script>
+<script src="10-ui.js?v=20260401aa" defer></script>
 
-<script src="06-post-create.js?v=20260401z" defer></script>
-<script defer src="render/dashboard.js?v=20260401z"></script>
-<script defer src="render/client.js?v=20260401z"></script>
-<script defer src="render/pipeline.js?v=20260401z"></script>
-<script defer src="render/brief.js?v=20260401z"></script>
-<script defer src="actions/pcs.js?v=20260401z"></script>
-<script src="07-post-load.js?v=20260401z" defer></script>
-<script src="08-post-actions.js?v=20260401z" defer></script>
-<script src="09-library.js?v=20260401z" defer></script>
-<script src="09-approval.js?v=20260401z" defer></script>
-<script src="04-router.js?v=20260401z" defer></script>
+<script src="06-post-create.js?v=20260401aa" defer></script>
+<script defer src="render/dashboard.js?v=20260401aa"></script>
+<script defer src="render/client.js?v=20260401aa"></script>
+<script defer src="render/pipeline.js?v=20260401aa"></script>
+<script defer src="render/brief.js?v=20260401aa"></script>
+<script defer src="actions/pcs.js?v=20260401aa"></script>
+<script src="07-post-load.js?v=20260401aa" defer></script>
+<script src="08-post-actions.js?v=20260401aa" defer></script>
+<script src="09-library.js?v=20260401aa" defer></script>
+<script src="09-approval.js?v=20260401aa" defer></script>
+<script src="04-router.js?v=20260401aa" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6589,3 +6589,34 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-chip-drop-item:last-child { border-bottom: none; }
 .pcs-chip-drop-item:hover, .pcs-chip-drop-item:active { background: rgba(255,255,255,.06); color: #E8E8E8; }
 .pcs-chip-drop-item.selected { color: #F6A623; }
+
+/* FIX 5: Pane overflow */
+#pcs-pane-caption, #pcs-pane-client, #pcs-pane-internal { overflow: hidden; }
+
+/* FIX 7: No gap between topbar and photos */
+#pcs-scroll { padding-top: 0; }
+.pcs-photo-header { padding: 4px 16px 3px; margin-top: 0; }
+
+/* FIX 8: Tighter caption */
+#pcs-caption-text, .pcs-caption-text {
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* FIX 10: Photo grid min-height (mobile Safari) */
+.pcs-pg-1 { flex-shrink:0; min-height:260px; }
+.pcs-pg-2 { flex-shrink:0; min-height:220px; }
+.pcs-pg-3 { flex-shrink:0; min-height:220px; }
+.pcs-pg-4 { flex-shrink:0; min-height:240px; }
+.pcs-pg-5 { flex-shrink:0; min-height:220px; }
+
+/* FIX 11: Title size */
+#pcs-topbar-title, .pc-title {
+  font-size: 24px !important;
+  font-weight: 700 !important;
+  letter-spacing: -0.03em !important;
+  line-height: 1.1 !important;
+  color: #FFFFFF !important;
+  padding: 9px 16px 6px !important;
+}


### PR DESCRIPTION
## Summary — 11 fixes

### Chat pane rewrites
- **FIX 1**: Client pane — pill input bar with gradient gold `↑` send, `+` attach left, thread with scroll padding, reply indicator above input
- **FIX 2**: Internal pane — styled vis chips at top (amber active, dim inactive), pill input bar with amber gradient `↑` send, notes thread with scroll padding

### Chip improvements
- **FIX 3**: Chip order → Owner · Date · Format · Pillar · Location (accountability first, urgency second)
- **FIX 4**: Date chip ALWAYS renders — shows "Add Date" when empty (dashed `pcs-chip--empty` style), never disappears

### Layout fixes
- **FIX 5**: `overflow:hidden` on all three tab panes — prevents stray content below tab bar
- **FIX 6**: Vis-selector innerHTML rebuild removed from `loadPcsComments` — static vis chips survive, no more `ALL (2)` counts
- **FIX 7**: Zero gap between topbar and photos — `padding-top:0` on scroll body
- **FIX 8**: Caption text `line-height:1.55`, `word-break:break-word`

### Consistency
- **FIX 9**: Overdue pill excludes `scheduled` stage (added to exclusion list)
- **FIX 10**: Photo grid `min-height` on all variants for mobile Safari
- **FIX 11**: Title 24px bold, -0.03em tracking

## Test plan
- [x] `npx vitest run` — 297/297 passing
- [ ] Client tab: pill input with gold `↑`, `+` left, thread scrolls
- [ ] Internal tab: vis chips at top (no counts), amber `↑` send
- [ ] Date chip visible even when empty ("Add Date")
- [ ] Chip order: Owner → Date → Format → Pillar → Location
- [ ] No stray numbers below tab bar
- [ ] No gap between topbar and photo section
- [ ] Title 24px, tight caption spacing

https://claude.ai/code/session_016Yb1akXfJKAMRbkBoXifkr