### PR TITLE
route client requests to requests table instead of posts table

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -178,7 +178,34 @@ async function loadPosts() {
   try {
     const data = await apiFetch('/posts?select=*&order=id.desc');
     if (!_commitPostsResult(reqId, 'network')) return;
-    mergePosts(normalise(data));
+    // Fetch pending requests and merge as brief-stage entries
+    var reqData = [];
+    try {
+      var rawReqs = await apiFetch('/requests?status=eq.pending&order=created_at.desc');
+      if (Array.isArray(rawReqs)) {
+        reqData = rawReqs.map(function(r) {
+          return {
+            post_id: r.id,
+            id: r.id,
+            title: r.title || '',
+            stage: 'brief',
+            owner: 'Chitra',
+            client_feedback: r.description || '',
+            content_type: r.content_type || '',
+            target_date: r.target_date || '',
+            images: Array.isArray(r.images) ? r.images : [],
+            drive_link: r.drive_link || null,
+            created_at: r.created_at || '',
+            updated_at: r.created_at || '',
+            _isRequest: true
+          };
+        });
+      }
+    } catch (err) {
+      console.error('[post-load] requests fetch failed', err);
+      window.logError && window.logError(err && err.message, err && err.stack, 'load-requests');
+    }
+    mergePosts(normalise(data.concat(reqData)));
     hideErrorBanner();
     scheduleRender();
     // Fetch comment counts + client comment timestamps for all posts
@@ -239,6 +266,33 @@ async function loadPostsForClient() {
       ')&select=*&order=created_at.desc'
     );
     if (!_commitPostsResult(reqId, 'network')) return;
+
+    // Fetch pending requests for client view (shows as brief cards)
+    try {
+      var clientReqs = await apiFetch('/requests?status=eq.pending&order=created_at.desc');
+      if (Array.isArray(clientReqs)) {
+        clientReqs.forEach(function(r) {
+          data.push({
+            post_id: r.id,
+            id: r.id,
+            title: r.title || '',
+            stage: 'brief',
+            owner: 'Chitra',
+            client_feedback: r.description || '',
+            content_type: r.content_type || '',
+            target_date: r.target_date || '',
+            images: Array.isArray(r.images) ? r.images : [],
+            drive_link: r.drive_link || null,
+            created_at: r.created_at || '',
+            updated_at: r.created_at || '',
+            _isRequest: true
+          });
+        });
+      }
+    } catch (err) {
+      console.error('[post-load] client requests fetch failed', err);
+      window.logError && window.logError(err && err.message, err && err.stack, 'load-requests-client');
+    }
 
     var postIds = data.map(function(p) { return p.post_id || p.id; }).filter(Boolean);
     if (postIds.length) {

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -284,14 +284,14 @@ async function submitClientRequest() {
   if (btn) {
     btn.disabled = true;
     btn.style.color = '#444';
-    btn.style.borderColor = 'rgba(255,255,255,0.1)';
+    btn.style.borderColor = '#2a2a2a';
     btn.style.background = 'transparent';
     btn.style.boxShadow = 'none';
     btn.style.cursor = 'not-allowed';
     btn.innerHTML = 'Sending...';
   }
   try {
-    const postId = 'REQ-' + Date.now();
+    const reqId = 'REQ-' + Date.now();
     const email  = localStorage.getItem('hinglish_email') || 'Client';
     const reqDate = document.getElementById('req-date')?.value || null;
     var reqName = (document.getElementById('req-name') || {}).value || '';
@@ -300,54 +300,46 @@ async function submitClientRequest() {
       now.toLocaleDateString('en-IN', { day:'numeric', month:'short', timeZone:'Asia/Kolkata' }) +
       ' - ' +
       now.toLocaleTimeString('en-IN', { hour:'numeric', minute:'2-digit', timeZone:'Asia/Kolkata' });
-    const payload = {
-      post_id:     postId,
-      title:       reqName.trim() || fallbackTitle,
-      stage:       'brief',
-      owner:       'Chitra',
-      client_feedback: brief,
-      target_date: reqDate,
-      created_at:  new Date().toISOString(),
-      updated_at:  new Date().toISOString(),
-    };
+
     // Read selected content type chip
     var selectedChip = document.querySelector(
-      '#req-overlay button[style*="rgb(200, 168, 75)"]'
+      '#req-overlay button[data-action="reqChip"][style*="rgb(200, 168, 75)"]'
     );
-    if (selectedChip) {
-      payload.client_feedback = (payload.client_feedback || '') +
-        ' [Type: ' + selectedChip.textContent.trim() + ']';
-    }
-    // Read urgency
-    var urgentBtn = document.getElementById('req-urgency-urgent');
-    var isUrgent = urgentBtn &&
-      urgentBtn.style.color === 'rgb(255, 75, 75)';
-    if (isUrgent) {
-      payload.client_feedback = '[URGENT] ' + (payload.client_feedback || '');
-    }
+    var contentType = selectedChip ? selectedChip.textContent.trim() : null;
+
     var imageUrls = [];
     if (files.length) {
       imageUrls = await Promise.all(
-        files.map(function(f) { return uploadPostAsset(f, postId); })
+        files.map(function(f) { return uploadPostAsset(f, reqId); })
       );
     }
-    if (imageUrls.length) {
-      payload.images = imageUrls;
-    }
+
+    const payload = {
+      id:           reqId,
+      title:        reqName.trim() || fallbackTitle,
+      description:  brief,
+      content_type: contentType,
+      target_date:  reqDate,
+      images:       imageUrls.length ? imageUrls : [],
+      drive_link:   window._reqDriveLink || null,
+      created_by:   window.AppState.user.name || window.AppState.user.email || email,
+      status:       'pending'
+    };
+
     console.log('[REQUEST] PAYLOAD:', payload);
-    await apiFetch('/posts', {
+    await apiFetch('/requests', {
       method: 'POST',
       body: JSON.stringify(payload),
     });
     console.log('[REQUEST] API SUCCESS');
-    await logActivity({ post_id: postId, actor: email, actor_role: 'Client', action: 'New request: ' + brief.substring(0, 60) });
+    await logActivity({ post_id: reqId, actor: email, actor_role: 'Client', action: 'New request: ' + brief.substring(0, 60) });
     var _reqTitle = (document.getElementById('req-name') || {}).value ||
       'New request';
     await apiFetch('/notifications', {
       method: 'POST',
       body: JSON.stringify({
         user_role: 'Servicing',
-        post_id: postId,
+        post_id: reqId,
         type: 'new_request',
         message: (window.AppState.user.name || 'Client') + ' submitted a new request: ' + _reqTitle,
         actor: window.AppState.user.name || window.currentUserName || 'Client',
@@ -393,7 +385,6 @@ async function submitClientRequest() {
     if (btn) {
       btn.disabled = false;
       btn.textContent = '-- SEND REQUEST';
-      btn.style.opacity = '1';
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260403d
+Version format: ?v=YYYYMMDDx. Current: ?v=20260403e
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -161,8 +161,14 @@ PURPOSE: Controls who has access and what role they have.
 
 requests: id(text PK), title(text), description(text),
 created_by(text), created_at(timestamp), status(text),
-content_type(text), target_date(date), images(jsonb)
+content_type(text), target_date(date), images(jsonb),
+drive_link(text)
 PURPOSE: Client brief requests submitted via the New Request form.
+Now the PRIMARY destination for client submissions (was posts table).
+Status values: pending → assigned → closed.
+On assign, Chitra creates a new post linked to the request.
+Entries with status=pending are fetched by loadPosts() and merged
+into AppState.posts.all with _isRequest:true flag.
 RLS: UNRESTRICTED
 
 post_comment_reactions: id(uuid PK), comment_id(uuid), post_id(text),
@@ -331,6 +337,9 @@ Pages branch:   main-/-root
 1. Vitest must pass 297/297 before every push
 1. Posts get _commentCount (int) and _clientCommentAt (ISO string or null)
    after loadPosts() — these are runtime-enriched fields, not DB columns
+1. Requests from requests table get _isRequest:true flag after loadPosts().
+   Brief sheet, assign, close, and reopen all check this flag to route
+   API calls to /requests instead of /posts. Do not remove this flag.
 
 ## SECTION 11 — GLOBAL FUNCTIONS
 
@@ -493,6 +502,14 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Status: FIXED (PR#TBD) — all rgba replaced with hex, single-select
    chips, max 5 photos / 5MB limit, auto-grow textarea, field 01 numbered,
    drive link field added (unwired to DB), button styles updated
+1. Client requests writing to posts table instead of requests table
+   Location: 08-post-actions.js submitClientRequest()
+   Status: FIXED (PR#TBD) — now writes to requests table with proper
+   columns (id, title, description, content_type, target_date, images,
+   drive_link, created_by, status). loadPosts() fetches pending requests
+   and merges into AppState with _isRequest:true flag. Brief sheet reads
+   content_type and drive_link as direct fields. Assign creates a new
+   post linked to the request. Close/reopen patches requests table.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260403d">
+ <link rel="stylesheet" href="styles.css?v=20260403e">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260403d"></script>
-<script src="00-appstate-compat.js?v=20260403d"></script>
-<script src="01-config.js?v=20260403d" defer></script>
-<script src="02-session.js?v=20260403d" defer></script>
-<script src="utils.js?v=20260403d" defer></script>
-<script src="03-auth.js?v=20260403d" defer></script>
-<script src="05-api.js?v=20260403d" defer></script>
-<script src="10-ui.js?v=20260403d" defer></script>
+<script src="00-appstate.js?v=20260403e"></script>
+<script src="00-appstate-compat.js?v=20260403e"></script>
+<script src="01-config.js?v=20260403e" defer></script>
+<script src="02-session.js?v=20260403e" defer></script>
+<script src="utils.js?v=20260403e" defer></script>
+<script src="03-auth.js?v=20260403e" defer></script>
+<script src="05-api.js?v=20260403e" defer></script>
+<script src="10-ui.js?v=20260403e" defer></script>
 
-<script src="06-post-create.js?v=20260403d" defer></script>
-<script defer src="render/dashboard.js?v=20260403d"></script>
-<script defer src="render/client.js?v=20260403d"></script>
-<script defer src="render/pipeline.js?v=20260403d"></script>
-<script defer src="render/brief.js?v=20260403d"></script>
-<script defer src="actions/pcs.js?v=20260403d"></script>
-<script src="07-post-load.js?v=20260403d" defer></script>
-<script src="08-post-actions.js?v=20260403d" defer></script>
-<script src="09-library.js?v=20260403d" defer></script>
-<script src="09-approval.js?v=20260403d" defer></script>
-<script src="04-router.js?v=20260403d" defer></script>
+<script src="06-post-create.js?v=20260403e" defer></script>
+<script defer src="render/dashboard.js?v=20260403e"></script>
+<script defer src="render/client.js?v=20260403e"></script>
+<script defer src="render/pipeline.js?v=20260403e"></script>
+<script defer src="render/brief.js?v=20260403e"></script>
+<script defer src="actions/pcs.js?v=20260403e"></script>
+<script src="07-post-load.js?v=20260403e" defer></script>
+<script src="08-post-actions.js?v=20260403e" defer></script>
+<script src="09-library.js?v=20260403e" defer></script>
+<script src="09-approval.js?v=20260403e" defer></script>
+<script src="04-router.js?v=20260403e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -36,19 +36,28 @@ window._openBriefSheet = function(postId) {
 
   var rawComments = post.client_feedback || post.description || '';
   var contentType = '';
-  var typeMatch = rawComments.match(/\[Type:\s*([^\]]+)\]/);
-  if (typeMatch) {
-    contentType = typeMatch[1].trim();
-    rawComments = rawComments.replace(/\s*\[Type:[^\]]+\]/, '').trim();
-  }
-  var briefText = rawComments;
-  briefText = briefText.replace(/^\[URGENT\]\s*/, '').trim();
-
   var chitraNote = '';
-  var chitraMatch = briefText.match(/\[CHITRA NOTE\]([\s\S]*)/i);
-  if (chitraMatch) {
-    chitraNote = chitraMatch[1].trim();
-    briefText = briefText.replace(/\[CHITRA NOTE\][\s\S]*/i, '').trim();
+  var briefText = '';
+
+  if (post._isRequest) {
+    // Request from requests table — fields are direct, no string parsing
+    contentType = post.content_type || '';
+    briefText = rawComments;
+  } else {
+    // Legacy post — parse [Type:], [URGENT], [CHITRA NOTE] from client_feedback
+    var typeMatch = rawComments.match(/\[Type:\s*([^\]]+)\]/);
+    if (typeMatch) {
+      contentType = typeMatch[1].trim();
+      rawComments = rawComments.replace(/\s*\[Type:[^\]]+\]/, '').trim();
+    }
+    briefText = rawComments;
+    briefText = briefText.replace(/^\[URGENT\]\s*/, '').trim();
+
+    var chitraMatch = briefText.match(/\[CHITRA NOTE\]([\s\S]*)/i);
+    if (chitraMatch) {
+      chitraNote = chitraMatch[1].trim();
+      briefText = briefText.replace(/\[CHITRA NOTE\][\s\S]*/i, '').trim();
+    }
   }
 
   var _isAssignedToPranav =
@@ -177,6 +186,19 @@ window._openBriefSheet = function(postId) {
         'display:block;cursor:pointer;">';
       }).join('') +
       '</div></div>'
+      : '') +
+
+    // Drive link (from requests table)
+    (post.drive_link ?
+      '<div style="padding:0 18px 24px;">' +
+      '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
+      'letter-spacing:0.1em;text-transform:uppercase;' +
+      'color:#8E8E93;margin-bottom:6px;">Drive Link</div>' +
+      '<a href="' + esc(post.drive_link) + '" target="_blank" rel="noopener" ' +
+      'style="font-family:\'DM Sans\',sans-serif;font-size:13px;' +
+      'color:#3ECF8E;word-break:break-all;text-decoration:none;">' +
+      esc(post.drive_link) + '</a>' +
+      '</div>'
       : '') +
 
     // Role-based bottom action (state machine)
@@ -313,7 +335,77 @@ window._openBriefSheet = function(postId) {
 window._assignBriefToPranav = function(postId) {
   var direction = (document.getElementById('brief-direction-' + postId) || {}).value || '';
   var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
-  var updatedFeedback = (post ? (post.client_feedback || '') : '');
+  if (!post) return;
+
+  if (post._isRequest) {
+    // Request from requests table: mark assigned, then create a new post
+    var nowISO = new Date().toISOString();
+    var updatedFeedback = (post.client_feedback || '');
+    if (direction.trim()) {
+      updatedFeedback += '\n\n[CHITRA NOTE] ' + direction.trim();
+    }
+    var newPostId = 'POST-' + Date.now();
+    // 1. PATCH request status to assigned
+    apiFetch('/requests?id=eq.' + encodeURIComponent(postId), {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'assigned', updated_at: nowISO })
+    }).then(function() {
+      // 2. Create new post linked to this request
+      return apiFetch('/posts', {
+        method: 'POST',
+        body: JSON.stringify({
+          post_id: newPostId,
+          title: post.title || '',
+          stage: 'brief',
+          owner: 'Pranav',
+          client_feedback: updatedFeedback,
+          target_date: post.target_date || null,
+          images: post.images || [],
+          linked_post_id: post.post_id,
+          created_at: nowISO,
+          updated_at: nowISO
+        })
+      });
+    }).then(function() {
+      logActivity({
+        post_id: newPostId,
+        actor: 'Chitra',
+        actor_role: 'Servicing',
+        action: 'Brief assigned to Pranav' +
+          (direction.trim() ? ' with direction' : '')
+      });
+      // Update AppState: remove request entry, add new post
+      var filtered = (window.AppState.posts.all || []).filter(function(p) {
+        return (p.post_id || p.id) !== postId;
+      });
+      filtered.push({
+        post_id: newPostId,
+        id: newPostId,
+        title: post.title || '',
+        stage: 'brief',
+        owner: 'Pranav',
+        client_feedback: updatedFeedback,
+        target_date: post.target_date || null,
+        images: post.images || [],
+        linked_post_id: post.post_id,
+        created_at: nowISO,
+        updated_at: nowISO
+      });
+      window.AppState.posts.setAll(filtered);
+      document.getElementById('brief-sheet-overlay').remove();
+      document.body.style.overflow = '';
+      showToast('Assigned to Pranav', 'success');
+      if (typeof scheduleRender === 'function') scheduleRender();
+    }).catch(function(err) {
+      console.error('[brief] assign request to Pranav failed', err);
+      window.logError && window.logError(err && err.message, err && err.stack, 'assign-request-pranav');
+      showToast('Failed - try again', 'error');
+    });
+    return;
+  }
+
+  // Existing posts flow — PATCH the post directly
+  var updatedFeedback = (post.client_feedback || '');
   if (direction.trim()) {
     updatedFeedback += '\n\n[CHITRA NOTE] ' + direction.trim();
   }
@@ -392,6 +484,35 @@ window._closeBrief = function(postId) {
   document.getElementById('brief-confirm-overlay') &&
     document.getElementById('brief-confirm-overlay').remove();
 
+  var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
+
+  if (post && post._isRequest) {
+    // Request from requests table — PATCH status to closed
+    apiFetch('/requests?id=eq.' + encodeURIComponent(postId), {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'closed' })
+    }).then(function() {
+      // Update AppState — change stage to brief_done
+      var updated = (window.AppState.posts.all || []).map(function(p) {
+        if ((p.post_id || p.id) === postId) {
+          return Object.assign({}, p, { stage: 'brief_done' });
+        }
+        return p;
+      });
+      window.AppState.posts.setAll(updated);
+      var overlay = document.getElementById('brief-sheet-overlay');
+      if (overlay) overlay.remove();
+      document.body.style.overflow = '';
+      showToast('Brief closed', 'success');
+      if (typeof scheduleRender === 'function') scheduleRender();
+    }).catch(function(err) {
+      console.error('[brief] close request failed', err);
+      window.logError && window.logError(err && err.message, err && err.stack, 'close-request');
+      showToast('Failed - try again', 'error');
+    });
+    return;
+  }
+
   apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
     method: 'PATCH',
     body: JSON.stringify({
@@ -412,6 +533,35 @@ window._closeBrief = function(postId) {
 }
 
 window._reopenBrief = function(postId) {
+  var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
+
+  if (post && post._isRequest) {
+    // Request from requests table — PATCH status back to pending
+    apiFetch('/requests?id=eq.' + encodeURIComponent(postId), {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'pending' })
+    }).then(function() {
+      // Update AppState — change stage back to brief
+      var updated = (window.AppState.posts.all || []).map(function(p) {
+        if ((p.post_id || p.id) === postId) {
+          return Object.assign({}, p, { stage: 'brief' });
+        }
+        return p;
+      });
+      window.AppState.posts.setAll(updated);
+      var overlay = document.getElementById('brief-sheet-overlay');
+      if (overlay) overlay.remove();
+      document.body.style.overflow = '';
+      showToast('Brief reopened', 'success');
+      if (typeof scheduleRender === 'function') scheduleRender();
+    }).catch(function(err) {
+      console.error('[brief] reopen request failed', err);
+      window.logError && window.logError(err && err.message, err && err.stack, 'reopen-request');
+      showToast('Failed - try again', 'error');
+    });
+    return;
+  }
+
   apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
     method: 'PATCH',
     body: JSON.stringify({


### PR DESCRIPTION
- submitClientRequest() now POSTs to /requests with proper columns: id, title, description, content_type, target_date, images, drive_link, created_by, status (pending)
- Remove [Type:] and [URGENT] string manipulation — each field has its own column now
- loadPosts() and loadPostsForClient() fetch pending requests and merge into AppState.posts.all with _isRequest:true flag
- _openBriefSheet() reads content_type and drive_link as direct fields when _isRequest is true (no string parsing)
- Drive link shown as tappable green link in brief sheet
- _assignBriefToPranav(): for requests, PATCHes request status to assigned, then creates a new post linked to the request
- _closeBrief()/_reopenBrief(): for requests, PATCHes request status to closed/pending instead of posts table
- Fix rgba in submit button disabled state (#2a2a2a)
- Bump ?v= to 20260403e
- Update CLAUDE.md: requests table schema with drive_link column, _isRequest flag documented in gotchas

https://claude.ai/code/session_0162LC83ocusRuPFv3zY3f7J