### PR TITLE
Wire cut: config and notification targets use DB roles

### DIFF
--- a/01-config.js
+++ b/01-config.js
@@ -161,8 +161,6 @@ const ROLE_TABS = {
   'Admin':     _FULL_TABS,
   'Servicing': _FULL_TABS,
   'Creative':  _FULL_TABS,
-  'Pranav':    _FULL_TABS,
-  'Chitra':    _FULL_TABS,
   'Client':    _FULL_TABS,
 };
 
@@ -199,7 +197,7 @@ const STRIP_STAGES = [
 ];
 
 // Canonical owner list  -  used by dropdowns, validation, and grid
-const ALLOWED_OWNERS = ['Pranav', 'Chitra', 'Client'];
+const ALLOWED_OWNERS = ['Creative', 'Servicing', 'Client', 'Admin'];
 
 // -- Stage change interceptor  -  logs every .stage mutation --
 function setStage(post, newStage, source) {

--- a/03-auth.js
+++ b/03-auth.js
@@ -353,7 +353,7 @@ function _buildUserMenu() {
   if (window.AppState.user.role === 'Admin' ||
       localStorage.getItem('hinglish_role') === 'Admin' ||
       localStorage.getItem('hinglish_role') === 'admin') {
-    const roles = ['Admin', 'Pranav', 'Chitra', 'Client'];
+    const roles = ['Admin', 'Creative', 'Servicing', 'Client'];
     html += '<div class="um-section-label">View</div>';
     html += '<div class="um-role-options">';
     roles.forEach(r => {

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -36,13 +36,13 @@ window._sendStageNotif = function(postId, postTitle, stage, recipients, actorNam
 // -- Stage → notification recipients map --
 function _stageRecipients(stage) {
   var map = {
-    'brief':                 ['Pranav'],
-    'in_production':         ['Pranav'],
-    'ready':                 ['Chitra'],
+    'brief':                 ['Creative'],
+    'in_production':         ['Creative'],
+    'ready':                 ['Servicing'],
     'awaiting_approval':     ['Client'],
     'awaiting_brand_input':  ['Client'],
-    'scheduled':             ['Admin', 'Chitra', 'Pranav'],
-    'published':             ['Admin', 'Chitra', 'Pranav', 'Client']
+    'scheduled':             ['Admin', 'Servicing', 'Creative'],
+    'published':             ['Admin', 'Servicing', 'Creative', 'Client']
   };
   return map[stage] || [];
 }
@@ -215,7 +215,7 @@ async function clientApprove(postId, btn) {
       body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: 'Client' }),
     });
     await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
-    window._sendStageNotif(postId, getTitle(post), 'scheduled', ['Admin', 'Chitra', 'Pranav'], window.AppState.user.name || 'Client');
+    window._sendStageNotif(postId, getTitle(post), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || 'Client');
     const confirmEl = document.getElementById(`approved-confirm-${postId}`);
     if (confirmEl) confirmEl.classList.add('show');
     var cardEl = document.getElementById('approved-confirm-' + postId);
@@ -247,7 +247,7 @@ async function clientAcknowledge(postId) {
     });
     await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Acknowledged  -  sending via WhatsApp' });
     var _ackPost = getPostById(postId);
-    window._sendStageNotif(postId, (_ackPost ? getTitle(_ackPost) : postId), 'in_production', ['Pranav'], window.AppState.user.name || 'Client');
+    window._sendStageNotif(postId, (_ackPost ? getTitle(_ackPost) : postId), 'in_production', ['Creative'], window.AppState.user.name || 'Client');
     showToast('Got it! The team has been notified.', 'success');
     setTimeout(() => loadPostsForClient(), 800);
   } catch { showToast('Failed  -  try again', 'error'); }
@@ -463,7 +463,7 @@ function _confirmPublish(postId) {
       action: 'published'
     });
     var _pubPost = getPostById(postId);
-    window._sendStageNotif(postId, (_pubPost ? getTitle(_pubPost) : postId), 'published', ['Admin', 'Chitra', 'Pranav', 'Client'], window.AppState.user.name || 'Shubham');
+    window._sendStageNotif(postId, (_pubPost ? getTitle(_pubPost) : postId), 'published', ['Admin', 'Servicing', 'Creative', 'Client'], window.AppState.user.name || 'Shubham');
     showToast('Published', 'success');
     if (typeof closePCS === 'function') closePCS();
     loadPosts();

--- a/09-approval.js
+++ b/09-approval.js
@@ -145,7 +145,7 @@ async function submitApproval(type, postId, btn) {
         body: JSON.stringify({ stage: 'in_production', client_feedback: text, updated_at: new Date().toISOString() }),
       });
       await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: `Changes requested: ${text.substring(0,80)}` });
-      if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, postId, 'in_production', ['Pranav'], 'Client');
+      if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, postId, 'in_production', ['Creative'], 'Client');
       const c = document.getElementById('approval-confirmation');
       if (c) { c.style.display = ''; c.textContent = 'Changes sent  -  the team will review it.'; }
       document.querySelector('.approval-actions')?.remove();
@@ -162,7 +162,7 @@ async function submitApproval(type, postId, btn) {
         body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString() }),
       });
       await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
-      if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, esc(title), 'scheduled', ['Admin', 'Chitra', 'Pranav'], 'Client');
+      if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, esc(title), 'scheduled', ['Admin', 'Servicing', 'Creative'], 'Client');
       const c = document.getElementById('approval-confirmation');
       if (c) { c.style.display = ''; c.textContent = 'ok Approved! The team has been notified.'; }
       document.querySelector('.approval-actions')?.remove();

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260403l
+Version format: ?v=YYYYMMDDx. Current: ?v=20260403m
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -524,7 +524,7 @@ Ph0 Safety            — DONE
 Ph1 File Architecture — DONE (render/ + actions/ extracted)
 Ph2 AppState          — DONE (all globals migrated)
 Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast, Pass 5 dashboard — 4 fixes + 1 post-load fix, Pass 6 post-load — 12 fixes + 4 duplicate function overwrites fixed, Pass 7 auth — 6 fixes incl. silent refreshSession catch)
-Ph3.5 Role Standardization — IN PROGRESS (Phase A: normalizeRole() added, rollback.sql created)
+Ph3.5 Role Standardization — IN PROGRESS (Phase A: normalizeRole() added, rollback.sql created; Phase B: config wire cut — ALLOWED_OWNERS, ROLE_TABS, notification recipients, HTML option values all use DB roles)
 Ph4 Event Delegation  — PENDING
 Ph5 Optimistic UI     — IN PROGRESS (client comments done)
 Ph6 PWA               — PENDING

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -442,7 +442,7 @@ window._pcsChipDrop = function(chipEl, field, postId) {
     items = ['Mumbai','Sakarwadi','Sameerwadi','Other'];
     currentVal = post ? (post.location || '') : '';
   } else if (field === 'owner') {
-    items = typeof ALLOWED_OWNERS !== 'undefined' ? ALLOWED_OWNERS : ['Pranav','Chitra','Client'];
+    items = typeof ALLOWED_OWNERS !== 'undefined' ? ALLOWED_OWNERS : ['Creative','Servicing','Client','Admin'];
     currentVal = post ? (post.owner || '') : '';
   } else if (field === 'stage') {
     items = typeof STAGES_DB !== 'undefined' ? STAGES_DB : [];

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260403l">
+ <link rel="stylesheet" href="styles.css?v=20260403m">
 
 </head>
 <body>
@@ -518,8 +518,8 @@
           <span class="nps-label">Owner <span class="nps-req">*</span></span>
           <select class="nps-select" id="new-post-owner">
             <option value="">Assign to...</option>
-            <option value="Pranav">Pranav</option>
-            <option value="Chitra">Chitra</option>
+            <option value="Creative">Pranav</option>
+            <option value="Servicing">Chitra</option>
             <option value="Client">Client</option>
           </select>
         </div>
@@ -667,8 +667,8 @@
         <label class="form-label-sm">Owner</label>
         <select id="ae-owner">
           <option value="">Select owner</option>
-          <option>Pranav</option>
-          <option>Chitra</option>
+          <option value="Creative">Pranav</option>
+          <option value="Servicing">Chitra</option>
           <option>Client</option>
         </select>
       </div>
@@ -807,8 +807,8 @@
         <div class="nrs-cell">
           <div class="nrs-field-label">Assign to</div>
           <select class="nrs-select" id="nrs-assign">
-            <option value="Pranav">Pranav</option>
-            <option value="Chitra">Chitra</option>
+            <option value="Creative">Pranav</option>
+            <option value="Servicing">Chitra</option>
           </select>
         </div>
         <div class="nrs-cell">
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260403l"></script>
-<script src="00-appstate-compat.js?v=20260403l"></script>
-<script src="01-config.js?v=20260403l" defer></script>
-<script src="02-session.js?v=20260403l" defer></script>
-<script src="utils.js?v=20260403l" defer></script>
-<script src="03-auth.js?v=20260403l" defer></script>
-<script src="05-api.js?v=20260403l" defer></script>
-<script src="10-ui.js?v=20260403l" defer></script>
+<script src="00-appstate.js?v=20260403m"></script>
+<script src="00-appstate-compat.js?v=20260403m"></script>
+<script src="01-config.js?v=20260403m" defer></script>
+<script src="02-session.js?v=20260403m" defer></script>
+<script src="utils.js?v=20260403m" defer></script>
+<script src="03-auth.js?v=20260403m" defer></script>
+<script src="05-api.js?v=20260403m" defer></script>
+<script src="10-ui.js?v=20260403m" defer></script>
 
-<script src="06-post-create.js?v=20260403l" defer></script>
-<script defer src="render/dashboard.js?v=20260403l"></script>
-<script defer src="render/client.js?v=20260403l"></script>
-<script defer src="render/pipeline.js?v=20260403l"></script>
-<script defer src="render/brief.js?v=20260403l"></script>
-<script defer src="actions/pcs.js?v=20260403l"></script>
-<script src="07-post-load.js?v=20260403l" defer></script>
-<script src="08-post-actions.js?v=20260403l" defer></script>
-<script src="09-library.js?v=20260403l" defer></script>
-<script src="09-approval.js?v=20260403l" defer></script>
-<script src="04-router.js?v=20260403l" defer></script>
+<script src="06-post-create.js?v=20260403m" defer></script>
+<script defer src="render/dashboard.js?v=20260403m"></script>
+<script defer src="render/client.js?v=20260403m"></script>
+<script defer src="render/pipeline.js?v=20260403m"></script>
+<script defer src="render/brief.js?v=20260403m"></script>
+<script defer src="actions/pcs.js?v=20260403m"></script>
+<script src="07-post-load.js?v=20260403m" defer></script>
+<script src="08-post-actions.js?v=20260403m" defer></script>
+<script src="09-library.js?v=20260403m" defer></script>
+<script src="09-approval.js?v=20260403m" defer></script>
+<script src="04-router.js?v=20260403m" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
Phase B of role standardization. All config maps and notification recipient arrays now use canonical DB roles (Creative/Servicing) instead of person names (Pranav/Chitra).

- ALLOWED_OWNERS: ['Creative','Servicing','Client','Admin']
- ROLE_TABS: removed redundant Pranav/Chitra entries
- Role preview dropdown: Admin/Creative/Servicing/Client
- HTML option values: Creative/Servicing (display text unchanged)
- _stageRecipients: all keys use DB roles
- All _sendStageNotif calls: recipients use DB roles
- PCS fallback owners: use DB roles
- Bump ?v= to 20260403m

https://claude.ai/code/session_01NmYun6ABE1KWXPce2tDNd1