### PR TITLE
refactor: Phase 4 Group C — delegate PCS visibility chip clicks

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -1609,5 +1609,6 @@ document.addEventListener('click', function handleGlobalClick(e) {
     case 'nav-library':  return showLibrary();
     case 'nav-insights': return showInsights();
     case 'pcs-tab':      return window._pcsTabSwitch(tab);
+    case 'pcs-vis':      return window.setPcsVisibility && window.setPcsVisibility(actionEl, actionEl.dataset.vis);
   }
 });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260405i
+Version format: ?v=YYYYMMDDx. Current: ?v=20260405j
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -671,7 +671,7 @@ Ph1 File Architecture — DONE (render/ + actions/ extracted)
 Ph2 AppState          — DONE (all globals migrated)
 Ph3 Error Handling    — DONE (logError, _showErrorToast, onerror, onunhandledrejection, 8 silent catches fixed, Pass 3 pipeline, Pass 4 PCS — 12 fixes, 3 alert→toast, Pass 5 dashboard — 4 fixes + 1 post-load fix, Pass 6 post-load — 12 fixes + 4 duplicate function overwrites fixed, Pass 7 auth — 6 fixes incl. silent refreshSession catch)
 Ph3.5 Role Standardization — DONE (Phase A: normalizeRole() added, rollback.sql created; Phase B: config wire cut — ALLOWED_OWNERS, ROLE_TABS, notification recipients, HTML option values all use DB roles; Phase C: DB write payloads — owner fields in brief.js, post-load.js, post-create.js all use DB roles; Phase D: owner read checks — pipeline.js isMine/filter checks + pcs.js chip color all use DB role names Creative/Servicing)
-Ph4 Event Delegation  — IN PROGRESS (Group A: bottom nav done — global action router in 10-ui.js, 4 inline onclicks on .nav-item replaced with data-action; Group B: PCS tabs done — 3 inline onclicks on .pcs-tab replaced with data-action="pcs-tab", router guard reworked to skip interactive descendants instead of blocking all PCS)
+Ph4 Event Delegation  — IN PROGRESS (Group A: bottom nav done — global action router in 10-ui.js, 4 inline onclicks on .nav-item replaced with data-action; Group B: PCS tabs done — 3 inline onclicks on .pcs-tab replaced with data-action="pcs-tab", router guard reworked to skip interactive descendants instead of blocking all PCS; Group C: PCS visibility chips done — 4 inline onclicks on .pcs-vis-chip replaced with data-action="pcs-vis" data-vis=..., router routes to setPcsVisibility(actionEl, dataset.vis))
 Ph5 Optimistic UI     — IN PROGRESS (client comments done)
 Ph6 PWA               — PENDING
 Ph7 Light Mode        — PENDING

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260405i">
+ <link rel="stylesheet" href="styles.css?v=20260405j">
 
 </head>
 <body>
@@ -923,10 +923,10 @@
       <div id="pcs-pane-internal" class="pcs-tab-pane" style="display:none;flex:1;flex-direction:column;overflow:hidden">
         <span id="pcs-notes-count" style="display:none">0</span>
         <div id="pcs-vis-selector" style="flex-shrink:0;display:flex;gap:4px;padding:8px 16px;border-bottom:1px solid #0f0f16;background:#09080a">
-          <button class="pcs-vis-chip" data-vis="all" onclick="window.setPcsVisibility&&setPcsVisibility(this,'all')" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid rgba(246,166,35,.35);color:#F6A623;background:rgba(246,166,35,.04);cursor:pointer">ALL</button>
-          <button class="pcs-vis-chip" data-vis="admin" onclick="window.setPcsVisibility&&setPcsVisibility(this,'admin')" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">ADMIN</button>
-          <button class="pcs-vis-chip" data-vis="servicing" onclick="window.setPcsVisibility&&setPcsVisibility(this,'servicing')" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">SERV</button>
-          <button class="pcs-vis-chip" data-vis="creative" onclick="window.setPcsVisibility&&setPcsVisibility(this,'creative')" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">CREATIVE</button>
+          <button class="pcs-vis-chip" data-vis="all" data-action="pcs-vis" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid rgba(246,166,35,.35);color:#F6A623;background:rgba(246,166,35,.04);cursor:pointer">ALL</button>
+          <button class="pcs-vis-chip" data-vis="admin" data-action="pcs-vis" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">ADMIN</button>
+          <button class="pcs-vis-chip" data-vis="servicing" data-action="pcs-vis" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">SERV</button>
+          <button class="pcs-vis-chip" data-vis="creative" data-action="pcs-vis" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">CREATIVE</button>
         </div>
         <div id="pcs-notes-section" style="flex:1;display:flex;flex-direction:column;min-height:0">
           <div id="pcs-notes-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:12px 16px;background:#080806;scrollbar-width:none;min-height:0"></div>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260405i"></script>
-<script src="00-appstate-compat.js?v=20260405i"></script>
-<script src="01-config.js?v=20260405i" defer></script>
-<script src="02-session.js?v=20260405i" defer></script>
-<script src="utils.js?v=20260405i" defer></script>
-<script src="03-auth.js?v=20260405i" defer></script>
-<script src="05-api.js?v=20260405i" defer></script>
-<script src="10-ui.js?v=20260405i" defer></script>
+<script src="00-appstate.js?v=20260405j"></script>
+<script src="00-appstate-compat.js?v=20260405j"></script>
+<script src="01-config.js?v=20260405j" defer></script>
+<script src="02-session.js?v=20260405j" defer></script>
+<script src="utils.js?v=20260405j" defer></script>
+<script src="03-auth.js?v=20260405j" defer></script>
+<script src="05-api.js?v=20260405j" defer></script>
+<script src="10-ui.js?v=20260405j" defer></script>
 
-<script src="06-post-create.js?v=20260405i" defer></script>
-<script defer src="render/dashboard.js?v=20260405i"></script>
-<script defer src="render/client.js?v=20260405i"></script>
-<script defer src="render/pipeline.js?v=20260405i"></script>
-<script defer src="render/brief.js?v=20260405i"></script>
-<script defer src="actions/pcs.js?v=20260405i"></script>
-<script src="07-post-load.js?v=20260405i" defer></script>
-<script src="08-post-actions.js?v=20260405i" defer></script>
-<script src="09-library.js?v=20260405i" defer></script>
-<script src="09-approval.js?v=20260405i" defer></script>
-<script src="04-router.js?v=20260405i" defer></script>
+<script src="06-post-create.js?v=20260405j" defer></script>
+<script defer src="render/dashboard.js?v=20260405j"></script>
+<script defer src="render/client.js?v=20260405j"></script>
+<script defer src="render/pipeline.js?v=20260405j"></script>
+<script defer src="render/brief.js?v=20260405j"></script>
+<script defer src="actions/pcs.js?v=20260405j"></script>
+<script src="07-post-load.js?v=20260405j" defer></script>
+<script src="08-post-actions.js?v=20260405j" defer></script>
+<script src="09-library.js?v=20260405j" defer></script>
+<script src="09-approval.js?v=20260405j" defer></script>
+<script src="04-router.js?v=20260405j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
- removed 4 inline onclick attributes from .pcs-vis-chip buttons in index.html (ALL/ADMIN/SERV/CREATIVE), replaced with data-action="pcs-vis" (data-vis already present)
- extended handleGlobalClick router with pcs-vis case that calls window.setPcsVisibility(actionEl, actionEl.dataset.vis)

version: ?v=20260405j
tests: 316/316 passing

https://claude.ai/code/session_01TGR3LaU3hws3ZkxWH8GDJL