### PR TITLE
Fix: brief submission writing to non-existent comments column

### DIFF
--- a/09-approval.js
+++ b/09-approval.js
@@ -142,7 +142,7 @@ async function submitApproval(type, postId, btn) {
     try {
       await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
         method: 'PATCH',
-        body: JSON.stringify({ stage: 'in_production', comments: text, updated_at: new Date().toISOString() }),
+        body: JSON.stringify({ stage: 'in_production', client_feedback: text, updated_at: new Date().toISOString() }),
       });
       await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: `Changes requested: ${text.substring(0,80)}` });
       const c = document.getElementById('approval-confirmation');

--- a/10-ui.js
+++ b/10-ui.js
@@ -1330,9 +1330,7 @@ async function _nrsSubmit() {
       content_pillar: document.getElementById('nrs-pillar').value || null,
       format:        document.getElementById('nrs-format').value || null,
       target_date:   document.getElementById('nrs-date').value || null,
-      comments:      brief,
-      created_by:    actor,
-      updated_by:    actor,
+      client_feedback: brief,
       updated_at:    new Date().toISOString()
     };
     await apiFetch('/posts', { method: 'POST', body: JSON.stringify(body) });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260402d
+Version format: ?v=YYYYMMDDx. Current: ?v=20260402e
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -201,7 +201,7 @@ Run: npx vitest run
 Single file: npx vitest run tests/filename.test.js
 E2E: npx playwright test
 
-Current (verified 2026-04-01):
+Current (verified 2026-04-02):
 Unit test files: 13
 Unit tests:      297 passing, 0 failing
 E2E specs:       7
@@ -366,6 +366,10 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
 
 ## SECTION 12 — CURRENT KNOWN BUGS
 
+1. Brief/request submission writing to non-existent 'comments' column
+   Location: 10-ui.js _nrsSubmit(), render/brief.js _assignBriefToPranav(),
+   09-approval.js changes_submit — all wrote 'comments' to posts table
+   Status: FIXED (PR#TBD) — changed to client_feedback in all 3 locations
 1. LinkedIn URL not saving from publish dialog
    Location: actions/pcs.js ~lines 548-580
    Status: OPEN

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260402d">
+ <link rel="stylesheet" href="styles.css?v=20260402e">
 
 </head>
 <body>
@@ -1070,26 +1070,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260402d"></script>
-<script src="00-appstate-compat.js?v=20260402d"></script>
-<script src="01-config.js?v=20260402d" defer></script>
-<script src="02-session.js?v=20260402d" defer></script>
-<script src="utils.js?v=20260402d" defer></script>
-<script src="03-auth.js?v=20260402d" defer></script>
-<script src="05-api.js?v=20260402d" defer></script>
-<script src="10-ui.js?v=20260402d" defer></script>
+<script src="00-appstate.js?v=20260402e"></script>
+<script src="00-appstate-compat.js?v=20260402e"></script>
+<script src="01-config.js?v=20260402e" defer></script>
+<script src="02-session.js?v=20260402e" defer></script>
+<script src="utils.js?v=20260402e" defer></script>
+<script src="03-auth.js?v=20260402e" defer></script>
+<script src="05-api.js?v=20260402e" defer></script>
+<script src="10-ui.js?v=20260402e" defer></script>
 
-<script src="06-post-create.js?v=20260402d" defer></script>
-<script defer src="render/dashboard.js?v=20260402d"></script>
-<script defer src="render/client.js?v=20260402d"></script>
-<script defer src="render/pipeline.js?v=20260402d"></script>
-<script defer src="render/brief.js?v=20260402d"></script>
-<script defer src="actions/pcs.js?v=20260402d"></script>
-<script src="07-post-load.js?v=20260402d" defer></script>
-<script src="08-post-actions.js?v=20260402d" defer></script>
-<script src="09-library.js?v=20260402d" defer></script>
-<script src="09-approval.js?v=20260402d" defer></script>
-<script src="04-router.js?v=20260402d" defer></script>
+<script src="06-post-create.js?v=20260402e" defer></script>
+<script defer src="render/dashboard.js?v=20260402e"></script>
+<script defer src="render/client.js?v=20260402e"></script>
+<script defer src="render/pipeline.js?v=20260402e"></script>
+<script defer src="render/brief.js?v=20260402e"></script>
+<script defer src="actions/pcs.js?v=20260402e"></script>
+<script src="07-post-load.js?v=20260402e" defer></script>
+<script src="08-post-actions.js?v=20260402e" defer></script>
+<script src="09-library.js?v=20260402e" defer></script>
+<script src="09-approval.js?v=20260402e" defer></script>
+<script src="04-router.js?v=20260402e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -313,16 +313,16 @@ window._openBriefSheet = function(postId) {
 window._assignBriefToPranav = function(postId) {
   var direction = (document.getElementById('brief-direction-' + postId) || {}).value || '';
   var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
-  var updatedComments = (post ? (post.comments || '') : '');
+  var updatedFeedback = (post ? (post.client_feedback || '') : '');
   if (direction.trim()) {
-    updatedComments += '\n\n[CHITRA NOTE] ' + direction.trim();
+    updatedFeedback += '\n\n[CHITRA NOTE] ' + direction.trim();
   }
   apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
     method: 'PATCH',
     body: JSON.stringify({
       stage: 'brief',
       owner: 'Pranav',
-      comments: updatedComments,
+      client_feedback: updatedFeedback,
       status_changed_at: new Date().toISOString(),
       updated_at: new Date().toISOString()
     })


### PR DESCRIPTION
## Summary
- **Production bug**: Client brief submissions failing with PostgREST error "Could not find the 'comments' column of 'posts' in the schema cache"
- Three locations were writing to `posts.comments` which no longer exists (migrated to `post_comments` table):
  - `10-ui.js` `_nrsSubmit()`: `comments` → `client_feedback`, also removed invalid `created_by`/`updated_by` columns
  - `render/brief.js` `_assignBriefToPranav()`: `comments` → `client_feedback`
  - `09-approval.js` changes_submit: `comments` → `client_feedback`
- Bumped all 20 `?v=` to `20260402e`
- CLAUDE.md updated: bug logged as fixed, version bumped

## Test plan
- [x] `npx vitest run` — 297/297 passing
- [ ] Client submits a new brief request → saves to Supabase without error
- [ ] Chitra assigns brief to Pranav with direction note → PATCH succeeds
- [ ] Client requests changes via approval flow → PATCH succeeds
- [ ] Admin creates request via NRS sheet → POST succeeds
- [ ] Purge Cloudflare cache after merge
- [ ] Hard refresh all devices before testing

https://claude.ai/code/session_01L36sxkaCFyuRobwRLAAkan