### PR TITLE
fix: 3 hardening fixes + Phase 4 Group A event delegation

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -1585,3 +1585,24 @@ window.AppState.timers.notifBadgeTimer = setInterval(function() {
   if (!localStorage.getItem('sb_access_token') && !localStorage.getItem('sb_refresh_token')) return;
   if (typeof updateNotifBadge === 'function') updateNotifBadge();
 }, 60000);
+
+// ===============================================
+// GLOBAL ACTION ROUTER (Phase 4 — event delegation)
+// Resolves [data-action] targets to their handler.
+// Skips interactive elements so inputs/buttons still
+// receive native taps; PCS overlay is excluded because
+// it owns its own delegate.
+// ===============================================
+document.addEventListener('click', function handleGlobalClick(e) {
+  if (e.target.closest('#pcs-overlay')) return;
+  if (e.target.closest('input, textarea, button, [contenteditable="true"], a, [role="button"]')) return;
+  const actionEl = e.target.closest('[data-action]');
+  if (!actionEl) return;
+  const type = actionEl.dataset.action;
+  const tab = actionEl.dataset.tab;
+  switch (type) {
+    case 'nav-tab':      return switchTab(actionEl);
+    case 'nav-library':  return showLibrary();
+    case 'nav-insights': return showInsights();
+  }
+});

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260405g
+Version format: ?v=YYYYMMDDx. Current: ?v=20260405h
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -671,7 +671,7 @@ Ph1 File Architecture — DONE (render/ + actions/ extracted)
 Ph2 AppState          — DONE (all globals migrated)
 Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast, Pass 5 dashboard — 4 fixes + 1 post-load fix, Pass 6 post-load — 12 fixes + 4 duplicate function overwrites fixed, Pass 7 auth — 6 fixes incl. silent refreshSession catch)
 Ph3.5 Role Standardization — DONE (Phase A: normalizeRole() added, rollback.sql created; Phase B: config wire cut — ALLOWED_OWNERS, ROLE_TABS, notification recipients, HTML option values all use DB roles; Phase C: DB write payloads — owner fields in brief.js, post-load.js, post-create.js all use DB roles; Phase D: owner read checks — pipeline.js isMine/filter checks + pcs.js chip color all use DB role names Creative/Servicing)
-Ph4 Event Delegation  — PENDING
+Ph4 Event Delegation  — IN PROGRESS (Group A: bottom nav done — global action router in 10-ui.js, 4 inline onclicks on .nav-item replaced with data-action)
 Ph5 Optimistic UI     — IN PROGRESS (client comments done)
 Ph6 PWA               — PENDING
 Ph7 Light Mode        — PENDING

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260405g">
+ <link rel="stylesheet" href="styles.css?v=20260405h">
 
 </head>
 <body>
@@ -433,19 +433,19 @@
 
 <!-- BOTTOM NAVIGATION (global -- outside all views so it persists across roles) -->
 <nav class="bottom-nav" id="bottom-nav">
-  <div class="nav-item tab-btn active" data-tab="tasks" onclick="switchTab(this)">
+  <div class="nav-item tab-btn active" data-tab="tasks" data-action="nav-tab">
     <svg class="nav-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
     <span class="nav-label">Dashboard</span>
   </div>
-  <div class="nav-item tab-btn" data-tab="pipeline" onclick="switchTab(this)">
+  <div class="nav-item tab-btn" data-tab="pipeline" data-action="nav-tab">
     <svg class="nav-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
     <span class="nav-label">Pipeline</span>
   </div>
-  <div class="nav-item tab-btn" data-tab="library" onclick="showLibrary()">
+  <div class="nav-item tab-btn" data-tab="library" data-action="nav-library">
     <svg class="nav-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
     <span class="nav-label">Library</span>
   </div>
-  <div class="nav-item tab-btn" id="nav-insights" data-tab="insights" onclick="showInsights()" style="position:relative">
+  <div class="nav-item tab-btn" id="nav-insights" data-tab="insights" data-action="nav-insights" style="position:relative">
     <svg class="nav-icon" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"/></svg>
     <span class="nav-label">Insights</span>
   </div>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260405g"></script>
-<script src="00-appstate-compat.js?v=20260405g"></script>
-<script src="01-config.js?v=20260405g" defer></script>
-<script src="02-session.js?v=20260405g" defer></script>
-<script src="utils.js?v=20260405g" defer></script>
-<script src="03-auth.js?v=20260405g" defer></script>
-<script src="05-api.js?v=20260405g" defer></script>
-<script src="10-ui.js?v=20260405g" defer></script>
+<script src="00-appstate.js?v=20260405h"></script>
+<script src="00-appstate-compat.js?v=20260405h"></script>
+<script src="01-config.js?v=20260405h" defer></script>
+<script src="02-session.js?v=20260405h" defer></script>
+<script src="utils.js?v=20260405h" defer></script>
+<script src="03-auth.js?v=20260405h" defer></script>
+<script src="05-api.js?v=20260405h" defer></script>
+<script src="10-ui.js?v=20260405h" defer></script>
 
-<script src="06-post-create.js?v=20260405g" defer></script>
-<script defer src="render/dashboard.js?v=20260405g"></script>
-<script defer src="render/client.js?v=20260405g"></script>
-<script defer src="render/pipeline.js?v=20260405g"></script>
-<script defer src="render/brief.js?v=20260405g"></script>
-<script defer src="actions/pcs.js?v=20260405g"></script>
-<script src="07-post-load.js?v=20260405g" defer></script>
-<script src="08-post-actions.js?v=20260405g" defer></script>
-<script src="09-library.js?v=20260405g" defer></script>
-<script src="09-approval.js?v=20260405g" defer></script>
-<script src="04-router.js?v=20260405g" defer></script>
+<script src="06-post-create.js?v=20260405h" defer></script>
+<script defer src="render/dashboard.js?v=20260405h"></script>
+<script defer src="render/client.js?v=20260405h"></script>
+<script defer src="render/pipeline.js?v=20260405h"></script>
+<script defer src="render/brief.js?v=20260405h"></script>
+<script defer src="actions/pcs.js?v=20260405h"></script>
+<script src="07-post-load.js?v=20260405h" defer></script>
+<script src="08-post-actions.js?v=20260405h" defer></script>
+<script src="09-library.js?v=20260405h" defer></script>
+<script src="09-approval.js?v=20260405h" defer></script>
+<script src="04-router.js?v=20260405h" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

Two commits on this branch:

**1) 3 hardening fixes for bugs shipped today**
- Strengthen `_cardClickDelegate` guard in 07-post-load.js to use `closest('input, textarea, button, [contenteditable="true"], a, [role="button"]')` so links, contenteditable fields, custom `[role=button]` elements, and children of native buttons are reliably skipped.
- Add UUID failure fallback in `render/client.js` `_handleSubmitComment` — if POST returns no id, splice optimistic commentObj from `post.post_comments`, remove the last list child from the DOM, toast error, and bail before firing notifications. Prevents headless comments with empty id.
- Add `TODO (Phase 6)` comment above the desktop `min-height:60vh` patch in styles.css flagging it for flex layout overhaul.

**2) Phase 4 Group A — bottom nav event delegation**
- Removed 4 inline `onclick` attributes from `.nav-item` elements in index.html; replaced with `data-action` attributes (`nav-tab` / `nav-library` / `nav-insights`).
- Added global action router at the bottom of 10-ui.js that resolves `[data-action]` targets to `switchTab` / `showLibrary` / `showInsights`, skipping `#pcs-overlay` and interactive elements.
- Preserved existing `data-tab` values (tasks, pipeline, library, insights) so `switchTab`'s `panel-*` lookup continues to work.

## Files Changed
- `07-post-load.js` — broadened click delegate guard
- `render/client.js` — added `!_createdId` fallback in `_handleSubmitComment`
- `styles.css` — added Phase 6 TODO above desktop min-height block
- `index.html` — removed 4 nav-item onclicks, added data-action, bumped all 20 `?v=` strings
- `10-ui.js` — added global `[data-action]` router (`handleGlobalClick`)
- `CLAUDE.md` — documented 2 new FIXED bugs, Phase 4 IN PROGRESS, version bump

## Tests
316/316 passing (13 files)

## Version
`?v=20260405h` (all 20 strings bumped together)

https://claude.ai/code/session_01TGR3LaU3hws3ZkxWH8GDJL