### PR TITLE
refactor: Phase 4 Group B — delegate PCS tab clicks

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -1594,15 +1594,20 @@ window.AppState.timers.notifBadgeTimer = setInterval(function() {
 // it owns its own delegate.
 // ===============================================
 document.addEventListener('click', function handleGlobalClick(e) {
-  if (e.target.closest('#pcs-overlay')) return;
-  if (e.target.closest('input, textarea, button, [contenteditable="true"], a, [role="button"]')) return;
   const actionEl = e.target.closest('[data-action]');
   if (!actionEl) return;
+  // Skip if the click landed on an interactive element nested INSIDE
+  // the action container (e.g., an <input> inside a card with
+  // data-action). The action element itself may be a <button> — don't
+  // block that case.
+  const interactive = e.target.closest('input, textarea, [contenteditable="true"], a');
+  if (interactive && interactive !== actionEl && actionEl.contains(interactive)) return;
   const type = actionEl.dataset.action;
   const tab = actionEl.dataset.tab;
   switch (type) {
     case 'nav-tab':      return switchTab(actionEl);
     case 'nav-library':  return showLibrary();
     case 'nav-insights': return showInsights();
+    case 'pcs-tab':      return window._pcsTabSwitch(tab);
   }
 });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260405h
+Version format: ?v=YYYYMMDDx. Current: ?v=20260405i
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -671,7 +671,7 @@ Ph1 File Architecture — DONE (render/ + actions/ extracted)
 Ph2 AppState          — DONE (all globals migrated)
 Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast, Pass 5 dashboard — 4 fixes + 1 post-load fix, Pass 6 post-load — 12 fixes + 4 duplicate function overwrites fixed, Pass 7 auth — 6 fixes incl. silent refreshSession catch)
 Ph3.5 Role Standardization — DONE (Phase A: normalizeRole() added, rollback.sql created; Phase B: config wire cut — ALLOWED_OWNERS, ROLE_TABS, notification recipients, HTML option values all use DB roles; Phase C: DB write payloads — owner fields in brief.js, post-load.js, post-create.js all use DB roles; Phase D: owner read checks — pipeline.js isMine/filter checks + pcs.js chip color all use DB role names Creative/Servicing)
-Ph4 Event Delegation  — IN PROGRESS (Group A: bottom nav done — global action router in 10-ui.js, 4 inline onclicks on .nav-item replaced with data-action)
+Ph4 Event Delegation  — IN PROGRESS (Group A: bottom nav done — global action router in 10-ui.js, 4 inline onclicks on .nav-item replaced with data-action; Group B: PCS tabs done — 3 inline onclicks on .pcs-tab replaced with data-action="pcs-tab", router guard reworked to skip interactive descendants instead of blocking all PCS)
 Ph5 Optimistic UI     — IN PROGRESS (client comments done)
 Ph6 PWA               — PENDING
 Ph7 Light Mode        — PENDING

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260405h">
+ <link rel="stylesheet" href="styles.css?v=20260405i">
 
 </head>
 <body>
@@ -890,9 +890,9 @@
 
       <!-- Tab bar -->
       <div id="pcs-tab-bar" class="pcs-tab-bar">
-        <button class="pcs-tab active" data-tab="caption" onclick="window._pcsTabSwitch('caption')">Caption</button>
-        <button class="pcs-tab" data-tab="client" onclick="window._pcsTabSwitch('client')">Client <span id="pcs-tab-client-count" style="opacity:.6"></span></button>
-        <button class="pcs-tab" data-tab="internal" onclick="window._pcsTabSwitch('internal')">Internal <span id="pcs-tab-notes-count" style="opacity:.6"></span></button>
+        <button class="pcs-tab active" data-tab="caption" data-action="pcs-tab">Caption</button>
+        <button class="pcs-tab" data-tab="client" data-action="pcs-tab">Client <span id="pcs-tab-client-count" style="opacity:.6"></span></button>
+        <button class="pcs-tab" data-tab="internal" data-action="pcs-tab">Internal <span id="pcs-tab-notes-count" style="opacity:.6"></span></button>
       </div>
 
       <!-- Tab pane: Caption -->
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260405h"></script>
-<script src="00-appstate-compat.js?v=20260405h"></script>
-<script src="01-config.js?v=20260405h" defer></script>
-<script src="02-session.js?v=20260405h" defer></script>
-<script src="utils.js?v=20260405h" defer></script>
-<script src="03-auth.js?v=20260405h" defer></script>
-<script src="05-api.js?v=20260405h" defer></script>
-<script src="10-ui.js?v=20260405h" defer></script>
+<script src="00-appstate.js?v=20260405i"></script>
+<script src="00-appstate-compat.js?v=20260405i"></script>
+<script src="01-config.js?v=20260405i" defer></script>
+<script src="02-session.js?v=20260405i" defer></script>
+<script src="utils.js?v=20260405i" defer></script>
+<script src="03-auth.js?v=20260405i" defer></script>
+<script src="05-api.js?v=20260405i" defer></script>
+<script src="10-ui.js?v=20260405i" defer></script>
 
-<script src="06-post-create.js?v=20260405h" defer></script>
-<script defer src="render/dashboard.js?v=20260405h"></script>
-<script defer src="render/client.js?v=20260405h"></script>
-<script defer src="render/pipeline.js?v=20260405h"></script>
-<script defer src="render/brief.js?v=20260405h"></script>
-<script defer src="actions/pcs.js?v=20260405h"></script>
-<script src="07-post-load.js?v=20260405h" defer></script>
-<script src="08-post-actions.js?v=20260405h" defer></script>
-<script src="09-library.js?v=20260405h" defer></script>
-<script src="09-approval.js?v=20260405h" defer></script>
-<script src="04-router.js?v=20260405h" defer></script>
+<script src="06-post-create.js?v=20260405i" defer></script>
+<script defer src="render/dashboard.js?v=20260405i"></script>
+<script defer src="render/client.js?v=20260405i"></script>
+<script defer src="render/pipeline.js?v=20260405i"></script>
+<script defer src="render/brief.js?v=20260405i"></script>
+<script defer src="actions/pcs.js?v=20260405i"></script>
+<script src="07-post-load.js?v=20260405i" defer></script>
+<script src="08-post-actions.js?v=20260405i" defer></script>
+<script src="09-library.js?v=20260405i" defer></script>
+<script src="09-approval.js?v=20260405i" defer></script>
+<script src="04-router.js?v=20260405i" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
- removed 3 inline onclick attributes from .pcs-tab buttons in index.html, replaced with data-action="pcs-tab" + data-tab
- extended handleGlobalClick router with pcs-tab case that calls window._pcsTabSwitch(tab)
- reworked the router guard: previously blocked everything inside #pcs-overlay and all interactive elements, which would have swallowed the new pcs-tab data-action. Now looks up actionEl first, and only skips when an interactive descendant (input/textarea/contenteditable/a) is nested strictly inside the action container. Button action elements are allowed.

version: ?v=20260405i
tests: 316/316 passing

https://claude.ai/code/session_01TGR3LaU3hws3ZkxWH8GDJL