### PR TITLE
Add ?id= direct post_id lookup to preview/index.html

### DIFF
--- a/preview/index.html
+++ b/preview/index.html
@@ -696,14 +696,36 @@ body {
 
   /* ===== INIT ===== */
   function init() {
-    var shortId = new URL(window.location.href)
-      .searchParams.get('p') || '';
-    if (!shortId) {
+    var params = new URL(window.location.href).searchParams;
+    var directId = params.get('id') || '';
+    var shortId = params.get('p') || '';
+    if (!directId && !shortId) {
       app.innerHTML = '<div class="status-msg">Post not found.</div>';
       return;
     }
 
     app.innerHTML = '<div class="status-msg">Loading...</div>';
+
+    if (directId) {
+      fetch(SUPABASE_URL + '/rest/v1/posts?select=*&post_id=eq.' + encodeURIComponent(directId) + '&limit=1', {
+        headers: {
+          'apikey': SUPABASE_ANON_KEY,
+          'Authorization': 'Bearer ' + SUPABASE_ANON_KEY
+        }
+      })
+      .then(function(res) { return res.json(); })
+      .then(function(posts) {
+        if (!posts || !posts.length) {
+          app.innerHTML = '<div class="status-msg">Post not found.</div>';
+          return;
+        }
+        renderPost(posts[0]);
+      })
+      .catch(function() {
+        app.innerHTML = '<div class="status-msg">Post not found.</div>';
+      });
+      return;
+    }
 
     fetch(SUPABASE_URL + '/rest/v1/posts?select=*', {
       headers: {


### PR DESCRIPTION
## Summary
- preview/index.html now checks `?id=POST_ID` first for direct Supabase `post_id=eq.` query
- Falls back to existing `?p=` short code matching (unchanged)
- Avoids fetching entire posts table when post_id is known

## Test plan
- [x] All 316/316 unit tests pass
- [ ] Visit `preview/index.html?id=POST-XXXX` — should load post directly
- [ ] Visit `preview/index.html?p=1234` — should still work (legacy short code)
- [ ] Visit `preview/index.html` with no params — should show "Post not found"

https://claude.ai/code/session_01PD6YvoFMdrSxdYojh8iaph