### PR TITLE
Add normalizeRole() — Phase A of role standardization

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -4,6 +4,23 @@
 =============================================== */
 console.log("LOADED:", "03-auth.js");
 
+function normalizeRole(r) {
+  if (!r) return null;
+  var map = {
+    pranav: 'Creative',
+    chitra: 'Servicing',
+    shubham: 'Admin',
+    manisha: 'Client',
+    shivangini: 'Client',
+    creative: 'Creative',
+    servicing: 'Servicing',
+    admin: 'Admin',
+    client: 'Client'
+  };
+  return map[String(r).toLowerCase()] || r;
+}
+window.normalizeRole = normalizeRole;
+
 function _normaliseRole(r) {
   if (!r) return 'Admin';
   var map = {
@@ -165,11 +182,12 @@ async function resolveRoleFromToken(accessToken, email) {
     if (userName) window.AppState.user.name = userName;
     if (userName) localStorage.setItem('hinglish_name', userName);
     window.AppState.user.email = email;
-    localStorage.setItem('hinglish_role', role);
+    var normalizedRole = normalizeRole(role) || role;
+    localStorage.setItem('hinglish_role', normalizedRole);
     localStorage.setItem('hinglish_email', email);
     const overlay = document.getElementById('login-overlay');
     if (overlay) overlay.classList.add('hidden');
-    activateRole(role);
+    activateRole(normalizedRole);
   } catch (err) {
     console.error('[auth] resolveRoleFromToken failed', err);
     window.logError && window.logError(err && err.message, err && err.stack, 'resolve-role-token');
@@ -216,6 +234,7 @@ function logout() {
 }
 
 function activateRole(role) {
+  role = normalizeRole(role) || role;
   // Clear stale preview role for non-admin users
   var _dbRole = (role || '').toLowerCase();
   if (_dbRole !== 'admin') {

--- a/10-ui.js
+++ b/10-ui.js
@@ -130,6 +130,7 @@ function closeUserMenu() {
 
 // -- Global Admin Menu -------------------------
 function gamSwitchRole(role) {
+  role = typeof normalizeRole === 'function' ? (normalizeRole(role) || role) : role;
   if (role === 'Admin') {
     localStorage.removeItem('pcs_role_preview');
   } else {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,12 @@ Repo: github.com/Guneygaar/guneygaar.github.io
 Branch: main-/-root. Deployed at srtd.io.
 ALL files at REPO ROOT. No /sorted/ subdirectory. Never reference /sorted/.
 Subdirs: render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ ok/ no/ preview/ mockups/
+Root files: rollback.sql — DB rollback for role standardization (run if production breaks)
 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260403g
+Version format: ?v=YYYYMMDDx. Current: ?v=20260403j
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -258,7 +259,7 @@ E2E: npx playwright test
 
 Current (verified 2026-04-03):
 Unit test files: 13
-Unit tests:      297 passing, 0 failing
+Unit tests:      316 passing, 0 failing
 E2E specs:       7
 
 Files:
@@ -334,7 +335,7 @@ Pages branch:   main-/-root
 1. 15-second poll interval, 50-minute token refresh
 1. Client DB role takes absolute priority over pcs_role_preview
 1. Silent .catch(function(){}) is a bug — always use window.logError
-1. Vitest must pass 297/297 before every push
+1. Vitest must pass 316/316 before every push
 1. Posts get _commentCount (int) and _clientCommentAt (ISO string or null)
    after loadPosts() — these are runtime-enriched fields, not DB columns
 1. Requests from requests table get _isRequest:true flag after loadPosts().
@@ -352,6 +353,7 @@ window.onunhandledrejection — global promise rejection handler → logError
 window._showErrorToast      — show transient error toast to user
 
 03-auth.js:
+window.normalizeRole        — canonical role normalizer (person names → DB roles)
 window.sendMagicLink        — send OTP email to user
 window.verifyOTPCode        — verify OTP and set session
 window.resetRolePreview     — clear role preview, restore Admin
@@ -517,6 +519,7 @@ Ph0 Safety            — DONE
 Ph1 File Architecture — DONE (render/ + actions/ extracted)
 Ph2 AppState          — DONE (all globals migrated)
 Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast, Pass 5 dashboard — 4 fixes + 1 post-load fix, Pass 6 post-load — 12 fixes + 4 duplicate function overwrites fixed, Pass 7 auth — 6 fixes incl. silent refreshSession catch)
+Ph3.5 Role Standardization — IN PROGRESS (Phase A: normalizeRole() added, rollback.sql created)
 Ph4 Event Delegation  — PENDING
 Ph5 Optimistic UI     — IN PROGRESS (client comments done)
 Ph6 PWA               — PENDING

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260403g">
+ <link rel="stylesheet" href="styles.css?v=20260403j">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260403g"></script>
-<script src="00-appstate-compat.js?v=20260403g"></script>
-<script src="01-config.js?v=20260403g" defer></script>
-<script src="02-session.js?v=20260403g" defer></script>
-<script src="utils.js?v=20260403g" defer></script>
-<script src="03-auth.js?v=20260403g" defer></script>
-<script src="05-api.js?v=20260403g" defer></script>
-<script src="10-ui.js?v=20260403g" defer></script>
+<script src="00-appstate.js?v=20260403j"></script>
+<script src="00-appstate-compat.js?v=20260403j"></script>
+<script src="01-config.js?v=20260403j" defer></script>
+<script src="02-session.js?v=20260403j" defer></script>
+<script src="utils.js?v=20260403j" defer></script>
+<script src="03-auth.js?v=20260403j" defer></script>
+<script src="05-api.js?v=20260403j" defer></script>
+<script src="10-ui.js?v=20260403j" defer></script>
 
-<script src="06-post-create.js?v=20260403g" defer></script>
-<script defer src="render/dashboard.js?v=20260403g"></script>
-<script defer src="render/client.js?v=20260403g"></script>
-<script defer src="render/pipeline.js?v=20260403g"></script>
-<script defer src="render/brief.js?v=20260403g"></script>
-<script defer src="actions/pcs.js?v=20260403g"></script>
-<script src="07-post-load.js?v=20260403g" defer></script>
-<script src="08-post-actions.js?v=20260403g" defer></script>
-<script src="09-library.js?v=20260403g" defer></script>
-<script src="09-approval.js?v=20260403g" defer></script>
-<script src="04-router.js?v=20260403g" defer></script>
+<script src="06-post-create.js?v=20260403j" defer></script>
+<script defer src="render/dashboard.js?v=20260403j"></script>
+<script defer src="render/client.js?v=20260403j"></script>
+<script defer src="render/pipeline.js?v=20260403j"></script>
+<script defer src="render/brief.js?v=20260403j"></script>
+<script defer src="actions/pcs.js?v=20260403j"></script>
+<script src="07-post-load.js?v=20260403j" defer></script>
+<script src="08-post-actions.js?v=20260403j" defer></script>
+<script src="09-library.js?v=20260403j" defer></script>
+<script src="09-approval.js?v=20260403j" defer></script>
+<script src="04-router.js?v=20260403j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/rollback.sql
+++ b/rollback.sql
@@ -1,0 +1,22 @@
+-- ROLLBACK: Role standardization (run if production breaks)
+-- Reverts DB to person-name based owner values
+
+-- Step 1: Drop new constraints
+ALTER TABLE posts DROP CONSTRAINT IF EXISTS posts_owner_check;
+ALTER TABLE notifications DROP CONSTRAINT IF EXISTS valid_roles;
+
+-- Step 2: Revert posts.owner
+UPDATE posts SET owner = 'Pranav' WHERE owner = 'Creative';
+UPDATE posts SET owner = 'Chitra' WHERE owner = 'Servicing';
+
+-- Step 3: Revert notifications.user_role
+UPDATE notifications SET user_role = 'Pranav' WHERE user_role = 'Creative';
+UPDATE notifications SET user_role = 'Chitra' WHERE user_role = 'Servicing';
+
+-- Step 4: Restore old constraints
+ALTER TABLE posts ADD CONSTRAINT owner_check
+CHECK (owner = ANY (ARRAY['Pranav'::text, 'Chitra'::text, 'Client'::text]));
+ALTER TABLE notifications ADD CONSTRAINT valid_roles
+CHECK (user_role = ANY (ARRAY['Admin'::text, 'Pranav'::text, 'Chitra'::text, 'Servicing'::text, 'Client'::text]));
+
+-- End rollback

--- a/tests/role.test.js
+++ b/tests/role.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-// Load 03-auth.js and extract _normaliseRole
+// Load 03-auth.js and extract _normaliseRole + normalizeRole
 const authSrc = readFileSync(resolve(__dirname, '..', '03-auth.js'), 'utf8');
 
 function loadNormaliseRole() {
@@ -12,7 +12,15 @@ function loadNormaliseRole() {
   return fn();
 }
 
+function loadNormalizeRole() {
+  const match = authSrc.match(/function normalizeRole\(r\)\s*\{[\s\S]*?\n\}/);
+  if (!match) throw new Error('Could not find normalizeRole function');
+  const fn = new Function(match[0] + '\n return normalizeRole;');
+  return fn();
+}
+
 const _normaliseRole = loadNormaliseRole();
+const normalizeRole = loadNormalizeRole();
 
 // Role detection helpers — inline pure logic matching codebase patterns
 function isPranav(role) {
@@ -127,5 +135,84 @@ describe('isClient', () => {
 
   it("'admin' -> false", () => {
     expect(isClient('admin')).toBe(false);
+  });
+});
+
+// normalizeRole — maps person names to canonical DB roles
+describe('normalizeRole', () => {
+  it("null -> null", () => {
+    expect(normalizeRole(null)).toBe(null);
+  });
+
+  it("undefined -> null", () => {
+    expect(normalizeRole(undefined)).toBe(null);
+  });
+
+  it("'pranav' -> 'Creative'", () => {
+    expect(normalizeRole('pranav')).toBe('Creative');
+  });
+
+  it("'Pranav' -> 'Creative'", () => {
+    expect(normalizeRole('Pranav')).toBe('Creative');
+  });
+
+  it("'chitra' -> 'Servicing'", () => {
+    expect(normalizeRole('chitra')).toBe('Servicing');
+  });
+
+  it("'Chitra' -> 'Servicing'", () => {
+    expect(normalizeRole('Chitra')).toBe('Servicing');
+  });
+
+  it("'shubham' -> 'Admin'", () => {
+    expect(normalizeRole('shubham')).toBe('Admin');
+  });
+
+  it("'Shubham' -> 'Admin'", () => {
+    expect(normalizeRole('Shubham')).toBe('Admin');
+  });
+
+  it("'manisha' -> 'Client'", () => {
+    expect(normalizeRole('manisha')).toBe('Client');
+  });
+
+  it("'shivangini' -> 'Client'", () => {
+    expect(normalizeRole('shivangini')).toBe('Client');
+  });
+
+  it("'creative' -> 'Creative'", () => {
+    expect(normalizeRole('creative')).toBe('Creative');
+  });
+
+  it("'Creative' -> 'Creative'", () => {
+    expect(normalizeRole('Creative')).toBe('Creative');
+  });
+
+  it("'servicing' -> 'Servicing'", () => {
+    expect(normalizeRole('servicing')).toBe('Servicing');
+  });
+
+  it("'admin' -> 'Admin'", () => {
+    expect(normalizeRole('admin')).toBe('Admin');
+  });
+
+  it("'Admin' -> 'Admin'", () => {
+    expect(normalizeRole('Admin')).toBe('Admin');
+  });
+
+  it("'client' -> 'Client'", () => {
+    expect(normalizeRole('client')).toBe('Client');
+  });
+
+  it("'Client' -> 'Client'", () => {
+    expect(normalizeRole('Client')).toBe('Client');
+  });
+
+  it("unknown role passes through unchanged", () => {
+    expect(normalizeRole('SuperAdmin')).toBe('SuperAdmin');
+  });
+
+  it("normalizeRole is exported on window in source", () => {
+    expect(authSrc).toContain('window.normalizeRole = normalizeRole');
   });
 });


### PR DESCRIPTION
- Add normalizeRole() to 03-auth.js: maps person names (Pranav, Chitra, Shubham, Manisha, Shivangini) to canonical DB roles (Creative, Servicing, Admin, Client). Exported on window.normalizeRole.
- Wrap all role entry points: resolveRoleFromToken(), activateRole(), gamSwitchRole() now pass through normalizeRole() before use.
- Create rollback.sql at repo root for emergency DB revert.
- Add 19 new tests for normalizeRole() in tests/role.test.js (316 total).
- Bump all 20 ?v= strings to 20260403j.
- Update CLAUDE.md: new function, test count, version, roadmap.

https://claude.ai/code/session_01NmYun6ABE1KWXPce2tDNd1