### PR TITLE
Fix photo grid: remove old X, rgba→hex, object-fit cover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,12 @@ Team:
 Repo: github.com/Guneygaar/guneygaar.github.io
 Branch: main-/-root. Deployed at srtd.io.
 ALL files at REPO ROOT. No /sorted/ subdirectory. Never reference /sorted/.
-Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ preview/
+Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ preview/ mockups/
 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260402b
+Version format: ?v=YYYYMMDDx. Current: ?v=20260402c
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -160,6 +160,10 @@ Theme: dark default (data-theme=“dark”)
 Image compression:
 Post images:    max 1200px, quality 0.82, saves as .jpg
 Comment images: max 800px, quality 0.80, saves as .jpg
+
+Photo grid: object-fit:cover + object-position:center center
+(fills cells edge-to-edge, no black bars — LinkedIn collage style)
+Old .pcs-photo-x removed — use edit mode .pcs-edit-x only
 
 ## SECTION 7 — DEPLOYMENT RULES (never skip any step)
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -289,7 +289,6 @@ function _buildPhotoGrid(imgs, canEdit, canEditCreative, isAdmin, id) {
   function _cell(idx, heroClass, overlayHtml) {
     return '<div class="pcs-pcell' + (heroClass ? ' hero' : '') + '" onclick="window._pcsOpenLightbox(\'' + esc(id) + '\',' + idx + ')">' +
       '<img src="' + esc(imgs[idx]) + '" onerror="this.style.display=\'none\'">' +
-      (isAdmin ? '<button class="pcs-photo-x" onclick="event.stopPropagation();window._pcsRemovePhoto(\'' + esc(id) + '\',' + idx + ')">&#x2715;</button>' : '') +
       (overlayHtml || '') +
       '</div>';
   }
@@ -299,7 +298,7 @@ function _buildPhotoGrid(imgs, canEdit, canEditCreative, isAdmin, id) {
   if (count === 0) {
     if (canManage) {
       gridHtml = '<div class="pcs-photo-empty" onclick="window._pcsAddPhotos(\'' + esc(id) + '\')">' +
-        '<div style="font-size:22px;color:rgba(246,166,35,.3)">+</div>' +
+        '<div style="font-size:22px;color:#C8A84B">+</div>' +
         '<div style="font-family:\'Courier New\',monospace;font-size:8px;letter-spacing:.1em;text-transform:uppercase;color:#F6A623">Upload Photos</div>' +
         '<div style="font-family:\'Courier New\',monospace;font-size:7px;color:#333;letter-spacing:.06em">JPG / PNG</div>' +
         '</div>';
@@ -307,7 +306,6 @@ function _buildPhotoGrid(imgs, canEdit, canEditCreative, isAdmin, id) {
   } else if (count === 1) {
     gridHtml = '<div class="pcs-pg-1">' +
       '<img src="' + esc(imgs[0]) + '" onclick="window._pcsOpenLightbox(\'' + esc(id) + '\',0)" onerror="this.style.display=\'none\'">' +
-      (isAdmin ? '<button class="pcs-photo-x" onclick="event.stopPropagation();window._pcsRemovePhoto(\'' + esc(id) + '\',0)">&#x2715;</button>' : '') +
       '</div>';
   } else if (count === 2) {
     gridHtml = '<div class="pcs-pg-2">' + _cell(0) + _cell(1) + '</div>';

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260402b">
+ <link rel="stylesheet" href="styles.css?v=20260402c">
 
 </head>
 <body>
@@ -1070,26 +1070,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260402b"></script>
-<script src="00-appstate-compat.js?v=20260402b"></script>
-<script src="01-config.js?v=20260402b" defer></script>
-<script src="02-session.js?v=20260402b" defer></script>
-<script src="utils.js?v=20260402b" defer></script>
-<script src="03-auth.js?v=20260402b" defer></script>
-<script src="05-api.js?v=20260402b" defer></script>
-<script src="10-ui.js?v=20260402b" defer></script>
+<script src="00-appstate.js?v=20260402c"></script>
+<script src="00-appstate-compat.js?v=20260402c"></script>
+<script src="01-config.js?v=20260402c" defer></script>
+<script src="02-session.js?v=20260402c" defer></script>
+<script src="utils.js?v=20260402c" defer></script>
+<script src="03-auth.js?v=20260402c" defer></script>
+<script src="05-api.js?v=20260402c" defer></script>
+<script src="10-ui.js?v=20260402c" defer></script>
 
-<script src="06-post-create.js?v=20260402b" defer></script>
-<script defer src="render/dashboard.js?v=20260402b"></script>
-<script defer src="render/client.js?v=20260402b"></script>
-<script defer src="render/pipeline.js?v=20260402b"></script>
-<script defer src="render/brief.js?v=20260402b"></script>
-<script defer src="actions/pcs.js?v=20260402b"></script>
-<script src="07-post-load.js?v=20260402b" defer></script>
-<script src="08-post-actions.js?v=20260402b" defer></script>
-<script src="09-library.js?v=20260402b" defer></script>
-<script src="09-approval.js?v=20260402b" defer></script>
-<script src="04-router.js?v=20260402b" defer></script>
+<script src="06-post-create.js?v=20260402c" defer></script>
+<script defer src="render/dashboard.js?v=20260402c"></script>
+<script defer src="render/client.js?v=20260402c"></script>
+<script defer src="render/pipeline.js?v=20260402c"></script>
+<script defer src="render/brief.js?v=20260402c"></script>
+<script defer src="actions/pcs.js?v=20260402c"></script>
+<script src="07-post-load.js?v=20260402c" defer></script>
+<script src="08-post-actions.js?v=20260402c" defer></script>
+<script src="09-library.js?v=20260402c" defer></script>
+<script src="09-approval.js?v=20260402c" defer></script>
+<script src="04-router.js?v=20260402c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/mockups/pcs-photo-fix.html
+++ b/mockups/pcs-photo-fix.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PCS Photo Fix Mockup — Sorted</title>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: #080808; color: #E8E8E8; font-family: 'DM Sans', sans-serif; max-width: 420px; margin: 0 auto; }
+
+  .mockup-label {
+    font-family: 'IBM Plex Mono', monospace; font-size: 9px;
+    color: #C8A84B; letter-spacing: .2em; text-transform: uppercase;
+    padding: 28px 16px 12px; border-bottom: 1px solid #1a1a1a;
+  }
+
+  .scene { padding: 0; }
+
+  /* Photo header */
+  .photo-header {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 4px 16px 3px; margin-top: 8px;
+  }
+  .photo-label {
+    font-family: 'Courier New', monospace; font-size: 8px;
+    color: #52525c; letter-spacing: .07em; text-transform: uppercase;
+  }
+  .photo-menu-btn {
+    background: none; border: none; color: #52525c;
+    font-size: 14px; letter-spacing: .15em; cursor: pointer; padding: 2px 6px;
+  }
+
+  /* Photo grid — 1 large + 2 small (pcs-pg-3 layout) */
+  .photo-grid-3 {
+    display: grid; grid-template-columns: 62% 38%;
+    grid-template-rows: 1fr 1fr; gap: 2px;
+    height: 272px; margin-top: 4px;
+  }
+  .pcell { position: relative; overflow: hidden; cursor: pointer; background: #080808; }
+  .pcell.hero { grid-row: span 2; }
+  .pcell img { width: 100%; height: 100%; object-fit: cover; object-position: center center; display: block; background: #080808; }
+
+  /* Edit mode DONE button */
+  .pcs-edit-done {
+    font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+    color: #3ECF8E; background: none; border: none;
+    letter-spacing: .1em; cursor: pointer; padding: 2px 6px;
+  }
+
+  /* Edit mode X overlay */
+  .pcs-edit-x {
+    position: absolute; top: 8px; left: 8px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: #000000; border: 1.5px solid #FF4B4B;
+    color: #FF4B4B; font-size: 12px; cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    z-index: 6; line-height: 1;
+  }
+
+  .sep { height: 1px; background: #1a1a1a; margin-top: 16px; }
+
+  .note {
+    font-family: 'IBM Plex Mono', monospace; font-size: 8px;
+    color: #333; letter-spacing: .06em; padding: 12px 16px;
+  }
+</style>
+</head>
+<body>
+
+<!-- ===== SCENE 1: View Mode — No X buttons visible ===== -->
+<div class="mockup-label">Scene 1 — View Mode (no X buttons, object-fit: cover)</div>
+<div class="scene">
+  <div class="photo-header">
+    <span class="photo-label">PHOTOS · 3</span>
+    <button class="photo-menu-btn">···</button>
+  </div>
+  <div class="photo-grid-3">
+    <div class="pcell hero">
+      <img src="https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=600&h=400&fit=crop" alt="Photo 1">
+    </div>
+    <div class="pcell">
+      <img src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=300&h=200&fit=crop" alt="Photo 2">
+    </div>
+    <div class="pcell">
+      <img src="https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?w=300&h=200&fit=crop" alt="Photo 3">
+    </div>
+  </div>
+  <div class="note">No X buttons visible. Photos fill cells edge-to-edge with object-fit: cover. No black bars.</div>
+</div>
+
+<div class="sep"></div>
+
+<!-- ===== SCENE 2: Edit Mode — X overlays on each photo ===== -->
+<div class="mockup-label">Scene 2 — Edit Mode (DONE button, X on each photo)</div>
+<div class="scene">
+  <div class="photo-header">
+    <span class="photo-label">PHOTOS · 3</span>
+    <button class="pcs-edit-done">DONE</button>
+  </div>
+  <div class="photo-grid-3">
+    <div class="pcell hero">
+      <img src="https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=600&h=400&fit=crop" alt="Photo 1">
+      <button class="pcs-edit-x">&#x2715;</button>
+    </div>
+    <div class="pcell">
+      <img src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=300&h=200&fit=crop" alt="Photo 2">
+      <button class="pcs-edit-x">&#x2715;</button>
+    </div>
+    <div class="pcell">
+      <img src="https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?w=300&h=200&fit=crop" alt="Photo 3">
+      <button class="pcs-edit-x">&#x2715;</button>
+    </div>
+  </div>
+  <div class="note">DONE replaces ···. Red X overlays on each photo. Tapping X shows confirm dialog before removing.</div>
+</div>
+
+<div style="padding:40px 16px;text-align:center">
+  <div style="font-family:'IBM Plex Mono',monospace;font-size:8px;color:#333;letter-spacing:.12em;text-transform:uppercase">
+    End of mockup — Photo fix PR
+  </div>
+</div>
+
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -6398,30 +6398,22 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* Photo grids */
 .pcs-pg-1 { width:100%; height:312px; overflow:hidden; cursor:pointer; position:relative; }
-.pcs-pg-1 img { width:100%; height:100%; object-fit:contain; display:block; background:#080808; }
+.pcs-pg-1 img { width:100%; height:100%; object-fit:cover; object-position:center center; display:block; background:#080808; }
 .pcs-pg-2 { display:grid; grid-template-columns:1fr 1fr; gap:2px; height:272px; }
 .pcs-pg-3, .pcs-pg-5 { display:grid; grid-template-columns:62% 38%; grid-template-rows:1fr 1fr; gap:2px; height:272px; }
 .pcs-pg-4 { display:grid; grid-template-columns:1fr 1fr; grid-template-rows:1fr 1fr; gap:2px; height:292px; }
 .pcs-pcell { position:relative; overflow:hidden; cursor:pointer; background:#080808; flex-shrink:0; }
 .pcs-pcell.hero { grid-row:span 2; }
-.pcs-pcell img { width:100%; height:100%; object-fit:contain; display:block; background:#080808; }
-.pcs-photo-x {
-  position:absolute; top:6px; left:6px;
-  width:22px; height:22px; border-radius:50%;
-  background:rgba(0,0,0,.78); border:none;
-  color:rgba(255,255,255,.85); font-size:10px;
-  cursor:pointer; display:flex; align-items:center;
-  justify-content:center; z-index:5;
-}
+.pcs-pcell img { width:100%; height:100%; object-fit:cover; object-position:center center; display:block; background:#080808; }
 .pcs-more-ov {
-  position:absolute; inset:0; background:rgba(0,0,0,.62);
+  position:absolute; inset:0; background:#1a1a1a;
   display:flex; flex-direction:column;
   align-items:center; justify-content:center; gap:3px;
 }
 .pcs-more-n { font-size:26px; font-weight:300; color:#fff; line-height:1; }
 .pcs-more-l {
   font-family:'Courier New',monospace; font-size:7px;
-  color:rgba(255,255,255,.6); letter-spacing:.08em; text-transform:uppercase;
+  color:#AEAEB2; letter-spacing:.08em; text-transform:uppercase;
 }
 .pcs-photo-empty {
   padding: 28px 16px;


### PR DESCRIPTION
## Summary

- **FIX 1:** Removed always-visible `.pcs-photo-x` buttons from `_buildPhotoGrid()`. Admin users no longer see permanent ✕ on every photo. Removal is now exclusively via edit mode (`.pcs-edit-x` from `_pcsEnterEditMode`). Deleted `.pcs-photo-x` CSS block entirely.
- **FIX 2:** Replaced all `rgba()` in photo section with solid hex per design system: `.pcs-more-ov` → `#1a1a1a`, `.pcs-more-l` → `#AEAEB2`, empty state "+" → `#C8A84B`
- **FIX 3:** Photo grid `object-fit: contain` → `cover` with `object-position: center center`. Photos fill cells edge-to-edge (LinkedIn collage style), no black bars.

**Visual mockup:** Preview at `guneygaar.github.io/mockups/pcs-photo-fix.html` after cache purge

## Test plan

- [x] 297/297 unit tests passing
- [ ] Open PCS for post with photos → no ✕ buttons visible in view mode
- [ ] Tap ··· → Edit Photos → ✕ overlays appear on each photo
- [ ] Tap DONE → ✕ overlays disappear, ··· returns
- [ ] Photos fill grid cells edge-to-edge, no black bars or letterboxing
- [ ] "+N more" overlay on 5+ photo grids renders with solid colors
- [ ] Empty photo state shows gold "+" icon

https://claude.ai/code/session_01Kyenrgpok1MR6L6eA2wMeD