### PR TITLE
fix: notification panel follow-ups (close btn + spacing + safe area)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260406a
+Version format: ?v=YYYYMMDDx. Current: ?v=20260406b
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -865,6 +865,30 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
        .nftab all absent).
    Status: FIXED (PR#TBD) — 433/433 passing. Bumped to
    ?v=20260406a across all 20 resources.
+1. Notification panel — four follow-up fixes after PR 1.
+   (a) Close button missing from the full-page overlay.
+       Added .notif-close-btn (18px DM Sans X) as a third
+       child of .notif-topbar-row wired to
+       closeNotifications() (index.html), plus matching
+       styles.css rule (no-border text button, #555566,
+       hovers to #F0F0F2).
+   (b) Timestamp wiring verified — loadNotifications already
+       SELECTs created_at, renderNotifications calls
+       _notifRelTime(n.created_at), and the .notif-time
+       div is emitted for every item. .notif-time CSS
+       matches spec (IBM Plex Mono 8px #555566 .05em). No
+       code change, but confirmed end-to-end.
+   (c) Day-label spacing tightened: .notif-day-label
+       padding 14px 20px 8px -> 10px 20px 6px; .notif-summary
+       padding-bottom 14px -> 8px for tighter chip-to-list
+       rhythm.
+   (d) Bottom tab bar breathing room: .ntab padding
+       12px 0 -> 14px 0 18px so label sits above iPhone
+       Safari's browser bar. Added padding-bottom:
+       env(safe-area-inset-bottom, 0px) to .notif-tabs so
+       the row never overlaps the iPhone home indicator.
+   Status: FIXED (PR#TBD) — 433/433 unit + 40/40 CI e2e
+   passing. Bumped to ?v=20260406b.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260406a">
+ <link rel="stylesheet" href="styles.css?v=20260406b">
 
 </head>
 <body>
@@ -397,6 +397,7 @@
           <div class="notif-hey">Hey, <span id="notif-name">Shubham</span></div>
         </div>
         <button class="mark-all-btn" onclick="markAllNotificationsRead()">Mark all read</button>
+        <button class="notif-close-btn" onclick="closeNotifications()">&#x2715;</button>
       </div>
       <div class="notif-summary" id="notif-summary"></div>
     </div>
@@ -1069,26 +1070,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260406a"></script>
-<script src="00-appstate-compat.js?v=20260406a"></script>
-<script src="01-config.js?v=20260406a" defer></script>
-<script src="02-session.js?v=20260406a" defer></script>
-<script src="utils.js?v=20260406a" defer></script>
-<script src="03-auth.js?v=20260406a" defer></script>
-<script src="05-api.js?v=20260406a" defer></script>
-<script src="10-ui.js?v=20260406a" defer></script>
+<script src="00-appstate.js?v=20260406b"></script>
+<script src="00-appstate-compat.js?v=20260406b"></script>
+<script src="01-config.js?v=20260406b" defer></script>
+<script src="02-session.js?v=20260406b" defer></script>
+<script src="utils.js?v=20260406b" defer></script>
+<script src="03-auth.js?v=20260406b" defer></script>
+<script src="05-api.js?v=20260406b" defer></script>
+<script src="10-ui.js?v=20260406b" defer></script>
 
-<script src="06-post-create.js?v=20260406a" defer></script>
-<script defer src="render/dashboard.js?v=20260406a"></script>
-<script defer src="render/client.js?v=20260406a"></script>
-<script defer src="render/pipeline.js?v=20260406a"></script>
-<script defer src="render/brief.js?v=20260406a"></script>
-<script defer src="actions/pcs.js?v=20260406a"></script>
-<script src="07-post-load.js?v=20260406a" defer></script>
-<script src="08-post-actions.js?v=20260406a" defer></script>
-<script src="09-library.js?v=20260406a" defer></script>
-<script src="09-approval.js?v=20260406a" defer></script>
-<script src="04-router.js?v=20260406a" defer></script>
+<script src="06-post-create.js?v=20260406b" defer></script>
+<script defer src="render/dashboard.js?v=20260406b"></script>
+<script defer src="render/client.js?v=20260406b"></script>
+<script defer src="render/pipeline.js?v=20260406b"></script>
+<script defer src="render/brief.js?v=20260406b"></script>
+<script defer src="actions/pcs.js?v=20260406b"></script>
+<script src="07-post-load.js?v=20260406b" defer></script>
+<script src="08-post-actions.js?v=20260406b" defer></script>
+<script src="09-library.js?v=20260406b" defer></script>
+<script src="09-approval.js?v=20260406b" defer></script>
+<script src="04-router.js?v=20260406b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4080,11 +4080,24 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 }
 .mark-all-btn:hover { color: #9090A0; border-color: #333344; }
 
+.notif-close-btn {
+  font-size: 18px;
+  color: #555566;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  margin-top: 2px;
+  font-family: 'DM Sans', sans-serif;
+  line-height: 1;
+}
+.notif-close-btn:hover { color: #F0F0F2; }
+
 /* SUMMARY CHIPS */
 .notif-summary {
   display: flex;
   gap: 8px;
-  padding-bottom: 14px;
+  padding-bottom: 8px;
   flex-wrap: wrap;
 }
 .summary-chip {
@@ -4115,6 +4128,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   flex-shrink: 0;
   border-top: 1px solid #1e1e2e;
   background: #0e0e16;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 .ntab {
   flex: 1;
@@ -4122,7 +4136,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   font-size: 9px;
   letter-spacing: .1em;
   text-transform: uppercase;
-  padding: 12px 0;
+  padding: 14px 0 18px;
   text-align: center;
   cursor: pointer;
   color: #555566;
@@ -4162,7 +4176,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   letter-spacing: .1em;
   color: #555566;
   text-transform: uppercase;
-  padding: 14px 20px 8px;
+  padding: 10px 20px 6px;
   border-bottom: 1px dotted #1e1e2e;
 }
 


### PR DESCRIPTION
Four follow-ups after PR 1's notification panel rebuild.

FIX 1 — Close button
- index.html: new .notif-close-btn (X glyph) added as the last child of .notif-topbar-row, wired to closeNotifications().
- styles.css: .notif-close-btn + :hover rules. 18px DM Sans text button, #555566 -> #F0F0F2 on hover, no border.

FIX 2 — Timestamp (verify only)
- loadNotifications already includes created_at in the SELECT, renderNotifications already calls _notifRelTime(n.created_at), .notif-time div is emitted per item and .notif-time CSS matches spec (IBM Plex Mono 8px #555566 letter-spacing .05em). No code change — confirmed wired end-to-end.

FIX 3 — Day label spacing
- .notif-day-label padding: 14px 20px 8px -> 10px 20px 6px
- .notif-summary padding-bottom: 14px -> 8px Tighter rhythm between summary chips and first day label.

FIX 4 — Bottom tab bar breathing room
- .ntab padding: 12px 0 -> 14px 0 18px so the NEEDS YOU / UPDATES labels sit above iPhone Safari's browser bar.
- .notif-tabs padding-bottom: env(safe-area-inset-bottom, 0px) so the tab row never overlaps the iPhone home indicator.

All 20 ?v= strings bumped to ?v=20260406b.
CLAUDE.md: documented four fixes in Section 12.

Tests:
- Unit: 433/433 passing
- E2E (CI critical): 40/40 passing (admin-flows, pcs, client-flows)

Version: ?v=20260406b

https://claude.ai/code/session_01FA6u8CmLY3wtXi6rjyqcXg