### PR TITLE
fix: 3 hardening fixes for bugs shipped today

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -2560,7 +2560,7 @@ function toggleStageOverflow(btn, totalHidden) {
 // Covers: .row-tile, .pcs-cal-cell, .upc-list-row (any element with data-post-id)
 // ===============================================
 document.addEventListener('click', function _cardClickDelegate(e) {
-  if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'BUTTON') return;
+  if (e.target.closest('input, textarea, button, [contenteditable="true"], a, [role="button"]')) return;
   if (!window.AppState.user.effectiveRole) return;
   var _role = (window.AppState.user.effectiveRole || '').toLowerCase();
   if (_role === 'client') {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260405f
+Version format: ?v=YYYYMMDDx. Current: ?v=20260405g
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -630,6 +630,27 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    05-api.js:12) and assign it to commentObj.id. Optimistic
    append and rendering remain unchanged; only commentObj.id
    is patched silently in memory.
+1. _cardClickDelegate guard too narrow — only blocked INPUT,
+   TEXTAREA, BUTTON by tagName, so taps on links, contenteditable
+   fields, custom [role=button] elements, and children of native
+   buttons (e.g. a span inside a <button>) fell through and
+   triggered card-open logic on [data-post-id] ancestors.
+   Location: 07-post-load.js:2563 _cardClickDelegate guard.
+   Status: FIXED (PR#TBD) — replaced tagName checks with
+   e.target.closest('input, textarea, button, [contenteditable="true"],
+   a, [role="button"]') so interactive elements and their children
+   are reliably skipped.
+1. Optimistic client comment could end up in the DOM with no
+   UUID if the POST response returned no id, leaving a ghost
+   comment that the DELETE button could never remove.
+   Location: render/client.js _handleSubmitComment after the
+   POST /post_comments resolve — previously only patched id when
+   present, with no fallback branch.
+   Status: FIXED (PR#TBD) — if _createdId is falsy, splice
+   commentObj out of post.post_comments, remove the last list
+   child from the DOM, showToast('Failed to sync comment.
+   Please try again.', 'error') and return before firing any
+   notifications. Prevents headless comments with empty id.
 1. Four dead-function onclick handlers in index.html (Phase 4
    audit) — buttons silently did nothing when tapped
    Location: index.html:486 closeClientMenu() (undefined);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260405f">
+ <link rel="stylesheet" href="styles.css?v=20260405g">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260405f"></script>
-<script src="00-appstate-compat.js?v=20260405f"></script>
-<script src="01-config.js?v=20260405f" defer></script>
-<script src="02-session.js?v=20260405f" defer></script>
-<script src="utils.js?v=20260405f" defer></script>
-<script src="03-auth.js?v=20260405f" defer></script>
-<script src="05-api.js?v=20260405f" defer></script>
-<script src="10-ui.js?v=20260405f" defer></script>
+<script src="00-appstate.js?v=20260405g"></script>
+<script src="00-appstate-compat.js?v=20260405g"></script>
+<script src="01-config.js?v=20260405g" defer></script>
+<script src="02-session.js?v=20260405g" defer></script>
+<script src="utils.js?v=20260405g" defer></script>
+<script src="03-auth.js?v=20260405g" defer></script>
+<script src="05-api.js?v=20260405g" defer></script>
+<script src="10-ui.js?v=20260405g" defer></script>
 
-<script src="06-post-create.js?v=20260405f" defer></script>
-<script defer src="render/dashboard.js?v=20260405f"></script>
-<script defer src="render/client.js?v=20260405f"></script>
-<script defer src="render/pipeline.js?v=20260405f"></script>
-<script defer src="render/brief.js?v=20260405f"></script>
-<script defer src="actions/pcs.js?v=20260405f"></script>
-<script src="07-post-load.js?v=20260405f" defer></script>
-<script src="08-post-actions.js?v=20260405f" defer></script>
-<script src="09-library.js?v=20260405f" defer></script>
-<script src="09-approval.js?v=20260405f" defer></script>
-<script src="04-router.js?v=20260405f" defer></script>
+<script src="06-post-create.js?v=20260405g" defer></script>
+<script defer src="render/dashboard.js?v=20260405g"></script>
+<script defer src="render/client.js?v=20260405g"></script>
+<script defer src="render/pipeline.js?v=20260405g"></script>
+<script defer src="render/brief.js?v=20260405g"></script>
+<script defer src="actions/pcs.js?v=20260405g"></script>
+<script src="07-post-load.js?v=20260405g" defer></script>
+<script src="08-post-actions.js?v=20260405g" defer></script>
+<script src="09-library.js?v=20260405g" defer></script>
+<script src="09-approval.js?v=20260405g" defer></script>
+<script src="04-router.js?v=20260405g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1007,6 +1007,18 @@ console.log('LOADED:', 'render/client.js');
         ? _resp[0].id
         : (_resp && _resp.id) || null;
       if (_createdId) commentObj.id = _createdId;
+      if (!_createdId) {
+        if (post && Array.isArray(post.post_comments)) {
+          post.post_comments = post.post_comments.filter(function(c){ return c !== commentObj; });
+        }
+        if (listEl && listEl.lastChild) {
+          listEl.removeChild(listEl.lastChild);
+        }
+        if (typeof window.showToast === 'function') {
+          window.showToast('Failed to sync comment. Please try again.', 'error');
+        }
+        return;
+      }
       window.apiFetch('/notifications', {
         method: 'POST',
         body: JSON.stringify({

--- a/styles.css
+++ b/styles.css
@@ -6558,6 +6558,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
    does not collapse to 0 and stack the input footer against the
    photo grid. .pc-scroll-body is a block container, so flex:1 on
    the pane is ignored as a flex item — scope this fix to desktop. */
+/* TODO (Phase 6): min-height patch — replace with proper flex layout system overhaul */
 @media (min-width: 768px) {
   #pcs-pane-client, #pcs-pane-internal { min-height: 60vh; }
 }


### PR DESCRIPTION
- strengthen _cardClickDelegate guard in 07-post-load.js to use closest() so links, contenteditable, [role=button] and button children are all skipped
- add UUID failure fallback in render/client.js _handleSubmitComment that removes the optimistic comment from DOM + array and toasts error if the POST returns no id
- add TODO comment above the desktop min-height:60vh patch in styles.css flagging it for Phase 6 flex layout overhaul

version: ?v=20260405g

https://claude.ai/code/session_01TGR3LaU3hws3ZkxWH8GDJL