### PR TITLE
fix: PCS topbar gap reduced, photo grid height increased

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260401aa
+Version format: ?v=YYYYMMDDx. Current: ?v=20260402a
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260401aa">
+ <link rel="stylesheet" href="styles.css?v=20260402a">
 
 </head>
 <body>
@@ -1070,26 +1070,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260401aa"></script>
-<script src="00-appstate-compat.js?v=20260401aa"></script>
-<script src="01-config.js?v=20260401aa" defer></script>
-<script src="02-session.js?v=20260401aa" defer></script>
-<script src="utils.js?v=20260401aa" defer></script>
-<script src="03-auth.js?v=20260401aa" defer></script>
-<script src="05-api.js?v=20260401aa" defer></script>
-<script src="10-ui.js?v=20260401aa" defer></script>
+<script src="00-appstate.js?v=20260402a"></script>
+<script src="00-appstate-compat.js?v=20260402a"></script>
+<script src="01-config.js?v=20260402a" defer></script>
+<script src="02-session.js?v=20260402a" defer></script>
+<script src="utils.js?v=20260402a" defer></script>
+<script src="03-auth.js?v=20260402a" defer></script>
+<script src="05-api.js?v=20260402a" defer></script>
+<script src="10-ui.js?v=20260402a" defer></script>
 
-<script src="06-post-create.js?v=20260401aa" defer></script>
-<script defer src="render/dashboard.js?v=20260401aa"></script>
-<script defer src="render/client.js?v=20260401aa"></script>
-<script defer src="render/pipeline.js?v=20260401aa"></script>
-<script defer src="render/brief.js?v=20260401aa"></script>
-<script defer src="actions/pcs.js?v=20260401aa"></script>
-<script src="07-post-load.js?v=20260401aa" defer></script>
-<script src="08-post-actions.js?v=20260401aa" defer></script>
-<script src="09-library.js?v=20260401aa" defer></script>
-<script src="09-approval.js?v=20260401aa" defer></script>
-<script src="04-router.js?v=20260401aa" defer></script>
+<script src="06-post-create.js?v=20260402a" defer></script>
+<script defer src="render/dashboard.js?v=20260402a"></script>
+<script defer src="render/client.js?v=20260402a"></script>
+<script defer src="render/pipeline.js?v=20260402a"></script>
+<script defer src="render/brief.js?v=20260402a"></script>
+<script defer src="actions/pcs.js?v=20260402a"></script>
+<script src="07-post-load.js?v=20260402a" defer></script>
+<script src="08-post-actions.js?v=20260402a" defer></script>
+<script src="09-library.js?v=20260402a" defer></script>
+<script src="09-approval.js?v=20260402a" defer></script>
+<script src="04-router.js?v=20260402a" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -3429,7 +3429,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 14px 20px 14px;
+  padding: 8px 16px 0;
   flex-shrink: 0;
 }
 .pc-icon-btn {
@@ -6397,11 +6397,11 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 /* Photo grids */
-.pcs-pg-1 { width:100%; height:260px; overflow:hidden; cursor:pointer; position:relative; }
+.pcs-pg-1 { width:100%; height:312px; overflow:hidden; cursor:pointer; position:relative; }
 .pcs-pg-1 img { width:100%; height:100%; object-fit:cover; display:block; }
-.pcs-pg-2 { display:grid; grid-template-columns:1fr 1fr; gap:2px; height:220px; }
-.pcs-pg-3, .pcs-pg-5 { display:grid; grid-template-columns:62% 38%; grid-template-rows:1fr 1fr; gap:2px; height:220px; }
-.pcs-pg-4 { display:grid; grid-template-columns:1fr 1fr; grid-template-rows:1fr 1fr; gap:2px; height:240px; }
+.pcs-pg-2 { display:grid; grid-template-columns:1fr 1fr; gap:2px; height:272px; }
+.pcs-pg-3, .pcs-pg-5 { display:grid; grid-template-columns:62% 38%; grid-template-rows:1fr 1fr; gap:2px; height:272px; }
+.pcs-pg-4 { display:grid; grid-template-columns:1fr 1fr; grid-template-rows:1fr 1fr; gap:2px; height:292px; }
 .pcs-pcell { position:relative; overflow:hidden; cursor:pointer; background:#111; flex-shrink:0; }
 .pcs-pcell.hero { grid-row:span 2; }
 .pcs-pcell img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -6605,11 +6605,11 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 /* FIX 10: Photo grid min-height (mobile Safari) */
-.pcs-pg-1 { flex-shrink:0; min-height:260px; }
-.pcs-pg-2 { flex-shrink:0; min-height:220px; }
-.pcs-pg-3 { flex-shrink:0; min-height:220px; }
-.pcs-pg-4 { flex-shrink:0; min-height:240px; }
-.pcs-pg-5 { flex-shrink:0; min-height:220px; }
+.pcs-pg-1 { flex-shrink:0; min-height:312px; }
+.pcs-pg-2 { flex-shrink:0; min-height:272px; }
+.pcs-pg-3 { flex-shrink:0; min-height:272px; }
+.pcs-pg-4 { flex-shrink:0; min-height:292px; }
+.pcs-pg-5 { flex-shrink:0; min-height:272px; }
 
 /* FIX 11: Title size */
 #pcs-topbar-title, .pc-title {


### PR DESCRIPTION
## Summary
- Reduce `.pc-topbar` padding from `14px 20px 14px` to `8px 16px 0` — removes ~52px dead space between topbar and photo section
- Add 52px to all photo grid heights and min-heights:
  - `.pcs-pg-1`: 260→312px
  - `.pcs-pg-2`: 220→272px
  - `.pcs-pg-3`/`.pcs-pg-5`: 220→272px
  - `.pcs-pg-4`: 240→292px

## Test plan
- [x] `npx vitest run` — 297/297 passing
- [ ] Verify tight gap between topbar and photos
- [ ] Verify photos are taller (more visual real estate)

https://claude.ai/code/session_016Yb1akXfJKAMRbkBoXifkr