### PR TITLE
Add persistent approved strip for scheduled posts + PCS back button f…

### DIFF
--- a/00-appstate.js
+++ b/00-appstate.js
@@ -39,7 +39,8 @@ window.AppState = window.AppState || {
       images: [],
       index: 0
     },
-    activeMenu: null
+    activeMenu: null,
+    openedFrom: null
   },
 
   ui: {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260402e
+Version format: ?v=YYYYMMDDx. Current: ?v=20260402f
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -74,7 +74,8 @@ setAll: function(newPosts) — ONLY way to update posts.all
 },
 pcs: {
 open, postId, post, editingTarget, closeTimer,
-pendingComment, lightbox: {images, index}, activeMenu
+pendingComment, lightbox: {images, index}, activeMenu,
+openedFrom
 },
 ui: {
 modalOpen, deferredRender, activeTab, taskFilter,
@@ -369,7 +370,13 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
 1. Brief/request submission writing to non-existent 'comments' column
    Location: 10-ui.js _nrsSubmit(), render/brief.js _assignBriefToPranav(),
    09-approval.js changes_submit — all wrote 'comments' to posts table
-   Status: FIXED (PR#TBD) — changed to client_feedback in all 3 locations
+   Status: FIXED (PR#633) — changed to client_feedback in all 3 locations
+1. Approved posts not highlighted after refresh in client feed
+   Location: render/client.js approved-strip was display:none, only shown in-session
+   Status: FIXED (PR#TBD) — strip now renders with stage==='scheduled', solid bg #0a1a12
+1. No back button when PCS opens from dashboard bottom sheet
+   Location: actions/pcs.js, render/dashboard.js openPostOverSheet()
+   Status: FIXED (PR#TBD) — added AppState.pcs.openedFrom, back arrow in PCS topbar
 1. LinkedIn URL not saving from publish dialog
    Location: actions/pcs.js ~lines 548-580
    Status: OPEN

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -138,6 +138,7 @@ window.forcePCSReset = function() {
 
   // 6. Clear PCS context
   window._pcs.postId = null;
+  window.AppState.pcs.openedFrom = null;
 
   // 7. Flush any deferred background renders
   _drainDeferredRender();
@@ -145,6 +146,12 @@ window.forcePCSReset = function() {
 
 window._renderPCS = function(postId) {
   _removePcsConfirm();
+
+  // Show/hide back arrow based on whether PCS was opened from a sheet
+  var backBtn = document.getElementById('pcs-back-btn');
+  if (backBtn) {
+    backBtn.style.display = (window.AppState.pcs.openedFrom === 'sheet') ? 'block' : 'none';
+  }
 
   // 1. Fetch post
   var post = getPostById(postId);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260402e">
+ <link rel="stylesheet" href="styles.css?v=20260402f">
 
 </head>
 <body>
@@ -861,11 +861,14 @@
 <div id="pcs-overlay" onclick="if(event.target===this)closePCS()">
   <div id="pcs-screen" class="pc-sheet">
 
-    <!-- Topbar: X left, stage+overdue pills right -->
+    <!-- Topbar: back+X left, stage+overdue pills right -->
     <div class="pc-topbar">
-      <button class="pc-icon-btn" onclick="closePCS()" aria-label="Close">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-      </button>
+      <div style="display:flex;align-items:center;gap:0;">
+        <button id="pcs-back-btn" style="display:none;background:none;border:none;color:#AEAEB2;font-family:'IBM Plex Mono',monospace;font-size:18px;padding:8px;cursor:pointer;" onclick="closePCS()" aria-label="Back to sheet">&#x2190;</button>
+        <button class="pc-icon-btn" onclick="closePCS()" aria-label="Close">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
+      </div>
       <div id="pcs-topbar-right" style="display:flex;align-items:center;gap:6px"></div>
     </div>
 
@@ -1070,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260402e"></script>
-<script src="00-appstate-compat.js?v=20260402e"></script>
-<script src="01-config.js?v=20260402e" defer></script>
-<script src="02-session.js?v=20260402e" defer></script>
-<script src="utils.js?v=20260402e" defer></script>
-<script src="03-auth.js?v=20260402e" defer></script>
-<script src="05-api.js?v=20260402e" defer></script>
-<script src="10-ui.js?v=20260402e" defer></script>
+<script src="00-appstate.js?v=20260402f"></script>
+<script src="00-appstate-compat.js?v=20260402f"></script>
+<script src="01-config.js?v=20260402f" defer></script>
+<script src="02-session.js?v=20260402f" defer></script>
+<script src="utils.js?v=20260402f" defer></script>
+<script src="03-auth.js?v=20260402f" defer></script>
+<script src="05-api.js?v=20260402f" defer></script>
+<script src="10-ui.js?v=20260402f" defer></script>
 
-<script src="06-post-create.js?v=20260402e" defer></script>
-<script defer src="render/dashboard.js?v=20260402e"></script>
-<script defer src="render/client.js?v=20260402e"></script>
-<script defer src="render/pipeline.js?v=20260402e"></script>
-<script defer src="render/brief.js?v=20260402e"></script>
-<script defer src="actions/pcs.js?v=20260402e"></script>
-<script src="07-post-load.js?v=20260402e" defer></script>
-<script src="08-post-actions.js?v=20260402e" defer></script>
-<script src="09-library.js?v=20260402e" defer></script>
-<script src="09-approval.js?v=20260402e" defer></script>
-<script src="04-router.js?v=20260402e" defer></script>
+<script src="06-post-create.js?v=20260402f" defer></script>
+<script defer src="render/dashboard.js?v=20260402f"></script>
+<script defer src="render/client.js?v=20260402f"></script>
+<script defer src="render/pipeline.js?v=20260402f"></script>
+<script defer src="render/brief.js?v=20260402f"></script>
+<script defer src="actions/pcs.js?v=20260402f"></script>
+<script src="07-post-load.js?v=20260402f" defer></script>
+<script src="08-post-actions.js?v=20260402f" defer></script>
+<script src="09-library.js?v=20260402f" defer></script>
+<script src="09-approval.js?v=20260402f" defer></script>
+<script src="04-router.js?v=20260402f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/mockups/back-button.html
+++ b/mockups/back-button.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>PCS Back Button Mockup</title>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: #080808; color: #E8E8E8; font-family: 'DM Sans', sans-serif; }
+
+  .label {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 9px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: #C8A84B;
+    padding: 24px 16px 8px;
+  }
+
+  /* PCS topbar */
+  .pc-topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 14px;
+    border-bottom: 1px solid #1a1a1a;
+    background: #080808;
+  }
+  .pc-topbar-left {
+    display: flex;
+    align-items: center;
+    gap: 0;
+  }
+  .pcs-back-btn {
+    display: block;
+    background: none;
+    border: none;
+    color: #AEAEB2;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 18px;
+    padding: 8px;
+    cursor: pointer;
+  }
+  .pc-icon-btn {
+    background: none;
+    border: none;
+    color: #AEAEB2;
+    cursor: pointer;
+    padding: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .pcs-stage-pill {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    padding: 4px 10px;
+    background: #1a1a2e;
+    color: #22D3EE;
+    border: 1px solid #1e3a4a;
+  }
+
+  /* Approved strip */
+  .approved-strip {
+    padding: 10px 14px;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 10px;
+    color: #3ECF8E;
+    background: #0a1a12;
+    margin: 16px;
+  }
+
+  .section { margin-bottom: 32px; border: 1px solid #1a1a1a; margin: 16px; }
+</style>
+</head>
+<body>
+
+<div class="label">State A: PCS opened from pipeline (no back button)</div>
+<div class="section">
+  <div class="pc-topbar">
+    <div class="pc-topbar-left">
+      <!-- No back button -->
+      <button class="pc-icon-btn" aria-label="Close">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+    </div>
+    <div style="display:flex;align-items:center;gap:6px;">
+      <span class="pcs-stage-pill">IN PRODUCTION</span>
+    </div>
+  </div>
+</div>
+
+<div class="label">State B: PCS opened from bottom sheet (back arrow visible)</div>
+<div class="section">
+  <div class="pc-topbar">
+    <div class="pc-topbar-left">
+      <button class="pcs-back-btn" aria-label="Back to sheet">&#x2190;</button>
+      <button class="pc-icon-btn" aria-label="Close">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+    </div>
+    <div style="display:flex;align-items:center;gap:6px;">
+      <span class="pcs-stage-pill">SCHEDULED</span>
+    </div>
+  </div>
+</div>
+
+<div class="label">Approved strip (persistent on scheduled posts)</div>
+<div class="section">
+  <div class="approved-strip">
+    <span style="display:inline-flex;align-items:center;gap:5px;">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#3ECF8E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+      Approved
+    </span>
+  </div>
+</div>
+
+</body>
+</html>

--- a/render/client.js
+++ b/render/client.js
@@ -406,7 +406,10 @@ console.log('LOADED:', 'render/client.js');
 
     return '<div class="eng-bar" data-engagement="' + pid + '" style="display:flex;">' +
       btn1 + btn2 + btn3 + '</div>' +
-      '<div id="approved-strip-' + pid + '" style="display:none;padding:10px 14px;font-family:\'IBM Plex Mono\',monospace;font-size:10px;color:#3ECF8E;background:rgba(62,207,142,0.05);margin-top:6px;">' +
+      '<div id="approved-strip-' + pid + '" style="' +
+      (post.stage === 'scheduled' ? 'display:block;' : 'display:none;') +
+      'padding:10px 14px;font-family:\'IBM Plex Mono\',monospace;font-size:10px;color:#3ECF8E;background:#0a1a12;margin-top:6px;">' +
+      (post.stage === 'scheduled' ? '<span style="display:inline-flex;align-items:center;gap:5px;">' + ICON_CHECK + ' Approved</span>' : '') +
       '</div>';
   }
 

--- a/render/dashboard.js
+++ b/render/dashboard.js
@@ -660,6 +660,7 @@ window.openPostOverSheet = function(pid) {
     return p.id === pid || p.post_id === pid;
   });
   var realId = match ? (match.id || match.post_id) : pid;
+  window.AppState.pcs.openedFrom = 'sheet';
   if (typeof openPCS === 'function') {
     openPCS(realId, 'pipeline');
   }


### PR DESCRIPTION
…rom sheets

Fix 1: Approved posts now show green "Approved" strip permanently in client feed when stage==='scheduled'. Background changed from rgba to solid #0a1a12. Strip renders from post data, not session state — survives page refresh.

Fix 2: PCS opened from dashboard bottom sheets now shows a back arrow (←) in the topbar. Added AppState.pcs.openedFrom to track opener context. openPostOverSheet() sets it to 'sheet', forcePCSReset() clears it. Tapping back arrow calls closePCS() — sheet is already visible behind PCS.

Bumped ?v= to 20260402f (all 20 resources). CLAUDE.md updated. Mockup: mockups/back-button.html

https://claude.ai/code/session_01L36sxkaCFyuRobwRLAAkan