### PR TITLE
fix: PCS photo display object-fit contain, no crop

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6398,13 +6398,13 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* Photo grids */
 .pcs-pg-1 { width:100%; height:312px; overflow:hidden; cursor:pointer; position:relative; }
-.pcs-pg-1 img { width:100%; height:100%; object-fit:cover; display:block; }
+.pcs-pg-1 img { width:100%; height:100%; object-fit:contain; display:block; background:#080808; }
 .pcs-pg-2 { display:grid; grid-template-columns:1fr 1fr; gap:2px; height:272px; }
 .pcs-pg-3, .pcs-pg-5 { display:grid; grid-template-columns:62% 38%; grid-template-rows:1fr 1fr; gap:2px; height:272px; }
 .pcs-pg-4 { display:grid; grid-template-columns:1fr 1fr; grid-template-rows:1fr 1fr; gap:2px; height:292px; }
-.pcs-pcell { position:relative; overflow:hidden; cursor:pointer; background:#111; flex-shrink:0; }
+.pcs-pcell { position:relative; overflow:hidden; cursor:pointer; background:#080808; flex-shrink:0; }
 .pcs-pcell.hero { grid-row:span 2; }
-.pcs-pcell img { width:100%; height:100%; object-fit:cover; display:block; }
+.pcs-pcell img { width:100%; height:100%; object-fit:contain; display:block; background:#080808; }
 .pcs-photo-x {
   position:absolute; top:6px; left:6px;
   width:22px; height:22px; border-radius:50%;


### PR DESCRIPTION
## Summary
- Change `.pcs-pg-1 img` and `.pcs-pcell img` from `object-fit:cover` to `object-fit:contain` — full image always visible, no cropping
- Set `background:#080808` on img elements and `.pcs-pcell` container — no white letterboxing

## Test plan
- [x] `npx vitest run` — 297/297 passing
- [ ] Open PCS on a post with photos — image fully visible, no crop
- [ ] Tall/wide images show dark letterbox bars, not white

https://claude.ai/code/session_016Yb1akXfJKAMRbkBoXifkr