### PR TITLE
Replace ok/index.html with preview/index.html in all flows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260404f
+Version format: ?v=YYYYMMDDx. Current: ?v=20260404g
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -314,7 +314,10 @@ WhatsApp preview: generated at post creation time (06-post-create.js, render/bri
                   Fire-and-forget POST to OG Worker /generate-preview endpoint
                   Worker builds OG HTML via buildOgHtml(), stores in KV by shortCode + slug
                   Redirect uses ?id=POST_ID for direct post_id lookup (not title slug)
-                  ok/index.html supports both ?id=POST_ID (direct) and ?p=SLUG (legacy)
+                  preview/index.html supports both ?id=POST_ID (direct) and ?p=SLUG (legacy)
+                  ok/index.html is no longer referenced by any flow — preview/index.html is
+                  the only client-facing page. All Worker redirects, /no/ back link, and
+                  client feed Copy Approval Link point to preview/ or srtd.io/p/SHORTCODE
                   Zero Supabase egress for previews — Worker + KV only
 Resend FROM:    hinglish@srtd.io
 Short URLs:     srtd.io/p/XXXX via Cloudflare Page Rule

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260404f">
+ <link rel="stylesheet" href="styles.css?v=20260404g">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260404f"></script>
-<script src="00-appstate-compat.js?v=20260404f"></script>
-<script src="01-config.js?v=20260404f" defer></script>
-<script src="02-session.js?v=20260404f" defer></script>
-<script src="utils.js?v=20260404f" defer></script>
-<script src="03-auth.js?v=20260404f" defer></script>
-<script src="05-api.js?v=20260404f" defer></script>
-<script src="10-ui.js?v=20260404f" defer></script>
+<script src="00-appstate.js?v=20260404g"></script>
+<script src="00-appstate-compat.js?v=20260404g"></script>
+<script src="01-config.js?v=20260404g" defer></script>
+<script src="02-session.js?v=20260404g" defer></script>
+<script src="utils.js?v=20260404g" defer></script>
+<script src="03-auth.js?v=20260404g" defer></script>
+<script src="05-api.js?v=20260404g" defer></script>
+<script src="10-ui.js?v=20260404g" defer></script>
 
-<script src="06-post-create.js?v=20260404f" defer></script>
-<script defer src="render/dashboard.js?v=20260404f"></script>
-<script defer src="render/client.js?v=20260404f"></script>
-<script defer src="render/pipeline.js?v=20260404f"></script>
-<script defer src="render/brief.js?v=20260404f"></script>
-<script defer src="actions/pcs.js?v=20260404f"></script>
-<script src="07-post-load.js?v=20260404f" defer></script>
-<script src="08-post-actions.js?v=20260404f" defer></script>
-<script src="09-library.js?v=20260404f" defer></script>
-<script src="09-approval.js?v=20260404f" defer></script>
-<script src="04-router.js?v=20260404f" defer></script>
+<script src="06-post-create.js?v=20260404g" defer></script>
+<script defer src="render/dashboard.js?v=20260404g"></script>
+<script defer src="render/client.js?v=20260404g"></script>
+<script defer src="render/pipeline.js?v=20260404g"></script>
+<script defer src="render/brief.js?v=20260404g"></script>
+<script defer src="actions/pcs.js?v=20260404g"></script>
+<script src="07-post-load.js?v=20260404g" defer></script>
+<script src="08-post-actions.js?v=20260404g" defer></script>
+<script src="09-library.js?v=20260404g" defer></script>
+<script src="09-approval.js?v=20260404g" defer></script>
+<script src="04-router.js?v=20260404g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/no/index.html
+++ b/no/index.html
@@ -205,7 +205,7 @@ async function loadPost() {
     var titleEl = document.getElementById('form-title');
     if (titleEl) titleEl.textContent = post.title || '';
     var backLink = document.getElementById('back-link');
-    if (backLink) backLink.href = '/ok/?p=' + slug;
+    if (backLink) backLink.href = '/preview/index.html?p=' + slug;
     showState('state-form');
 
   } catch(e) {

--- a/render/client.js
+++ b/render/client.js
@@ -462,8 +462,9 @@ console.log('LOADED:', 'render/client.js');
         break;
       case 'cardMenuCopyApproval':
         if (post) {
-          var cpSlug = _makeSlug(post.title || '');
-          navigator.clipboard.writeText('https://srtd.io/ok/?p=' + cpSlug).then(function () {
+          var cpPostId = post.post_id || '';
+          var cpShortCode = cpPostId.replace(/[^0-9]/g, '').slice(-4);
+          navigator.clipboard.writeText('https://srtd.io/p/' + cpShortCode).then(function () {
             if (typeof window.showToast === 'function') window.showToast('Approval link copied', 'success');
           }).catch(function () {
             if (typeof window.showToast === 'function') window.showToast('Failed to copy', 'error');

--- a/sorted-preview-worker/src/index.js
+++ b/sorted-preview-worker/src/index.js
@@ -13,7 +13,7 @@ function getFallbackHtml(slug, postId) {
     '<meta charset="UTF-8">' +
     '<meta name="viewport" content="width=device-width,initial-scale=1.0">' +
     '<title>Sorted — Post Review</title>' +
-    '<meta http-equiv="refresh" content="0; url=https://guneygaar.github.io/ok/index.html?' + redirectParam + '" />' +
+    '<meta http-equiv="refresh" content="0; url=https://guneygaar.github.io/preview/index.html?' + redirectParam + '" />' +
     '<meta property="og:title" content="Review this post on Sorted">' +
     '<meta property="og:description" content="Tap to open and approve this post.">' +
     '</head><body>Opening Sorted...</body></html>';
@@ -23,8 +23,8 @@ function buildOgHtml(shortCode, title, imageUrl, postId) {
   var safeTitle = escAttr(title || 'Review Post');
   var safeImg = escAttr(imageUrl || '');
   var redirectUrl = postId
-    ? 'https://guneygaar.github.io/ok/index.html?id=' + escAttr(postId)
-    : 'https://guneygaar.github.io/ok/index.html?p=' + escAttr(shortCode);
+    ? 'https://guneygaar.github.io/preview/index.html?id=' + escAttr(postId)
+    : 'https://guneygaar.github.io/preview/index.html?p=' + escAttr(shortCode);
   return '<!DOCTYPE html><html><head>' +
     '<meta charset="UTF-8">' +
     '<meta name="viewport" content="width=device-width,initial-scale=1.0">' +


### PR DESCRIPTION
## Summary
- Worker: `getFallbackHtml` + `buildOgHtml` redirects now point to `guneygaar.github.io/preview/index.html?id=POST_ID` (or `?p=SLUG`)
- `render/client.js` Copy Approval Link: writes `srtd.io/p/SHORTCODE` to clipboard (stable short URL through Worker preview route), removing dependency on title-slug matching
- `no/index.html` back link: points to `/preview/index.html?p=SLUG`
- CLAUDE.md: documents that `ok/index.html` is no longer referenced by any flow

## Test plan
- [x] All 316/316 unit tests pass
- [ ] Share post on WhatsApp → link lands on LinkedIn-style preview page
- [ ] Copy Approval Link (desktop client feed) → clipboard has `srtd.io/p/XXXX`
- [ ] Submit feedback from `/no/` → back link goes to `/preview/`
- [ ] Worker: `npx wrangler deploy` from `sorted-preview-worker/` after merge

https://claude.ai/code/session_01PD6YvoFMdrSxdYojh8iaph