### PR TITLE
Allow comment authors to delete their own comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260403j
+Version format: ?v=YYYYMMDDx. Current: ?v=20260403l
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -512,6 +512,11 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    and merges into AppState with _isRequest:true flag. Brief sheet reads
    content_type and drive_link as direct fields. Assign creates a new
    post linked to the request. Close/reopen patches requests table.
+1. Comment delete restricted to Admin only — authors cannot delete own comments
+   Location: actions/pcs.js lines 952 and 1040 — delete button render
+   condition was (_roleLower === 'admin') only
+   Status: FIXED (PR#TBD) — changed to (c.author === _name || _roleLower === 'admin')
+   so comment authors can delete their own comments, Admin can delete any
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -949,7 +949,7 @@ window.loadPcsComments = async function(postId) {
             _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
             _imgHtml +
             '<div class="pcs-comment-actions">' +
-            (_roleLower === 'admin' ?
+            (c.author === _name || _roleLower === 'admin' ?
               '<span class="pcs-comment-action pcs-comment-delete-btn" ' +
               'onclick="window._pcsConfirmDeleteComment(\'' +
               esc(c.id) + '\',\'' + esc(postId) + '\')">DELETE</span>'
@@ -1037,7 +1037,7 @@ window.loadPcsComments = async function(postId) {
             _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
             _imgHtml +
             '<div class="pcs-comment-actions">' +
-            (_roleLower === 'admin' ?
+            (c.author === _name || _roleLower === 'admin' ?
               '<span class="pcs-comment-action pcs-comment-delete-btn" ' +
               'onclick="window._pcsConfirmDeleteComment(\'' +
               esc(c.id) + '\',\'' + esc(postId) + '\',true)">DELETE</span>'

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260403j">
+ <link rel="stylesheet" href="styles.css?v=20260403l">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260403j"></script>
-<script src="00-appstate-compat.js?v=20260403j"></script>
-<script src="01-config.js?v=20260403j" defer></script>
-<script src="02-session.js?v=20260403j" defer></script>
-<script src="utils.js?v=20260403j" defer></script>
-<script src="03-auth.js?v=20260403j" defer></script>
-<script src="05-api.js?v=20260403j" defer></script>
-<script src="10-ui.js?v=20260403j" defer></script>
+<script src="00-appstate.js?v=20260403l"></script>
+<script src="00-appstate-compat.js?v=20260403l"></script>
+<script src="01-config.js?v=20260403l" defer></script>
+<script src="02-session.js?v=20260403l" defer></script>
+<script src="utils.js?v=20260403l" defer></script>
+<script src="03-auth.js?v=20260403l" defer></script>
+<script src="05-api.js?v=20260403l" defer></script>
+<script src="10-ui.js?v=20260403l" defer></script>
 
-<script src="06-post-create.js?v=20260403j" defer></script>
-<script defer src="render/dashboard.js?v=20260403j"></script>
-<script defer src="render/client.js?v=20260403j"></script>
-<script defer src="render/pipeline.js?v=20260403j"></script>
-<script defer src="render/brief.js?v=20260403j"></script>
-<script defer src="actions/pcs.js?v=20260403j"></script>
-<script src="07-post-load.js?v=20260403j" defer></script>
-<script src="08-post-actions.js?v=20260403j" defer></script>
-<script src="09-library.js?v=20260403j" defer></script>
-<script src="09-approval.js?v=20260403j" defer></script>
-<script src="04-router.js?v=20260403j" defer></script>
+<script src="06-post-create.js?v=20260403l" defer></script>
+<script defer src="render/dashboard.js?v=20260403l"></script>
+<script defer src="render/client.js?v=20260403l"></script>
+<script defer src="render/pipeline.js?v=20260403l"></script>
+<script defer src="render/brief.js?v=20260403l"></script>
+<script defer src="actions/pcs.js?v=20260403l"></script>
+<script src="07-post-load.js?v=20260403l" defer></script>
+<script src="08-post-actions.js?v=20260403l" defer></script>
+<script src="09-library.js?v=20260403l" defer></script>
+<script src="09-approval.js?v=20260403l" defer></script>
+<script src="04-router.js?v=20260403l" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- Change delete button render condition in PCS from Admin-only to author-or-Admin
- Two locations: client comments (line 952) and internal notes (line 1040)
- Condition changed from `(_roleLower === 'admin')` to `(c.author === _name || _roleLower === 'admin')`
- No changes to `_pcsDoDeleteComment()` or `_pcsConfirmDeleteComment()` — already correct
- No delete button exists in client feed (`render/client.js`) — confirmed, none added
- Includes normalizeRole() from Phase A (prior commit on same branch)

## What this enables

- Admin can delete any comment ✅
- Any user can delete their own comment ✅
- Nobody can delete someone else's comment ✅

## Test plan

- [x] `npx vitest run` passes 316/316
- [x] All 20 `?v=` strings bumped to `20260403l`
- [x] CLAUDE.md updated with bug fix entry
- [ ] Manual: login as Pranav, post a comment, verify DELETE button appears on own comment
- [ ] Manual: login as Pranav, verify DELETE button does NOT appear on others' comments
- [ ] Manual: login as Admin, verify DELETE button appears on all comments

https://claude.ai/code/session_01NmYun6ABE1KWXPce2tDNd1