### PR TITLE
Add WhatsApp preview generation at post creation time

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -3,6 +3,22 @@
 =============================================== */
 console.log("LOADED:", "06-post-create.js");
 
+function _generateWhatsAppPreview(postId, title, imageUrl) {
+  var shortCode = postId.replace(/[^0-9]/g, '').slice(-4);
+  fetch('https://srtd-og-inject.ksg-kumarshubhamgune.workers.dev/generate-preview', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Preview-Secret': 'srtd2026xK9mN3pQ'
+    },
+    body: JSON.stringify({
+      post_id: postId,
+      title: title,
+      image_url: imageUrl || ''
+    })
+  }).catch(function() {});
+}
+
 const DRAFT_KEY = 'hinglish_new_post_draft';
 let _draftTimer = null;
 let _draftDebounce = null;
@@ -296,6 +312,11 @@ body: JSON.stringify(payload)
 });
 
 console.log('[submitNewPost] API SUCCESS');
+
+var _newPostTitle = payload.title || '';
+var _newPostImage = (Array.isArray(payload.images) && payload.images.length) ? payload.images[0] : '';
+_generateWhatsAppPreview(payload.post_id, _newPostTitle, _newPostImage);
+
 clearDraft();
 localStorage.removeItem('hinglish_new_post_draft');
 stopDraftAutosave();

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Sorted (srtd.io)
 
-# Last updated: 2026-04-03
+# Last updated: 2026-04-04
 
 # All facts verified from actual codebase
 
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260404c
+Version format: ?v=YYYYMMDDx. Current: ?v=20260404e
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -310,6 +310,9 @@ R2 Worker:      srtd-r2-upload.ksg-kumarshubhamgune.workers.dev
 OG Worker:      srtd-og-inject (route: srtd.io/preview/*)
 OG source:      sorted-preview-worker/src/index.js
 KV:             sorted-whatsapp-previews
+WhatsApp preview: generated at post creation time (06-post-create.js, render/brief.js)
+                  Fire-and-forget POST to OG Worker /generate-preview endpoint
+                  Zero Supabase egress for previews — Worker + KV only
 Resend FROM:    hinglish@srtd.io
 Short URLs:     srtd.io/p/XXXX via Cloudflare Page Rule
 PREVIEW_SECRET: srtd2026xK9mN3pQ

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260404c">
+ <link rel="stylesheet" href="styles.css?v=20260404e">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260404c"></script>
-<script src="00-appstate-compat.js?v=20260404c"></script>
-<script src="01-config.js?v=20260404c" defer></script>
-<script src="02-session.js?v=20260404c" defer></script>
-<script src="utils.js?v=20260404c" defer></script>
-<script src="03-auth.js?v=20260404c" defer></script>
-<script src="05-api.js?v=20260404c" defer></script>
-<script src="10-ui.js?v=20260404c" defer></script>
+<script src="00-appstate.js?v=20260404e"></script>
+<script src="00-appstate-compat.js?v=20260404e"></script>
+<script src="01-config.js?v=20260404e" defer></script>
+<script src="02-session.js?v=20260404e" defer></script>
+<script src="utils.js?v=20260404e" defer></script>
+<script src="03-auth.js?v=20260404e" defer></script>
+<script src="05-api.js?v=20260404e" defer></script>
+<script src="10-ui.js?v=20260404e" defer></script>
 
-<script src="06-post-create.js?v=20260404c" defer></script>
-<script defer src="render/dashboard.js?v=20260404c"></script>
-<script defer src="render/client.js?v=20260404c"></script>
-<script defer src="render/pipeline.js?v=20260404c"></script>
-<script defer src="render/brief.js?v=20260404c"></script>
-<script defer src="actions/pcs.js?v=20260404c"></script>
-<script src="07-post-load.js?v=20260404c" defer></script>
-<script src="08-post-actions.js?v=20260404c" defer></script>
-<script src="09-library.js?v=20260404c" defer></script>
-<script src="09-approval.js?v=20260404c" defer></script>
-<script src="04-router.js?v=20260404c" defer></script>
+<script src="06-post-create.js?v=20260404e" defer></script>
+<script defer src="render/dashboard.js?v=20260404e"></script>
+<script defer src="render/client.js?v=20260404e"></script>
+<script defer src="render/pipeline.js?v=20260404e"></script>
+<script defer src="render/brief.js?v=20260404e"></script>
+<script defer src="actions/pcs.js?v=20260404e"></script>
+<script src="07-post-load.js?v=20260404e" defer></script>
+<script src="08-post-actions.js?v=20260404e" defer></script>
+<script src="09-library.js?v=20260404e" defer></script>
+<script src="09-approval.js?v=20260404e" defer></script>
+<script src="04-router.js?v=20260404e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -4,6 +4,22 @@
 =============================================== */
 console.log("LOADED:", "render/brief.js");
 
+function _generateWhatsAppPreview(postId, title, imageUrl) {
+  var shortCode = postId.replace(/[^0-9]/g, '').slice(-4);
+  fetch('https://srtd-og-inject.ksg-kumarshubhamgune.workers.dev/generate-preview', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Preview-Secret': 'srtd2026xK9mN3pQ'
+    },
+    body: JSON.stringify({
+      post_id: postId,
+      title: title,
+      image_url: imageUrl || ''
+    })
+  }).catch(function() {});
+}
+
 // ===============================================
 // Brief Sheet - full-screen overlay for brief/REQ posts
 // ===============================================
@@ -368,6 +384,10 @@ window._assignBriefToPranav = function(postId) {
         })
       });
     }).then(function() {
+      var _briefPostTitle = post.title || '';
+      var _briefPostImage = (Array.isArray(post.images) && post.images.length) ? post.images[0] : '';
+      _generateWhatsAppPreview(newPostId, _briefPostTitle, _briefPostImage);
+
       logActivity({
         post_id: newPostId,
         actor: 'Chitra',


### PR DESCRIPTION
Fire-and-forget call to OG Worker /generate-preview after every successful POST /posts — both in submitNewPost (06-post-create.js) and _assignBriefToPranav (render/brief.js). Zero Supabase egress for previews. Silent on failure — never blocks post creation.

Bump ?v= to 20260404e (all 20 resources).

https://claude.ai/code/session_01PD6YvoFMdrSxdYojh8iaph