### PR TITLE
fix: pcsDateChange DOM crash + surface client comments for Chitra

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -181,21 +181,26 @@ async function loadPosts() {
     mergePosts(normalise(data));
     hideErrorBanner();
     scheduleRender();
-    // Fetch comment counts for all posts
-    apiFetch('/post_comments?select=post_id')
+    // Fetch comment counts + client comment timestamps for all posts
+    apiFetch('/post_comments?select=post_id,created_at,author_role&order=created_at.desc')
       .then(function(rows) {
         if (!Array.isArray(rows)) return;
         var counts = {};
+        var clientLatest = {};
         rows.forEach(function(r) {
           if (r.post_id) {
             counts[r.post_id] = (counts[r.post_id] || 0) + 1;
+            if (r.author_role === 'Client' && !clientLatest[r.post_id]) {
+              clientLatest[r.post_id] = r.created_at;
+            }
           }
         });
         (window.AppState.posts.all || []).forEach(function(p) {
           p._commentCount = counts[p.post_id] || 0;
+          p._clientCommentAt = clientLatest[p.post_id] || null;
         });
         scheduleRender();
-      }).catch(function(err){ console.error('[07-post-load] activity-log', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'activity-log-post'); });
+      }).catch(function(err){ console.error('[07-post-load] comment-counts', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'comment-counts'); });
     showToast(`${window.AppState.posts.all.length} posts loaded`, 'success');
   } catch (err) {
     console.error('loadPosts:', err);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260403b
+Version format: ?v=YYYYMMDDx. Current: ?v=20260403c
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -329,6 +329,8 @@ Pages branch:   main-/-root
 1. Client DB role takes absolute priority over pcs_role_preview
 1. Silent .catch(function(){}) is a bug — always use window.logError
 1. Vitest must pass 297/297 before every push
+1. Posts get _commentCount (int) and _clientCommentAt (ISO string or null)
+   after loadPosts() — these are runtime-enriched fields, not DB columns
 
 ## SECTION 11 — GLOBAL FUNCTIONS
 
@@ -468,6 +470,13 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
 1. Batch action removed Admin from notification recipients
    Location: render/pipeline.js executeBatchAction() — both branches returned ['Client'] only
    Status: FIXED (PR#639) — added 'Admin' to both branches
+1. _pcsDateChange DOM crash — activeMenu.remove() on detached element
+   Location: actions/pcs.js _pcsDateChange() — blur event detaches element before remove
+   Status: FIXED (PR#640) — added parentNode guard before remove()
+1. Client comments not surfaced for Chitra in pipeline
+   Location: 07-post-load.js comment fetch, render/pipeline.js COMMENTED group
+   Status: FIXED (PR#640) — enriched with _clientCommentAt, sorted by
+   recency, amber dot on cards with client comments
 1. LinkedIn URL not saving from publish dialog
    Location: actions/pcs.js ~lines 548-580
    Status: OPEN

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -494,7 +494,9 @@ window._pcsChipDrop = function(chipEl, field, postId) {
 // -- Date change from inline date picker --
 window._pcsDateChange = function(postId, dateValue) {
   if (window.AppState.pcs.activeMenu) {
-    window.AppState.pcs.activeMenu.remove();
+    if (window.AppState.pcs.activeMenu.parentNode) {
+      window.AppState.pcs.activeMenu.remove();
+    }
     window.AppState.pcs.activeMenu = null;
   }
   if (typeof updatePost === 'function') updatePost(postId, 'targetDate', dateValue);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260403b">
+ <link rel="stylesheet" href="styles.css?v=20260403c">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260403b"></script>
-<script src="00-appstate-compat.js?v=20260403b"></script>
-<script src="01-config.js?v=20260403b" defer></script>
-<script src="02-session.js?v=20260403b" defer></script>
-<script src="utils.js?v=20260403b" defer></script>
-<script src="03-auth.js?v=20260403b" defer></script>
-<script src="05-api.js?v=20260403b" defer></script>
-<script src="10-ui.js?v=20260403b" defer></script>
+<script src="00-appstate.js?v=20260403c"></script>
+<script src="00-appstate-compat.js?v=20260403c"></script>
+<script src="01-config.js?v=20260403c" defer></script>
+<script src="02-session.js?v=20260403c" defer></script>
+<script src="utils.js?v=20260403c" defer></script>
+<script src="03-auth.js?v=20260403c" defer></script>
+<script src="05-api.js?v=20260403c" defer></script>
+<script src="10-ui.js?v=20260403c" defer></script>
 
-<script src="06-post-create.js?v=20260403b" defer></script>
-<script defer src="render/dashboard.js?v=20260403b"></script>
-<script defer src="render/client.js?v=20260403b"></script>
-<script defer src="render/pipeline.js?v=20260403b"></script>
-<script defer src="render/brief.js?v=20260403b"></script>
-<script defer src="actions/pcs.js?v=20260403b"></script>
-<script src="07-post-load.js?v=20260403b" defer></script>
-<script src="08-post-actions.js?v=20260403b" defer></script>
-<script src="09-library.js?v=20260403b" defer></script>
-<script src="09-approval.js?v=20260403b" defer></script>
-<script src="04-router.js?v=20260403b" defer></script>
+<script src="06-post-create.js?v=20260403c" defer></script>
+<script defer src="render/dashboard.js?v=20260403c"></script>
+<script defer src="render/client.js?v=20260403c"></script>
+<script defer src="render/pipeline.js?v=20260403c"></script>
+<script defer src="render/brief.js?v=20260403c"></script>
+<script defer src="actions/pcs.js?v=20260403c"></script>
+<script src="07-post-load.js?v=20260403c" defer></script>
+<script src="08-post-actions.js?v=20260403c" defer></script>
+<script src="09-library.js?v=20260403c" defer></script>
+<script src="09-approval.js?v=20260403c" defer></script>
+<script src="04-router.js?v=20260403c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/pipeline.js
+++ b/render/pipeline.js
@@ -321,6 +321,11 @@ window.buildPipelineCard = function(p, listKey) {
       'background:#C8A84B;color:#000;font-weight:600;' +
       'padding:4px 8px;flex-shrink:0;">BRIEF</div>';
   } else if (_hasComments) {
+    var _hasClientComment = !!(p._clientCommentAt);
+    var _amberDot = _hasClientComment
+      ? '<span style="display:inline-block;width:6px;height:6px;' +
+        'background:#F6A623;vertical-align:super;margin-left:2px;"></span>'
+      : '';
     chipHtml =
       '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
       'letter-spacing:0.1em;text-transform:uppercase;' +
@@ -328,7 +333,7 @@ window.buildPipelineCard = function(p, listKey) {
       'color:#C8A84B;font-weight:600;' +
       'padding:3px 8px;flex-shrink:0;' +
       'display:flex;align-items:center;gap:4px;">' +
-      '&#x1F4AC; ' + _commentCount +
+      '&#x1F4AC; ' + _commentCount + _amberDot +
       '</div>';
   }
 
@@ -1149,6 +1154,12 @@ window._renderPipelineInner = function() {
     return (p._commentCount || 0) > 0;
   });
   commentedPosts = commentedPosts.slice().sort(function(a, b) {
+    // Client-commented posts first, sorted by most recent client comment
+    var aClient = a._clientCommentAt || '';
+    var bClient = b._clientCommentAt || '';
+    if (bClient && !aClient) return 1;
+    if (aClient && !bClient) return -1;
+    if (aClient && bClient) return bClient > aClient ? 1 : bClient < aClient ? -1 : 0;
     return (b._commentCount||0) - (a._commentCount||0);
   });
   var commentedHtml = '';


### PR DESCRIPTION
## Summary
- **actions/pcs.js**: `_pcsDateChange()` crashes with `NotFoundError` when blur event detaches the date dropdown before `onchange` fires — added `parentNode` guard before `.remove()`
- **07-post-load.js**: Enriched comment fetch with `created_at` + `author_role`, now tracks `_clientCommentAt` (latest client comment timestamp) per post
- **render/pipeline.js**: COMMENTED group now sorts client-commented posts first by recency (most recent at top); amber dot indicator on cards with client comments so Chitra can scan at a glance

All 20 `?v=` bumped to `20260403c`. CLAUDE.md updated. 297/297 tests passing.

## Test plan
- [ ] Open PCS, pick a date from the date chip — confirm no DOM crash, date saves correctly
- [ ] Rapidly tap date chip and close PCS — confirm no NotFoundError in error_log
- [ ] As Chitra, open pipeline — COMMENTED group should show posts with client comments first
- [ ] Posts with client comments should have amber dot next to 💬 chip
- [ ] Posts with only agency comments should appear below client-commented posts, no amber dot
- [ ] Hard refresh after Cloudflare purge — confirm ?v=20260403c loads

https://claude.ai/code/session_01W8b38ZFeHpW6CuwRomtXHm