### PR TITLE
fix: pipeline and PCS owner checks use DB role names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260403n
+Version format: ?v=YYYYMMDDx. Current: ?v=20260403o
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -524,7 +524,7 @@ Ph0 Safety            — DONE
 Ph1 File Architecture — DONE (render/ + actions/ extracted)
 Ph2 AppState          — DONE (all globals migrated)
 Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast, Pass 5 dashboard — 4 fixes + 1 post-load fix, Pass 6 post-load — 12 fixes + 4 duplicate function overwrites fixed, Pass 7 auth — 6 fixes incl. silent refreshSession catch)
-Ph3.5 Role Standardization — DONE (Phase A: normalizeRole() added, rollback.sql created; Phase B: config wire cut — ALLOWED_OWNERS, ROLE_TABS, notification recipients, HTML option values all use DB roles; Phase C: DB write payloads — owner fields in brief.js, post-load.js, post-create.js all use DB roles)
+Ph3.5 Role Standardization — DONE (Phase A: normalizeRole() added, rollback.sql created; Phase B: config wire cut — ALLOWED_OWNERS, ROLE_TABS, notification recipients, HTML option values all use DB roles; Phase C: DB write payloads — owner fields in brief.js, post-load.js, post-create.js all use DB roles; Phase D: owner read checks — pipeline.js isMine/filter checks + pcs.js chip color all use DB role names Creative/Servicing)
 Ph4 Event Delegation  — PENDING
 Ph5 Optimistic UI     — IN PROGRESS (client comments done)
 Ph6 PWA               — PENDING

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -345,7 +345,7 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
   if (post.owner) {
     var ownerColor = ' pcs-chip--dim';
     var ownerLC = (post.owner || '').toLowerCase();
-    if (ownerLC === 'chitra' || ownerLC === 'pranav') ownerColor = ' pcs-chip--cyan';
+    if (ownerLC === 'servicing' || ownerLC === 'creative') ownerColor = ' pcs-chip--cyan';
     else if (ownerLC === 'client') ownerColor = ' pcs-chip--amber';
     var ownerArr = canEdit ? ' <span class="pcs-chip-arr">&#9662;</span>' : '';
     chips.push('<button class="pcs-chip' + ownerColor + '"' +

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260403n">
+ <link rel="stylesheet" href="styles.css?v=20260403o">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260403n"></script>
-<script src="00-appstate-compat.js?v=20260403n"></script>
-<script src="01-config.js?v=20260403n" defer></script>
-<script src="02-session.js?v=20260403n" defer></script>
-<script src="utils.js?v=20260403n" defer></script>
-<script src="03-auth.js?v=20260403n" defer></script>
-<script src="05-api.js?v=20260403n" defer></script>
-<script src="10-ui.js?v=20260403n" defer></script>
+<script src="00-appstate.js?v=20260403o"></script>
+<script src="00-appstate-compat.js?v=20260403o"></script>
+<script src="01-config.js?v=20260403o" defer></script>
+<script src="02-session.js?v=20260403o" defer></script>
+<script src="utils.js?v=20260403o" defer></script>
+<script src="03-auth.js?v=20260403o" defer></script>
+<script src="05-api.js?v=20260403o" defer></script>
+<script src="10-ui.js?v=20260403o" defer></script>
 
-<script src="06-post-create.js?v=20260403n" defer></script>
-<script defer src="render/dashboard.js?v=20260403n"></script>
-<script defer src="render/client.js?v=20260403n"></script>
-<script defer src="render/pipeline.js?v=20260403n"></script>
-<script defer src="render/brief.js?v=20260403n"></script>
-<script defer src="actions/pcs.js?v=20260403n"></script>
-<script src="07-post-load.js?v=20260403n" defer></script>
-<script src="08-post-actions.js?v=20260403n" defer></script>
-<script src="09-library.js?v=20260403n" defer></script>
-<script src="09-approval.js?v=20260403n" defer></script>
-<script src="04-router.js?v=20260403n" defer></script>
+<script src="06-post-create.js?v=20260403o" defer></script>
+<script defer src="render/dashboard.js?v=20260403o"></script>
+<script defer src="render/client.js?v=20260403o"></script>
+<script defer src="render/pipeline.js?v=20260403o"></script>
+<script defer src="render/brief.js?v=20260403o"></script>
+<script defer src="actions/pcs.js?v=20260403o"></script>
+<script src="07-post-load.js?v=20260403o" defer></script>
+<script src="08-post-actions.js?v=20260403o" defer></script>
+<script src="09-library.js?v=20260403o" defer></script>
+<script src="09-approval.js?v=20260403o" defer></script>
+<script src="04-router.js?v=20260403o" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/pipeline.js
+++ b/render/pipeline.js
@@ -400,14 +400,13 @@ window.updatePipelineChipCounts = function() {
   var _isPranavChip = _chipRole === 'creative' ||
     _chipRole === 'pranav' ||
     (window.AppState.user.email||'').toLowerCase().includes('pranav');
-  var _isChitraChip = (_chipRole === 'servicing' ||
-    _chipRole === 'chitra') && !_isPranavChip;
+  var _isChitraChip = _chipRole === 'servicing' && !_isPranavChip;
   var chipPosts = posts.filter(function(p) {
     var s = p.stage || '';
     if (s === 'published' || s === 'parked' || s === 'rejected') return false;
     if (_isPranavChip) {
       var owner = (p.owner || '').toLowerCase();
-      var isMine = owner === 'pranav';
+      var isMine = owner === 'creative';
       return (s === 'brief' || s === 'in_production' || s === 'ready') && isMine;
     }
     return true;
@@ -688,15 +687,15 @@ window.updatePipelineNarrative = function(posts) {
     if (narrEl) {
       var _myProd = (window.AppState.posts.all || []).filter(function(p) {
         return (p.stage === 'in_production') &&
-          (p.owner || '').toLowerCase() === 'pranav';
+          (p.owner || '').toLowerCase() === 'creative';
       }).length;
       var _myBriefs = (window.AppState.posts.all || []).filter(function(p) {
         return (p.stage === 'brief') &&
-          (p.owner || '').toLowerCase() === 'pranav';
+          (p.owner || '').toLowerCase() === 'creative';
       }).length;
       var _myReady = (window.AppState.posts.all || []).filter(function(p) {
         return (p.stage === 'ready') &&
-          (p.owner || '').toLowerCase() === 'pranav';
+          (p.owner || '').toLowerCase() === 'creative';
       }).length;
 
       if (_myBriefs > 0) {
@@ -818,8 +817,7 @@ window.updatePipelineNarrative = function(posts) {
 
   // PRIORITY 5: Pranav idle 3+ days
   var pranavPosts = allP.filter(function(p) {
-    return (p.owner||'').toLowerCase() === 'pranav' ||
-           (p.owner||'').toLowerCase() === 'creative';
+    return (p.owner||'').toLowerCase() === 'creative';
   });
   if (pranavPosts.length) {
     var last = pranavPosts.sort(function(a,b) {
@@ -907,14 +905,14 @@ window._renderPipelineInner = function() {
   var _isPranavPL = _rolePL === 'creative' ||
     _rolePL === 'pranav' ||
     (window.AppState.user.email || '').toLowerCase().includes('pranav');
-  var _isChitraPL = (_rolePL === 'servicing' || _rolePL === 'chitra') && !_isPranavPL;
+  var _isChitraPL = _rolePL === 'servicing' && !_isPranavPL;
   var _isAdminPL = !_isClient && !_isPranavPL && !_isChitraPL;
 
   if (_isPranavPL) {
     source = source.filter(function(p) {
       var stage = p.stage || '';
       var owner = (p.owner || '').toLowerCase();
-      var isMine = owner === 'pranav';
+      var isMine = owner === 'creative';
       if (stage === 'brief') return isMine;
       if (stage === 'in_production') return isMine;
       if (stage === 'ready') return isMine;
@@ -936,7 +934,7 @@ window._renderPipelineInner = function() {
       var stage = p.stage || '';
       if (!_chitraStages.includes(stage)) return false;
       if (stage === 'brief') {
-        return (p.owner || '').toLowerCase() === 'chitra';
+        return (p.owner || '').toLowerCase() === 'servicing';
       }
       return true;
     });
@@ -973,7 +971,7 @@ window._renderPipelineInner = function() {
       (window.AppState.user.email || '').toLowerCase().includes('pranav');
     if (_isPranavBF) {
       grouped['brief'] = (grouped['brief'] || []).filter(function(p) {
-        return (p.owner || '').toLowerCase() === 'pranav';
+        return (p.owner || '').toLowerCase() === 'creative';
       });
       if (!grouped['brief'].length) delete grouped['brief'];
     }


### PR DESCRIPTION
## Summary
- **render/pipeline.js**: All owner read-path checks (`isMine`, narrative counts, brief filter, chip filter, Pranav idle detection) now use DB role names (`creative`/`servicing`) instead of person names (`pranav`/`chitra`)
- **actions/pcs.js**: Chip color check uses `servicing`/`creative` instead of `chitra`/`pranav`
- Removed duplicate `'chitra'` from `_isChitraPL` and `_isChitraChip` guards (was `_rolePL === 'servicing' || _rolePL === 'chitra'`, now just `_rolePL === 'servicing'`)

Phase D of role standardization. All 20 `?v=` bumped to `20260403o`. 316/316 tests passing.

## Test plan
- [ ] Login as Creative — pipeline shows only owned briefs/in_production/ready posts
- [ ] Login as Servicing — pipeline shows briefs owned by Servicing, plus approval/brand input/ready/scheduled
- [ ] Admin role preview as Creative/Servicing — same filtering behavior
- [ ] PCS owner chip shows cyan color for Creative and Servicing owners
- [ ] Pipeline narrative counts match actual post counts for Creative role

https://claude.ai/code/session_01W8b38ZFeHpW6CuwRomtXHm