### PR TITLE
Notification panel rebuild (PR 1 of 4): structure, visual, dead code

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -298,8 +298,67 @@ function switchTab(btn) {
 }
 
 // -- Notifications (Updates Tab) ---------------
-var _notifFilter = 'all';
+var _notifFilter = 'needs';
 var _notifData = [];
+
+// Relative time formatter for notification timestamps
+function _notifRelTime(iso) {
+  if (!iso) return '';
+  var now = Date.now();
+  var then = new Date((iso||'').replace(' ','T').replace('+00','Z')).getTime();
+  if (isNaN(then)) return '';
+  var diff = Math.floor((now - then) / 1000);
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return Math.floor(diff / 60) + ' min ago';
+  if (diff < 86400) return Math.floor(diff / 3600) + ' hr ago';
+  var d = new Date(then);
+  var todayD = new Date(); todayD.setHours(0,0,0,0);
+  var yesterdayD = new Date(todayD); yesterdayD.setDate(yesterdayD.getDate()-1);
+  var thenD = new Date(d); thenD.setHours(0,0,0,0);
+  var timeStr = d.toLocaleTimeString('en-IN', {hour:'numeric', minute:'2-digit', hour12:true}).toLowerCase();
+  if (thenD.getTime() === yesterdayD.getTime()) return 'Yesterday \xB7 ' + timeStr;
+  return d.toLocaleDateString('en-IN', {weekday:'short', day:'numeric', month:'short'}) + ' \xB7 ' + timeStr;
+}
+
+// Needs-tab types: actionable items
+var _NOTIF_NEEDS_TYPES = ['awaiting_approval','awaiting_brand_input','brief','comment'];
+// Updates-tab types: informational items
+var _NOTIF_UPDATES_TYPES = ['published','scheduled','stage_change','in_production','ready'];
+
+function _notifIsOverdue(post) {
+  if (!post || post.stage === 'published') return false;
+  if (!post.status_changed_at) return false;
+  var diff = Date.now() - new Date(post.status_changed_at).getTime();
+  return diff > 2 * 24 * 60 * 60 * 1000;
+}
+
+function _notifTypeClass(n, post) {
+  if (_notifIsOverdue(post)) return 'ntype-overdue';
+  if (n.type === 'comment') return 'ntype-comment';
+  if (n.type === 'awaiting_approval' || n.type === 'awaiting_brand_input') return 'ntype-approval';
+  if (n.type === 'published') return 'ntype-live';
+  return 'ntype-stage';
+}
+
+function _notifStagePillClass(stage) {
+  if (stage === 'awaiting_approval')    return 'nsp-approval';
+  if (stage === 'awaiting_brand_input') return 'nsp-input';
+  if (stage === 'ready')                return 'nsp-ready';
+  if (stage === 'scheduled')            return 'nsp-scheduled';
+  if (stage === 'published')            return 'nsp-published';
+  if (stage === 'in_production')        return 'nsp-production';
+  return 'nsp-ready';
+}
+
+function _notifActorClass(actor) {
+  var a = (actor || '').toLowerCase();
+  if (!a) return 'av-n-system';
+  if (a === 'manisha' || a === 'shivangini' || a === 'client') return 'av-n-client';
+  if (a === 'chitra' || a === 'servicing') return 'av-n-chitra';
+  if (a === 'pranav' || a === 'creative') return 'av-n-pranav';
+  if (a === 'shubham' || a === 'admin') return 'av-n-shubham';
+  return 'av-n-system';
+}
 var roleDisplayMap = {
   'Admin':      { name: 'Shubham', label: 'Admin - Sorted' },
   'admin':      { name: 'Shubham', label: 'Admin - Sorted' },
@@ -320,7 +379,7 @@ async function loadNotifications() {
     _notifRole = _notifRole.charAt(0).toUpperCase() + _notifRole.slice(1).toLowerCase();
     var currentName = resolveActor() || 'there';
     var _loadActor = window.AppState.user.name || window.currentUserName || '';
-    var _loadUrl = '/notifications?select=id,type,message,read,created_at,post_id,user_role&user_role=eq.' + encodeURIComponent(_notifRole) + '&order=created_at.desc&limit=50';
+    var _loadUrl = '/notifications?select=id,type,message,read,created_at,post_id,user_role,actor&user_role=eq.' + encodeURIComponent(_notifRole) + '&order=created_at.desc&limit=50';
     if (_loadActor) _loadUrl += '&actor=neq.' + encodeURIComponent(_loadActor);
     var data = await apiFetch(_loadUrl);
     if (!Array.isArray(data)) { console.error('Notifications load error:', data); return; }
@@ -352,262 +411,200 @@ function renderNotifications(name, role) {
     }
   }
   if (roleEl) roleEl.textContent = displayLabel;
-  var unread = notifs.filter(function(n) { return !n.read; });
-  var urgent = notifs.filter(function(n) { return !n.read && ['awaiting_approval','awaiting_brand_input'].includes(n.type); });
-  var newItems = notifs.filter(function(n) { return !n.read && n.type === 'ready'; });
-  var infoItems = notifs.filter(function(n) { return !n.read && ['scheduled','published','in_production'].includes(n.type); });
-  var total = unread.length;
-  var attEl = document.getElementById('notif-attention');
-  if (attEl) {
-    if (total === 0) {
-      attEl.innerHTML = 'All sorted';
-    } else {
-      attEl.innerHTML = '<strong>' + total + '</strong> ' + (total === 1 ? 'thing needs' : 'things need') + ' your attention';
-    }
+
+  // ----- Smart summary chips (from AppState.posts.all - no new fetch) -----
+  var posts = (window.AppState.posts && window.AppState.posts.all) || [];
+  var approvalPosts = posts.filter(function(p){ return p.stage === 'awaiting_approval'; });
+  var approvalCount = approvalPosts.length;
+  var oldestDays = 0;
+  if (approvalCount > 0) {
+    var oldestTs = Date.now();
+    approvalPosts.forEach(function(p){
+      if (!p.status_changed_at) return;
+      var t = new Date(p.status_changed_at).getTime();
+      if (!isNaN(t) && t < oldestTs) oldestTs = t;
+    });
+    oldestDays = Math.floor((Date.now() - oldestTs) / 86400000);
   }
-  var bdEl = document.getElementById('notif-breakdown');
-  if (bdEl) {
-    if (total === 0) {
-      bdEl.innerHTML = '<span class="bk-allclear">All sorted</span>';
-    } else {
-      var parts = [];
-      if (urgent.length > 0)
-        parts.push('<span class="bk-item bk-urgent" onclick="setNotifFilter(\'action\', document.querySelectorAll(\'.nftab\')[1])">'
-          + urgent.length + ' urgent</span>');
-      if (newItems.length > 0)
-        parts.push('<span class="bk-item bk-new">'
-          + newItems.length + ' new</span>');
-      if (infoItems.length > 0)
-        parts.push('<span class="bk-item bk-info" onclick="setNotifFilter(\'info\', document.querySelectorAll(\'.nftab\')[2])">'
-          + infoItems.length + ' ' + (infoItems.length === 1 ? 'update' : 'updates') + '</span>');
-      if (unread.length > 0)
-        parts.push('<span class="bk-item bk-unread">'
-          + unread.length + ' unread</span>');
-      bdEl.innerHTML = parts.join('<span class="bk-sep">&#183;</span>');
+  var commentCount = posts.filter(function(p){ return p._clientCommentAt; }).length;
+  var todayStr = new Date().toDateString();
+  var liveToday = posts.filter(function(p){
+    if (p.stage !== 'published') return false;
+    if (!p.status_changed_at) return false;
+    var d = new Date(p.status_changed_at);
+    return !isNaN(d.getTime()) && d.toDateString() === todayStr;
+  }).length;
+
+  var summaryEl = document.getElementById('notif-summary');
+  if (summaryEl) {
+    var chips = [];
+    if (approvalCount > 0) {
+      chips.push('<div class="summary-chip chip-urgent">' +
+        '<div class="chip-dot"></div>' +
+        approvalCount + ' NEED APPROVAL' +
+        (oldestDays > 0 ? ' \xB7 ' + oldestDays + 'D OLDEST' : '') +
+        '</div>');
     }
+    if (commentCount > 0) {
+      chips.push('<div class="summary-chip chip-reply">' +
+        '<div class="chip-dot"></div>' +
+        commentCount + ' COMMENTS WAITING' +
+        '</div>');
+    }
+    if (liveToday > 0) {
+      chips.push('<div class="summary-chip chip-live">' +
+        '<div class="chip-dot"></div>' +
+        liveToday + ' LIVE TODAY' +
+        '</div>');
+    }
+    if (chips.length === 0) {
+      chips.push('<div class="summary-chip chip-allclear">' +
+        '<div class="chip-dot"></div>ALL SORTED</div>');
+    }
+    summaryEl.innerHTML = chips.join('');
   }
-  var badgeAll = document.getElementById('nftab-badge-all');
-  if (badgeAll) { badgeAll.textContent = notifs.length; badgeAll.style.display = notifs.length ? '' : 'none'; }
-  var filtered = notifs;
-  if (_notifFilter === 'action') filtered = notifs.filter(function(n) {
-    return n.type === 'awaiting_approval' ||
-      n.type === 'awaiting_brand_input' ||
-      n.type === 'brief' ||
-      n.type === 'comment' ||
-      (n.type === 'stage_change' && (
-        (n.message||'').toLowerCase().includes('brief') ||
-        (n.message||'').toLowerCase().includes('feedback') ||
-        (n.message||'').toLowerCase().includes('changes') ||
-        (n.message||'').toLowerCase().includes('assigned')
-      ));
-  });
-  if (_notifFilter === 'info') filtered = notifs.filter(function(n) {
-    return n.type === 'published' ||
-      n.type === 'scheduled' ||
-      (n.type === 'stage_change' && !(
-        (n.message||'').toLowerCase().includes('brief') ||
-        (n.message||'').toLowerCase().includes('feedback') ||
-        (n.message||'').toLowerCase().includes('changes') ||
-        (n.message||'').toLowerCase().includes('assigned')
-      ));
-  });
+
+  // ----- Tab counts (unread per bucket) -----
+  var needsUnread = notifs.filter(function(n){
+    return !n.read && _NOTIF_NEEDS_TYPES.indexOf(n.type) !== -1;
+  }).length;
+  var updatesUnread = notifs.filter(function(n){
+    return !n.read && _NOTIF_UPDATES_TYPES.indexOf(n.type) !== -1;
+  }).length;
+  var needsCountEl = document.getElementById('ntab-needs-count');
+  var updatesCountEl = document.getElementById('ntab-updates-count');
+  if (needsCountEl) {
+    if (needsUnread > 0) { needsCountEl.textContent = needsUnread; needsCountEl.style.display = ''; }
+    else { needsCountEl.textContent = ''; needsCountEl.style.display = 'none'; }
+  }
+  if (updatesCountEl) {
+    if (updatesUnread > 0) { updatesCountEl.textContent = updatesUnread; updatesCountEl.style.display = ''; }
+    else { updatesCountEl.textContent = ''; updatesCountEl.style.display = 'none'; }
+  }
+
+  // ----- Apply active tab filter -----
+  var activeTypes = _notifFilter === 'needs' ? _NOTIF_NEEDS_TYPES : _NOTIF_UPDATES_TYPES;
+  var filtered = notifs.filter(function(n){ return activeTypes.indexOf(n.type) !== -1; });
+
   var scroll = document.getElementById('notif-list-scroll');
-  var empty = document.getElementById('notif-empty');
   if (!scroll) return;
+
+  // ----- Empty state (per-tab) -----
   if (filtered.length === 0) {
-    scroll.innerHTML = '';
-    if (empty) empty.classList.add('visible');
+    if (_notifFilter === 'needs') {
+      scroll.innerHTML =
+        '<div class="notif-empty-state">' +
+          '<div class="notif-empty-icon">\u2713</div>' +
+          '<div class="notif-empty-title">You&#39;re all caught up</div>' +
+          '<div class="notif-empty-sub">NOTHING NEEDS YOUR ATTENTION</div>' +
+        '</div>';
+    } else {
+      var weekAgo = Date.now() - 7 * 86400000;
+      var approvedThisWeek = _notifData.filter(function(n){
+        if (n.type !== 'awaiting_approval') return false;
+        if (!n.read) return false;
+        if (!n.created_at) return false;
+        var t = new Date(n.created_at).getTime();
+        return !isNaN(t) && t > weekAgo;
+      }).length;
+      scroll.innerHTML =
+        '<div class="notif-empty-state">' +
+          '<div class="notif-empty-icon">\u25CB</div>' +
+          '<div class="notif-empty-title">No updates yet</div>' +
+          '<div class="notif-empty-sub">ACTIVITY WILL APPEAR HERE</div>' +
+          (approvedThisWeek > 0
+            ? '<div class="notif-empty-stat">' + approvedThisWeek + ' APPROVED THIS WEEK</div>'
+            : '') +
+        '</div>';
+    }
     return;
   }
-  if (empty) empty.classList.remove('visible');
-  var today = new Date().toDateString();
+
+  // ----- Group by day -----
+  var todayKey = new Date().toDateString();
   var yesterday = new Date(); yesterday.setDate(yesterday.getDate()-1);
-  var yesterdayStr = yesterday.toDateString();
+  var yesterdayKey = yesterday.toDateString();
   var groups = { Today: [], Yesterday: [], Earlier: [] };
   filtered.forEach(function(n) {
     var d = new Date(n.created_at).toDateString();
-    if (d === today) groups.Today.push(n);
-    else if (d === yesterdayStr) groups.Yesterday.push(n);
+    if (d === todayKey) groups.Today.push(n);
+    else if (d === yesterdayKey) groups.Yesterday.push(n);
     else groups.Earlier.push(n);
   });
-  var typeClass = {
-    'awaiting_approval':    'ntype-awaiting_approval',
-    'awaiting_brand_input': 'ntype-awaiting_brand_input',
-    'ready':                'ntype-ready',
-    'scheduled':            'ntype-scheduled',
-    'published':            'ntype-published',
-    'stage_change':         'ntype-info',
-    'in_production':        'ntype-in_production',
-  };
-  var stagePills = {
-    'awaiting_approval':    { label: 'Approval', cls: 'pill-approval' },
-    'awaiting_brand_input': { label: 'Brand Input', cls: 'pill-input' },
-    'ready':                { label: 'Ready', cls: 'pill-ready' },
-    'scheduled':            { label: 'Scheduled', cls: 'pill-scheduled' },
-    'published':            { label: 'Published', cls: 'pill-published' },
-    'in_production':        { label: 'Production', cls: 'pill-production' },
-  };
-  function parseActor(msg) {
-    if (!msg) return { name: 'System', initials: 'S', cls: 'av-system' };
-    var first = msg.split(/\s/)[0].toLowerCase();
-    if (first.includes('pranav'))  return { name: 'Pranav',  initials: 'P',  cls: 'av-pranav' };
-    if (first.includes('chitra'))  return { name: 'Chitra',  initials: 'Ch', cls: 'av-chitra' };
-    if (first.includes('shubham')) return { name: 'Shubham', initials: 'S',  cls: 'av-shubham' };
-    if (first.includes('client'))  return { name: 'Client',  initials: 'Cl', cls: 'av-client' };
-    return { name: first.charAt(0).toUpperCase() + first.slice(1), initials: first.charAt(0).toUpperCase(), cls: 'av-system' };
-  }
-  function getActions(n) {
-    if (n.type === 'awaiting_approval') return [
-      { label: 'Chase Client', cls: 'danger', action: 'chase' },
-      { label: 'View', cls: '', action: 'view' }
-    ];
-    if (n.type === 'ready') return [
-      { label: 'Send for Approval', cls: 'success', action: 'approve' },
-      { label: 'View', cls: '', action: 'view' }
-    ];
-    if (n.type === 'awaiting_brand_input') return [
-      { label: 'Chase Input', cls: 'danger', action: 'chase' },
-      { label: 'View', cls: '', action: 'view' }
-    ];
-    if (n.type === 'scheduled' || n.type === 'published' || n.type === 'stage_change') return [
-      { label: 'View', cls: '', action: 'view' }
-    ];
-    return [];
-  }
-  function formatTime(created_at) {
-    var d = new Date(created_at);
-    return d.toLocaleTimeString('en-GB', { hour: 'numeric', minute: '2-digit' });
-  }
+
+  // ----- Build item HTML -----
   var html = '';
   ['Today','Yesterday','Earlier'].forEach(function(day) {
     if (!groups[day] || groups[day].length === 0) return;
     html += '<div class="notif-day-label">' + day + '</div>';
     groups[day].forEach(function(n) {
-      var _notifPost = (window.AppState.posts.all||[]).find(function(p) {
-        return p.post_id === n.post_id;
-      });
-      var _thumb = _notifPost && Array.isArray(_notifPost.images) &&
-        _notifPost.images[0] ? _notifPost.images[0] : '';
-      var _postTitle = _notifPost ? (_notifPost.title || '') : '';
-      var _postStage = _notifPost ? (_notifPost.stage || '') :
-        (n.type || '');
+      var post = posts.find(function(p) { return p.post_id === n.post_id; });
+      var thumb = post && Array.isArray(post.images) && post.images[0] ? post.images[0] : '';
+      var postTitle = post ? (post.title || '') : '';
+      var postStage = post ? (post.stage || '') : (n.type || '');
+      var stageLabel = (postStage||'').replace(/_/g,' ');
+      if (postStage === 'awaiting_approval') stageLabel = 'Awaiting Approval';
+      if (postStage === 'awaiting_brand_input') stageLabel = 'Awaiting Input';
+      var tClass = _notifTypeClass(n, post);
+      var avClass = _notifActorClass(n.actor);
+      var actorName = n.actor || '';
+      var initial = actorName ? actorName.charAt(0).toUpperCase() : '\u00B7';
+      var isUnread = !n.read;
+      var ts = _notifRelTime(n.created_at);
+      var msg = n.message || '';
+      var msgParts = msg.split(' ');
+      var msgHtml = msgParts.length > 1
+        ? '<strong>' + esc(msgParts[0]) + '</strong> ' + esc(msgParts.slice(1).join(' '))
+        : esc(msg);
+      var isLive = n.type === 'published';
+      var isOverdueItem = tClass === 'ntype-overdue';
 
-      var _chipColor = '#888';
-      var _chipBg = 'rgba(255,255,255,0.06)';
-      if (_postStage === 'published')  { _chipColor='#22c55e'; _chipBg='rgba(34,197,94,0.12)'; }
-      if (_postStage === 'awaiting_approval') { _chipColor='#3b82f6'; _chipBg='rgba(59,130,246,0.12)'; }
-      if (_postStage === 'brief')      { _chipColor='#C8A84B'; _chipBg='rgba(200,168,75,0.12)'; }
-      if (_postStage === 'in_production') { _chipColor='#9b87f5'; _chipBg='rgba(155,135,245,0.12)'; }
-      if (n.type === 'awaiting_brand_input') { _chipColor='#F6A623'; _chipBg='rgba(246,166,35,0.12)'; }
-      var _stageLabel = (_postStage||'').replace(/_/g,' ');
-      if (_postStage === 'awaiting_approval') _stageLabel = 'Awaiting Approval';
-
-      var _actorName = parseActor(n.message).name;
-      var _initial = _actorName ? _actorName.charAt(0).toUpperCase() : 'S';
-      var _avatarColor = '#C8A84B';
-      if (_actorName === 'Pranav') { _avatarColor = '#9b87f5'; }
-      if (_actorName === 'Chitra') { _avatarColor = '#22D3EE'; }
-      if (_actorName === 'Client' || _actorName === 'Manisha' ||
-          _actorName === 'Shivangini') { _avatarColor = '#FF4B4B'; }
-
-      var _ts = '';
-      if (n.created_at) {
-        var _d = new Date((n.created_at||'').replace(' ','T').replace('+00','Z'));
-        if (!isNaN(_d.getTime())) {
-          _ts = _d.toLocaleDateString('en-IN',{
-            weekday:'short',day:'numeric',month:'short',
-            timeZone:'Asia/Kolkata'}) + ' \xB7 ' +
-            _d.toLocaleTimeString('en-IN',{
-            hour:'numeric',minute:'2-digit',
-            hour12:true,timeZone:'Asia/Kolkata'});
-        }
-      }
-
-      var _isUnread = !n.read;
-
-      var _msgParts = (n.message||'').split(' ');
-      var _msgHtml = _msgParts.length > 1 ?
-        '<strong>' + esc(_msgParts[0]) + '</strong> ' +
-        esc(_msgParts.slice(1).join(' '))
-        : esc(n.message||'');
-
-      var itemHtml =
-        '<div class="notif-item' + (_isUnread ? ' unread' : '') + '" ' +
-        'data-notif-id="' + n.id + '" ' +
-        'style="padding:14px 18px;border-bottom:1px solid rgba(255,255,255,0.05);' +
-        'cursor:default;">' +
-
-        '<div style="display:flex;align-items:flex-start;gap:10px;' +
-        'margin-bottom:' + (n.post_id ? '10px' : '0') + ';">' +
-
-        '<div style="width:28px;height:28px;border-radius:50%;flex-shrink:0;' +
-        'background:' + _avatarColor + '22;border:1px solid ' + _avatarColor + '55;' +
-        'display:flex;align-items:center;justify-content:center;' +
-        'font-family:\'IBM Plex Mono\',monospace;font-size:9px;font-weight:600;' +
-        'color:' + _avatarColor + ';">' + _initial + '</div>' +
-
-        '<div style="flex:1;min-width:0;">' +
-        '<div style="font-family:\'DM Sans\',sans-serif;font-size:13px;' +
-        'color:' + (_isUnread ? '#e8e2d9' : 'rgba(255,255,255,0.5)') + ';' +
-        'line-height:1.4;margin-bottom:3px;">' +
-        _msgHtml + '</div>' +
-        '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
-        'letter-spacing:0.06em;color:rgba(255,255,255,0.45);">' + _ts + '</div>' +
-        '</div>' +
-
-        (_isUnread ? '<div style="width:6px;height:6px;border-radius:50%;' +
-        'background:#C8A84B;flex-shrink:0;margin-top:5px;"></div>' : '') +
-        '</div>' +
-
-        (n.post_id && (_postTitle || _thumb) ?
-          '<div class="notif-post-card-tap" ' +
-          'data-post-id="' + esc(n.post_id) + '" ' +
-          'data-is-brief="' + (_postStage === 'brief' ? '1' : '0') + '" ' +
-          'style="display:flex;align-items:center;gap:10px;' +
-          'background:rgba(255,255,255,0.03);' +
-          'border:1px solid rgba(255,255,255,0.07);' +
-          'padding:8px 10px 8px 8px;cursor:pointer;' +
-          'margin-left:38px;' +
-          'transition:background 0.15s;">' +
-
-          (_thumb ?
-            '<img src="' + _thumb + '" style="width:44px;height:44px;' +
-            'object-fit:cover;flex-shrink:0;display:block;" />'
-            :
-            '<div style="width:44px;height:44px;background:#111118;' +
-            'flex-shrink:0;display:flex;align-items:center;' +
-            'justify-content:center;font-size:16px;opacity:0.4;">' +
-            (_postStage === 'brief' ? '&#x1F4CB;' : '&#x1F5BC;') +
-            '</div>') +
-
-          '<div style="flex:1;min-width:0;">' +
-          '<div style="font-family:\'DM Sans\',sans-serif;font-size:13px;' +
-          'font-weight:600;color:#e8e2d9;line-height:1.2;' +
-          'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;' +
-          'margin-bottom:4px;">' + esc(_postTitle) + '</div>' +
-          '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
-          'letter-spacing:0.1em;text-transform:uppercase;' +
-          'padding:2px 6px;font-weight:600;' +
-          'background:' + _chipBg + ';color:' + _chipColor + ';">' +
-          _stageLabel + '</span>' +
+      html += '<div class="notif-item ' + tClass + (isUnread ? '' : ' read') + '"' +
+        ' data-notif-id="' + esc(n.id || '') + '"' +
+        (n.post_id ? ' data-post-id="' + esc(n.post_id) + '"' : '') +
+        ' data-is-brief="' + (postStage === 'brief' ? '1' : '0') + '">' +
+        '<div class="notif-row">' +
+          '<div class="notif-av ' + avClass + '">' + esc(initial) + '</div>' +
+          '<div class="notif-body">' +
+            '<div class="notif-msg">' + msgHtml +
+              (isOverdueItem ? ' <span class="notif-overdue-badge">OVERDUE</span>' : '') +
+            '</div>' +
+            '<div class="notif-time">' + esc(ts) + '</div>' +
           '</div>' +
-
-          '<div style="color:rgba(255,255,255,0.2);font-size:14px;' +
-          'flex-shrink:0;">&#x203A;</div>' +
+          (isUnread ? '<div class="notif-unread-dot"></div>' : '') +
+        '</div>' +
+        (isLive && n.post_id && (postTitle || thumb) ?
+          '<div class="notif-live-card">' +
+            (thumb
+              ? '<img class="notif-live-thumb" src="' + esc(thumb) + '" onerror="this.style.display=\'none\'">'
+              : '<div class="notif-live-thumb"></div>') +
+            '<div>' +
+              '<div class="notif-live-title">' + esc(postTitle) + '</div>' +
+              '<div class="notif-live-sub">\u2713 POST IS LIVE \xB7 VIEW ON LINKEDIN \u2192</div>' +
+            '</div>' +
           '</div>'
-          : '') +
-
+        : (n.post_id && (postTitle || thumb) ?
+          '<div class="notif-post-card" data-post-id="' + esc(n.post_id) + '">' +
+            (thumb
+              ? '<img class="notif-post-thumb" src="' + esc(thumb) + '" onerror="this.style.display=\'none\'">'
+              : '<div class="notif-post-thumb"></div>') +
+            '<div class="notif-post-info">' +
+              '<div class="notif-post-title">' + esc(postTitle) + '</div>' +
+              '<span class="notif-stage-pill ' + _notifStagePillClass(postStage) + '">' + esc(stageLabel) + '</span>' +
+            '</div>' +
+            '<div class="notif-post-arrow">\u203A</div>' +
+          '</div>'
+        : '')) +
         '</div>';
-
-      html += itemHtml;
     });
   });
   scroll.innerHTML = html;
 }
 
 function setNotifFilter(filter, btn) {
+  if (filter !== 'needs' && filter !== 'updates') filter = 'needs';
   _notifFilter = filter;
-  document.querySelectorAll('.nftab').forEach(function(t) { t.classList.remove('active'); });
+  document.querySelectorAll('.ntab').forEach(function(t) { t.classList.remove('active'); });
   if (btn) btn.classList.add('active');
   var _notifRole = window.AppState.user.effectiveRole || window.AppState.user.role || 'Admin';
   _notifRole = _notifRole.charAt(0).toUpperCase() + _notifRole.slice(1).toLowerCase();
@@ -634,23 +631,31 @@ async function markAllNotificationsRead() {
     var currentName = resolveActor() || 'there';
     renderNotifications(currentName, _notifRole);
     updateNotifBadge();
-    var unreadEls = document.querySelectorAll(
-      '#panel-updates .notif-item.unread');
-    unreadEls.forEach(function(el) {
-      el.classList.remove('unread');
+    var readEls = document.querySelectorAll(
+      '#panel-updates .notif-item:not(.read)');
+    readEls.forEach(function(el) {
+      el.classList.add('read');
+      var dot = el.querySelector('.notif-unread-dot');
+      if (dot && dot.parentNode) dot.parentNode.removeChild(dot);
     });
     ['notif-bell-badge','notif-pipeline-badge',
-     'notif-lib-badge','notif-ins-badge',
-     'notif-client-badge'].forEach(function(id) {
+     'notif-lib-badge','notif-ins-badge'].forEach(function(id) {
       var el = document.getElementById(id);
       if (el) el.style.display = 'none';
     });
-    var _marRole = (window.AppState.user.effectiveRole || 'Admin');
-    await apiFetch('/notifications?read=eq.false&user_role=eq.' + encodeURIComponent(_marRole), {
+    ['ntab-needs-count','ntab-updates-count'].forEach(function(id) {
+      var el = document.getElementById(id);
+      if (el) { el.textContent = ''; el.style.display = 'none'; }
+    });
+    await apiFetch('/notifications?read=eq.false&user_role=eq.' + encodeURIComponent(_notifRole), {
       method: 'PATCH',
       body: JSON.stringify({ read: true }),
     });
-  } catch(e) { console.error('markAllRead error:', e); }
+    if (typeof showToast === 'function') showToast('All notifications marked as read', 'success');
+  } catch(e) {
+    console.error('markAllRead error:', e);
+    window.logError && window.logError(e && e.message, e && e.stack, 'mark-all-notifications-read');
+  }
 }
 
 function updateNotifBadge() {
@@ -672,8 +677,7 @@ function updateNotifBadge() {
       'notif-bell-badge',
       'notif-pipeline-badge',
       'notif-lib-badge',
-      'notif-ins-badge',
-      'notif-client-badge'
+      'notif-ins-badge'
     ].forEach(function(id) {
       var el = document.getElementById(id);
       if (!el) return;
@@ -1416,21 +1420,24 @@ async function _nrsSubmit() {
   }
 }
 
-// -- Notification Bell Sheet -------------------
+// -- Notification Panel (full-page overlay) -------------------
 function openNotifications() {
   var panel = document.getElementById('panel-updates');
   if (!panel) return;
   if (!panel._notifTapWired) {
     panel._notifTapWired = true;
     panel.addEventListener('click', function(e) {
-      var card = e.target.closest('.notif-post-card-tap');
-      if (!card) return;
+      // Skip the tabs row and mark-all button
+      if (e.target.closest('.notif-tabs')) return;
+      if (e.target.closest('.mark-all-btn')) return;
+      var item = e.target.closest('.notif-item');
+      if (!item) return;
       e.stopPropagation();
-      var pid = card.getAttribute('data-post-id');
-      var isBrief = card.getAttribute('data-is-brief') === '1';
-      if (!pid) return;
-      var notifId = card.getAttribute('data-notif-id') || (card.closest('[data-notif-id]') ? card.closest('[data-notif-id]').getAttribute('data-notif-id') : null);
+      var pid = item.getAttribute('data-post-id');
+      var isBrief = item.getAttribute('data-is-brief') === '1';
+      var notifId = item.getAttribute('data-notif-id');
       if (notifId) markNotifRead(notifId);
+      if (!pid) return;
       closeNotifications();
       setTimeout(function() {
         var _role = (window.AppState.user.effectiveRole || '').toLowerCase();
@@ -1451,13 +1458,13 @@ function openNotifications() {
   if (!overlay) {
     overlay = document.createElement('div');
     overlay.id = 'notif-overlay';
-    overlay.style.cssText = 'position:fixed;inset:0;z-index:1300;background:rgba(0,0,0,0.75);display:flex;align-items:flex-end;justify-content:center;';
+    overlay.style.cssText = 'position:fixed;inset:0;z-index:1300;background:#0a0a0f;display:flex;align-items:stretch;justify-content:center;';
     overlay.onclick = function(e) { if (e.target === overlay) closeNotifications(); };
     document.body.appendChild(overlay);
     overlay.appendChild(panel);
   }
   overlay.style.display = 'flex';
-  panel.style.cssText = 'width:100%;max-width:480px;max-height:62vh;min-height:40vh;overflow-y:auto;background:#0e0e0e;display:block;';
+  panel.style.cssText = 'width:100%;max-width:480px;height:100%;overflow:hidden;background:#0e0e16;display:flex;flex-direction:column;';
   document.body.style.overflow = 'hidden';
   window.AppState.ui.modalOpen = true;
   loadNotifications();
@@ -1470,17 +1477,8 @@ function closeNotifications() {
   window.AppState.ui.modalOpen = false;
 }
 
-async function loadNotifBadge() {
-  try {
-    var role = window._userRole || 'admin';
-    var data = await apiFetch('/notifications?user_role=eq.' + role + '&read=eq.false&select=id');
-    updateNotifBadge(data ? data.length : 0);
-  } catch(e) {}
-}
-
 window.openNotifications = openNotifications;
 window.closeNotifications = closeNotifications;
-window.loadNotifBadge = loadNotifBadge;
 
 // -- FAB menu wiring --
 document.addEventListener('DOMContentLoaded', function() {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Sorted (srtd.io)
 
-# Last updated: 2026-04-05
+# Last updated: 2026-04-06
 
 # All facts verified from actual codebase
 
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260405z
+Version format: ?v=YYYYMMDDx. Current: ?v=20260406a
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -295,9 +295,9 @@ Post-deploy smoke (.github/workflows/smoke.yml):
   required env vars are missing skip with a console.warn rather
   than failing the whole suite.
 
-Current (verified 2026-04-05):
-Unit test files: 16
-Unit tests:      384 passing, 0 failing
+Current (verified 2026-04-06):
+Unit test files: 17
+Unit tests:      433 passing, 0 failing
 E2E specs:       7
 
 Files:
@@ -310,6 +310,7 @@ tests/dom-sanity.test.js
 tests/error-handling.test.js
 tests/normalise.test.js
 tests/notifications.test.js
+tests/notif-render.test.js
 tests/postlookup.test.js
 tests/role.test.js
 tests/timestamp.test.js
@@ -329,7 +330,7 @@ TEST FILE MAPPING (run targeted tests during development):
   render/brief.js       → npx vitest run tests/brief.test.js (future)
   00-appstate.js        → npx vitest run tests/appstate-posts.test.js
   03-auth.js            → npx vitest run tests/role.test.js
-  10-ui.js              → npx vitest run tests/notifications.test.js
+  10-ui.js              → npx vitest run tests/notifications.test.js tests/notif-render.test.js
   utils.js              → npx vitest run tests/utils.test.js
   Full suite before push: npx vitest run
 
@@ -429,7 +430,7 @@ _flushClickBuffer           — drains _clickBuffer to POST /click_log
 window._showErrorToast      — show transient error toast to user
 window.showToast            — show success/error/info toast (top-level, auto-hoisted)
 window.gamSwitchRole        — switch role preview
-window.openNotifications, window.closeNotifications, window.loadNotifBadge
+window.openNotifications, window.closeNotifications
 window.openPipelineFilter, window.closePipelineFilter, window.applyPipelineFilter
 
 03-auth.js:
@@ -785,6 +786,85 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    comments above each button so they are not silent dead
    buttons. No behavior change needed — these buttons were
    already no-ops in production.
+1. Notification panel rebuild (PR 1 of 4) — bottom-sheet shell
+   replaced with full-page overlay; dead code pruned; actor
+   plumbed; tabs collapsed ALL/ACTION/INFO → NEEDS YOU/UPDATES.
+   Scope:
+   (a) 10-ui.js: deleted dead typeClass/stagePills/getActions/
+       formatTime/parseActor helpers inside renderNotifications;
+       deleted loadNotifBadge() (stale global, no callers);
+       removed notif-client-badge target (element never existed
+       in HTML) from updateNotifBadge + markAllNotificationsRead;
+       added actor to /notifications SELECT so avatar no longer
+       relies on message first-word regex.
+   (b) 10-ui.js: renderNotifications fully rewritten — class-
+       driven markup only (no inline style= attributes), uses
+       solid hex per design tokens. Emits .notif-item wrappers
+       with data-notif-id + data-post-id + ntype-* color bar
+       class. Builds summary chips (chip-urgent, chip-reply,
+       chip-live, chip-allclear) from AppState.posts.all with
+       no new fetch. Tab counts on #ntab-needs-count /
+       #ntab-updates-count. Per-tab empty states with
+       "CAUGHT UP" (needs) and "APPROVED THIS WEEK" stat
+       (updates).
+   (c) 10-ui.js: _notifRelTime() added ("just now" / "X min
+       ago" / "X hr ago" / "Yesterday \xB7 H:MM am/pm" / full
+       date for older).
+   (d) 10-ui.js: openNotifications — overlay is now solid
+       #0a0a0f with align-items:stretch, panel is a flex
+       column at 100% height with .notif-topbar (fixed),
+       .notif-scroll (flex:1), .notif-tabs (fixed bottom).
+       Delegated click moved from .notif-post-card-tap →
+       .notif-item so the whole row taps through.
+   (e) 10-ui.js: markAllNotificationsRead — uses Title-cased
+       role (same logic as loadNotifications) for the PATCH,
+       clears both ntab-*-count spans, calls window.logError
+       on failure with action 'mark-all-notifications-read',
+       fires a success toast.
+   (f) index.html L389–420: #panel-updates markup rebuilt —
+       .notif-topbar (role label + hey + mark-all-btn +
+       .notif-summary), .notif-scroll, .notif-tabs with two
+       .ntab buttons (NEEDS YOU / UPDATES).
+   (g) styles.css: deleted legacy .notif-panel/.notif-list
+       block (old L529-567) and dead L4217-4304 .notif-item/
+       .notif-avatar/.notif-msg/.notif-meta/.notif-stage-pill
+       system. New class system inserted at L4023+:
+       #panel-updates flex column, .notif-topbar,
+       .notif-topbar-row, .notif-role-label, .notif-hey,
+       .mark-all-btn, .notif-summary + .summary-chip +
+       .chip-dot + .chip-urgent/.chip-reply/.chip-live/
+       .chip-allclear, .notif-tabs + .ntab + .ntab-count,
+       .notif-scroll, .notif-day-label, .notif-item +
+       ntype-comment/approval/live/stage/overdue left bars
+       (with @keyframes notif-pulse), .notif-row, .notif-av +
+       av-n-client/chitra/pranav/shubham/system,
+       .notif-body/.notif-msg/.notif-time/.notif-unread-dot,
+       .notif-post-card/.notif-post-thumb/.notif-post-info/
+       .notif-post-title/.notif-post-arrow, .notif-stage-pill
+       + nsp-approval/input/ready/scheduled/published/
+       production, .notif-live-card/.notif-live-thumb/
+       .notif-live-title/.notif-live-sub, .notif-overdue-
+       badge, .notif-empty-state + .notif-empty-icon +
+       .notif-empty-title/.notif-empty-sub/.notif-empty-stat.
+       All solid hex, no rgba, no design-system violations.
+   (h) L5800 .av-client rule KEPT (originally flagged as a
+       duplicate, but actions/pcs.js:882 uses it with
+       .pcs-avatar — deleting would break PCS client avatars.
+       After deleting the 4217-4304 block, L5800 is no longer
+       a duplicate, it's the sole definition).
+   (i) Tests: tests/notifications.test.js updated ("all 5" →
+       "all 4" badges twice, tap handler regex switched from
+       .notif-post-card-tap to .notif-item). New file
+       tests/notif-render.test.js adds 49 tests covering
+       _notifRelTime, bucket types, _notifTypeClass,
+       _notifActorClass, _notifStagePillClass, summary chip
+       wiring, markAllNotificationsRead source shape,
+       openNotifications overlay shape, and a dead-code
+       removal audit (loadNotifBadge/getActions/typeClass/
+       stagePills/parseActor/formatTime/notif-client-badge/
+       .nftab all absent).
+   Status: FIXED (PR#TBD) — 433/433 passing. Bumped to
+   ?v=20260406a across all 20 resources.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260405z">
+ <link rel="stylesheet" href="styles.css?v=20260406a">
 
 </head>
 <body>
@@ -389,33 +389,29 @@
   <!-- TAB: UPDATES -->
   <div class="tab-panel" id="panel-updates">
 
-    <!-- HEADER -->
-    <div class="notif-header">
-      <div class="notif-top">
+    <!-- TOP BAR (fixed) -->
+    <div class="notif-topbar">
+      <div class="notif-topbar-row">
         <div>
-          <div class="notif-role" id="notif-role">Admin</div>
+          <div class="notif-role-label" id="notif-role">Admin</div>
           <div class="notif-hey">Hey, <span id="notif-name">Shubham</span></div>
         </div>
         <button class="mark-all-btn" onclick="markAllNotificationsRead()">Mark all read</button>
       </div>
-      <div class="notif-attention" id="notif-attention">0 things need your attention</div>
-      <div class="notif-breakdown" id="notif-breakdown"></div>
+      <div class="notif-summary" id="notif-summary"></div>
     </div>
 
-    <!-- FILTER TABS -->
-    <div class="notif-filter-tabs">
-      <button class="nftab active" data-filter="all" data-action="notif-filter">All <span class="nftab-badge" id="nftab-badge-all"></span></button>
-      <button class="nftab" data-filter="action" data-action="notif-filter">Action</button>
-      <button class="nftab" data-filter="info" data-action="notif-filter">Info</button>
-    </div>
+    <!-- LIST (scrolls) -->
+    <div class="notif-scroll" id="notif-list-scroll"></div>
 
-    <!-- LIST -->
-    <div class="notif-list-scroll" id="notif-list-scroll"></div>
-
-    <!-- EMPTY STATE -->
-    <div class="notif-empty" id="notif-empty">
-      <div class="notif-empty-title">All sorted</div>
-      <div class="notif-empty-sub">Nothing to sort</div>
+    <!-- TABS (fixed bottom) -->
+    <div class="notif-tabs" id="notif-tabs">
+      <button class="ntab active" data-filter="needs" data-action="notif-filter">
+        NEEDS YOU <span class="ntab-count" id="ntab-needs-count"></span>
+      </button>
+      <button class="ntab" data-filter="updates" data-action="notif-filter">
+        UPDATES <span class="ntab-count" id="ntab-updates-count"></span>
+      </button>
     </div>
 
   </div>
@@ -1073,26 +1069,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260405z"></script>
-<script src="00-appstate-compat.js?v=20260405z"></script>
-<script src="01-config.js?v=20260405z" defer></script>
-<script src="02-session.js?v=20260405z" defer></script>
-<script src="utils.js?v=20260405z" defer></script>
-<script src="03-auth.js?v=20260405z" defer></script>
-<script src="05-api.js?v=20260405z" defer></script>
-<script src="10-ui.js?v=20260405z" defer></script>
+<script src="00-appstate.js?v=20260406a"></script>
+<script src="00-appstate-compat.js?v=20260406a"></script>
+<script src="01-config.js?v=20260406a" defer></script>
+<script src="02-session.js?v=20260406a" defer></script>
+<script src="utils.js?v=20260406a" defer></script>
+<script src="03-auth.js?v=20260406a" defer></script>
+<script src="05-api.js?v=20260406a" defer></script>
+<script src="10-ui.js?v=20260406a" defer></script>
 
-<script src="06-post-create.js?v=20260405z" defer></script>
-<script defer src="render/dashboard.js?v=20260405z"></script>
-<script defer src="render/client.js?v=20260405z"></script>
-<script defer src="render/pipeline.js?v=20260405z"></script>
-<script defer src="render/brief.js?v=20260405z"></script>
-<script defer src="actions/pcs.js?v=20260405z"></script>
-<script src="07-post-load.js?v=20260405z" defer></script>
-<script src="08-post-actions.js?v=20260405z" defer></script>
-<script src="09-library.js?v=20260405z" defer></script>
-<script src="09-approval.js?v=20260405z" defer></script>
-<script src="04-router.js?v=20260405z" defer></script>
+<script src="06-post-create.js?v=20260406a" defer></script>
+<script defer src="render/dashboard.js?v=20260406a"></script>
+<script defer src="render/client.js?v=20260406a"></script>
+<script defer src="render/pipeline.js?v=20260406a"></script>
+<script defer src="render/brief.js?v=20260406a"></script>
+<script defer src="actions/pcs.js?v=20260406a"></script>
+<script src="07-post-load.js?v=20260406a" defer></script>
+<script src="08-post-actions.js?v=20260406a" defer></script>
+<script src="09-library.js?v=20260406a" defer></script>
+<script src="09-approval.js?v=20260406a" defer></script>
+<script src="04-router.js?v=20260406a" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4024,8 +4024,11 @@ label.pcs-date-tap:active { transform: scale(0.98); }
    NOTIFICATION PANEL (rebuilt PR 1 of 4)
    =================================================== */
 
-/* PANEL STRUCTURE */
-#panel-updates {
+/* PANEL STRUCTURE (only when mounted inside the overlay)
+   — the bare #panel-updates is still governed by
+   .tab-panel / .tab-panel.active so it stays hidden on
+   other tabs. */
+#notif-overlay #panel-updates {
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/styles.css
+++ b/styles.css
@@ -526,46 +526,6 @@ a:hover { text-decoration: underline; }
 .icon-btn:hover { background: var(--surface2); color: var(--text); }
 .icon-btn:active { transform: scale(0.93); }
 
-/* Notification bell */
-.notif-panel.open { display: flex; }
-
-.notif-list {
-  overflow-y: auto;
-  flex: 1;
-  overscroll-behavior: contain;
-}
-
-.notif-item {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: var(--sp-3) var(--sp-4);
-  border-bottom: 1px solid var(--border);
-  transition: background var(--transition-fast), transform 0.1s ease;
-  cursor: pointer;
-  opacity: 0.7;
-}
-.notif-item:hover { background: var(--surface2); opacity: 1; }
-.notif-item:active { transform: scale(0.98); }
-.notif-item.unread {
-  background: var(--accent-dim);
-  opacity: 1;
-}
-.notif-item.unread .notif-primary { font-weight: 700; }
-.notif-item.unread:hover { background: var(--accent-hover); }
-
-/* Flash highlight when post opens from notification */
-@keyframes flashBg {
-  0%   { box-shadow: inset 0 0 0 2px rgba(50,215,75,0.5); }
-  100% { box-shadow: inset 0 0 0 2px transparent; }
-}
-.notif-empty {
-  padding: var(--sp-6) var(--sp-4);
-  text-align: center;
-  color: var(--text3);
-  font-size: 13px;
-}
-
 /* User menu */
 .user-menu-wrap { position: relative; }
 .user-menu {
@@ -4060,272 +4020,363 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   transition: opacity 0.2s;
 }
 
-/* 
-   UPDATES / NOTIFICATIONS TAB
- */
+/* ===================================================
+   NOTIFICATION PANEL (rebuilt PR 1 of 4)
+   =================================================== */
 
-.notif-header {
-  padding: 22px 20px 14px;
-  border-bottom: 1px dotted var(--dotline);
-  flex-shrink: 0;
+/* PANEL STRUCTURE */
+#panel-updates {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #0e0e16;
+  overflow: hidden;
 }
 
-.notif-top {
+.notif-topbar {
+  flex-shrink: 0;
+  padding: 52px 20px 0;
+  background: #0e0e16;
+  border-bottom: 1px solid #1e1e2e;
+}
+
+.notif-topbar-row {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: 12px;
+  margin-bottom: 14px;
 }
 
-.notif-role {
-  font-family: var(--mono);
-  font-size: 9px;
-  letter-spacing: 0.22em;
-  color: var(--muted);
+.notif-role-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .12em;
+  color: #555566;
   text-transform: uppercase;
   margin-bottom: 4px;
 }
 
 .notif-hey {
-  font-family: var(--sans);
-  font-size: 26px;
-  font-weight: 600;
-  color: var(--text);
-  letter-spacing: -0.4px;
+  font-size: 24px;
+  font-weight: 700;
+  color: #F0F0F2;
   line-height: 1.1;
 }
-
-.notif-hey span { color: var(--gold); }
+.notif-hey span { color: #C8A84B; }
 
 .mark-all-btn {
-  font-family: var(--mono);
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 8px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--muted);
-  border: 1px dotted var(--dotline);
-  background: transparent;
-  padding: 6px 10px;
+  letter-spacing: .08em;
+  color: #555566;
+  background: none;
+  border: 1px solid #1e1e2e;
+  padding: 5px 10px;
   cursor: pointer;
-  white-space: nowrap;
-  transition: all 0.15s;
-  flex-shrink: 0;
+  margin-top: 4px;
 }
-.mark-all-btn:hover { color: var(--text2); }
+.mark-all-btn:hover { color: #9090A0; border-color: #333344; }
 
-.notif-attention {
-  font-family: var(--sans);
-  font-size: 15px;
-  font-weight: 400;
-  color: var(--text2);
-  margin-bottom: 5px;
+/* SUMMARY CHIPS */
+.notif-summary {
+  display: flex;
+  gap: 8px;
+  padding-bottom: 14px;
+  flex-wrap: wrap;
 }
-
-.notif-attention strong {
-  font-weight: 600;
-  color: var(--text);
-}
-
-.notif-breakdown {
-  font-family: var(--mono);
-  font-size: 10px;
-  letter-spacing: 0.04em;
+.summary-chip {
   display: flex;
   align-items: center;
-  flex-wrap: nowrap;
-  gap: 0;
+  gap: 5px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  letter-spacing: .06em;
+  padding: 4px 10px;
+  border-radius: 2px;
+  font-weight: 500;
 }
-
-.bk-item {
-  cursor: pointer;
-  transition: opacity 0.15s;
-  white-space: nowrap;
-}
-.bk-item:hover { opacity: 0.7; }
-.bk-urgent { color: var(--red); font-weight: 600; }
-.bk-new    { color: var(--green); font-weight: 600; }
-.bk-info   { color: var(--gold); font-weight: 600; }
-.bk-unread { color: var(--text2); font-weight: 500; }
-.bk-sep    { color: var(--muted2); margin: 0 7px; user-select: none; }
-.bk-allclear { color: var(--green); font-weight: 600; }
-
-.notif-filter-tabs {
-  display: flex;
-  border-bottom: 1px dotted var(--dotline);
+.chip-dot {
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: currentColor;
   flex-shrink: 0;
 }
+.chip-urgent { background: #FF4B4B14; color: #FF4B4B; border: 1px solid #FF4B4B30; }
+.chip-reply  { background: #22D3EE12; color: #22D3EE; border: 1px solid #22D3EE30; }
+.chip-live   { background: #3ECF8E12; color: #3ECF8E; border: 1px solid #3ECF8E30; }
+.chip-allclear { background: #3ECF8E12; color: #3ECF8E; border: 1px solid #3ECF8E30; }
 
-.nftab {
+/* TABS - bottom of panel */
+.notif-tabs {
+  display: flex;
+  flex-shrink: 0;
+  border-top: 1px solid #1e1e2e;
+  background: #0e0e16;
+}
+.ntab {
   flex: 1;
-  font-family: var(--mono);
-  font-size: 8px;
-  letter-spacing: 0.14em;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  letter-spacing: .1em;
   text-transform: uppercase;
-  color: var(--muted);
-  padding: 11px 0;
+  padding: 12px 0;
   text-align: center;
   cursor: pointer;
+  color: #555566;
   border: none;
-  background: transparent;
-  border-bottom: 2px solid transparent;
-  transition: all 0.15s;
+  border-top: 2px solid transparent;
+  background: none;
 }
-.nftab.active { color: var(--text); border-bottom-color: var(--gold); }
-
-.nftab-badge {
+.ntab.active { color: #C8A84B; border-top-color: #C8A84B; }
+.ntab-count {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--red);
+  width: 16px; height: 16px;
+  border-radius: 50%;
+  background: #FF4B4B;
   color: #fff;
-  font-size: 7px;
+  font-size: 8px;
   font-weight: 700;
-  min-width: 14px;
-  height: 14px;
-  border-radius: 7px;
-  padding: 0 3px;
-  margin-left: 4px;
+  margin-left: 5px;
   vertical-align: middle;
 }
+.ntab.active .ntab-count { background: #C8A84B; color: #000; }
 
-.notif-list-scroll {
+/* SCROLL AREA */
+.notif-scroll {
   flex: 1;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
-  padding-bottom: 100px;
 }
-.notif-list-scroll::-webkit-scrollbar { display: none; }
+.notif-scroll::-webkit-scrollbar { display: none; }
 
+/* DAY LABEL */
 .notif-day-label {
-  font-family: var(--mono);
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 8px;
-  letter-spacing: 0.22em;
+  letter-spacing: .1em;
+  color: #555566;
   text-transform: uppercase;
-  color: var(--muted);
-  padding: 14px 20px 7px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.notif-day-label::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  border-top: 1px dotted var(--dotline);
+  padding: 14px 20px 8px;
+  border-bottom: 1px dotted #1e1e2e;
 }
 
+/* NOTIFICATION ITEM */
 .notif-item {
+  position: relative;
+  padding: 14px 16px 14px 20px;
+  border-bottom: 1px solid #1e1e2e;
+  cursor: pointer;
+  background: #0e0e16;
+}
+.notif-item:hover { background: #141420; }
+.notif-item.read { opacity: 0.55; }
+
+/* LEFT COLOR BAR */
+.notif-item::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 3px;
+}
+.notif-item.ntype-comment::before  { background: #22D3EE; }
+.notif-item.ntype-approval::before { background: #FF4B4B; }
+.notif-item.ntype-live::before     { background: #3ECF8E; }
+.notif-item.ntype-stage::before    { background: #9b87f5; }
+.notif-item.ntype-overdue::before  { background: #F6A623; animation: notif-pulse 1.5s infinite; }
+@keyframes notif-pulse { 0%,100%{opacity:1} 50%{opacity:0.3} }
+
+/* ITEM ROW */
+.notif-row {
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  padding: 10px 16px 10px 20px;
-  border-bottom: 1px dotted var(--muted2);
-  cursor: pointer;
-  transition: background 0.15s;
-  position: relative;
 }
-.notif-item:hover { background: var(--surface); }
-.notif-item.unread { background: rgba(255,255,255,0.012); }
 
-.notif-item::before { content:''; position:absolute; left:0; top:8px; bottom:8px; width:2px; border-radius:1px; background:var(--muted2); }
-.notif-item.ntype-awaiting_approval::before { background:var(--red); }
-.notif-item.ntype-ready::before { background:var(--green); }
-.notif-item.ntype-scheduled::before { background:var(--cyan); }
-.notif-item.ntype-in_production::before { background:var(--amber); }
-.notif-item.ntype-published::before { background:var(--green); }
-.notif-item.ntype-awaiting_brand_input::before { background:var(--purple); }
-
-.notif-avatar { width:26px; height:26px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-family:var(--mono); font-size:9px; font-weight:700; flex-shrink:0; margin-top:1px; }
-.av-pranav  { background:var(--amber-bg); color:var(--amber); border:1px solid rgba(246,166,35,0.2); }
-.av-chitra  { background:var(--green-bg); color:var(--green); border:1px solid rgba(62,207,142,0.2); }
-.av-shubham { background:var(--gold-bg);  color:var(--gold);  border:1px solid rgba(200,168,75,0.2); }
-.av-client  { background:var(--red-bg);   color:var(--red);   border:1px solid rgba(255,75,75,0.2); }
-.av-system  { background:var(--surface2); color:var(--muted); border:1px solid var(--muted2); }
-
-.notif-body { flex: 1; min-width: 0; }
-
-.notif-msg {
-  font-size: 13px;
-  font-weight: 400;
-  color: var(--text2);
-  line-height: 1.4;
-  margin-bottom: 3px;
-}
-.notif-item.unread .notif-msg { color: var(--text); }
-.notif-msg .actor { font-weight: 600; color: var(--text); }
-
-.notif-meta {
-  font-family: var(--mono);
-  font-size: 8px;
-  letter-spacing: 0.06em;
-  color: var(--muted);
-  text-transform: uppercase;
+/* AVATAR */
+.notif-av {
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  flex-shrink: 0;
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-bottom: 5px;
+  justify-content: center;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  font-weight: 600;
+  margin-top: 1px;
 }
+.av-n-manisha, .av-n-client    { background: #FF4B4B18; border: 1px solid #FF4B4B44; color: #FF4B4B; }
+.av-n-chitra, .av-n-servicing  { background: #22D3EE18; border: 1px solid #22D3EE44; color: #22D3EE; }
+.av-n-pranav, .av-n-creative   { background: #9b87f518; border: 1px solid #9b87f544; color: #9b87f5; }
+.av-n-admin, .av-n-shubham     { background: #C8A84B18; border: 1px solid #C8A84B44; color: #C8A84B; }
+.av-n-system                   { background: #F6A62318; border: 1px solid #F6A62344; color: #F6A623; }
 
-.notif-stage-pill { padding:1px 6px; border-radius:2px; font-family:var(--mono); font-size:7px; font-weight:600; letter-spacing:0.08em; text-transform:uppercase; }
-.pill-approval  { background:var(--red-bg);    color:var(--red); }
-.pill-ready     { background:var(--green-bg);  color:var(--green); }
-.pill-scheduled { background:var(--cyan-bg);   color:var(--cyan); }
-.pill-production{ background:var(--amber-bg);  color:var(--amber); }
-.pill-published { background:var(--green-bg);  color:var(--green); }
-.pill-input     { background:var(--purple-bg); color:var(--purple); }
-
-.notif-actions-inline { display:flex; gap:12px; align-items:center; margin-top:5px; }
-
-.notif-action-link { font-family:var(--mono); font-size:8px; letter-spacing:0.12em; text-transform:uppercase; color:var(--muted); cursor:pointer; border-bottom:1px dotted var(--muted); display:inline; transition:color 0.15s; background:none; border-top:none; border-left:none; border-right:none; padding:0; }
-.notif-action-link:hover { color:var(--text2); }
-.notif-action-link.danger { color:var(--red); border-bottom-color:var(--red); }
-.notif-action-link.success { color:var(--green); border-bottom-color:var(--green); }
-
-.notif-right {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 6px;
-  flex-shrink: 0;
+/* MESSAGE BODY */
+.notif-body { flex: 1; min-width: 0; }
+.notif-msg {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 400;
+  color: #9090A0;
+  line-height: 1.45;
+  margin-bottom: 3px;
 }
+.notif-item:not(.read) .notif-msg { color: #F0F0F2; }
+.notif-msg strong { font-weight: 600; color: #F0F0F2; }
 
 .notif-time {
-  font-family: var(--mono);
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 8px;
-  color: var(--text-secondary);
-  white-space: nowrap;
+  letter-spacing: .05em;
+  color: #555566;
 }
 
+/* UNREAD DOT */
 .notif-unread-dot {
-  width: 7px;
-  height: 7px;
+  width: 6px; height: 6px;
   border-radius: 50%;
-  background: var(--gold);
+  background: #C8A84B;
+  flex-shrink: 0;
+  margin-top: 6px;
 }
 
-#panel-updates .notif-empty {
-  display: none;
+/* POST CARD inside notification */
+.notif-post-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #141420;
+  border: 1px solid #1e1e2e;
+  padding: 8px 10px;
+  margin: 8px 0 0 38px;
+  cursor: pointer;
+}
+.notif-post-card:hover { background: #1c1c2a; }
+.notif-post-thumb {
+  width: 40px; height: 40px;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: #1c1c2a;
+}
+.notif-post-info { flex: 1; min-width: 0; }
+.notif-post-title {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: #F0F0F2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 4px;
+}
+.notif-post-arrow { color: #555566; font-size: 14px; }
+
+/* STAGE PILLS */
+.notif-stage-pill {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  display: inline-block;
+  font-weight: 600;
+}
+.nsp-approval  { background: #FF4B4B14; color: #FF4B4B; border: 1px solid #FF4B4B30; }
+.nsp-input     { background: #F6A62314; color: #F6A623; border: 1px solid #F6A62330; }
+.nsp-ready     { background: #22D3EE12; color: #22D3EE; border: 1px solid #22D3EE30; }
+.nsp-scheduled { background: #C8A84B18; color: #C8A84B; border: 1px solid #C8A84B30; }
+.nsp-published { background: #3ECF8E12; color: #3ECF8E; border: 1px solid #3ECF8E30; }
+.nsp-production{ background: #9b87f514; color: #9b87f5; border: 1px solid #9b87f530; }
+
+/* LIVE MOMENT */
+.notif-live-card {
+  margin: 8px 0 0 38px;
+  padding: 10px 12px;
+  background: #0e1a14;
+  border: 1px solid #3ECF8E30;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.notif-live-thumb {
+  width: 44px; height: 44px;
+  flex-shrink: 0;
+  background: #1c1c2a;
+  object-fit: cover;
+}
+.notif-live-title {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: #F0F0F2;
+  margin-bottom: 3px;
+}
+.notif-live-sub {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  color: #3ECF8E;
+  letter-spacing: .06em;
+}
+
+/* OVERDUE BADGE */
+.notif-overdue-badge {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .06em;
+  color: #F6A623;
+  background: #F6A62314;
+  border: 1px solid #F6A62330;
+  padding: 2px 7px;
+  display: inline-block;
+  margin-left: 6px;
+  font-weight: 600;
+  vertical-align: middle;
+}
+
+/* EMPTY STATE */
+.notif-empty-state {
+  display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 60px 40px;
+  padding: 48px 24px;
   text-align: center;
+  gap: 12px;
 }
-#panel-updates .notif-empty.visible { display: flex; }
+.notif-empty-icon {
+  width: 48px; height: 48px;
+  border-radius: 50%;
+  background: #3ECF8E12;
+  border: 1px solid #3ECF8E30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  color: #3ECF8E;
+  margin-bottom: 4px;
+}
 .notif-empty-title {
-  font-family: var(--mono);
-  font-size: 10px;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--text2);
-  margin-bottom: 6px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: #F0F0F2;
 }
 .notif-empty-sub {
-  font-family: var(--mono);
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 9px;
-  letter-spacing: 0.08em;
-  color: var(--muted);
-  text-transform: uppercase;
+  color: #555566;
+  letter-spacing: .06em;
+  line-height: 1.6;
+}
+.notif-empty-stat {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #3ECF8E;
+  letter-spacing: .06em;
+  margin-top: 4px;
 }
 
 /* ===================================================

--- a/tests/notif-render.test.js
+++ b/tests/notif-render.test.js
@@ -1,0 +1,310 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Source for static analysis
+var uiSrc = readFileSync(resolve(__dirname, '..', '10-ui.js'), 'utf8');
+
+// ---------------------------------------------------------------
+// Extract helpers from 10-ui.js as executable JS
+// ---------------------------------------------------------------
+function extract(fnSig) {
+  var re = new RegExp('function\\s+' + fnSig + '[\\s\\S]*?\\n\\}\\n');
+  var m = uiSrc.match(re);
+  if (!m) throw new Error('Could not find ' + fnSig);
+  return m[0];
+}
+
+// Build a tiny sandbox with extracted pure helpers
+var sandbox = '';
+sandbox += 'var _NOTIF_NEEDS_TYPES = ["awaiting_approval","awaiting_brand_input","brief","comment"];\n';
+sandbox += 'var _NOTIF_UPDATES_TYPES = ["published","scheduled","stage_change","in_production","ready"];\n';
+sandbox += extract('_notifRelTime\\(iso\\)');
+sandbox += extract('_notifIsOverdue\\(post\\)');
+sandbox += extract('_notifTypeClass\\(n, post\\)');
+sandbox += extract('_notifActorClass\\(actor\\)');
+sandbox += extract('_notifStagePillClass\\(stage\\)');
+sandbox += '\nreturn { _notifRelTime:_notifRelTime, _notifIsOverdue:_notifIsOverdue, _notifTypeClass:_notifTypeClass, _notifActorClass:_notifActorClass, _notifStagePillClass:_notifStagePillClass, _NOTIF_NEEDS_TYPES:_NOTIF_NEEDS_TYPES, _NOTIF_UPDATES_TYPES:_NOTIF_UPDATES_TYPES };\n';
+var helpers = (new Function(sandbox))();
+
+
+// ---------------------------------------------------------------
+// _notifRelTime
+// ---------------------------------------------------------------
+describe('_notifRelTime', function() {
+  it('returns "just now" for under a minute', function() {
+    var iso = new Date(Date.now() - 30*1000).toISOString();
+    expect(helpers._notifRelTime(iso)).toBe('just now');
+  });
+  it('returns "X min ago" under an hour', function() {
+    var iso = new Date(Date.now() - 15*60*1000).toISOString();
+    expect(helpers._notifRelTime(iso)).toBe('15 min ago');
+  });
+  it('returns "X hr ago" under a day', function() {
+    var iso = new Date(Date.now() - 3*60*60*1000).toISOString();
+    expect(helpers._notifRelTime(iso)).toBe('3 hr ago');
+  });
+  it('returns Yesterday label for yesterday', function() {
+    var d = new Date(); d.setDate(d.getDate()-1); d.setHours(10,0,0,0);
+    var out = helpers._notifRelTime(d.toISOString());
+    expect(out.indexOf('Yesterday')).toBe(0);
+  });
+  it('returns full date for older than yesterday', function() {
+    var d = new Date(); d.setDate(d.getDate()-5); d.setHours(9,0,0,0);
+    var out = helpers._notifRelTime(d.toISOString());
+    // Should contain a weekday abbreviation and month
+    expect(out).toMatch(/[A-Z][a-z]{2}/);
+    expect(out.indexOf('Yesterday')).toBe(-1);
+    expect(out.indexOf('just now')).toBe(-1);
+  });
+  it('returns empty string on bad input', function() {
+    expect(helpers._notifRelTime('')).toBe('');
+    expect(helpers._notifRelTime(null)).toBe('');
+  });
+});
+
+
+// ---------------------------------------------------------------
+// Needs / Updates filter buckets
+// ---------------------------------------------------------------
+describe('Notification tab buckets', function() {
+  it('needs types cover awaiting_approval, awaiting_brand_input, brief, comment', function() {
+    expect(helpers._NOTIF_NEEDS_TYPES).toEqual(
+      ['awaiting_approval','awaiting_brand_input','brief','comment']
+    );
+  });
+  it('updates types cover published, scheduled, stage_change, in_production, ready', function() {
+    expect(helpers._NOTIF_UPDATES_TYPES).toEqual(
+      ['published','scheduled','stage_change','in_production','ready']
+    );
+  });
+  it('buckets are disjoint (no type overlap)', function() {
+    helpers._NOTIF_NEEDS_TYPES.forEach(function(t) {
+      expect(helpers._NOTIF_UPDATES_TYPES.indexOf(t)).toBe(-1);
+    });
+  });
+});
+
+
+// ---------------------------------------------------------------
+// ntype class assignment
+// ---------------------------------------------------------------
+describe('_notifTypeClass', function() {
+  it('returns ntype-comment for comment type', function() {
+    expect(helpers._notifTypeClass({type:'comment'}, null)).toBe('ntype-comment');
+  });
+  it('returns ntype-approval for awaiting_approval', function() {
+    expect(helpers._notifTypeClass({type:'awaiting_approval'}, null)).toBe('ntype-approval');
+  });
+  it('returns ntype-approval for awaiting_brand_input', function() {
+    expect(helpers._notifTypeClass({type:'awaiting_brand_input'}, null)).toBe('ntype-approval');
+  });
+  it('returns ntype-live for published', function() {
+    expect(helpers._notifTypeClass({type:'published'}, null)).toBe('ntype-live');
+  });
+  it('returns ntype-stage for stage_change', function() {
+    expect(helpers._notifTypeClass({type:'stage_change'}, null)).toBe('ntype-stage');
+  });
+  it('returns ntype-stage for ready/scheduled/in_production', function() {
+    expect(helpers._notifTypeClass({type:'ready'}, null)).toBe('ntype-stage');
+    expect(helpers._notifTypeClass({type:'scheduled'}, null)).toBe('ntype-stage');
+    expect(helpers._notifTypeClass({type:'in_production'}, null)).toBe('ntype-stage');
+  });
+  it('returns ntype-overdue when post is overdue (>2d, not published)', function() {
+    var threeDaysAgo = new Date(Date.now() - 3*24*60*60*1000).toISOString();
+    var post = { stage: 'in_production', status_changed_at: threeDaysAgo };
+    expect(helpers._notifTypeClass({type:'stage_change'}, post)).toBe('ntype-overdue');
+  });
+  it('never marks published posts as overdue', function() {
+    var tenDaysAgo = new Date(Date.now() - 10*24*60*60*1000).toISOString();
+    var post = { stage: 'published', status_changed_at: tenDaysAgo };
+    expect(helpers._notifTypeClass({type:'published'}, post)).toBe('ntype-live');
+  });
+});
+
+
+// ---------------------------------------------------------------
+// Avatar class mapping
+// ---------------------------------------------------------------
+describe('_notifActorClass', function() {
+  it('maps names to correct CSS classes', function() {
+    expect(helpers._notifActorClass('Manisha')).toBe('av-n-client');
+    expect(helpers._notifActorClass('Shivangini')).toBe('av-n-client');
+    expect(helpers._notifActorClass('Client')).toBe('av-n-client');
+    expect(helpers._notifActorClass('Chitra')).toBe('av-n-chitra');
+    expect(helpers._notifActorClass('Servicing')).toBe('av-n-chitra');
+    expect(helpers._notifActorClass('Pranav')).toBe('av-n-pranav');
+    expect(helpers._notifActorClass('Creative')).toBe('av-n-pranav');
+    expect(helpers._notifActorClass('Shubham')).toBe('av-n-shubham');
+    expect(helpers._notifActorClass('Admin')).toBe('av-n-shubham');
+  });
+  it('returns av-n-system for missing actor', function() {
+    expect(helpers._notifActorClass('')).toBe('av-n-system');
+    expect(helpers._notifActorClass(null)).toBe('av-n-system');
+    expect(helpers._notifActorClass(undefined)).toBe('av-n-system');
+  });
+  it('is case-insensitive', function() {
+    expect(helpers._notifActorClass('CHITRA')).toBe('av-n-chitra');
+    expect(helpers._notifActorClass('chitra')).toBe('av-n-chitra');
+  });
+});
+
+
+// ---------------------------------------------------------------
+// Stage pill class mapping
+// ---------------------------------------------------------------
+describe('_notifStagePillClass', function() {
+  it('maps all stages to nsp-* classes', function() {
+    expect(helpers._notifStagePillClass('awaiting_approval')).toBe('nsp-approval');
+    expect(helpers._notifStagePillClass('awaiting_brand_input')).toBe('nsp-input');
+    expect(helpers._notifStagePillClass('ready')).toBe('nsp-ready');
+    expect(helpers._notifStagePillClass('scheduled')).toBe('nsp-scheduled');
+    expect(helpers._notifStagePillClass('published')).toBe('nsp-published');
+    expect(helpers._notifStagePillClass('in_production')).toBe('nsp-production');
+  });
+});
+
+
+// ---------------------------------------------------------------
+// Source analysis: renderNotifications wiring
+// ---------------------------------------------------------------
+describe('renderNotifications wiring (source)', function() {
+  it('fetches actor field from notifications SELECT', function() {
+    expect(uiSrc).toContain('select=id,type,message,read,created_at,post_id,user_role,actor');
+  });
+  it('uses n.actor directly for avatar (no parseActor)', function() {
+    expect(uiSrc).not.toContain('parseActor');
+  });
+  it('initial filter defaults to "needs"', function() {
+    expect(uiSrc).toMatch(/var\s+_notifFilter\s*=\s*['"]needs['"]/);
+  });
+  it('setNotifFilter only accepts needs or updates', function() {
+    var match = uiSrc.match(/function setNotifFilter[\s\S]*?\n\}/);
+    expect(match).not.toBeNull();
+    expect(match[0]).toContain("'needs'");
+    expect(match[0]).toContain("'updates'");
+  });
+  it('renderNotifications writes to notif-summary element', function() {
+    expect(uiSrc).toContain("getElementById('notif-summary')");
+  });
+  it('renderNotifications reads approvals from AppState.posts.all', function() {
+    var match = uiSrc.match(/function renderNotifications[\s\S]*?\n\}/);
+    expect(match).not.toBeNull();
+    expect(match[0]).toContain("AppState.posts.all");
+    expect(match[0]).toContain("stage === 'awaiting_approval'");
+  });
+  it('renderNotifications reads _clientCommentAt for comment count', function() {
+    var match = uiSrc.match(/function renderNotifications[\s\S]*?\n\}/);
+    expect(match[0]).toContain("_clientCommentAt");
+  });
+  it('summary chip classes use chip-urgent, chip-reply, chip-live, chip-allclear', function() {
+    var match = uiSrc.match(/function renderNotifications[\s\S]*?\n\}/);
+    expect(match[0]).toContain('chip-urgent');
+    expect(match[0]).toContain('chip-reply');
+    expect(match[0]).toContain('chip-live');
+    expect(match[0]).toContain('chip-allclear');
+  });
+  it('renderNotifications writes to ntab-needs-count and ntab-updates-count', function() {
+    expect(uiSrc).toContain('ntab-needs-count');
+    expect(uiSrc).toContain('ntab-updates-count');
+  });
+  it('renderNotifications uses no inline style= attributes', function() {
+    var start = uiSrc.indexOf('function renderNotifications');
+    expect(start).toBeGreaterThan(-1);
+    // Find matching close brace by walking forward to next top-level fn
+    var end = uiSrc.indexOf('\nfunction setNotifFilter', start);
+    expect(end).toBeGreaterThan(start);
+    var body = uiSrc.slice(start, end);
+    var styleMatches = (body.match(/\bstyle=/g) || []);
+    expect(styleMatches.length).toBe(0);
+  });
+});
+
+
+// ---------------------------------------------------------------
+// Source analysis: markAllNotificationsRead
+// ---------------------------------------------------------------
+describe('markAllNotificationsRead (source)', function() {
+  var body = uiSrc.match(/function markAllNotificationsRead\(\)[\s\S]*?catch\(e\)[\s\S]*?\n\s*\}/)[0];
+
+  it('title-cases role for PATCH (same logic as loadNotifications)', function() {
+    expect(body).toMatch(/charAt\(0\)\.toUpperCase\(\)\s*\+[\s\S]*slice\(1\)\.toLowerCase/);
+  });
+  it('uses Title-cased role variable in PATCH URL', function() {
+    expect(body).toContain('user_role=eq.');
+    expect(body).toContain('_notifRole');
+  });
+  it('clears ntab-needs-count and ntab-updates-count', function() {
+    expect(body).toContain('ntab-needs-count');
+    expect(body).toContain('ntab-updates-count');
+  });
+  it('calls logError on catch', function() {
+    expect(body).toContain('logError');
+    expect(body).toContain('mark-all-notifications-read');
+  });
+  it('shows success toast', function() {
+    expect(body).toContain('showToast');
+    expect(body).toContain("'success'");
+  });
+});
+
+
+// ---------------------------------------------------------------
+// Source analysis: full-page overlay + item tap
+// ---------------------------------------------------------------
+describe('openNotifications overlay (source)', function() {
+  var body = uiSrc.match(/function openNotifications\(\)[\s\S]*?\n\}/)[0];
+
+  it('overlay uses solid background #0a0a0f (not rgba)', function() {
+    expect(body).toContain('background:#0a0a0f');
+    expect(body).not.toContain('rgba(0,0,0,0.75)');
+  });
+  it('overlay aligns items stretch (full page)', function() {
+    expect(body).toContain('align-items:stretch');
+    expect(body).not.toContain('align-items:flex-end');
+  });
+  it('panel is a flex column with height:100%', function() {
+    expect(body).toContain('height:100%');
+    expect(body).toContain('flex-direction:column');
+  });
+  it('tap handler targets .notif-item (not .notif-post-card-tap)', function() {
+    expect(body).toContain("closest('.notif-item')");
+    expect(body).not.toContain('notif-post-card-tap');
+  });
+  it('tap handler reads data-post-id and data-notif-id from item', function() {
+    expect(body).toContain("getAttribute('data-post-id')");
+    expect(body).toContain("getAttribute('data-notif-id')");
+  });
+});
+
+
+// ---------------------------------------------------------------
+// Source analysis: dead code removal
+// ---------------------------------------------------------------
+describe('dead code removed', function() {
+  it('loadNotifBadge function is gone', function() {
+    expect(uiSrc).not.toMatch(/function\s+loadNotifBadge/);
+    expect(uiSrc).not.toContain('window.loadNotifBadge');
+  });
+  it('getActions helper is gone', function() {
+    expect(uiSrc).not.toContain('getActions');
+  });
+  it('typeClass map is gone', function() {
+    expect(uiSrc).not.toMatch(/var\s+typeClass\s*=\s*\{/);
+  });
+  it('stagePills map is gone', function() {
+    expect(uiSrc).not.toMatch(/var\s+stagePills\s*=\s*\{/);
+  });
+  it('parseActor regex helper is gone', function() {
+    expect(uiSrc).not.toContain('parseActor');
+  });
+  it('formatTime helper is gone (replaced by _notifRelTime)', function() {
+    expect(uiSrc).not.toMatch(/function\s+formatTime\(created_at\)/);
+  });
+  it('notif-client-badge reference is gone', function() {
+    expect(uiSrc).not.toContain('notif-client-badge');
+  });
+  it('old .nftab selector is gone (replaced with .ntab)', function() {
+    expect(uiSrc).not.toContain(".nftab");
+  });
+});

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -91,15 +91,14 @@ describe('Notification badge', function() {
     expect(body).toContain('AppState.user.effectiveRole');
   });
 
-  it('updateNotifBadge updates all 5 badge element IDs', function() {
+  it('updateNotifBadge updates all 4 badge element IDs', function() {
     var match = uiSrc.match(/function updateNotifBadge\(\)[\s\S]*?\.catch/);
     var body = match[0];
     var expectedIds = [
       'notif-bell-badge',
       'notif-pipeline-badge',
       'notif-lib-badge',
-      'notif-ins-badge',
-      'notif-client-badge'
+      'notif-ins-badge'
     ];
     expectedIds.forEach(function(id) {
       expect(body).toContain(id);
@@ -272,14 +271,13 @@ describe('Mark as read', function() {
     expect(body).toContain("method: 'PATCH'");
   });
 
-  it('markAllNotificationsRead hides all 5 badge elements', function() {
+  it('markAllNotificationsRead hides all 4 badge elements', function() {
     var match = uiSrc.match(/function markAllNotificationsRead\(\)[\s\S]*?catch\(e\)/);
     var body = match[0];
     expect(body).toContain('notif-bell-badge');
     expect(body).toContain('notif-pipeline-badge');
     expect(body).toContain('notif-lib-badge');
     expect(body).toContain('notif-ins-badge');
-    expect(body).toContain('notif-client-badge');
     expect(body).toContain("display = 'none'");
   });
 
@@ -300,14 +298,14 @@ describe('Notification card tap', function() {
   });
 
   it('card tap handler reads data-notif-id and calls markNotifRead', function() {
-    // The delegated click handler for .notif-post-card-tap must read notif-id
-    var match = uiSrc.match(/notif-post-card-tap[\s\S]{0,800}markNotifRead/);
+    // The delegated click handler targets .notif-item wrappers
+    var match = uiSrc.match(/closest\('\.notif-item'\)[\s\S]{0,800}markNotifRead/);
     expect(match).not.toBeNull();
   });
 
-  it('card tap handler reads notif-id from closest parent if not on card itself', function() {
-    // The delegated handler uses closest to walk up to the notif-item with the id
-    expect(uiSrc).toContain("closest('[data-notif-id]')");
+  it('tap handler uses closest(.notif-item) to find the row', function() {
+    // Entire row is now tappable, not just inner post card
+    expect(uiSrc).toContain("closest('.notif-item')");
   });
 
 });


### PR DESCRIPTION
## Summary

Rebuild the notification panel as a **full-page overlay** (was a 62vh bottom sheet) with a fixed topbar, scrolling list, and fixed bottom tabs. Prune dead helpers, plumb the `actor` field through, and replace inline-style rendering with a solid-hex CSS class system per the approved design.

- All 20 `?v=` strings bumped to `?v=20260406a`
- Tests: **433/433 passing** (384 existing + 49 new)
- Zero rgba in the new CSS — solid hex only
- Zero inline `style=` attributes in `renderNotifications`

## Files changed

### `10-ui.js`
- Deleted dead helpers inside `renderNotifications`: `typeClass` map, `stagePills` map, `getActions()`, `formatTime()`, `parseActor()`.
- Deleted entire `loadNotifBadge()` function + `window.loadNotifBadge` export (never called, stale global, passed arg to a zero-arg function).
- Removed `notif-client-badge` from `updateNotifBadge` and `markAllNotificationsRead` (element never existed in HTML).
- Added `actor` to the `/notifications` SELECT; avatar initial/color now reads `n.actor` directly.
- Rewrote `renderNotifications`: class-driven markup, no inline styles. Summary chips from `AppState.posts.all` (NEED APPROVAL / COMMENTS WAITING / LIVE TODAY / ALL SORTED). `ntab-needs-count` + `ntab-updates-count` driven from `_notifData` buckets. Per-tab empty states.
- Added `_notifRelTime()` (just now / X min ago / X hr ago / Yesterday · H:MM am/pm / full date).
- `openNotifications`: overlay is `#0a0a0f` `align-items:stretch`; panel is `display:flex;flex-direction:column;height:100%`. Delegated click now targets `.notif-item` (whole row tappable).
- `markAllNotificationsRead`: Title-case role in PATCH (matches `loadNotifications`), clears `ntab-*-count` spans, calls `logError` on failure, fires success toast.
- `setNotifFilter` whitelisted to `needs` / `updates`.

### `index.html`
- `#panel-updates` rebuilt: `.notif-topbar` (role label + hey + `mark-all-btn` + `.notif-summary`) / `.notif-scroll` / `.notif-tabs` with two `.ntab` buttons (`NEEDS YOU` / `UPDATES`) at the bottom.
- All 20 `?v=` strings bumped to `?v=20260406a`.

### `styles.css`
- Deleted legacy `.notif-panel` / `.notif-list` block.
- Deleted dead `.notif-item` / `.notif-avatar` / `.notif-msg` / `.notif-meta` / `.notif-stage-pill` / `.pill-*` system the renderer never applied.
- Added the spec's notification panel CSS: `#panel-updates` flex column, `.notif-topbar`, `.notif-topbar-row`, `.notif-role-label`, `.notif-hey`, `.mark-all-btn`, `.notif-summary` + `.summary-chip` + `.chip-dot` + `.chip-urgent`/`.chip-reply`/`.chip-live`/`.chip-allclear`, `.notif-tabs` + `.ntab` + `.ntab-count`, `.notif-scroll`, `.notif-day-label`, `.notif-item` + `ntype-comment`/`approval`/`live`/`stage`/`overdue` left bars (with `@keyframes notif-pulse`), `.notif-row`, `.notif-av` + `av-n-client`/`chitra`/`pranav`/`shubham`/`system`, `.notif-body` / `.notif-msg` / `.notif-time` / `.notif-unread-dot`, `.notif-post-card` + children, `.notif-stage-pill` + `nsp-*`, `.notif-live-card` + children, `.notif-overdue-badge`, `.notif-empty-state` + children. All solid hex.

### `tests/notifications.test.js`
- "all 5" → "all 4" badge assertions (`notif-client-badge` removed).
- Tap handler regex switched from `.notif-post-card-tap` to `.notif-item`.

### `tests/notif-render.test.js` (new, 49 tests)
- `_notifRelTime` buckets (just now / min / hr / Yesterday / older / bad input).
- Needs/updates bucket definitions and disjointness.
- `_notifTypeClass` coverage incl. overdue detection and published-never-overdue.
- `_notifActorClass` mapping incl. case-insensitive and missing-actor fallback.
- `_notifStagePillClass` mapping.
- Source audit: actor in SELECT, no `parseActor`, initial filter is `needs`, `setNotifFilter` accepts only `needs`/`updates`, `notif-summary` target, `AppState.posts.all` reads, `chip-*` classes present, `ntab-*-count` targets, **zero inline `style=` attributes in `renderNotifications`**.
- `markAllNotificationsRead` source audit: Title-case role, clears tab counts, `logError` call, success toast.
- `openNotifications` source audit: solid `#0a0a0f`, `align-items:stretch`, `height:100%` + `flex-direction:column`, `.notif-item` tap selector.
- Dead-code audit: `loadNotifBadge`, `getActions`, `typeClass`, `stagePills`, `parseActor`, `formatTime`, `notif-client-badge`, `.nftab` all absent.

### `CLAUDE.md`
- Version `20260405z` → `20260406a`.
- Test count `384` → `433` (17 unit test files, added `tests/notif-render.test.js`).
- Removed `window.loadNotifBadge` from Section 11 global list.
- Added the full rebuild entry to Section 12.

## Deviation from spec

The brief listed `styles.css` L5800 `.av-client` as a "duplicate" to delete. After the L4217-4304 block is removed it is no longer a duplicate, and `actions/pcs.js:882` uses it with `.pcs-avatar` for client comment avatars — deleting would break PCS. **Kept intact.**

## Verification (per brief)

| check | result |
|---|---|
| `grep styles.css '.notif-panel'` | 0 ✓ |
| `grep 10-ui.js 'getActions'` | 0 ✓ |
| `grep 10-ui.js 'loadNotifBadge'` | 0 ✓ |
| `grep 10-ui.js 'notif-client-badge'` | 0 ✓ |
| inline `style=` in `renderNotifications` | 0 ✓ |
| full suite | 433/433 ✓ |

## Test plan

- [ ] Open notifications from bell → full-page overlay loads with topbar, scroll list, bottom tabs
- [ ] `NEEDS YOU` tab shows only `awaiting_approval` / `awaiting_brand_input` / `brief` / `comment` rows
- [ ] `UPDATES` tab shows only `published` / `scheduled` / `stage_change` / `in_production` / `ready` rows
- [ ] Summary chips reflect live counts from `AppState.posts.all`
- [ ] Tap anywhere on a row opens PCS (agency) or client overlay (client) or brief sheet (brief stage)
- [ ] `Mark all read` clears bell badge, both tab counts, all unread dots, and shows success toast
- [ ] Empty states render per-tab with correct copy
- [ ] Overdue notifications (>2d not published) show amber pulsing left bar + `OVERDUE` inline badge
- [ ] Relative timestamps render: "just now", "X min ago", "X hr ago", "Yesterday · H:MM am/pm", older date
- [ ] No layout regression on desktop (480px max-width cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)