### PR TITLE
fix: iOS keyboard ghost input in client feed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260405a
+Version format: ?v=YYYYMMDDx. Current: ?v=20260405b
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -570,6 +570,17 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
 1. NRS owner fallback writes person name 'Pranav' to DB
    Location: 10-ui.js line 1330 — owner field fallback was || 'Pranav'
    Status: FIXED (PR#TBD) — changed fallback to 'Creative' (DB role)
+1. iOS keyboard ghost input — fixed bottom nav overlays client feed
+   comment input when keyboard opens, and tapping input does not
+   scroll it into view
+   Location: render/client.js renderClientView() — no visualViewport
+   handling, no focus scrollIntoView on comment inputs
+   Status: FIXED (PR#TBD) — added _wireKeyboardPushNav() wiring a
+   visualViewport resize listener that translates #bottom-nav up by
+   the keyboard height when >100px, and _wireCommentInputFocus() that
+   attaches a focus listener to every [id^="comment-input-"] input to
+   scrollIntoView (center, smooth) after a 300ms delay so keyboard
+   finishes opening first. Both called at the end of renderClientView.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260405a">
+ <link rel="stylesheet" href="styles.css?v=20260405b">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260405a"></script>
-<script src="00-appstate-compat.js?v=20260405a"></script>
-<script src="01-config.js?v=20260405a" defer></script>
-<script src="02-session.js?v=20260405a" defer></script>
-<script src="utils.js?v=20260405a" defer></script>
-<script src="03-auth.js?v=20260405a" defer></script>
-<script src="05-api.js?v=20260405a" defer></script>
-<script src="10-ui.js?v=20260405a" defer></script>
+<script src="00-appstate.js?v=20260405b"></script>
+<script src="00-appstate-compat.js?v=20260405b"></script>
+<script src="01-config.js?v=20260405b" defer></script>
+<script src="02-session.js?v=20260405b" defer></script>
+<script src="utils.js?v=20260405b" defer></script>
+<script src="03-auth.js?v=20260405b" defer></script>
+<script src="05-api.js?v=20260405b" defer></script>
+<script src="10-ui.js?v=20260405b" defer></script>
 
-<script src="06-post-create.js?v=20260405a" defer></script>
-<script defer src="render/dashboard.js?v=20260405a"></script>
-<script defer src="render/client.js?v=20260405a"></script>
-<script defer src="render/pipeline.js?v=20260405a"></script>
-<script defer src="render/brief.js?v=20260405a"></script>
-<script defer src="actions/pcs.js?v=20260405a"></script>
-<script src="07-post-load.js?v=20260405a" defer></script>
-<script src="08-post-actions.js?v=20260405a" defer></script>
-<script src="09-library.js?v=20260405a" defer></script>
-<script src="09-approval.js?v=20260405a" defer></script>
-<script src="04-router.js?v=20260405a" defer></script>
+<script src="06-post-create.js?v=20260405b" defer></script>
+<script defer src="render/dashboard.js?v=20260405b"></script>
+<script defer src="render/client.js?v=20260405b"></script>
+<script defer src="render/pipeline.js?v=20260405b"></script>
+<script defer src="render/brief.js?v=20260405b"></script>
+<script defer src="actions/pcs.js?v=20260405b"></script>
+<script src="07-post-load.js?v=20260405b" defer></script>
+<script src="08-post-actions.js?v=20260405b" defer></script>
+<script src="09-library.js?v=20260405b" defer></script>
+<script src="09-approval.js?v=20260405b" defer></script>
+<script src="04-router.js?v=20260405b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1498,6 +1498,42 @@ console.log('LOADED:', 'render/client.js');
     });
   }
 
+  /* ---- iOS keyboard: push bottom nav up, scroll focused input into view ---- */
+
+  var _kbPushWired = false;
+  function _wireKeyboardPushNav() {
+    if (_kbPushWired) return;
+    if (!window.visualViewport) return;
+    _kbPushWired = true;
+    window.visualViewport.addEventListener('resize', function() {
+      var nav = document.querySelector('#app nav') ||
+                document.getElementById('client-bottom-nav') ||
+                document.getElementById('bottom-nav');
+      if (!nav) return;
+      var keyboardHeight = window.innerHeight - window.visualViewport.height;
+      if (keyboardHeight > 100) {
+        nav.style.transform = 'translateY(-' + keyboardHeight + 'px)';
+        nav.style.transition = 'transform 0.1s ease';
+      } else {
+        nav.style.transform = '';
+      }
+    });
+  }
+
+  function _wireCommentInputFocus(root) {
+    if (!root) return;
+    var inputs = root.querySelectorAll('[id^="comment-input-"]');
+    for (var i = 0; i < inputs.length; i++) {
+      (function(input) {
+        input.addEventListener('focus', function() {
+          setTimeout(function() {
+            input.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          }, 300);
+        });
+      })(inputs[i]);
+    }
+  }
+
   /* ---- main render ---- */
 
   window.renderClientView = function () {
@@ -1577,6 +1613,8 @@ console.log('LOADED:', 'render/client.js');
       _wireEvents(lbEl);
       lbEl.dataset.clickWired = '1';
     }
+    _wireKeyboardPushNav();
+    _wireCommentInputFocus(cv);
     } catch(err) {
       console.error('[client] renderClientView crashed', err);
       window.logError && window.logError(err && err.message, err && err.stack, 'render-client-view');


### PR DESCRIPTION
Push fixed bottom nav up when the iOS virtual keyboard opens, and scroll the focused comment input into view so it is no longer hidden behind the keyboard or the pinned nav.

- render/client.js: added _wireKeyboardPushNav() (visualViewport resize listener translating #bottom-nav by keyboard height when
  >100px) and _wireCommentInputFocus() (attaches a focus listener to
  every [id^="comment-input-"] input, scrollIntoView smooth/center after a 300ms delay so the keyboard is fully open). Both called at the end of renderClientView().
- index.html: bumped all 20 ?v= strings to 20260405b.
- CLAUDE.md: updated current ?v= to 20260405b, logged the fix in Section 12.

Tests: 316/316 passing. Version: ?v=20260405b.

https://claude.ai/code/session_01RQSSfFwKcHqN5FBcxxbcE8