### PR TITLE
fix: client cannot comment — remove nav push-up + add input to overlay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260405b
+Version format: ?v=YYYYMMDDx. Current: ?v=20260405c
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -575,12 +575,23 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    scroll it into view
    Location: render/client.js renderClientView() — no visualViewport
    handling, no focus scrollIntoView on comment inputs
-   Status: FIXED (PR#TBD) — added _wireKeyboardPushNav() wiring a
-   visualViewport resize listener that translates #bottom-nav up by
-   the keyboard height when >100px, and _wireCommentInputFocus() that
+   Status: FIXED (PR#TBD) — added _wireCommentInputFocus() that
    attaches a focus listener to every [id^="comment-input-"] input to
    scrollIntoView (center, smooth) after a 300ms delay so keyboard
-   finishes opening first. Both called at the end of renderClientView.
+   finishes opening first. Called at the end of renderClientView.
+1. Client cannot comment — taps on input blocked on iOS
+   Location: render/client.js _wireKeyboardPushNav() translated
+   #bottom-nav (z:100, fixed) up by keyboardHeight on visualViewport
+   resize, painting nav pixels on top of the static-flow comment
+   input row and intercepting taps; _openClientPostOverlay built
+   cardHtml without _commentInputHtml() so overlay opened with no
+   input in DOM; overlay root had user-select:none which can cause
+   flaky iOS Safari input behaviour
+   Status: FIXED (PR#TBD) — removed _wireKeyboardPushNav() entirely
+   (scrollIntoView alone handles positioning correctly), removed
+   user-select:none/-webkit-user-select:none from #client-post-overlay
+   style, and added _commentInputHtml(post) to the overlay cardHtml
+   build so the input exists in DOM immediately on open.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260405b">
+ <link rel="stylesheet" href="styles.css?v=20260405c">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260405b"></script>
-<script src="00-appstate-compat.js?v=20260405b"></script>
-<script src="01-config.js?v=20260405b" defer></script>
-<script src="02-session.js?v=20260405b" defer></script>
-<script src="utils.js?v=20260405b" defer></script>
-<script src="03-auth.js?v=20260405b" defer></script>
-<script src="05-api.js?v=20260405b" defer></script>
-<script src="10-ui.js?v=20260405b" defer></script>
+<script src="00-appstate.js?v=20260405c"></script>
+<script src="00-appstate-compat.js?v=20260405c"></script>
+<script src="01-config.js?v=20260405c" defer></script>
+<script src="02-session.js?v=20260405c" defer></script>
+<script src="utils.js?v=20260405c" defer></script>
+<script src="03-auth.js?v=20260405c" defer></script>
+<script src="05-api.js?v=20260405c" defer></script>
+<script src="10-ui.js?v=20260405c" defer></script>
 
-<script src="06-post-create.js?v=20260405b" defer></script>
-<script defer src="render/dashboard.js?v=20260405b"></script>
-<script defer src="render/client.js?v=20260405b"></script>
-<script defer src="render/pipeline.js?v=20260405b"></script>
-<script defer src="render/brief.js?v=20260405b"></script>
-<script defer src="actions/pcs.js?v=20260405b"></script>
-<script src="07-post-load.js?v=20260405b" defer></script>
-<script src="08-post-actions.js?v=20260405b" defer></script>
-<script src="09-library.js?v=20260405b" defer></script>
-<script src="09-approval.js?v=20260405b" defer></script>
-<script src="04-router.js?v=20260405b" defer></script>
+<script src="06-post-create.js?v=20260405c" defer></script>
+<script defer src="render/dashboard.js?v=20260405c"></script>
+<script defer src="render/client.js?v=20260405c"></script>
+<script defer src="render/pipeline.js?v=20260405c"></script>
+<script defer src="render/brief.js?v=20260405c"></script>
+<script defer src="actions/pcs.js?v=20260405c"></script>
+<script src="07-post-load.js?v=20260405c" defer></script>
+<script src="08-post-actions.js?v=20260405c" defer></script>
+<script src="09-library.js?v=20260405c" defer></script>
+<script src="09-approval.js?v=20260405c" defer></script>
+<script src="04-router.js?v=20260405c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1498,27 +1498,7 @@ console.log('LOADED:', 'render/client.js');
     });
   }
 
-  /* ---- iOS keyboard: push bottom nav up, scroll focused input into view ---- */
-
-  var _kbPushWired = false;
-  function _wireKeyboardPushNav() {
-    if (_kbPushWired) return;
-    if (!window.visualViewport) return;
-    _kbPushWired = true;
-    window.visualViewport.addEventListener('resize', function() {
-      var nav = document.querySelector('#app nav') ||
-                document.getElementById('client-bottom-nav') ||
-                document.getElementById('bottom-nav');
-      if (!nav) return;
-      var keyboardHeight = window.innerHeight - window.visualViewport.height;
-      if (keyboardHeight > 100) {
-        nav.style.transform = 'translateY(-' + keyboardHeight + 'px)';
-        nav.style.transition = 'transform 0.1s ease';
-      } else {
-        nav.style.transform = '';
-      }
-    });
-  }
+  /* ---- iOS keyboard: scroll focused input into view ---- */
 
   function _wireCommentInputFocus(root) {
     if (!root) return;
@@ -1613,7 +1593,6 @@ console.log('LOADED:', 'render/client.js');
       _wireEvents(lbEl);
       lbEl.dataset.clickWired = '1';
     }
-    _wireKeyboardPushNav();
     _wireCommentInputFocus(cv);
     } catch(err) {
       console.error('[client] renderClientView crashed', err);
@@ -1659,11 +1638,12 @@ console.log('LOADED:', 'render/client.js');
       _imgGridHtml(post.images) +
       _statsBarHtml(post, isPublished) +
       (isPublished ? '' : _engagementBarHtml(post)) +
-      _commentsListHtml(post);
+      _commentsListHtml(post) +
+      _commentInputHtml(post);
 
     var overlay = document.createElement('div');
     overlay.id = 'client-post-overlay';
-    overlay.style.cssText = 'position:fixed;inset:0;z-index:9000;background:#1b1f23;overflow-y:auto;-webkit-overflow-scrolling:touch;font-family:\'DM Sans\',sans-serif;user-select:none;-webkit-user-select:none;';
+    overlay.style.cssText = 'position:fixed;inset:0;z-index:9000;background:#1b1f23;overflow-y:auto;-webkit-overflow-scrolling:touch;font-family:\'DM Sans\',sans-serif;';
     overlay.innerHTML =
       '<div style="position:sticky;top:0;z-index:10;background:rgba(27,31,35,0.98);padding:0;border-bottom:1px solid rgba(255,255,255,0.06);">' +
         '<button id="client-overlay-close" style="background:none;border:none;color:#888;font-size:24px;cursor:pointer;padding:12px 16px;">&#x2715;</button>' +


### PR DESCRIPTION
Production bug: iOS clients could not comment. Three issues:

1. _wireKeyboardPushNav() translated #bottom-nav (z:100, fixed) up by keyboardHeight on visualViewport resize. The translated nav painted pixels on top of the static-flow comment input row, intercepting taps and blocking typing. Removed entirely; focus scrollIntoView alone handles positioning.
2. _openClientPostOverlay() built cardHtml without _commentInputHtml(), so the overlay opened with no input in DOM. Added _commentInputHtml(post) to the cardHtml build.
3. #client-post-overlay root style had user-select:none and -webkit-user-select:none which cause flaky input behaviour on iOS Safari. Removed both.

- render/client.js: removed _wireKeyboardPushNav and its call in renderClientView; removed user-select from overlay cssText; appended _commentInputHtml(post) to overlay cardHtml.
- index.html: bumped all 20 ?v= strings to 20260405c.
- CLAUDE.md: updated current version to 20260405c, noted fix.

Tests: 316/316 passing. Version: ?v=20260405c.

https://claude.ai/code/session_01RQSSfFwKcHqN5FBcxxbcE8