### PR TITLE
fix: click_log telemetry visibility + correct beforeunload send

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -47,7 +47,9 @@ function _flushClickBuffer() {
       method: 'POST',
       headers: { 'Prefer': 'return=minimal' },
       body: JSON.stringify(payload)
-    }).catch(function() {});
+    }).catch(function(err){
+      console.warn('[click_log] insert failed:', err && err.message);
+    });
   }
 }
 
@@ -73,10 +75,17 @@ window.addEventListener('beforeunload', function() {
       created_at:    entry.created_at
     };
   });
-  navigator.sendBeacon(
-    (window._SUPABASE_URL || '') + '/rest/v1/click_log',
-    JSON.stringify(payload)
-  );
+  fetch(SUPABASE_URL + '/rest/v1/click_log', {
+    method: 'POST',
+    keepalive: true,
+    headers: {
+      'Content-Type': 'application/json',
+      'apikey': SUPABASE_KEY,
+      'Authorization': 'Bearer ' + SUPABASE_KEY,
+      'Prefer': 'return=minimal'
+    },
+    body: JSON.stringify(payload)
+  }).catch(function(){});
 });
 
 window._showErrorToast = function() {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260405y
+Version format: ?v=YYYYMMDDx. Current: ?v=20260405z
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -416,9 +416,14 @@ window._clickBuffer         — array of pending click_log entries; the
                               Action Router pushes one per dispatch,
                               guardAction pushes failures
 _flushClickBuffer           — drains _clickBuffer to POST /click_log
-                              every 5s via apiFetch, fire-and-forget;
-                              on beforeunload sends the remainder via
-                              navigator.sendBeacon directly to Supabase
+                              every 5s via apiFetch; failures now
+                              console.warn so RLS/permission errors
+                              are visible in devtools. On beforeunload
+                              the remainder is POSTed via
+                              fetch(keepalive:true) with full
+                              apikey + Authorization headers
+                              (sendBeacon cannot set headers so
+                              Supabase would always reject it).
 
 10-ui.js:
 window._showErrorToast      — show transient error toast to user

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260405y">
+ <link rel="stylesheet" href="styles.css?v=20260405z">
 
 </head>
 <body>
@@ -1073,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260405y"></script>
-<script src="00-appstate-compat.js?v=20260405y"></script>
-<script src="01-config.js?v=20260405y" defer></script>
-<script src="02-session.js?v=20260405y" defer></script>
-<script src="utils.js?v=20260405y" defer></script>
-<script src="03-auth.js?v=20260405y" defer></script>
-<script src="05-api.js?v=20260405y" defer></script>
-<script src="10-ui.js?v=20260405y" defer></script>
+<script src="00-appstate.js?v=20260405z"></script>
+<script src="00-appstate-compat.js?v=20260405z"></script>
+<script src="01-config.js?v=20260405z" defer></script>
+<script src="02-session.js?v=20260405z" defer></script>
+<script src="utils.js?v=20260405z" defer></script>
+<script src="03-auth.js?v=20260405z" defer></script>
+<script src="05-api.js?v=20260405z" defer></script>
+<script src="10-ui.js?v=20260405z" defer></script>
 
-<script src="06-post-create.js?v=20260405y" defer></script>
-<script defer src="render/dashboard.js?v=20260405y"></script>
-<script defer src="render/client.js?v=20260405y"></script>
-<script defer src="render/pipeline.js?v=20260405y"></script>
-<script defer src="render/brief.js?v=20260405y"></script>
-<script defer src="actions/pcs.js?v=20260405y"></script>
-<script src="07-post-load.js?v=20260405y" defer></script>
-<script src="08-post-actions.js?v=20260405y" defer></script>
-<script src="09-library.js?v=20260405y" defer></script>
-<script src="09-approval.js?v=20260405y" defer></script>
-<script src="04-router.js?v=20260405y" defer></script>
+<script src="06-post-create.js?v=20260405z" defer></script>
+<script defer src="render/dashboard.js?v=20260405z"></script>
+<script defer src="render/client.js?v=20260405z"></script>
+<script defer src="render/pipeline.js?v=20260405z"></script>
+<script defer src="render/brief.js?v=20260405z"></script>
+<script defer src="actions/pcs.js?v=20260405z"></script>
+<script src="07-post-load.js?v=20260405z" defer></script>
+<script src="08-post-actions.js?v=20260405z" defer></script>
+<script src="09-library.js?v=20260405z" defer></script>
+<script src="09-approval.js?v=20260405z" defer></script>
+<script src="04-router.js?v=20260405z" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
- 10-ui.js _flushClickBuffer: the .catch now console.warn's the failure message so RLS / missing-column / 401 errors surface in devtools instead of being silently swallowed.
- 10-ui.js beforeunload handler: navigator.sendBeacon cannot set the apikey or Authorization headers, so every beacon was rejected by Supabase. Replaced with fetch(keepalive:true) which supports custom headers while still surviving page unload. Uses SUPABASE_URL + SUPABASE_KEY from 01-config.js (already available — 01-config.js loads before 10-ui.js).
- index.html: bumped all 20 ?v= strings to ?v=20260405z.
- CLAUDE.md: documented the visibility fix and the fetch-keepalive replacement under SECTION 11, version bumped.

tests: 384/384 passing (unchanged)
version: ?v=20260405z

https://claude.ai/code/session_01TGR3LaU3hws3ZkxWH8GDJL