### PR TITLE
Reorganize PCS overlay: unified dropdown + edit mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Sorted (srtd.io)
 
-# Last updated: 2026-04-01
+# Last updated: 2026-04-02
 
 # All facts verified from actual codebase
 
@@ -27,7 +27,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260402a
+Version format: ?v=YYYYMMDDx. Current: ?v=20260402b
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -337,6 +337,9 @@ window._buildInfoGrid, window._buildNotes, window._renderAdvanceButton,
 window._renderActivityCount, window._removePcsConfirm, window.pcsConfirmDelete,
 window.pcsDoDelete, window._pcsAddPhotos, window._pcsHandlePhotoInput,
 window._pcsRemovePhoto, window._pcsPhotoMenu, window._pcsSaveAllPhotos,
+window._pcsCloseUnifiedMenu, window._pcsEnterEditMode, window._pcsExitEditMode,
+window._pcsConfirmRemovePhoto, window._pcsDoRemovePhotoEdit,
+window._pcsConfirmClearCaption, window._pcsDoClearing,
 window._pcsCaptionMenu, window._pcsCopyCaption, window._pcsConfirmReplace,
 window._pcsDoReplace, window._pcsOpenLightbox, window._pcsLbRender,
 window._pcsLbNext, window._pcsLbPrev, window._pcsLbClose,

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -500,14 +500,6 @@ window._pcsDateChange = function(postId, dateValue) {
 function _buildCaptionHtml(post, canEdit, canEditCreative, id) {
   if (!post.caption && !canEdit && !canEditCreative) return '';
   return '<div id="pcs-caption-section" style="padding:12px 14px 8px;border-bottom:1px solid #1a1a2a;">' +
-    ((canEdit || canEditCreative) ?
-      '<div style="display:flex;justify-content:flex-end;margin-bottom:4px;">' +
-      '<button onclick="window._pcsCaptionMenu(\'' + esc(id) + '\',event)" ' +
-      'id="pcs-caption-edit-btn" ' +
-      'style="color:#8E8E93;background:transparent;border:none;padding:8px 12px;cursor:pointer;' +
-      'font-family:\'IBM Plex Mono\',monospace;font-size:13px;height:36px;letter-spacing:0.2em;">...</button>' +
-      '</div>'
-      : '') +
     (post.caption ?
       '<div id="pcs-caption-text" data-raw="' + esc(post.caption) + '" style="font-family:\'DM Sans\',sans-serif;' +
       'font-size:13px;color:#888;line-height:1.6;white-space:pre-wrap;word-wrap:break-word;' +
@@ -1570,6 +1562,9 @@ window._pcsRemovePhoto = async function(postId, idx) {
   }
 }
 
+// -- Edit mode state --
+window._pcsEditMode = false;
+
 window._pcsPhotoMenu = function(postId, e) {
   if (e) e.stopPropagation();
   if (window.AppState.pcs.activeMenu) {
@@ -1580,31 +1575,182 @@ window._pcsPhotoMenu = function(postId, e) {
   var btnEl = e ? e.currentTarget : null;
   var rect = btnEl ? btnEl.getBoundingClientRect() : { right: 40, bottom: 60 };
   var menu = document.createElement('div');
-  menu.id = 'pcs-photo-menu-drop';
-  menu.className = 'pcs-chip-drop';
+  menu.id = 'pcs-unified-menu';
+  menu.className = 'pcs-unified-drop';
   menu.style.cssText = 'position:fixed;top:' + (rect.bottom + 4) + 'px;right:' +
-    (window.innerWidth - rect.right) + 'px;z-index:9700;min-width:150px;';
+    (window.innerWidth - rect.right) + 'px;z-index:9700;';
+
   var post = (window.AppState.posts.all||[]).find(function(p) {
     return p.post_id === postId;
   });
   var imgs = (post && post.images) ? post.images : [];
-  var _menuRole = (window.AppState.user.effectiveRole || '').toLowerCase();
-  function _closeMenu() { if (window.AppState.pcs.activeMenu) { window.AppState.pcs.activeMenu.remove(); window.AppState.pcs.activeMenu = null; } }
+  var hasCaption = !!(post && post.caption);
+
   menu.innerHTML =
-    '<div class="pcs-chip-drop-item" onclick="window._pcsAddPhotos(\'' + postId + '\');' +
-      'if(window.AppState.pcs.activeMenu){window.AppState.pcs.activeMenu.remove();window.AppState.pcs.activeMenu=null;}">' +
-      '＋ Add More</div>' +
+    '<div class="pcs-udrop-label">PHOTOS</div>' +
+    '<div class="pcs-udrop-item" onclick="window._pcsAddPhotos(\'' + esc(postId) + '\');window._pcsCloseUnifiedMenu()">Add Photos</div>' +
     (imgs.length > 0
-      ? '<div class="pcs-chip-drop-item" onclick="window._pcsSaveAllPhotos(\'' + postId + '\');' +
-          'if(window.AppState.pcs.activeMenu){window.AppState.pcs.activeMenu.remove();window.AppState.pcs.activeMenu=null;}">' +
-          '↓ Save All</div>'
+      ? '<div class="pcs-udrop-item" onclick="window._pcsCloseUnifiedMenu();window._pcsEnterEditMode(\'' + esc(postId) + '\')">Edit Photos</div>'
       : '') +
-    (_menuRole === 'admin'
-      ? '<div class="pcs-chip-drop-item" style="color:#FF4B4B;" onclick="if(window.AppState.pcs.activeMenu){window.AppState.pcs.activeMenu.remove();window.AppState.pcs.activeMenu=null;}window.pcsConfirmDelete();">' +
-        '🗑 Delete Post</div>'
+    (imgs.length > 0
+      ? '<div class="pcs-udrop-item" onclick="window._pcsSaveAllPhotos(\'' + esc(postId) + '\');window._pcsCloseUnifiedMenu()">Save Photos</div>'
+      : '') +
+    '<div class="pcs-udrop-label" style="margin-top:4px">CAPTION</div>' +
+    '<div class="pcs-udrop-item" onclick="window._pcsCopyCaption(\'' + esc(postId) + '\');window._pcsCloseUnifiedMenu()">Copy Caption</div>' +
+    '<div class="pcs-udrop-item" onclick="window._pcsCloseUnifiedMenu();window._startCaptionEdit(\'' + esc(postId) + '\')">Edit Caption</div>' +
+    (hasCaption
+      ? '<div class="pcs-udrop-item" onclick="window._pcsCloseUnifiedMenu();window._pcsConfirmClearCaption(\'' + esc(postId) + '\')">Clear Caption</div>'
       : '');
+
   document.body.appendChild(menu);
   window.AppState.pcs.activeMenu = menu;
+};
+
+window._pcsCloseUnifiedMenu = function() {
+  if (window.AppState.pcs.activeMenu) {
+    window.AppState.pcs.activeMenu.remove();
+    window.AppState.pcs.activeMenu = null;
+  }
+};
+
+// -- Edit mode (Step C) --
+window._pcsEnterEditMode = function(postId) {
+  window._pcsEditMode = true;
+  var menuBtn = document.getElementById('pcs-photo-menu-btn');
+  if (menuBtn) menuBtn.style.display = 'none';
+  var doneBtn = document.getElementById('pcs-edit-done-btn');
+  if (!doneBtn) {
+    doneBtn = document.createElement('button');
+    doneBtn.id = 'pcs-edit-done-btn';
+    doneBtn.className = 'pcs-edit-done';
+    doneBtn.textContent = 'DONE';
+    doneBtn.onclick = function() { window._pcsExitEditMode(postId); };
+    var header = document.getElementById('pcs-photo-header-row');
+    if (header) header.appendChild(doneBtn);
+  } else {
+    doneBtn.style.display = '';
+  }
+  // Add X overlays to photos
+  var wrap = document.getElementById('pcs-photo-grid-wrap');
+  if (!wrap) return;
+  var cells = wrap.querySelectorAll('.pcs-pcell, .pcs-pg-1');
+  cells.forEach(function(cell, idx) {
+    if (cell.querySelector('.pcs-edit-x')) return;
+    var xBtn = document.createElement('button');
+    xBtn.className = 'pcs-edit-x';
+    xBtn.innerHTML = '&#x2715;';
+    xBtn.onclick = function(ev) {
+      ev.stopPropagation();
+      window._pcsConfirmRemovePhoto(postId, idx);
+    };
+    cell.style.position = 'relative';
+    cell.appendChild(xBtn);
+  });
+};
+
+window._pcsExitEditMode = function(postId) {
+  window._pcsEditMode = false;
+  var menuBtn = document.getElementById('pcs-photo-menu-btn');
+  if (menuBtn) menuBtn.style.display = '';
+  var doneBtn = document.getElementById('pcs-edit-done-btn');
+  if (doneBtn) doneBtn.remove();
+  var wrap = document.getElementById('pcs-photo-grid-wrap');
+  if (wrap) {
+    wrap.querySelectorAll('.pcs-edit-x').forEach(function(x) { x.remove(); });
+  }
+};
+
+// -- Confirm remove photo (Step D) --
+window._pcsConfirmRemovePhoto = function(postId, idx) {
+  _removePcsConfirm();
+  var overlay = document.createElement('div');
+  overlay.className = 'pcs-confirm-overlay';
+  overlay.addEventListener('click', function(e) {
+    if (e.target === overlay) overlay.remove();
+  });
+  overlay.innerHTML =
+    '<div class="pcs-bottom-confirm">' +
+    '<div class="pcs-bc-title">Remove this photo?</div>' +
+    '<div class="pcs-bc-sub">This action cannot be undone.</div>' +
+    '<div class="pcs-bc-btns">' +
+    '<button class="pcs-bc-cancel" onclick="this.closest(\'.pcs-confirm-overlay\').remove()">Cancel</button>' +
+    '<button class="pcs-bc-action" onclick="window._pcsDoRemovePhotoEdit(\'' + esc(postId) + '\',' + idx + ')">Remove</button>' +
+    '</div></div>';
+  document.body.appendChild(overlay);
+  setTimeout(function() { overlay.classList.add('open'); }, 10);
+};
+
+window._pcsDoRemovePhotoEdit = async function(postId, idx) {
+  _removePcsConfirm();
+  var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
+  if (!post) return;
+  var imgs = Array.isArray(post.images) ? post.images.slice() : [];
+  imgs.splice(idx, 1);
+  try {
+    await apiFetch('/posts?post_id=eq.' + postId, {
+      method: 'PATCH',
+      body: JSON.stringify({ images: imgs })
+    });
+    var _next = window.AppState.posts.all.map(function(p) {
+      if (getPostId(p) === postId) {
+        return Object.assign({}, p, { images: imgs });
+      }
+      return p;
+    });
+    window.AppState.posts.setAll(_next);
+    // Re-render and re-enter edit mode if photos remain
+    if (typeof openPCS === 'function') openPCS(postId, '');
+    if (imgs.length > 0) {
+      setTimeout(function() { window._pcsEnterEditMode(postId); }, 50);
+    }
+  } catch(e) {
+    console.error('[pcs] edit-mode remove photo failed', e);
+    window.logError && window.logError(e && e.message, e && e.stack, 'pcs-edit-remove-photo');
+    showToast && showToast('Failed to remove photo', 'error');
+  }
+};
+
+// -- Confirm clear caption (Step D) --
+window._pcsConfirmClearCaption = function(postId) {
+  _removePcsConfirm();
+  var overlay = document.createElement('div');
+  overlay.className = 'pcs-confirm-overlay';
+  overlay.addEventListener('click', function(e) {
+    if (e.target === overlay) overlay.remove();
+  });
+  overlay.innerHTML =
+    '<div class="pcs-bottom-confirm">' +
+    '<div class="pcs-bc-title">Clear caption?</div>' +
+    '<div class="pcs-bc-sub">This cannot be undone.</div>' +
+    '<div class="pcs-bc-btns">' +
+    '<button class="pcs-bc-cancel" onclick="this.closest(\'.pcs-confirm-overlay\').remove()">Cancel</button>' +
+    '<button class="pcs-bc-action" onclick="window._pcsDoClearing(\'' + esc(postId) + '\')">Clear</button>' +
+    '</div></div>';
+  document.body.appendChild(overlay);
+  setTimeout(function() { overlay.classList.add('open'); }, 10);
+};
+
+window._pcsDoClearing = async function(postId) {
+  _removePcsConfirm();
+  try {
+    await apiFetch('/posts?post_id=eq.' + postId, {
+      method: 'PATCH',
+      body: JSON.stringify({ caption: '' })
+    });
+    var _next = window.AppState.posts.all.map(function(p) {
+      if (getPostId(p) === postId) {
+        return Object.assign({}, p, { caption: '' });
+      }
+      return p;
+    });
+    window.AppState.posts.setAll(_next);
+    showToast && showToast('Caption cleared', 'success');
+    if (typeof openPCS === 'function') openPCS(postId, '');
+  } catch(e) {
+    console.error('[pcs] clear caption failed', e);
+    window.logError && window.logError(e && e.message, e && e.stack, 'pcs-clear-caption');
+    showToast && showToast('Failed to clear caption', 'error');
+  }
 };
 
 window._pcsSaveAllPhotos = async function(postId) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260402a">
+ <link rel="stylesheet" href="styles.css?v=20260402b">
 
 </head>
 <body>
@@ -1070,26 +1070,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260402a"></script>
-<script src="00-appstate-compat.js?v=20260402a"></script>
-<script src="01-config.js?v=20260402a" defer></script>
-<script src="02-session.js?v=20260402a" defer></script>
-<script src="utils.js?v=20260402a" defer></script>
-<script src="03-auth.js?v=20260402a" defer></script>
-<script src="05-api.js?v=20260402a" defer></script>
-<script src="10-ui.js?v=20260402a" defer></script>
+<script src="00-appstate.js?v=20260402b"></script>
+<script src="00-appstate-compat.js?v=20260402b"></script>
+<script src="01-config.js?v=20260402b" defer></script>
+<script src="02-session.js?v=20260402b" defer></script>
+<script src="utils.js?v=20260402b" defer></script>
+<script src="03-auth.js?v=20260402b" defer></script>
+<script src="05-api.js?v=20260402b" defer></script>
+<script src="10-ui.js?v=20260402b" defer></script>
 
-<script src="06-post-create.js?v=20260402a" defer></script>
-<script defer src="render/dashboard.js?v=20260402a"></script>
-<script defer src="render/client.js?v=20260402a"></script>
-<script defer src="render/pipeline.js?v=20260402a"></script>
-<script defer src="render/brief.js?v=20260402a"></script>
-<script defer src="actions/pcs.js?v=20260402a"></script>
-<script src="07-post-load.js?v=20260402a" defer></script>
-<script src="08-post-actions.js?v=20260402a" defer></script>
-<script src="09-library.js?v=20260402a" defer></script>
-<script src="09-approval.js?v=20260402a" defer></script>
-<script src="04-router.js?v=20260402a" defer></script>
+<script src="06-post-create.js?v=20260402b" defer></script>
+<script defer src="render/dashboard.js?v=20260402b"></script>
+<script defer src="render/client.js?v=20260402b"></script>
+<script defer src="render/pipeline.js?v=20260402b"></script>
+<script defer src="render/brief.js?v=20260402b"></script>
+<script defer src="actions/pcs.js?v=20260402b"></script>
+<script src="07-post-load.js?v=20260402b" defer></script>
+<script src="08-post-actions.js?v=20260402b" defer></script>
+<script src="09-library.js?v=20260402b" defer></script>
+<script src="09-approval.js?v=20260402b" defer></script>
+<script src="04-router.js?v=20260402b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/mockup-preview.html
+++ b/mockup-preview.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PCS Overlay Mockup — Sorted</title>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: #080808; color: #E8E8E8; font-family: 'DM Sans', sans-serif; }
+
+  .mockup-label {
+    font-family: 'IBM Plex Mono', monospace; font-size: 9px;
+    color: #C8A84B; letter-spacing: .2em; text-transform: uppercase;
+    padding: 32px 16px 12px; border-bottom: 1px solid #1a1a1a;
+  }
+  .mockup-label:first-child { padding-top: 20px; }
+
+  /* ===== SCENE 1: Unified ··· Dropdown ===== */
+  .scene { position: relative; padding: 16px; min-height: 200px; }
+
+  .photo-header {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 4px 0 3px; margin-top: 8px;
+  }
+  .photo-label {
+    font-family: 'Courier New', monospace; font-size: 8px;
+    color: #52525c; letter-spacing: .07em; text-transform: uppercase;
+  }
+  .photo-menu-btn {
+    background: none; border: none; color: #52525c;
+    font-size: 14px; letter-spacing: .15em; cursor: pointer;
+    padding: 2px 6px;
+  }
+
+  /* Photo grid mockup */
+  .photo-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 2px;
+    height: 160px; margin-top: 4px;
+  }
+  .photo-cell {
+    background: #12121a; position: relative; overflow: hidden;
+    display: flex; align-items: center; justify-content: center;
+    color: #2a2a2a; font-family: 'IBM Plex Mono', monospace; font-size: 9px;
+  }
+
+  /* Unified dropdown */
+  .pcs-unified-drop {
+    background: #1a1a1a; border: 1px solid #2a2a2a;
+    min-width: 160px; box-shadow: 0 8px 24px rgba(0,0,0,.6);
+    position: absolute; right: 16px; top: 50px; z-index: 10;
+  }
+  .pcs-udrop-label {
+    font-family: 'IBM Plex Mono', monospace; font-size: 9px;
+    color: #555; text-transform: uppercase; letter-spacing: .1em;
+    padding: 10px 16px 4px;
+  }
+  .pcs-udrop-item {
+    font-family: 'DM Sans', sans-serif; font-size: 14px;
+    color: #E8E8E8; padding: 11px 16px; cursor: pointer;
+    border-bottom: 1px solid #222;
+  }
+  .pcs-udrop-item:last-child { border-bottom: none; }
+  .pcs-udrop-item:hover { background: rgba(255,255,255,.04); }
+
+  /* ===== SCENE 2: Edit Mode ===== */
+  .pcs-edit-done {
+    font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+    color: #3ECF8E; background: none; border: none;
+    letter-spacing: .1em; cursor: pointer; padding: 2px 6px;
+  }
+  .pcs-edit-x {
+    position: absolute; top: 8px; left: 8px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: #000000; border: 1.5px solid #FF4B4B;
+    color: #FF4B4B; font-size: 12px; cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    z-index: 6; line-height: 1;
+  }
+
+  /* ===== SCENE 3: Confirm Dialog ===== */
+  .confirm-scene {
+    position: relative; min-height: 240px;
+    background: rgba(0,0,0,0.6);
+  }
+  .pcs-bottom-confirm {
+    position: absolute; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #2a2a2a;
+    padding: 24px 16px 40px;
+  }
+  .pcs-bc-title {
+    font-family: 'DM Sans', sans-serif; font-size: 16px;
+    font-weight: 700; color: #E8E8E8; margin-bottom: 6px;
+  }
+  .pcs-bc-sub {
+    font-family: 'DM Sans', sans-serif; font-size: 13px;
+    color: #8E8E93; margin-bottom: 20px;
+  }
+  .pcs-bc-btns { display: flex; gap: 10px; }
+  .pcs-bc-cancel, .pcs-bc-action {
+    flex: 1; font-family: 'DM Sans', sans-serif; font-size: 14px;
+    padding: 13px; border: none; cursor: pointer; text-align: center;
+    border-radius: 0;
+  }
+  .pcs-bc-cancel { background: #2a2a2a; color: #E8E8E8; }
+  .pcs-bc-action { background: #FF4B4B; color: #E8E8E8; }
+
+  /* Caption section mockup */
+  .caption-section {
+    padding: 12px 14px 8px; border-bottom: 1px solid #1a1a2a;
+  }
+  .caption-text {
+    font-family: 'DM Sans', sans-serif; font-size: 13px;
+    color: #888; line-height: 1.6; white-space: pre-wrap;
+  }
+  .see-more {
+    font-family: 'IBM Plex Mono', monospace; font-size: 8px;
+    letter-spacing: .1em; text-transform: uppercase;
+    color: #F6A623; background: transparent; border: none;
+    cursor: pointer; padding: 6px 0 0 0;
+  }
+
+  /* Separator */
+  .sep { height: 1px; background: #1a1a1a; }
+</style>
+</head>
+<body>
+
+<!-- ==================== SCENE 1: Unified ··· Dropdown ==================== -->
+<div class="mockup-label">Scene 1 — Unified ··· Dropdown (open state)</div>
+<div class="scene">
+  <div class="photo-header">
+    <span class="photo-label">PHOTOS · 4</span>
+    <button class="photo-menu-btn">···</button>
+  </div>
+
+  <!-- Dropdown shown open -->
+  <div class="pcs-unified-drop">
+    <div class="pcs-udrop-label">PHOTOS</div>
+    <div class="pcs-udrop-item">Add Photos</div>
+    <div class="pcs-udrop-item">Edit Photos</div>
+    <div class="pcs-udrop-item">Save Photos</div>
+    <div class="pcs-udrop-label" style="margin-top:4px">CAPTION</div>
+    <div class="pcs-udrop-item">Copy Caption</div>
+    <div class="pcs-udrop-item">Edit Caption</div>
+    <div class="pcs-udrop-item">Clear Caption</div>
+  </div>
+
+  <div class="photo-grid">
+    <div class="photo-cell">IMG 1</div>
+    <div class="photo-cell">IMG 2</div>
+    <div class="photo-cell">IMG 3</div>
+    <div class="photo-cell">IMG 4</div>
+  </div>
+
+  <div class="caption-section">
+    <div class="caption-text">Diwali vibes at Sakarwadi — when the factory floor becomes a festival ground. This is what heritage looks like in action.</div>
+    <button class="see-more">See More</button>
+  </div>
+</div>
+
+<div class="sep"></div>
+
+<!-- ==================== SCENE 2: Edit Mode ==================== -->
+<div class="mockup-label">Scene 2 — Edit Mode (··· replaced by DONE, ✕ on each photo)</div>
+<div class="scene">
+  <div class="photo-header">
+    <span class="photo-label">PHOTOS · 4</span>
+    <button class="pcs-edit-done">DONE</button>
+  </div>
+
+  <div class="photo-grid">
+    <div class="photo-cell">
+      <button class="pcs-edit-x">✕</button>
+      IMG 1
+    </div>
+    <div class="photo-cell">
+      <button class="pcs-edit-x">✕</button>
+      IMG 2
+    </div>
+    <div class="photo-cell">
+      <button class="pcs-edit-x">✕</button>
+      IMG 3
+    </div>
+    <div class="photo-cell">
+      <button class="pcs-edit-x">✕</button>
+      IMG 4
+    </div>
+  </div>
+
+  <div class="caption-section">
+    <div class="caption-text">Diwali vibes at Sakarwadi — when the factory floor becomes a festival ground. This is what heritage looks like in action.</div>
+    <button class="see-more">See More</button>
+  </div>
+</div>
+
+<div class="sep"></div>
+
+<!-- ==================== SCENE 3: Remove Photo Confirm ==================== -->
+<div class="mockup-label">Scene 3 — Confirm Dialog: Remove Photo</div>
+<div class="confirm-scene">
+  <div class="pcs-bottom-confirm">
+    <div class="pcs-bc-title">Remove this photo?</div>
+    <div class="pcs-bc-sub">This action cannot be undone.</div>
+    <div class="pcs-bc-btns">
+      <button class="pcs-bc-cancel">Cancel</button>
+      <button class="pcs-bc-action">Remove</button>
+    </div>
+  </div>
+</div>
+
+<div class="sep"></div>
+
+<!-- ==================== SCENE 4: Clear Caption Confirm ==================== -->
+<div class="mockup-label">Scene 4 — Confirm Dialog: Clear Caption</div>
+<div class="confirm-scene">
+  <div class="pcs-bottom-confirm">
+    <div class="pcs-bc-title">Clear caption?</div>
+    <div class="pcs-bc-sub">This cannot be undone.</div>
+    <div class="pcs-bc-btns">
+      <button class="pcs-bc-cancel">Cancel</button>
+      <button class="pcs-bc-action">Clear</button>
+    </div>
+  </div>
+</div>
+
+<div style="padding:40px 16px;text-align:center">
+  <div style="font-family:'IBM Plex Mono',monospace;font-size:8px;color:#333;letter-spacing:.12em;text-transform:uppercase">
+    End of mockup — PR #630
+  </div>
+</div>
+
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -6593,9 +6593,10 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 /* FIX 5: Pane overflow */
 #pcs-pane-caption, #pcs-pane-client, #pcs-pane-internal { overflow: hidden; }
 
-/* FIX 7: No gap between topbar and photos */
+/* FIX 7: Tight spacing between topbar and photos */
 #pcs-scroll { padding-top: 0; }
-.pcs-photo-header { padding: 4px 16px 3px; margin-top: 0; }
+.pcs-photo-header { padding: 4px 16px 3px; margin-top: 8px; }
+#pcs-photo-grid-wrap { margin-top: 4px; }
 
 /* FIX 8: Tighter caption */
 #pcs-caption-text, .pcs-caption-text {
@@ -6620,3 +6621,60 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   color: #FFFFFF !important;
   padding: 9px 16px 6px !important;
 }
+
+/* Unified ··· dropdown (Photos + Caption groups) */
+.pcs-unified-drop {
+  background: #1a1a1a; border: 1px solid #2a2a2a;
+  min-width: 160px; box-shadow: 0 8px 24px rgba(0,0,0,.6);
+}
+.pcs-udrop-label {
+  font-family: 'IBM Plex Mono', monospace; font-size: 9px;
+  color: #555; text-transform: uppercase; letter-spacing: .1em;
+  padding: 10px 16px 4px;
+}
+.pcs-udrop-item {
+  font-family: 'DM Sans', sans-serif; font-size: 14px;
+  color: #E8E8E8; padding: 11px 16px; cursor: pointer;
+  border-bottom: 1px solid #222;
+}
+.pcs-udrop-item:last-child { border-bottom: none; }
+.pcs-udrop-item:active { background: rgba(255,255,255,.04); }
+
+/* Edit mode DONE button */
+.pcs-edit-done {
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+  color: #3ECF8E; background: none; border: none;
+  letter-spacing: .1em; cursor: pointer; padding: 2px 6px;
+}
+
+/* Edit mode ✕ overlay on photos */
+.pcs-edit-x {
+  position: absolute; top: 8px; left: 8px;
+  width: 28px; height: 28px; border-radius: 50%;
+  background: #000000; border: 1.5px solid #FF4B4B;
+  color: #FF4B4B; font-size: 12px; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  z-index: 6; line-height: 1;
+}
+
+/* Bottom confirm sheet (remove photo / clear caption) */
+.pcs-bottom-confirm {
+  position: fixed; bottom: 0; left: 0; right: 0;
+  background: #1a1a1a; border-top: 1px solid #2a2a2a;
+  padding: 24px 16px 40px;
+}
+.pcs-bc-title {
+  font-family: 'DM Sans', sans-serif; font-size: 16px;
+  font-weight: 700; color: #E8E8E8; margin-bottom: 6px;
+}
+.pcs-bc-sub {
+  font-family: 'DM Sans', sans-serif; font-size: 13px;
+  color: #8E8E93; margin-bottom: 20px;
+}
+.pcs-bc-btns { display: flex; gap: 10px; }
+.pcs-bc-cancel, .pcs-bc-action {
+  flex: 1; font-family: 'DM Sans', sans-serif; font-size: 14px;
+  padding: 13px; border: none; cursor: pointer;
+}
+.pcs-bc-cancel { background: #2a2a2a; color: #E8E8E8; }
+.pcs-bc-action { background: #FF4B4B; color: #E8E8E8; }


### PR DESCRIPTION
## Summary

- **Gap fixes (Step A):** Photo row margin-top → 8px, photo-to-grid gap → 4px, removed orphan ··· dots button from caption section
- **Unified dropdown (Step B):** Single ··· menu with two groups — PHOTOS (Add/Edit/Save) and CAPTION (Copy/Edit/Clear). Styled per spec: #1a1a1a bg, IBM Plex Mono 9px group labels, DM Sans 14px items
- **Edit mode (Step C):** Edit Photos enters mode with DONE button replacing ···, red ✕ overlays on each photo (28px circle, #FF4B4B border), confirm before removing
- **Confirm dialogs (Step D):** Bottom sheet confirms for Remove Photo and Clear Caption — #1a1a1a bg, DM Sans title/subtitle, Cancel (#2a2a2a) + action (#FF4B4B) buttons, zero border-radius

## Test plan

- [x] 297/297 unit tests passing
- [ ] Open PCS overlay → verify photo row has 8px top margin, 4px gap to grid
- [ ] Verify no orphan ··· dots above caption text
- [ ] Tap ··· → unified dropdown shows Photos + Caption groups
- [ ] Tap Add Photos → file picker opens
- [ ] Tap Edit Photos → DONE button appears, ✕ overlays on each photo
- [ ] Tap ✕ on photo → confirm dialog appears, Remove deletes photo
- [ ] Tap DONE → exits edit mode, ··· returns
- [ ] Tap Copy Caption → caption copied to clipboard
- [ ] Tap Edit Caption → inline textarea appears
- [ ] Tap Clear Caption → confirm dialog, Clear empties caption + saves to DB
- [ ] Outside tap on dropdown → closes menu
- [ ] Outside tap on confirm dialogs → dismisses

https://claude.ai/code/session_01Kyenrgpok1MR6L6eA2wMeD