### PR TITLE
Add stage-change notifications across all transition paths

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -3,6 +3,50 @@
 =============================================== */
 console.log("LOADED:", "08-post-actions.js");
 
+// -- Stage change notification helper --
+// recipients: array of names e.g. ['Admin', 'Chitra', 'Pranav', 'Client']
+// Maps names to DB user_role values before inserting.
+window._sendStageNotif = function(postId, postTitle, stage, recipients, actorName) {
+  var roleMap = {
+    'Admin': 'Admin',
+    'Chitra': 'Servicing',
+    'Pranav': 'Creative',
+    'Client': 'Client'
+  };
+  var label = (typeof _stageLabel === 'function' && _stageLabel(stage)) || stage;
+  recipients.forEach(function(name) {
+    var userRole = roleMap[name] || name;
+    apiFetch('/notifications', {
+      method: 'POST',
+      body: JSON.stringify({
+        user_role: userRole,
+        post_id: postId,
+        type: stage,
+        message: actorName + ' moved ' + postTitle + ' to ' + label,
+        actor: actorName,
+        read: false
+      })
+    }).catch(function(err) {
+      console.error('[stage-notif] failed for ' + userRole, err);
+      window.logError && window.logError(err && err.message, err && err.stack, 'stage-notif-' + stage);
+    });
+  });
+};
+
+// -- Stage → notification recipients map --
+function _stageRecipients(stage) {
+  var map = {
+    'brief':                 ['Pranav'],
+    'in_production':         ['Pranav'],
+    'ready':                 ['Chitra'],
+    'awaiting_approval':     ['Client'],
+    'awaiting_brand_input':  ['Client'],
+    'scheduled':             ['Admin', 'Chitra', 'Pranav'],
+    'published':             ['Admin', 'Chitra', 'Pranav', 'Client']
+  };
+  return map[stage] || [];
+}
+
 function _stageLabel(stage) {
   var map = {
     'brief': 'Brief',
@@ -52,6 +96,8 @@ async function quickStage(postId, newStage) {
     post._isSaving = false;
     scheduleRender();
     await logActivity({ post_id: postId, actor: actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}` });
+    var _qsRecipients = _stageRecipients(newStage);
+    if (_qsRecipients.length) window._sendStageNotif(postId, getTitle(post), newStage, _qsRecipients, actor);
     showUndoToast('Moved to ' + _stageLabel(newStage), function() { quickStage(postId, oldStage); });
   } catch (err) {
     post._isSaving = false;
@@ -169,6 +215,7 @@ async function clientApprove(postId, btn) {
       body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: 'Client' }),
     });
     await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
+    window._sendStageNotif(postId, getTitle(post), 'scheduled', ['Admin', 'Chitra', 'Pranav'], window.AppState.user.name || 'Client');
     const confirmEl = document.getElementById(`approved-confirm-${postId}`);
     if (confirmEl) confirmEl.classList.add('show');
     var cardEl = document.getElementById('approved-confirm-' + postId);
@@ -199,6 +246,8 @@ async function clientAcknowledge(postId) {
       body: JSON.stringify({ stage: 'in_production', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString() }),
     });
     await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Acknowledged  -  sending via WhatsApp' });
+    var _ackPost = getPostById(postId);
+    window._sendStageNotif(postId, (_ackPost ? getTitle(_ackPost) : postId), 'in_production', ['Pranav'], window.AppState.user.name || 'Client');
     showToast('Got it! The team has been notified.', 'success');
     setTimeout(() => loadPostsForClient(), 800);
   } catch { showToast('Failed  -  try again', 'error'); }
@@ -438,6 +487,8 @@ function _confirmPublish(postId) {
       actor_role: window.AppState.user.effectiveRole || 'Admin',
       action: 'published'
     });
+    var _pubPost = getPostById(postId);
+    window._sendStageNotif(postId, (_pubPost ? getTitle(_pubPost) : postId), 'published', ['Admin', 'Chitra', 'Pranav', 'Client'], window.AppState.user.name || 'Shubham');
     showToast('Published', 'success');
     if (typeof closePCS === 'function') closePCS();
     loadPosts();
@@ -523,6 +574,7 @@ async function _executeStageChangeAsync(post, postId, newStage, previousStage) {
 
   // -- NON-CRITICAL  -  completely outside DB try/catch --
   try { logActivity({ post_id: postId, actor: actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}` }); } catch(e) { console.warn('[PCS] logActivity failed:', e); }
+  try { var _esRecipients = _stageRecipients(newStage); if (_esRecipients.length) window._sendStageNotif(postId, getTitle(post), newStage, _esRecipients, actor); } catch(e) { console.warn('[PCS] stage notif failed:', e); }
   try { showUndoToast(`Moved to ${newStage}`, () => _executeStageChange(postId, previousStage)); } catch(e) { console.warn('[PCS] showUndoToast failed:', e); }
 }
 

--- a/09-approval.js
+++ b/09-approval.js
@@ -145,6 +145,7 @@ async function submitApproval(type, postId, btn) {
         body: JSON.stringify({ stage: 'in_production', client_feedback: text, updated_at: new Date().toISOString() }),
       });
       await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: `Changes requested: ${text.substring(0,80)}` });
+      if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, postId, 'in_production', ['Pranav'], 'Client');
       const c = document.getElementById('approval-confirmation');
       if (c) { c.style.display = ''; c.textContent = 'Changes sent  -  the team will review it.'; }
       document.querySelector('.approval-actions')?.remove();
@@ -161,6 +162,7 @@ async function submitApproval(type, postId, btn) {
         body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString() }),
       });
       await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
+      if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, esc(title), 'scheduled', ['Admin', 'Chitra', 'Pranav'], 'Client');
       const c = document.getElementById('approval-confirmation');
       if (c) { c.style.display = ''; c.textContent = 'ok Approved! The team has been notified.'; }
       document.querySelector('.approval-actions')?.remove();

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260402g
+Version format: ?v=YYYYMMDDx. Current: ?v=20260402h
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -297,6 +297,11 @@ window.sendMagicLink        — send OTP email to user
 window.verifyOTPCode        — verify OTP and set session
 window.resetRolePreview     — clear role preview, restore Admin
 
+08-post-actions.js:
+window._sendStageNotif      — send stage-change notifications to recipients
+window._confirmPublish      — publish post with LinkedIn URL
+window._skipPublish         — publish post without URL
+
 render/dashboard.js:
 window._safeStage, window.getScoreboardCounts, window.getScoreboardData,
 window.dashPad, window.updateDashGreeting, window.updateDashKicker,
@@ -389,6 +394,11 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Location: actions/pcs.js _doSubmitComment (comment + mention notifs),
    render/pipeline.js executeBatchAction (batch stage notif — also missing actor)
    Status: FIXED (PR#TBD) — added read:false to all, actor to pipeline batch
+1. Notifications: no stage-change notifications for most transitions
+   Location: 08-post-actions.js, 09-approval.js, render/pipeline.js
+   14 of 16 stage transitions had zero notifications
+   Status: FIXED (PR#TBD) — added _sendStageNotif helper + notifications
+   to all stage change functions per product rules
 1. LinkedIn URL not saving from publish dialog
    Location: actions/pcs.js ~lines 548-580
    Status: OPEN

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260402g">
+ <link rel="stylesheet" href="styles.css?v=20260402h">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260402g"></script>
-<script src="00-appstate-compat.js?v=20260402g"></script>
-<script src="01-config.js?v=20260402g" defer></script>
-<script src="02-session.js?v=20260402g" defer></script>
-<script src="utils.js?v=20260402g" defer></script>
-<script src="03-auth.js?v=20260402g" defer></script>
-<script src="05-api.js?v=20260402g" defer></script>
-<script src="10-ui.js?v=20260402g" defer></script>
+<script src="00-appstate.js?v=20260402h"></script>
+<script src="00-appstate-compat.js?v=20260402h"></script>
+<script src="01-config.js?v=20260402h" defer></script>
+<script src="02-session.js?v=20260402h" defer></script>
+<script src="utils.js?v=20260402h" defer></script>
+<script src="03-auth.js?v=20260402h" defer></script>
+<script src="05-api.js?v=20260402h" defer></script>
+<script src="10-ui.js?v=20260402h" defer></script>
 
-<script src="06-post-create.js?v=20260402g" defer></script>
-<script defer src="render/dashboard.js?v=20260402g"></script>
-<script defer src="render/client.js?v=20260402g"></script>
-<script defer src="render/pipeline.js?v=20260402g"></script>
-<script defer src="render/brief.js?v=20260402g"></script>
-<script defer src="actions/pcs.js?v=20260402g"></script>
-<script src="07-post-load.js?v=20260402g" defer></script>
-<script src="08-post-actions.js?v=20260402g" defer></script>
-<script src="09-library.js?v=20260402g" defer></script>
-<script src="09-approval.js?v=20260402g" defer></script>
-<script src="04-router.js?v=20260402g" defer></script>
+<script src="06-post-create.js?v=20260402h" defer></script>
+<script defer src="render/dashboard.js?v=20260402h"></script>
+<script defer src="render/client.js?v=20260402h"></script>
+<script defer src="render/pipeline.js?v=20260402h"></script>
+<script defer src="render/brief.js?v=20260402h"></script>
+<script defer src="actions/pcs.js?v=20260402h"></script>
+<script src="07-post-load.js?v=20260402h" defer></script>
+<script src="08-post-actions.js?v=20260402h" defer></script>
+<script src="09-library.js?v=20260402h" defer></script>
+<script src="09-approval.js?v=20260402h" defer></script>
+<script src="04-router.js?v=20260402h" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/pipeline.js
+++ b/render/pipeline.js
@@ -624,17 +624,25 @@ window.executeBatchAction = async function(targetStage) {
     var count = ids.length;
     var stageLabel = targetStage === 'awaiting_approval'
       ? 'for approval' : 'for brand input';
-
-    await apiFetch('/notifications', {
-      method: 'POST',
-      body: JSON.stringify({
-        user_role: 'Admin',
-        post_id: null,
-        type: targetStage,
-        message: notifActor + ' sent ' + count + ' posts ' + stageLabel,
-        actor: notifActor,
-        read: false
-      })
+    var batchMsg = notifActor + ' sent ' + count + ' posts ' + stageLabel;
+    var batchRecipients = targetStage === 'awaiting_approval'
+      ? ['Client'] : ['Client'];
+    batchRecipients.forEach(function(name) {
+      var roleMap = { 'Admin': 'Admin', 'Chitra': 'Servicing', 'Pranav': 'Creative', 'Client': 'Client' };
+      apiFetch('/notifications', {
+        method: 'POST',
+        body: JSON.stringify({
+          user_role: roleMap[name] || name,
+          post_id: null,
+          type: targetStage,
+          message: batchMsg,
+          actor: notifActor,
+          read: false
+        })
+      }).catch(function(err) {
+        console.error('[batch-notif]', err);
+        window.logError && window.logError(err && err.message, err && err.stack, 'batch-stage-notif');
+      });
     });
 
     toggleBatchMode();

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -347,11 +347,11 @@ describe('No duplicate stage-change notifications from JS', function() {
     expect(hasNotifPost).toBe(false);
   });
 
-  it('08-post-actions.js has exactly 1 notification POST (new_request only)', function() {
+  it('08-post-actions.js has exactly 2 notification POSTs (new_request + _sendStageNotif helper)', function() {
     var matches = actionsSrc.match(/apiFetch\('\/notifications',\s*\{[\s\S]*?method:\s*'POST'/g);
-    // Should be exactly 1 -- the client request notification
+    // 1 = submitClientRequest new_request, 2 = _sendStageNotif helper
     expect(matches).not.toBeNull();
-    expect(matches.length).toBe(1);
+    expect(matches.length).toBe(2);
   });
 
   it('07-post-load.js has zero notification POSTs', function() {


### PR DESCRIPTION
## Summary
- Created `window._sendStageNotif()` helper in `08-post-actions.js` — maps recipient names (Admin/Chitra/Pranav/Client) to DB `user_role` values, sends one notification per recipient with `read: false` and `actor` field
- Added stage-change notifications to all 8 transition functions per product rules:
  - `brief`/`in_production` → notify Pranav (Creative)
  - `ready` → notify Chitra (Servicing)
  - `awaiting_approval`/`awaiting_brand_input` → notify Client
  - `scheduled` (client approved) → notify Admin + Chitra + Pranav
  - `published` → notify Admin + Chitra + Pranav + Client
- Fixed `executeBatchAction` in `render/pipeline.js` — was only notifying Admin, now notifies Client per stage rules
- Updated test to expect 2 notification POSTs in `08-post-actions.js` (new_request + helper)
- Bumped all 20 `?v=` to `20260402h`. CLAUDE.md updated.

## Test plan
- [x] `npx vitest run` — 297/297 passing
- [ ] Move post in_production → ready via PCS pill → Chitra gets notification
- [ ] Move post ready → awaiting_approval → Client gets notification
- [ ] Client approves → Admin + Chitra + Pranav get notification
- [ ] Publish post → all 4 roles get notification
- [ ] Batch send posts for approval → Client gets notification
- [ ] Verify no duplicate notifications on same stage change
- [ ] Purge Cloudflare cache after merge

https://claude.ai/code/session_01L36sxkaCFyuRobwRLAAkan