### PR TITLE
feat: click_log telemetry batch pipeline

### DIFF
--- a/00-appstate.js
+++ b/00-appstate.js
@@ -106,6 +106,9 @@ window.onunhandledrejection = function(event) {
   window.logError(_msg, _stack, 'unhandledrejection');
 };
 
+// Click-analytics session id (click_log telemetry, Apr 5 2026)
+window._sessionId = 'sess_' + Date.now() + '_' + Math.random().toString(36).slice(2,8);
+
 // Per-action in-flight guard (CTO-approved pattern Apr 5 2026)
 // Prevents duplicate async calls from rapid taps or double-clicks.
 // Usage: guardAction('unique-key', () => myAsyncFunction())
@@ -121,6 +124,14 @@ window.guardAction = function(key, fn) {
       }
       if (typeof window.showToast === 'function') {
         window.showToast('Something went wrong', 'error');
+      }
+      if (window._clickBuffer) {
+        window._clickBuffer.push({
+          action:     key,
+          success:    false,
+          error:      err.message || String(err),
+          created_at: new Date().toISOString()
+        });
       }
     })
     .finally(function() {

--- a/10-ui.js
+++ b/10-ui.js
@@ -17,6 +17,68 @@ function hideErrorBanner() {
   document.getElementById('error-banner')?.classList.add('hidden');
 }
 
+// -- Click-log telemetry buffer ----------------
+window._clickBuffer = [];
+
+function _flushClickBuffer() {
+  if (!window._clickBuffer.length) return;
+  var batch = window._clickBuffer.splice(0);
+  var user = AppState.user || {};
+  var payload = batch.map(function(entry) {
+    return {
+      session_id:    window._sessionId || 'unknown',
+      action:        entry.action,
+      data:          entry.data || null,
+      user_email:    user.email || null,
+      user_role:     user.effectiveRole || null,
+      post_id:       entry.post_id || null,
+      success:       entry.success !== false,
+      error_message: entry.error || null,
+      duration_ms:   entry.duration_ms || null,
+      page:          window.location.pathname || '/',
+      device_type:   window.innerWidth <= 768 ? 'mobile' : 'desktop',
+      app_version:   (document.querySelector('script[src*="?v="]') || {}).src
+                     ? document.querySelector('script[src*="?v="]').src.split('?v=')[1] : null,
+      created_at:    entry.created_at
+    };
+  });
+  if (typeof apiFetch === 'function') {
+    apiFetch('/click_log', {
+      method: 'POST',
+      headers: { 'Prefer': 'return=minimal' },
+      body: JSON.stringify(payload)
+    }).catch(function() {});
+  }
+}
+
+setInterval(_flushClickBuffer, 5000);
+
+window.addEventListener('beforeunload', function() {
+  if (!window._clickBuffer.length) return;
+  var user = AppState.user || {};
+  var payload = window._clickBuffer.map(function(entry) {
+    return {
+      session_id:    window._sessionId || 'unknown',
+      action:        entry.action,
+      data:          entry.data || null,
+      user_email:    user.email || null,
+      user_role:     user.effectiveRole || null,
+      post_id:       entry.post_id || null,
+      success:       entry.success !== false,
+      error_message: entry.error || null,
+      duration_ms:   entry.duration_ms || null,
+      page:          window.location.pathname || '/',
+      device_type:   window.innerWidth <= 768 ? 'mobile' : 'desktop',
+      app_version:   null,
+      created_at:    entry.created_at
+    };
+  });
+  navigator.sendBeacon(
+    (window._SUPABASE_URL || '') + '/rest/v1/click_log',
+    JSON.stringify(payload)
+  );
+});
+
 window._showErrorToast = function() {
   if (document.getElementById('sorted-error-toast')) return;
   var _t = document.createElement('div');
@@ -1606,6 +1668,14 @@ if (!window._routerBound) {
     if (interactive && interactive !== actionEl && actionEl.contains(interactive)) return;
     const type = actionEl.dataset.action;
     const tab = actionEl.dataset.tab;
+    window._clickBuffer.push({
+      action:     type,
+      data:       Object.assign({}, actionEl.dataset),
+      post_id:    actionEl.dataset.postId || (actionEl.closest('[data-post-id]')
+                  ? actionEl.closest('[data-post-id]').dataset.postId : null),
+      success:    true,
+      created_at: new Date().toISOString()
+    });
     try {
       switch (type) {
         case 'nav-tab':      return guardAction('nav-tab-' + tab, () => switchTab(actionEl));

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260405x
+Version format: ?v=YYYYMMDDx. Current: ?v=20260405y
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -404,7 +404,21 @@ window.guardAction          — per-key in-flight guard for async handlers;
                               usage: guardAction('key', () => asyncFn());
                               skips re-entry while key is in-flight,
                               catches errors → logError + showToast,
+                              also pushes failure entries into
+                              window._clickBuffer with success:false,
                               releases key in .finally()
+window._sessionId           — unique session identifier minted once at
+                              page load (sess_<ts>_<rand6>), used as
+                              session_id on every click_log row
+
+10-ui.js (click telemetry):
+window._clickBuffer         — array of pending click_log entries; the
+                              Action Router pushes one per dispatch,
+                              guardAction pushes failures
+_flushClickBuffer           — drains _clickBuffer to POST /click_log
+                              every 5s via apiFetch, fire-and-forget;
+                              on beforeunload sends the remainder via
+                              navigator.sendBeacon directly to Supabase
 
 10-ui.js:
 window._showErrorToast      — show transient error toast to user

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260405x">
+ <link rel="stylesheet" href="styles.css?v=20260405y">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260405x"></script>
-<script src="00-appstate-compat.js?v=20260405x"></script>
-<script src="01-config.js?v=20260405x" defer></script>
-<script src="02-session.js?v=20260405x" defer></script>
-<script src="utils.js?v=20260405x" defer></script>
-<script src="03-auth.js?v=20260405x" defer></script>
-<script src="05-api.js?v=20260405x" defer></script>
-<script src="10-ui.js?v=20260405x" defer></script>
+<script src="00-appstate.js?v=20260405y"></script>
+<script src="00-appstate-compat.js?v=20260405y"></script>
+<script src="01-config.js?v=20260405y" defer></script>
+<script src="02-session.js?v=20260405y" defer></script>
+<script src="utils.js?v=20260405y" defer></script>
+<script src="03-auth.js?v=20260405y" defer></script>
+<script src="05-api.js?v=20260405y" defer></script>
+<script src="10-ui.js?v=20260405y" defer></script>
 
-<script src="06-post-create.js?v=20260405x" defer></script>
-<script defer src="render/dashboard.js?v=20260405x"></script>
-<script defer src="render/client.js?v=20260405x"></script>
-<script defer src="render/pipeline.js?v=20260405x"></script>
-<script defer src="render/brief.js?v=20260405x"></script>
-<script defer src="actions/pcs.js?v=20260405x"></script>
-<script src="07-post-load.js?v=20260405x" defer></script>
-<script src="08-post-actions.js?v=20260405x" defer></script>
-<script src="09-library.js?v=20260405x" defer></script>
-<script src="09-approval.js?v=20260405x" defer></script>
-<script src="04-router.js?v=20260405x" defer></script>
+<script src="06-post-create.js?v=20260405y" defer></script>
+<script defer src="render/dashboard.js?v=20260405y"></script>
+<script defer src="render/client.js?v=20260405y"></script>
+<script defer src="render/pipeline.js?v=20260405y"></script>
+<script defer src="render/brief.js?v=20260405y"></script>
+<script defer src="actions/pcs.js?v=20260405y"></script>
+<script src="07-post-load.js?v=20260405y" defer></script>
+<script src="08-post-actions.js?v=20260405y" defer></script>
+<script src="09-library.js?v=20260405y" defer></script>
+<script src="09-approval.js?v=20260405y" defer></script>
+<script src="04-router.js?v=20260405y" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/tests/action-router.test.js
+++ b/tests/action-router.test.js
@@ -43,6 +43,10 @@ describe('Phase 4/5 — Action Router & guardAction', function() {
     };
     // Prevent logError's fetch from touching the network.
     window.fetch = vi.fn(function() { return Promise.resolve({ ok:true }); });
+    // 10-ui.js owns window._clickBuffer in production; the router
+    // pushes to it on every dispatch. We're not evaluating 10-ui.js
+    // here (only the router block), so stub the buffer array.
+    window._clickBuffer = [];
     // Evaluate guardAction and the router ONCE.
     // Re-evaluating would either double-bind the listener or re-declare _inFlight,
     // so keep state stable across the suite and clear _inFlight via the


### PR DESCRIPTION
- 00-appstate.js: new window._sessionId (sess_<ts>_<rand6>) minted once at page load. guardAction's .catch block now also pushes a failure entry into window._clickBuffer so every handler error produces a click_log row with success:false + error_message.
- 10-ui.js: new window._clickBuffer array + _flushClickBuffer that drains every 5s via apiFetch POST /click_log (fire-and-forget, Prefer: return=minimal). Each row includes session_id, action, data, user_email/role, post_id, success, error_message, duration_ms, page, device_type (mobile/desktop from innerWidth), app_version (from the first ?v= script src), created_at. On beforeunload the remainder is flushed via navigator.sendBeacon directly to Supabase so we don't lose in-flight clicks.
- 10-ui.js handleGlobalClick: pushes one _clickBuffer entry for every [data-action] dispatch with the full dataset, post_id from data-post-id ancestor (if any), success:true.
- index.html: bumped all 20 ?v= strings to ?v=20260405y.
- tests/action-router.test.js: stubs window._clickBuffer=[] in beforeAll so the router push does not crash the extracted router block (10-ui.js is not fully evaluated in the unit test environment).
- CLAUDE.md: documented window._sessionId, window._clickBuffer, _flushClickBuffer, and the guardAction→click_log failure path under SECTION 11, and bumped current version string.

tests: 384/384 passing (unchanged)
version: ?v=20260405y

https://claude.ai/code/session_01TGR3LaU3hws3ZkxWH8GDJL