### PR TITLE
Notification panel rebuild (PR 2 of 4): chips + Instagram density

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -298,7 +298,7 @@ function switchTab(btn) {
 }
 
 // -- Notifications (Updates Tab) ---------------
-var _notifFilter = 'needs';
+var _notifChipFilter = 'all';
 var _notifData = [];
 
 // Relative time formatter for notification timestamps
@@ -320,11 +320,6 @@ function _notifRelTime(iso) {
   return d.toLocaleDateString('en-IN', {weekday:'short', day:'numeric', month:'short'}) + ' \xB7 ' + timeStr;
 }
 
-// Needs-tab types: actionable items
-var _NOTIF_NEEDS_TYPES = ['awaiting_approval','awaiting_brand_input','brief','comment'];
-// Updates-tab types: informational items
-var _NOTIF_UPDATES_TYPES = ['published','scheduled','stage_change','in_production','ready'];
-
 function _notifIsOverdue(post) {
   if (!post || post.stage === 'published') return false;
   if (!post.status_changed_at) return false;
@@ -340,25 +335,28 @@ function _notifTypeClass(n, post) {
   return 'ntype-stage';
 }
 
-function _notifStagePillClass(stage) {
-  if (stage === 'awaiting_approval')    return 'nsp-approval';
-  if (stage === 'awaiting_brand_input') return 'nsp-input';
-  if (stage === 'ready')                return 'nsp-ready';
-  if (stage === 'scheduled')            return 'nsp-scheduled';
-  if (stage === 'published')            return 'nsp-published';
-  if (stage === 'in_production')        return 'nsp-production';
-  return 'nsp-ready';
-}
-
 function _notifActorClass(actor) {
   var a = (actor || '').toLowerCase();
-  if (!a) return 'av-n-system';
-  if (a === 'manisha' || a === 'shivangini' || a === 'client') return 'av-n-client';
-  if (a === 'chitra' || a === 'servicing') return 'av-n-chitra';
-  if (a === 'pranav' || a === 'creative') return 'av-n-pranav';
-  if (a === 'shubham' || a === 'admin') return 'av-n-shubham';
-  return 'av-n-system';
+  if (!a) return 'nav-system';
+  if (a === 'manisha' || a === 'shivangini' || a === 'client') return 'nav-client';
+  if (a === 'chitra' || a === 'servicing') return 'nav-chitra';
+  if (a === 'pranav' || a === 'creative') return 'nav-pranav';
+  if (a === 'shubham' || a === 'admin') return 'nav-shubham';
+  return 'nav-system';
 }
+
+// Chip filter predicate. Returns true if notification n (+ its post)
+// should appear under the currently active chip.
+function _notifChipMatch(filter, n, post) {
+  if (filter === 'all') return true;
+  if (filter === 'approval') return n.type === 'awaiting_approval' || n.type === 'awaiting_brand_input';
+  if (filter === 'comment')  return n.type === 'comment';
+  if (filter === 'live')     return n.type === 'published';
+  if (filter === 'stage')    return n.type === 'stage_change' || n.type === 'ready' || n.type === 'in_production' || n.type === 'scheduled';
+  if (filter === 'overdue')  return _notifIsOverdue(post);
+  return true;
+}
+
 var roleDisplayMap = {
   'Admin':      { name: 'Shubham', label: 'Admin - Sorted' },
   'admin':      { name: 'Shubham', label: 'Admin - Sorted' },
@@ -412,115 +410,45 @@ function renderNotifications(name, role) {
   }
   if (roleEl) roleEl.textContent = displayLabel;
 
-  // ----- Smart summary chips (from AppState.posts.all - no new fetch) -----
   var posts = (window.AppState.posts && window.AppState.posts.all) || [];
-  var approvalPosts = posts.filter(function(p){ return p.stage === 'awaiting_approval'; });
-  var approvalCount = approvalPosts.length;
-  var oldestDays = 0;
-  if (approvalCount > 0) {
-    var oldestTs = Date.now();
-    approvalPosts.forEach(function(p){
-      if (!p.status_changed_at) return;
-      var t = new Date(p.status_changed_at).getTime();
-      if (!isNaN(t) && t < oldestTs) oldestTs = t;
-    });
-    oldestDays = Math.floor((Date.now() - oldestTs) / 86400000);
-  }
-  var commentCount = posts.filter(function(p){ return p._clientCommentAt; }).length;
-  var todayStr = new Date().toDateString();
-  var liveToday = posts.filter(function(p){
-    if (p.stage !== 'published') return false;
-    if (!p.status_changed_at) return false;
-    var d = new Date(p.status_changed_at);
-    return !isNaN(d.getTime()) && d.toDateString() === todayStr;
-  }).length;
-
-  var summaryEl = document.getElementById('notif-summary');
-  if (summaryEl) {
-    var chips = [];
-    if (approvalCount > 0) {
-      chips.push('<div class="summary-chip chip-urgent">' +
-        '<div class="chip-dot"></div>' +
-        approvalCount + ' NEED APPROVAL' +
-        (oldestDays > 0 ? ' \xB7 ' + oldestDays + 'D OLDEST' : '') +
-        '</div>');
-    }
-    if (commentCount > 0) {
-      chips.push('<div class="summary-chip chip-reply">' +
-        '<div class="chip-dot"></div>' +
-        commentCount + ' COMMENTS WAITING' +
-        '</div>');
-    }
-    if (liveToday > 0) {
-      chips.push('<div class="summary-chip chip-live">' +
-        '<div class="chip-dot"></div>' +
-        liveToday + ' LIVE TODAY' +
-        '</div>');
-    }
-    if (chips.length === 0) {
-      chips.push('<div class="summary-chip chip-allclear">' +
-        '<div class="chip-dot"></div>ALL SORTED</div>');
-    }
-    summaryEl.innerHTML = chips.join('');
+  function postFor(pid) {
+    if (!pid) return null;
+    for (var i = 0; i < posts.length; i++) { if (posts[i].post_id === pid) return posts[i]; }
+    return null;
   }
 
-  // ----- Tab counts (unread per bucket) -----
-  var needsUnread = notifs.filter(function(n){
-    return !n.read && _NOTIF_NEEDS_TYPES.indexOf(n.type) !== -1;
-  }).length;
-  var updatesUnread = notifs.filter(function(n){
-    return !n.read && _NOTIF_UPDATES_TYPES.indexOf(n.type) !== -1;
-  }).length;
-  var needsCountEl = document.getElementById('ntab-needs-count');
-  var updatesCountEl = document.getElementById('ntab-updates-count');
-  if (needsCountEl) {
-    if (needsUnread > 0) { needsCountEl.textContent = needsUnread; needsCountEl.style.display = ''; }
-    else { needsCountEl.textContent = ''; needsCountEl.style.display = 'none'; }
+  // Chip unread counts
+  var allCount      = notifs.length;
+  var approvalCount = notifs.filter(function(n){ return !n.read && (n.type === 'awaiting_approval' || n.type === 'awaiting_brand_input'); }).length;
+  var commentCount  = notifs.filter(function(n){ return !n.read && n.type === 'comment'; }).length;
+  var overdueCount  = notifs.filter(function(n){ return _notifIsOverdue(postFor(n.post_id)); }).length;
+  function _setCount(id, value) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    if (value > 0) { el.textContent = value; el.style.display = ''; }
+    else { el.textContent = ''; el.style.display = 'none'; }
   }
-  if (updatesCountEl) {
-    if (updatesUnread > 0) { updatesCountEl.textContent = updatesUnread; updatesCountEl.style.display = ''; }
-    else { updatesCountEl.textContent = ''; updatesCountEl.style.display = 'none'; }
-  }
+  _setCount('nchip-all-count', allCount);
+  _setCount('nchip-approval-count', approvalCount);
+  _setCount('nchip-comment-count', commentCount);
+  _setCount('nchip-overdue-count', overdueCount);
 
-  // ----- Apply active tab filter -----
-  var activeTypes = _notifFilter === 'needs' ? _NOTIF_NEEDS_TYPES : _NOTIF_UPDATES_TYPES;
-  var filtered = notifs.filter(function(n){ return activeTypes.indexOf(n.type) !== -1; });
+  // Apply active chip filter
+  var filter = _notifChipFilter || 'all';
+  var filtered = notifs.filter(function(n) { return _notifChipMatch(filter, n, postFor(n.post_id)); });
 
   var scroll = document.getElementById('notif-list-scroll');
+  var emptyEl = document.getElementById('notif-empty');
   if (!scroll) return;
 
-  // ----- Empty state (per-tab) -----
   if (filtered.length === 0) {
-    if (_notifFilter === 'needs') {
-      scroll.innerHTML =
-        '<div class="notif-empty-state">' +
-          '<div class="notif-empty-icon">\u2713</div>' +
-          '<div class="notif-empty-title">You&#39;re all caught up</div>' +
-          '<div class="notif-empty-sub">NOTHING NEEDS YOUR ATTENTION</div>' +
-        '</div>';
-    } else {
-      var weekAgo = Date.now() - 7 * 86400000;
-      var approvedThisWeek = _notifData.filter(function(n){
-        if (n.type !== 'awaiting_approval') return false;
-        if (!n.read) return false;
-        if (!n.created_at) return false;
-        var t = new Date(n.created_at).getTime();
-        return !isNaN(t) && t > weekAgo;
-      }).length;
-      scroll.innerHTML =
-        '<div class="notif-empty-state">' +
-          '<div class="notif-empty-icon">\u25CB</div>' +
-          '<div class="notif-empty-title">No updates yet</div>' +
-          '<div class="notif-empty-sub">ACTIVITY WILL APPEAR HERE</div>' +
-          (approvedThisWeek > 0
-            ? '<div class="notif-empty-stat">' + approvedThisWeek + ' APPROVED THIS WEEK</div>'
-            : '') +
-        '</div>';
-    }
+    scroll.innerHTML = '';
+    if (emptyEl) emptyEl.style.display = '';
     return;
   }
+  if (emptyEl) emptyEl.style.display = 'none';
 
-  // ----- Group by day -----
+  // Group by day
   var todayKey = new Date().toDateString();
   var yesterday = new Date(); yesterday.setDate(yesterday.getDate()-1);
   var yesterdayKey = yesterday.toDateString();
@@ -532,84 +460,64 @@ function renderNotifications(name, role) {
     else groups.Earlier.push(n);
   });
 
-  // ----- Build item HTML -----
   var html = '';
   ['Today','Yesterday','Earlier'].forEach(function(day) {
     if (!groups[day] || groups[day].length === 0) return;
     html += '<div class="notif-day-label">' + day + '</div>';
     groups[day].forEach(function(n) {
-      var post = posts.find(function(p) { return p.post_id === n.post_id; });
-      var thumb = post && Array.isArray(post.images) && post.images[0] ? post.images[0] : '';
+      var post = postFor(n.post_id);
+      var postThumb = post && Array.isArray(post.images) && post.images[0] ? post.images[0] : '';
       var postTitle = post ? (post.title || '') : '';
-      var postStage = post ? (post.stage || '') : (n.type || '');
-      var stageLabel = (postStage||'').replace(/_/g,' ');
-      if (postStage === 'awaiting_approval') stageLabel = 'Awaiting Approval';
-      if (postStage === 'awaiting_brand_input') stageLabel = 'Awaiting Input';
       var tClass = _notifTypeClass(n, post);
       var avClass = _notifActorClass(n.actor);
-      var actorName = n.actor || '';
-      var initial = actorName ? actorName.charAt(0).toUpperCase() : '\u00B7';
+      var actor = n.actor || '';
+      var initial = actor ? actor.charAt(0).toUpperCase() : '?';
       var isUnread = !n.read;
       var ts = _notifRelTime(n.created_at);
+      var isOverdue = tClass === 'ntype-overdue';
+
+      // Action text: strip leading actor word from message if present
       var msg = n.message || '';
       var msgParts = msg.split(' ');
-      var msgHtml = msgParts.length > 1
-        ? '<strong>' + esc(msgParts[0]) + '</strong> ' + esc(msgParts.slice(1).join(' '))
-        : esc(msg);
-      var isLive = n.type === 'published';
-      var isOverdueItem = tClass === 'ntype-overdue';
+      var actionText = msgParts.length > 1 && msgParts[0].toLowerCase() === actor.toLowerCase()
+        ? msgParts.slice(1).join(' ')
+        : msg;
+
+      if (n.type === 'published' && (postThumb || postTitle)) {
+        html += '<div class="notif-live-card"' +
+          ' data-notif-id="' + esc(n.id || '') + '"' +
+          (n.post_id ? ' data-post-id="' + esc(n.post_id) + '"' : '') + '>' +
+          (postThumb
+            ? '<img class="notif-live-thumb" src="' + esc(postThumb) + '" onerror="this.style.display=\'none\'">'
+            : '<div class="notif-live-thumb"></div>') +
+          '<div style="flex:1;min-width:0;">' +
+            '<div class="notif-live-tag">\u2713 POST IS LIVE</div>' +
+            '<div class="notif-live-title">' + esc(postTitle) + '</div>' +
+            '<div class="notif-live-sub">' + esc(actor) + ' \xB7 ' + esc(ts) + ' \xB7 VIEW ON LINKEDIN \u2192</div>' +
+          '</div>' +
+        '</div>';
+        return;
+      }
 
       html += '<div class="notif-item ' + tClass + (isUnread ? '' : ' read') + '"' +
         ' data-notif-id="' + esc(n.id || '') + '"' +
-        (n.post_id ? ' data-post-id="' + esc(n.post_id) + '"' : '') +
-        ' data-is-brief="' + (postStage === 'brief' ? '1' : '0') + '">' +
-        '<div class="notif-row">' +
-          '<div class="notif-av ' + avClass + '">' + esc(initial) + '</div>' +
-          '<div class="notif-body">' +
-            '<div class="notif-msg">' + msgHtml +
-              (isOverdueItem ? ' <span class="notif-overdue-badge">OVERDUE</span>' : '') +
-            '</div>' +
-            '<div class="notif-time">' + esc(ts) + '</div>' +
+        ' data-post-id="' + esc(n.post_id || '') + '"' +
+        ' data-is-brief="' + (post && post.stage === 'brief' ? '1' : '0') + '">' +
+        '<div class="notif-av ' + avClass + '">' + esc(initial) + '</div>' +
+        '<div class="notif-body">' +
+          '<div class="notif-text">' +
+            '<strong>' + esc(actor) + '</strong> ' + esc(actionText) +
+            (isOverdue ? '<span class="notif-overdue-inline"> \xB7 OVERDUE</span>' : '') +
+            '<span class="notif-time-inline"> \xB7 ' + esc(ts) + '</span>' +
           '</div>' +
-          (isUnread ? '<div class="notif-unread-dot"></div>' : '') +
         '</div>' +
-        (isLive && n.post_id && (postTitle || thumb) ?
-          '<div class="notif-live-card">' +
-            (thumb
-              ? '<img class="notif-live-thumb" src="' + esc(thumb) + '" onerror="this.style.display=\'none\'">'
-              : '<div class="notif-live-thumb"></div>') +
-            '<div>' +
-              '<div class="notif-live-title">' + esc(postTitle) + '</div>' +
-              '<div class="notif-live-sub">\u2713 POST IS LIVE \xB7 VIEW ON LINKEDIN \u2192</div>' +
-            '</div>' +
-          '</div>'
-        : (n.post_id && (postTitle || thumb) ?
-          '<div class="notif-post-card" data-post-id="' + esc(n.post_id) + '">' +
-            (thumb
-              ? '<img class="notif-post-thumb" src="' + esc(thumb) + '" onerror="this.style.display=\'none\'">'
-              : '<div class="notif-post-thumb"></div>') +
-            '<div class="notif-post-info">' +
-              '<div class="notif-post-title">' + esc(postTitle) + '</div>' +
-              '<span class="notif-stage-pill ' + _notifStagePillClass(postStage) + '">' + esc(stageLabel) + '</span>' +
-            '</div>' +
-            '<div class="notif-post-arrow">\u203A</div>' +
-          '</div>'
-        : '')) +
+        (postThumb
+          ? '<div class="notif-thumb-wrap"><img class="notif-thumb" src="' + esc(postThumb) + '" onerror="this.style.display=\'none\'"></div>'
+          : '') +
         '</div>';
     });
   });
   scroll.innerHTML = html;
-}
-
-function setNotifFilter(filter, btn) {
-  if (filter !== 'needs' && filter !== 'updates') filter = 'needs';
-  _notifFilter = filter;
-  document.querySelectorAll('.ntab').forEach(function(t) { t.classList.remove('active'); });
-  if (btn) btn.classList.add('active');
-  var _notifRole = window.AppState.user.effectiveRole || window.AppState.user.role || 'Admin';
-  _notifRole = _notifRole.charAt(0).toUpperCase() + _notifRole.slice(1).toLowerCase();
-  var currentName = resolveActor() || 'there';
-  renderNotifications(currentName, _notifRole);
 }
 
 async function markNotifRead(id) {
@@ -643,7 +551,9 @@ async function markAllNotificationsRead() {
       var el = document.getElementById(id);
       if (el) el.style.display = 'none';
     });
-    ['ntab-needs-count','ntab-updates-count'].forEach(function(id) {
+    // Unread-driven chip counts are rebuilt by renderNotifications above;
+    // belt-and-braces hide of the urgency chips in case render was skipped.
+    ['nchip-approval-count','nchip-comment-count','nchip-overdue-count'].forEach(function(id) {
       var el = document.getElementById(id);
       if (el) { el.textContent = ''; el.style.display = 'none'; }
     });
@@ -1427,10 +1337,11 @@ function openNotifications() {
   if (!panel._notifTapWired) {
     panel._notifTapWired = true;
     panel.addEventListener('click', function(e) {
-      // Skip the tabs row and mark-all button
-      if (e.target.closest('.notif-tabs')) return;
+      // Chips, mark-all, close button handle their own clicks.
+      if (e.target.closest('.notif-chips')) return;
       if (e.target.closest('.mark-all-btn')) return;
-      var item = e.target.closest('.notif-item');
+      if (e.target.closest('.notif-close-btn')) return;
+      var item = e.target.closest('.notif-item, .notif-live-card');
       if (!item) return;
       e.stopPropagation();
       var pid = item.getAttribute('data-post-id');
@@ -1453,6 +1364,23 @@ function openNotifications() {
         }
       }, 150);
     });
+  }
+  if (!panel._chipsWired) {
+    panel._chipsWired = true;
+    var chipsEl = document.getElementById('notif-chips');
+    if (chipsEl) {
+      chipsEl.addEventListener('click', function(e) {
+        var chip = e.target.closest('.notif-chip');
+        if (!chip) return;
+        document.querySelectorAll('#notif-chips .notif-chip').forEach(function(c) { c.classList.remove('active'); });
+        chip.classList.add('active');
+        _notifChipFilter = chip.dataset.filter || 'all';
+        var role = window.AppState.user.effectiveRole || window.AppState.user.role || 'Admin';
+        role = role.charAt(0).toUpperCase() + role.slice(1).toLowerCase();
+        var currentName = (typeof resolveActor === 'function' && resolveActor()) || 'there';
+        renderNotifications(currentName, role);
+      });
+    }
   }
   var overlay = document.getElementById('notif-overlay');
   if (!overlay) {
@@ -1690,7 +1618,6 @@ if (!window._routerBound) {
         case 'nav-insights': return guardAction('nav-insights', () => showInsights());
         case 'pcs-tab':      return guardAction('pcs-tab-' + tab, () => window._pcsTabSwitch(tab));
         case 'pcs-vis':      return guardAction('pcs-vis-' + actionEl.dataset.vis, () => window.setPcsVisibility && window.setPcsVisibility(actionEl, actionEl.dataset.vis));
-        case 'notif-filter': return guardAction('notif-filter-' + actionEl.dataset.filter, () => setNotifFilter(actionEl.dataset.filter, actionEl));
         case 'ins-metric':   return guardAction('ins-metric-' + actionEl.dataset.metric, () => insSetMetric(actionEl.dataset.metric, actionEl));
         case 'ins-range':    return guardAction('ins-range-' + actionEl.dataset.range, () => insSetRange(actionEl.dataset.range, actionEl));
         case 'ins-period':   return guardAction('ins-period-' + actionEl.dataset.period, () => insSetPostsPeriod(actionEl.dataset.period, actionEl));

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260406b
+Version format: ?v=YYYYMMDDx. Current: ?v=20260406c
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -889,6 +889,83 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
        the row never overlaps the iPhone home indicator.
    Status: FIXED (PR#TBD) — 433/433 unit + 40/40 CI e2e
    passing. Bumped to ?v=20260406b.
+1. Notification panel rebuild (PR 2 of 4) — CSS replacement,
+   new item layout at Instagram density, horizontal scroll
+   filter chips replacing NEEDS YOU / UPDATES bottom tabs.
+   Scope:
+   (a) styles.css: entire L4023-4398 notification panel CSS
+       block replaced. All new classes target the approved
+       mockup. Panel structure rule changed from
+       #panel-updates to #notif-overlay #panel-updates so
+       the flex column layout only applies when the panel
+       is mounted inside the overlay (keeps .tab-panel
+       hide-on-other-tabs working). Header now has two rows:
+       row1 (role label + close X), row2 (hey + mark-all).
+       New .notif-chips horizontal scroll container with six
+       .notif-chip buttons (ALL / APPROVAL / COMMENTS /
+       OVERDUE / LIVE / STAGE MOVES), scrollbar-hidden.
+       .notif-chip.active uses neutral #141420 background;
+       colored variants .nchip-red/cyan/amber/green apply
+       per-filter tint only when active. New single-row
+       .notif-item at 56px min-height with 10/14/10/18 px
+       padding, 11px DM Sans text with 2-line webkit-clamp,
+       inline 11px gray timestamp via .notif-time-inline,
+       inline 8px amber OVERDUE badge via
+       .notif-overdue-inline, 44x44 .notif-thumb-wrap/
+       .notif-thumb on the right edge, 34x34 .notif-av on
+       the left with new nav-* palette. Left color bar is
+       still driven by ntype-comment/approval/live/stage/
+       overdue (with pulse on overdue). New .notif-live-card
+       for type:published, tinted #091410 green with
+       VIEW ON LINKEDIN sub. Empty state matches the #notif-
+       empty element. All solid hex with 8-digit alpha
+       suffixes (#FF4B4B14 etc.) — zero rgba().
+   (b) index.html L389-423: #panel-updates body replaced.
+       .notif-topbar now has .notif-topbar-row1 (role +
+       close) and .notif-topbar-row2 (hey + mark-all),
+       then .notif-chips with six data-filter buttons,
+       then a 1px divider, then .notif-scroll list, then
+       #notif-empty state. Bottom .notif-tabs gone.
+   (c) 10-ui.js: _notifFilter renamed to _notifChipFilter
+       (default 'all'). setNotifFilter() removed entirely.
+       _NOTIF_NEEDS_TYPES / _NOTIF_UPDATES_TYPES removed.
+       _notifStagePillClass removed (post cards no longer
+       carry stage pills). _notifActorClass rewired from
+       av-n-* to nav-* prefix. New _notifChipMatch(filter,
+       n, post) predicate drives chip filtering (all /
+       approval / comment / live / stage / overdue).
+       renderNotifications body rewritten to single-row
+       density layout with inline timestamp. For
+       type:published rows the live-card HTML replaces the
+       item. Chip counts (nchip-all/approval/comment/
+       overdue-count) written to after filter application.
+       Click delegation in openNotifications now also
+       matches .notif-live-card (closest('.notif-item,
+       .notif-live-card')) and skips .notif-chips,
+       .mark-all-btn, .notif-close-btn. A new _chipsWired
+       guard attaches a delegated listener to #notif-chips
+       so chip taps flip active class + filter state + call
+       renderNotifications directly (no action-router hop).
+       markAllNotificationsRead clears nchip-*-count (unread
+       ones) instead of ntab-*-count.
+   (d) 10-ui.js router: case 'notif-filter' removed — chips
+       have their own delegated listener on the panel, no
+       data-action attribute is used.
+   (e) Tests: action-router.test.js dropped the notif-filter
+       router case test (36 -> 35). notifications.test.js
+       tap handler regexes updated for the comma selector
+       '.notif-item, .notif-live-card'. notif-render.test.js
+       rewritten for the new API: _notifRelTime (6),
+       _notifIsOverdue (5), _notifTypeClass (8),
+       _notifActorClass (3), _notifChipMatch (7),
+       renderNotifications wiring (8 incl. chip counts,
+       live-card branch, no inline styles), markAll source
+       audit (5), openNotifications overlay shape (6 incl.
+       .notif-item/.notif-live-card tap selector + chip
+       wiring), dead code audit (2 PR1+PR2 combined). Total
+       50 tests in notif-render.
+   Status: FIXED (PR#TBD) — 433/433 unit + 40/40 CI e2e
+   passing. Bumped to ?v=20260406c.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260406b">
+ <link rel="stylesheet" href="styles.css?v=20260406c">
 
 </head>
 <body>
@@ -389,30 +389,35 @@
   <!-- TAB: UPDATES -->
   <div class="tab-panel" id="panel-updates">
 
-    <!-- TOP BAR (fixed) -->
+    <!-- HEADER -->
     <div class="notif-topbar">
-      <div class="notif-topbar-row">
-        <div>
-          <div class="notif-role-label" id="notif-role">Admin</div>
-          <div class="notif-hey">Hey, <span id="notif-name">Shubham</span></div>
-        </div>
-        <button class="mark-all-btn" onclick="markAllNotificationsRead()">Mark all read</button>
-        <button class="notif-close-btn" onclick="closeNotifications()">&#x2715;</button>
+      <div class="notif-topbar-row1">
+        <div class="notif-role-label" id="notif-role">Admin</div>
+        <button class="notif-close-btn" onclick="closeNotifications()">&#x2715; CLOSE</button>
       </div>
-      <div class="notif-summary" id="notif-summary"></div>
+      <div class="notif-topbar-row2">
+        <div class="notif-hey">Hey, <span id="notif-name">Shubham</span></div>
+        <button class="mark-all-btn" onclick="markAllNotificationsRead()">MARK ALL READ</button>
+      </div>
+      <div class="notif-chips" id="notif-chips">
+        <button class="notif-chip active" data-filter="all">ALL <span class="notif-chip-count" id="nchip-all-count"></span></button>
+        <button class="notif-chip nchip-red" data-filter="approval"><span class="notif-chip-dot"></span>APPROVAL <span class="notif-chip-count" id="nchip-approval-count"></span></button>
+        <button class="notif-chip nchip-cyan" data-filter="comment"><span class="notif-chip-dot"></span>COMMENTS <span class="notif-chip-count" id="nchip-comment-count"></span></button>
+        <button class="notif-chip nchip-amber" data-filter="overdue"><span class="notif-chip-dot"></span>OVERDUE <span class="notif-chip-count" id="nchip-overdue-count"></span></button>
+        <button class="notif-chip nchip-green" data-filter="live"><span class="notif-chip-dot"></span>LIVE</button>
+        <button class="notif-chip" data-filter="stage">STAGE MOVES</button>
+      </div>
     </div>
+    <div style="height:1px;background:#1e1e2e;"></div>
 
-    <!-- LIST (scrolls) -->
+    <!-- LIST -->
     <div class="notif-scroll" id="notif-list-scroll"></div>
 
-    <!-- TABS (fixed bottom) -->
-    <div class="notif-tabs" id="notif-tabs">
-      <button class="ntab active" data-filter="needs" data-action="notif-filter">
-        NEEDS YOU <span class="ntab-count" id="ntab-needs-count"></span>
-      </button>
-      <button class="ntab" data-filter="updates" data-action="notif-filter">
-        UPDATES <span class="ntab-count" id="ntab-updates-count"></span>
-      </button>
+    <!-- EMPTY STATE -->
+    <div class="notif-empty-state" id="notif-empty" style="display:none">
+      <div class="notif-empty-icon">&#x2713;</div>
+      <div class="notif-empty-title">All sorted</div>
+      <div class="notif-empty-sub">NOTHING TO SHOW</div>
     </div>
 
   </div>
@@ -1070,26 +1075,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260406b"></script>
-<script src="00-appstate-compat.js?v=20260406b"></script>
-<script src="01-config.js?v=20260406b" defer></script>
-<script src="02-session.js?v=20260406b" defer></script>
-<script src="utils.js?v=20260406b" defer></script>
-<script src="03-auth.js?v=20260406b" defer></script>
-<script src="05-api.js?v=20260406b" defer></script>
-<script src="10-ui.js?v=20260406b" defer></script>
+<script src="00-appstate.js?v=20260406c"></script>
+<script src="00-appstate-compat.js?v=20260406c"></script>
+<script src="01-config.js?v=20260406c" defer></script>
+<script src="02-session.js?v=20260406c" defer></script>
+<script src="utils.js?v=20260406c" defer></script>
+<script src="03-auth.js?v=20260406c" defer></script>
+<script src="05-api.js?v=20260406c" defer></script>
+<script src="10-ui.js?v=20260406c" defer></script>
 
-<script src="06-post-create.js?v=20260406b" defer></script>
-<script defer src="render/dashboard.js?v=20260406b"></script>
-<script defer src="render/client.js?v=20260406b"></script>
-<script defer src="render/pipeline.js?v=20260406b"></script>
-<script defer src="render/brief.js?v=20260406b"></script>
-<script defer src="actions/pcs.js?v=20260406b"></script>
-<script src="07-post-load.js?v=20260406b" defer></script>
-<script src="08-post-actions.js?v=20260406b" defer></script>
-<script src="09-library.js?v=20260406b" defer></script>
-<script src="09-approval.js?v=20260406b" defer></script>
-<script src="04-router.js?v=20260406b" defer></script>
+<script src="06-post-create.js?v=20260406c" defer></script>
+<script defer src="render/dashboard.js?v=20260406c"></script>
+<script defer src="render/client.js?v=20260406c"></script>
+<script defer src="render/pipeline.js?v=20260406c"></script>
+<script defer src="render/brief.js?v=20260406c"></script>
+<script defer src="actions/pcs.js?v=20260406c"></script>
+<script src="07-post-load.js?v=20260406c" defer></script>
+<script src="08-post-actions.js?v=20260406c" defer></script>
+<script src="09-library.js?v=20260406c" defer></script>
+<script src="09-approval.js?v=20260406c" defer></script>
+<script src="04-router.js?v=20260406c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4021,33 +4021,42 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 }
 
 /* ===================================================
-   NOTIFICATION PANEL (rebuilt PR 1 of 4)
+   NOTIFICATION PANEL (rebuilt PR 2 of 4)
    =================================================== */
 
-/* PANEL STRUCTURE (only when mounted inside the overlay)
-   — the bare #panel-updates is still governed by
-   .tab-panel / .tab-panel.active so it stays hidden on
-   other tabs. */
+/* ── PANEL STRUCTURE ── */
+#notif-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1300;
+  background: #0a0a0f;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+}
+
 #notif-overlay #panel-updates {
+  width: 100%;
+  max-width: 480px;
+  height: 100%;
+  overflow: hidden;
+  background: #0e0e16;
   display: flex;
   flex-direction: column;
-  height: 100%;
-  background: #0e0e16;
-  overflow: hidden;
 }
 
+/* ── HEADER ── */
 .notif-topbar {
   flex-shrink: 0;
-  padding: 52px 20px 0;
+  padding: 12px 18px 0;
   background: #0e0e16;
-  border-bottom: 1px solid #1e1e2e;
 }
 
-.notif-topbar-row {
+.notif-topbar-row1 {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  margin-bottom: 14px;
+  margin-bottom: 5px;
 }
 
 .notif-role-label {
@@ -4056,14 +4065,41 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   letter-spacing: .12em;
   color: #555566;
   text-transform: uppercase;
-  margin-bottom: 4px;
+}
+
+.notif-close-btn {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .08em;
+  color: #555566;
+  background: none;
+  border: 1px solid #1e1e2e;
+  padding: 4px 10px;
+  cursor: pointer;
+  position: relative;
+}
+.notif-close-btn::after {
+  content: '';
+  position: absolute;
+  inset: -14px -18px;
+}
+.notif-close-btn:hover { color: #9090A0; border-color: #2a2a3a; }
+
+.notif-topbar-row2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
 }
 
 .notif-hey {
+  font-family: 'DM Sans', sans-serif;
   font-size: 24px;
   font-weight: 700;
   color: #F0F0F2;
   line-height: 1.1;
+  flex: 1;
 }
 .notif-hey span { color: #C8A84B; }
 
@@ -4076,91 +4112,62 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   border: 1px solid #1e1e2e;
   padding: 5px 10px;
   cursor: pointer;
-  margin-top: 4px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
-.mark-all-btn:hover { color: #9090A0; border-color: #333344; }
+.mark-all-btn:hover { color: #9090A0; }
 
-.notif-close-btn {
-  font-size: 18px;
+/* ── HORIZONTAL SCROLL FILTER CHIPS ── */
+.notif-chips {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding-bottom: 10px;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+.notif-chips::-webkit-scrollbar { display: none; }
+
+.notif-chip {
+  flex-shrink: 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  padding: 5px 12px;
+  border-radius: 20px;
+  cursor: pointer;
+  border: 1px solid #1e1e2e;
   color: #555566;
   background: none;
-  border: none;
-  cursor: pointer;
-  padding: 4px 8px;
-  margin-top: 2px;
-  font-family: 'DM Sans', sans-serif;
-  line-height: 1;
-}
-.notif-close-btn:hover { color: #F0F0F2; }
-
-/* SUMMARY CHIPS */
-.notif-summary {
-  display: flex;
-  gap: 8px;
-  padding-bottom: 8px;
-  flex-wrap: wrap;
-}
-.summary-chip {
+  white-space: nowrap;
   display: flex;
   align-items: center;
   gap: 5px;
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 9px;
-  letter-spacing: .06em;
-  padding: 4px 10px;
-  border-radius: 2px;
-  font-weight: 500;
 }
-.chip-dot {
+.notif-chip.active {
+  background: #141420;
+  border-color: #2a2a3a;
+  color: #F0F0F2;
+}
+.notif-chip.nchip-red.active   { border-color: #FF4B4B40; color: #FF4B4B; background: #FF4B4B0a; }
+.notif-chip.nchip-cyan.active  { border-color: #22D3EE40; color: #22D3EE; background: #22D3EE0a; }
+.notif-chip.nchip-amber.active { border-color: #F6A62340; color: #F6A623; background: #F6A6230a; }
+.notif-chip.nchip-green.active { border-color: #3ECF8E40; color: #3ECF8E; background: #3ECF8E0a; }
+
+.notif-chip-dot {
   width: 5px; height: 5px;
   border-radius: 50%;
   background: currentColor;
   flex-shrink: 0;
 }
-.chip-urgent { background: #FF4B4B14; color: #FF4B4B; border: 1px solid #FF4B4B30; }
-.chip-reply  { background: #22D3EE12; color: #22D3EE; border: 1px solid #22D3EE30; }
-.chip-live   { background: #3ECF8E12; color: #3ECF8E; border: 1px solid #3ECF8E30; }
-.chip-allclear { background: #3ECF8E12; color: #3ECF8E; border: 1px solid #3ECF8E30; }
-
-/* TABS - bottom of panel */
-.notif-tabs {
-  display: flex;
-  flex-shrink: 0;
-  border-top: 1px solid #1e1e2e;
-  background: #0e0e16;
-  padding-bottom: env(safe-area-inset-bottom, 0px);
-}
-.ntab {
-  flex: 1;
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 9px;
-  letter-spacing: .1em;
-  text-transform: uppercase;
-  padding: 14px 0 18px;
-  text-align: center;
-  cursor: pointer;
-  color: #555566;
-  border: none;
-  border-top: 2px solid transparent;
-  background: none;
-}
-.ntab.active { color: #C8A84B; border-top-color: #C8A84B; }
-.ntab-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px; height: 16px;
-  border-radius: 50%;
-  background: #FF4B4B;
-  color: #fff;
+.notif-chip-count {
   font-size: 8px;
   font-weight: 700;
-  margin-left: 5px;
-  vertical-align: middle;
+  opacity: 0.8;
 }
-.ntab.active .ntab-count { background: #C8A84B; color: #000; }
 
-/* SCROLL AREA */
+/* ── SCROLL AREA ── */
 .notif-scroll {
   flex: 1;
   overflow-y: auto;
@@ -4169,29 +4176,33 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 }
 .notif-scroll::-webkit-scrollbar { display: none; }
 
-/* DAY LABEL */
+/* ── DAY LABEL ── */
 .notif-day-label {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 8px;
   letter-spacing: .1em;
   color: #555566;
   text-transform: uppercase;
-  padding: 10px 20px 6px;
+  padding: 8px 18px 6px;
   border-bottom: 1px dotted #1e1e2e;
 }
 
-/* NOTIFICATION ITEM */
+/* ── NOTIFICATION ITEM ── */
 .notif-item {
   position: relative;
-  padding: 14px 16px 14px 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px 10px 18px;
   border-bottom: 1px solid #1e1e2e;
   cursor: pointer;
   background: #0e0e16;
+  min-height: 56px;
 }
 .notif-item:hover { background: #141420; }
-.notif-item.read { opacity: 0.55; }
+.notif-item.read  { opacity: 0.45; }
 
-/* LEFT COLOR BAR */
+/* left color bar */
 .notif-item::before {
   content: '';
   position: absolute;
@@ -4205,196 +4216,141 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 .notif-item.ntype-overdue::before  { background: #F6A623; animation: notif-pulse 1.5s infinite; }
 @keyframes notif-pulse { 0%,100%{opacity:1} 50%{opacity:0.3} }
 
-/* ITEM ROW */
-.notif-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-}
-
-/* AVATAR */
+/* avatar */
 .notif-av {
-  width: 28px; height: 28px;
+  width: 34px; height: 34px;
   border-radius: 50%;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 9px;
+  font-size: 11px;
   font-weight: 600;
-  margin-top: 1px;
 }
-.av-n-manisha, .av-n-client    { background: #FF4B4B18; border: 1px solid #FF4B4B44; color: #FF4B4B; }
-.av-n-chitra, .av-n-servicing  { background: #22D3EE18; border: 1px solid #22D3EE44; color: #22D3EE; }
-.av-n-pranav, .av-n-creative   { background: #9b87f518; border: 1px solid #9b87f544; color: #9b87f5; }
-.av-n-admin, .av-n-shubham     { background: #C8A84B18; border: 1px solid #C8A84B44; color: #C8A84B; }
-.av-n-system                   { background: #F6A62318; border: 1px solid #F6A62344; color: #F6A623; }
+.nav-manisha, .nav-client   { background: #FF4B4B18; border: 1px solid #FF4B4B44; color: #FF4B4B; }
+.nav-chitra, .nav-servicing { background: #22D3EE18; border: 1px solid #22D3EE44; color: #22D3EE; }
+.nav-pranav, .nav-creative  { background: #9b87f518; border: 1px solid #9b87f544; color: #9b87f5; }
+.nav-admin, .nav-shubham    { background: #C8A84B18; border: 1px solid #C8A84B44; color: #C8A84B; }
+.nav-system                 { background: #F6A62318; border: 1px solid #F6A62344; color: #F6A623; }
 
-/* MESSAGE BODY */
+/* message body */
 .notif-body { flex: 1; min-width: 0; }
-.notif-msg {
+
+.notif-text {
   font-family: 'DM Sans', sans-serif;
-  font-size: 13px;
+  font-size: 11px;
   font-weight: 400;
   color: #9090A0;
-  line-height: 1.45;
-  margin-bottom: 3px;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
-.notif-item:not(.read) .notif-msg { color: #F0F0F2; }
-.notif-msg strong { font-weight: 600; color: #F0F0F2; }
+.notif-item:not(.read) .notif-text { color: #F0F0F2; }
+.notif-text strong { font-weight: 600; }
 
-.notif-time {
+.notif-time-inline {
+  color: #555566;
+  font-size: 11px;
+  font-weight: 400;
+}
+
+.notif-overdue-inline {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 8px;
   letter-spacing: .05em;
-  color: #555566;
+  color: #F6A623;
+  font-weight: 600;
 }
 
-/* UNREAD DOT */
-.notif-unread-dot {
-  width: 6px; height: 6px;
-  border-radius: 50%;
-  background: #C8A84B;
+/* thumbnail */
+.notif-thumb-wrap {
   flex-shrink: 0;
-  margin-top: 6px;
+  width: 44px; height: 44px;
+}
+.notif-thumb {
+  width: 44px; height: 44px;
+  object-fit: cover;
+  background: #1c1c2a;
+  border-radius: 2px;
+  display: block;
 }
 
-/* POST CARD inside notification */
-.notif-post-card {
+/* live moment card */
+.notif-live-card {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 10px;
-  background: #141420;
-  border: 1px solid #1e1e2e;
-  padding: 8px 10px;
-  margin: 8px 0 0 38px;
+  gap: 12px;
+  padding: 12px 14px 12px 18px;
+  border-bottom: 1px solid #1e1e2e;
+  background: #091410;
   cursor: pointer;
 }
-.notif-post-card:hover { background: #1c1c2a; }
-.notif-post-thumb {
-  width: 40px; height: 40px;
+.notif-live-card::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 3px;
+  background: #3ECF8E;
+}
+.notif-live-thumb {
+  width: 44px; height: 44px;
   object-fit: cover;
   flex-shrink: 0;
+  border-radius: 2px;
   background: #1c1c2a;
 }
-.notif-post-info { flex: 1; min-width: 0; }
-.notif-post-title {
+.notif-live-tag {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .08em;
+  color: #3ECF8E;
+  margin-bottom: 2px;
+}
+.notif-live-title {
   font-family: 'DM Sans', sans-serif;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
   color: #F0F0F2;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 4px;
-}
-.notif-post-arrow { color: #555566; font-size: 14px; }
-
-/* STAGE PILLS */
-.notif-stage-pill {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 7px;
-  letter-spacing: .08em;
-  text-transform: uppercase;
-  padding: 2px 7px;
-  display: inline-block;
-  font-weight: 600;
-}
-.nsp-approval  { background: #FF4B4B14; color: #FF4B4B; border: 1px solid #FF4B4B30; }
-.nsp-input     { background: #F6A62314; color: #F6A623; border: 1px solid #F6A62330; }
-.nsp-ready     { background: #22D3EE12; color: #22D3EE; border: 1px solid #22D3EE30; }
-.nsp-scheduled { background: #C8A84B18; color: #C8A84B; border: 1px solid #C8A84B30; }
-.nsp-published { background: #3ECF8E12; color: #3ECF8E; border: 1px solid #3ECF8E30; }
-.nsp-production{ background: #9b87f514; color: #9b87f5; border: 1px solid #9b87f530; }
-
-/* LIVE MOMENT */
-.notif-live-card {
-  margin: 8px 0 0 38px;
-  padding: 10px 12px;
-  background: #0e1a14;
-  border: 1px solid #3ECF8E30;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.notif-live-thumb {
-  width: 44px; height: 44px;
-  flex-shrink: 0;
-  background: #1c1c2a;
-  object-fit: cover;
-}
-.notif-live-title {
-  font-family: 'DM Sans', sans-serif;
-  font-size: 12px;
-  font-weight: 600;
-  color: #F0F0F2;
-  margin-bottom: 3px;
 }
 .notif-live-sub {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 8px;
-  color: #3ECF8E;
-  letter-spacing: .06em;
+  color: #555566;
+  letter-spacing: .04em;
+  margin-top: 2px;
 }
 
-/* OVERDUE BADGE */
-.notif-overdue-badge {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  letter-spacing: .06em;
-  color: #F6A623;
-  background: #F6A62314;
-  border: 1px solid #F6A62330;
-  padding: 2px 7px;
-  display: inline-block;
-  margin-left: 6px;
-  font-weight: 600;
-  vertical-align: middle;
-}
-
-/* EMPTY STATE */
+/* empty state */
 .notif-empty-state {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   padding: 48px 24px;
   text-align: center;
-  gap: 12px;
+  gap: 8px;
 }
 .notif-empty-icon {
-  width: 48px; height: 48px;
+  width: 40px; height: 40px;
   border-radius: 50%;
   background: #3ECF8E12;
   border: 1px solid #3ECF8E30;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 20px;
-  color: #3ECF8E;
-  margin-bottom: 4px;
-}
-.notif-empty-title {
-  font-family: 'DM Sans', sans-serif;
   font-size: 16px;
-  font-weight: 600;
-  color: #F0F0F2;
-}
-.notif-empty-sub {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 9px;
-  color: #555566;
-  letter-spacing: .06em;
-  line-height: 1.6;
-}
-.notif-empty-stat {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 9px;
   color: #3ECF8E;
-  letter-spacing: .06em;
-  margin-top: 4px;
+  margin-bottom: 6px;
 }
+.notif-empty-title { font-family: 'DM Sans', sans-serif; font-size: 15px; font-weight: 600; color: #F0F0F2; }
+.notif-empty-sub   { font-family: 'IBM Plex Mono', monospace; font-size: 9px; color: #555566; letter-spacing: .06em; line-height: 1.6; }
+.notif-empty-stat  { font-family: 'IBM Plex Mono', monospace; font-size: 9px; color: #3ECF8E; letter-spacing: .06em; margin-top: 4px; }
 
 /* ===================================================
    DASHBOARD REDESIGN

--- a/tests/action-router.test.js
+++ b/tests/action-router.test.js
@@ -249,13 +249,6 @@ describe('Phase 4/5 — Action Router & guardAction', function() {
       expect(window.setPcsVisibility).toHaveBeenCalledWith(el, 'r16-admin');
     });
 
-    it('17. notif-filter → setNotifFilter(filterValue, actionEl)', async function() {
-      var el = makeEl({ 'data-action':'notif-filter', 'data-filter':'r17-all' });
-      dispatchClickOn(el);
-      await flush();
-      expect(window.setNotifFilter).toHaveBeenCalledTimes(1);
-      expect(window.setNotifFilter).toHaveBeenCalledWith('r17-all', el);
-    });
 
     it('18. ins-metric → insSetMetric(metricValue, actionEl)', async function() {
       var el = makeEl({ 'data-action':'ins-metric', 'data-metric':'r18-imp' });

--- a/tests/notif-render.test.js
+++ b/tests/notif-render.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
@@ -15,16 +15,13 @@ function extract(fnSig) {
   return m[0];
 }
 
-// Build a tiny sandbox with extracted pure helpers
 var sandbox = '';
-sandbox += 'var _NOTIF_NEEDS_TYPES = ["awaiting_approval","awaiting_brand_input","brief","comment"];\n';
-sandbox += 'var _NOTIF_UPDATES_TYPES = ["published","scheduled","stage_change","in_production","ready"];\n';
 sandbox += extract('_notifRelTime\\(iso\\)');
 sandbox += extract('_notifIsOverdue\\(post\\)');
 sandbox += extract('_notifTypeClass\\(n, post\\)');
 sandbox += extract('_notifActorClass\\(actor\\)');
-sandbox += extract('_notifStagePillClass\\(stage\\)');
-sandbox += '\nreturn { _notifRelTime:_notifRelTime, _notifIsOverdue:_notifIsOverdue, _notifTypeClass:_notifTypeClass, _notifActorClass:_notifActorClass, _notifStagePillClass:_notifStagePillClass, _NOTIF_NEEDS_TYPES:_NOTIF_NEEDS_TYPES, _NOTIF_UPDATES_TYPES:_NOTIF_UPDATES_TYPES };\n';
+sandbox += extract('_notifChipMatch\\(filter, n, post\\)');
+sandbox += '\nreturn { _notifRelTime:_notifRelTime, _notifIsOverdue:_notifIsOverdue, _notifTypeClass:_notifTypeClass, _notifActorClass:_notifActorClass, _notifChipMatch:_notifChipMatch };\n';
 var helpers = (new Function(sandbox))();
 
 
@@ -52,7 +49,6 @@ describe('_notifRelTime', function() {
   it('returns full date for older than yesterday', function() {
     var d = new Date(); d.setDate(d.getDate()-5); d.setHours(9,0,0,0);
     var out = helpers._notifRelTime(d.toISOString());
-    // Should contain a weekday abbreviation and month
     expect(out).toMatch(/[A-Z][a-z]{2}/);
     expect(out.indexOf('Yesterday')).toBe(-1);
     expect(out.indexOf('just now')).toBe(-1);
@@ -65,29 +61,32 @@ describe('_notifRelTime', function() {
 
 
 // ---------------------------------------------------------------
-// Needs / Updates filter buckets
+// _notifIsOverdue
 // ---------------------------------------------------------------
-describe('Notification tab buckets', function() {
-  it('needs types cover awaiting_approval, awaiting_brand_input, brief, comment', function() {
-    expect(helpers._NOTIF_NEEDS_TYPES).toEqual(
-      ['awaiting_approval','awaiting_brand_input','brief','comment']
-    );
+describe('_notifIsOverdue', function() {
+  it('returns false for null post', function() {
+    expect(helpers._notifIsOverdue(null)).toBe(false);
   });
-  it('updates types cover published, scheduled, stage_change, in_production, ready', function() {
-    expect(helpers._NOTIF_UPDATES_TYPES).toEqual(
-      ['published','scheduled','stage_change','in_production','ready']
-    );
+  it('returns false for published posts', function() {
+    var tenDaysAgo = new Date(Date.now() - 10*86400000).toISOString();
+    expect(helpers._notifIsOverdue({ stage:'published', status_changed_at: tenDaysAgo })).toBe(false);
   });
-  it('buckets are disjoint (no type overlap)', function() {
-    helpers._NOTIF_NEEDS_TYPES.forEach(function(t) {
-      expect(helpers._NOTIF_UPDATES_TYPES.indexOf(t)).toBe(-1);
-    });
+  it('returns false for posts missing status_changed_at', function() {
+    expect(helpers._notifIsOverdue({ stage:'in_production' })).toBe(false);
+  });
+  it('returns false for posts stuck < 2 days', function() {
+    var oneDayAgo = new Date(Date.now() - 1*86400000).toISOString();
+    expect(helpers._notifIsOverdue({ stage:'in_production', status_changed_at: oneDayAgo })).toBe(false);
+  });
+  it('returns true for posts stuck > 2 days and not published', function() {
+    var threeDaysAgo = new Date(Date.now() - 3*86400000).toISOString();
+    expect(helpers._notifIsOverdue({ stage:'in_production', status_changed_at: threeDaysAgo })).toBe(true);
   });
 });
 
 
 // ---------------------------------------------------------------
-// ntype class assignment
+// _notifTypeClass — left color bar assignment
 // ---------------------------------------------------------------
 describe('_notifTypeClass', function() {
   it('returns ntype-comment for comment type', function() {
@@ -111,56 +110,89 @@ describe('_notifTypeClass', function() {
     expect(helpers._notifTypeClass({type:'in_production'}, null)).toBe('ntype-stage');
   });
   it('returns ntype-overdue when post is overdue (>2d, not published)', function() {
-    var threeDaysAgo = new Date(Date.now() - 3*24*60*60*1000).toISOString();
-    var post = { stage: 'in_production', status_changed_at: threeDaysAgo };
+    var threeDaysAgo = new Date(Date.now() - 3*86400000).toISOString();
+    var post = { stage:'in_production', status_changed_at: threeDaysAgo };
     expect(helpers._notifTypeClass({type:'stage_change'}, post)).toBe('ntype-overdue');
   });
   it('never marks published posts as overdue', function() {
-    var tenDaysAgo = new Date(Date.now() - 10*24*60*60*1000).toISOString();
-    var post = { stage: 'published', status_changed_at: tenDaysAgo };
+    var tenDaysAgo = new Date(Date.now() - 10*86400000).toISOString();
+    var post = { stage:'published', status_changed_at: tenDaysAgo };
     expect(helpers._notifTypeClass({type:'published'}, post)).toBe('ntype-live');
   });
 });
 
 
 // ---------------------------------------------------------------
-// Avatar class mapping
+// _notifActorClass — avatar CSS mapping (new nav-* system)
 // ---------------------------------------------------------------
 describe('_notifActorClass', function() {
   it('maps names to correct CSS classes', function() {
-    expect(helpers._notifActorClass('Manisha')).toBe('av-n-client');
-    expect(helpers._notifActorClass('Shivangini')).toBe('av-n-client');
-    expect(helpers._notifActorClass('Client')).toBe('av-n-client');
-    expect(helpers._notifActorClass('Chitra')).toBe('av-n-chitra');
-    expect(helpers._notifActorClass('Servicing')).toBe('av-n-chitra');
-    expect(helpers._notifActorClass('Pranav')).toBe('av-n-pranav');
-    expect(helpers._notifActorClass('Creative')).toBe('av-n-pranav');
-    expect(helpers._notifActorClass('Shubham')).toBe('av-n-shubham');
-    expect(helpers._notifActorClass('Admin')).toBe('av-n-shubham');
+    expect(helpers._notifActorClass('Manisha')).toBe('nav-client');
+    expect(helpers._notifActorClass('Shivangini')).toBe('nav-client');
+    expect(helpers._notifActorClass('Client')).toBe('nav-client');
+    expect(helpers._notifActorClass('Chitra')).toBe('nav-chitra');
+    expect(helpers._notifActorClass('Servicing')).toBe('nav-chitra');
+    expect(helpers._notifActorClass('Pranav')).toBe('nav-pranav');
+    expect(helpers._notifActorClass('Creative')).toBe('nav-pranav');
+    expect(helpers._notifActorClass('Shubham')).toBe('nav-shubham');
+    expect(helpers._notifActorClass('Admin')).toBe('nav-shubham');
   });
-  it('returns av-n-system for missing actor', function() {
-    expect(helpers._notifActorClass('')).toBe('av-n-system');
-    expect(helpers._notifActorClass(null)).toBe('av-n-system');
-    expect(helpers._notifActorClass(undefined)).toBe('av-n-system');
+  it('returns nav-system for missing actor', function() {
+    expect(helpers._notifActorClass('')).toBe('nav-system');
+    expect(helpers._notifActorClass(null)).toBe('nav-system');
+    expect(helpers._notifActorClass(undefined)).toBe('nav-system');
   });
   it('is case-insensitive', function() {
-    expect(helpers._notifActorClass('CHITRA')).toBe('av-n-chitra');
-    expect(helpers._notifActorClass('chitra')).toBe('av-n-chitra');
+    expect(helpers._notifActorClass('CHITRA')).toBe('nav-chitra');
+    expect(helpers._notifActorClass('chitra')).toBe('nav-chitra');
   });
 });
 
 
 // ---------------------------------------------------------------
-// Stage pill class mapping
+// _notifChipMatch — horizontal chip filter predicate
 // ---------------------------------------------------------------
-describe('_notifStagePillClass', function() {
-  it('maps all stages to nsp-* classes', function() {
-    expect(helpers._notifStagePillClass('awaiting_approval')).toBe('nsp-approval');
-    expect(helpers._notifStagePillClass('awaiting_brand_input')).toBe('nsp-input');
-    expect(helpers._notifStagePillClass('ready')).toBe('nsp-ready');
-    expect(helpers._notifStagePillClass('scheduled')).toBe('nsp-scheduled');
-    expect(helpers._notifStagePillClass('published')).toBe('nsp-published');
-    expect(helpers._notifStagePillClass('in_production')).toBe('nsp-production');
+describe('_notifChipMatch', function() {
+  it('"all" matches every notification', function() {
+    expect(helpers._notifChipMatch('all', {type:'comment'}, null)).toBe(true);
+    expect(helpers._notifChipMatch('all', {type:'published'}, null)).toBe(true);
+    expect(helpers._notifChipMatch('all', {type:'stage_change'}, null)).toBe(true);
+  });
+  it('"approval" matches awaiting_approval + awaiting_brand_input', function() {
+    expect(helpers._notifChipMatch('approval', {type:'awaiting_approval'}, null)).toBe(true);
+    expect(helpers._notifChipMatch('approval', {type:'awaiting_brand_input'}, null)).toBe(true);
+    expect(helpers._notifChipMatch('approval', {type:'comment'}, null)).toBe(false);
+    expect(helpers._notifChipMatch('approval', {type:'published'}, null)).toBe(false);
+  });
+  it('"comment" matches only type:comment', function() {
+    expect(helpers._notifChipMatch('comment', {type:'comment'}, null)).toBe(true);
+    expect(helpers._notifChipMatch('comment', {type:'awaiting_approval'}, null)).toBe(false);
+    expect(helpers._notifChipMatch('comment', {type:'stage_change'}, null)).toBe(false);
+  });
+  it('"live" matches only type:published', function() {
+    expect(helpers._notifChipMatch('live', {type:'published'}, null)).toBe(true);
+    expect(helpers._notifChipMatch('live', {type:'scheduled'}, null)).toBe(false);
+    expect(helpers._notifChipMatch('live', {type:'comment'}, null)).toBe(false);
+  });
+  it('"stage" matches stage_change/ready/in_production/scheduled', function() {
+    expect(helpers._notifChipMatch('stage', {type:'stage_change'}, null)).toBe(true);
+    expect(helpers._notifChipMatch('stage', {type:'ready'}, null)).toBe(true);
+    expect(helpers._notifChipMatch('stage', {type:'in_production'}, null)).toBe(true);
+    expect(helpers._notifChipMatch('stage', {type:'scheduled'}, null)).toBe(true);
+    expect(helpers._notifChipMatch('stage', {type:'published'}, null)).toBe(false);
+    expect(helpers._notifChipMatch('stage', {type:'comment'}, null)).toBe(false);
+  });
+  it('"overdue" matches only when post is stuck > 2 days', function() {
+    var threeDaysAgo = new Date(Date.now() - 3*86400000).toISOString();
+    var fresh = new Date(Date.now() - 1*60*1000).toISOString();
+    var overduePost = { stage:'in_production', status_changed_at: threeDaysAgo };
+    var freshPost   = { stage:'in_production', status_changed_at: fresh };
+    expect(helpers._notifChipMatch('overdue', {type:'stage_change'}, overduePost)).toBe(true);
+    expect(helpers._notifChipMatch('overdue', {type:'stage_change'}, freshPost)).toBe(false);
+    expect(helpers._notifChipMatch('overdue', {type:'stage_change'}, null)).toBe(false);
+  });
+  it('unknown filter defaults to "all" (permissive)', function() {
+    expect(helpers._notifChipMatch('unknown', {type:'comment'}, null)).toBe(true);
   });
 });
 
@@ -172,51 +204,46 @@ describe('renderNotifications wiring (source)', function() {
   it('fetches actor field from notifications SELECT', function() {
     expect(uiSrc).toContain('select=id,type,message,read,created_at,post_id,user_role,actor');
   });
-  it('uses n.actor directly for avatar (no parseActor)', function() {
-    expect(uiSrc).not.toContain('parseActor');
+  it('initial chip filter defaults to "all"', function() {
+    expect(uiSrc).toMatch(/var\s+_notifChipFilter\s*=\s*['"]all['"]/);
   });
-  it('initial filter defaults to "needs"', function() {
-    expect(uiSrc).toMatch(/var\s+_notifFilter\s*=\s*['"]needs['"]/);
-  });
-  it('setNotifFilter only accepts needs or updates', function() {
-    var match = uiSrc.match(/function setNotifFilter[\s\S]*?\n\}/);
-    expect(match).not.toBeNull();
-    expect(match[0]).toContain("'needs'");
-    expect(match[0]).toContain("'updates'");
-  });
-  it('renderNotifications writes to notif-summary element', function() {
-    expect(uiSrc).toContain("getElementById('notif-summary')");
-  });
-  it('renderNotifications reads approvals from AppState.posts.all', function() {
-    var match = uiSrc.match(/function renderNotifications[\s\S]*?\n\}/);
-    expect(match).not.toBeNull();
-    expect(match[0]).toContain("AppState.posts.all");
-    expect(match[0]).toContain("stage === 'awaiting_approval'");
-  });
-  it('renderNotifications reads _clientCommentAt for comment count', function() {
-    var match = uiSrc.match(/function renderNotifications[\s\S]*?\n\}/);
-    expect(match[0]).toContain("_clientCommentAt");
-  });
-  it('summary chip classes use chip-urgent, chip-reply, chip-live, chip-allclear', function() {
-    var match = uiSrc.match(/function renderNotifications[\s\S]*?\n\}/);
-    expect(match[0]).toContain('chip-urgent');
-    expect(match[0]).toContain('chip-reply');
-    expect(match[0]).toContain('chip-live');
-    expect(match[0]).toContain('chip-allclear');
-  });
-  it('renderNotifications writes to ntab-needs-count and ntab-updates-count', function() {
-    expect(uiSrc).toContain('ntab-needs-count');
-    expect(uiSrc).toContain('ntab-updates-count');
-  });
-  it('renderNotifications uses no inline style= attributes', function() {
+  it('renderNotifications writes to all 4 chip-count ids', function() {
     var start = uiSrc.indexOf('function renderNotifications');
-    expect(start).toBeGreaterThan(-1);
-    // Find matching close brace by walking forward to next top-level fn
-    var end = uiSrc.indexOf('\nfunction setNotifFilter', start);
-    expect(end).toBeGreaterThan(start);
+    var end = uiSrc.indexOf('\nasync function markNotifRead', start);
     var body = uiSrc.slice(start, end);
-    var styleMatches = (body.match(/\bstyle=/g) || []);
-    expect(styleMatches.length).toBe(0);
+    expect(body).toContain('nchip-all-count');
+    expect(body).toContain('nchip-approval-count');
+    expect(body).toContain('nchip-comment-count');
+    expect(body).toContain('nchip-overdue-count');
+  });
+  it('item markup emits data-post-id + data-notif-id on .notif-item wrapper', function() {
+    var start = uiSrc.indexOf('function renderNotifications');
+    var end = uiSrc.indexOf('\nasync function markNotifRead', start);
+    var body = uiSrc.slice(start, end);
+    expect(body).toMatch(/class="notif-item[\s\S]*?data-notif-id/);
+    expect(body).toContain("data-post-id");
+  });
+  it('live moment branch uses .notif-live-card for type:published', function() {
+    var start = uiSrc.indexOf('function renderNotifications');
+    var end = uiSrc.indexOf('\nasync function markNotifRead', start);
+    var body = uiSrc.slice(start, end);
+    expect(body).toContain('notif-live-card');
+    expect(body).toContain("n.type === 'published'");
+  });
+  it('renderNotifications uses no style= attributes in item markup', function() {
+    var start = uiSrc.indexOf('function renderNotifications');
+    var end = uiSrc.indexOf('\nasync function markNotifRead', start);
+    var body = uiSrc.slice(start, end);
+    // Only live-card inner div uses style="flex:1..." which is allowed layout helper
+    var hits = (body.match(/\bstyle="/g) || []);
+    // At most 1 allowed (the live-card flex:1 wrapper)
+    expect(hits.length).toBeLessThanOrEqual(1);
+  });
+  it('relative time is rendered inline via notif-time-inline span', function() {
+    expect(uiSrc).toContain('notif-time-inline');
+  });
+  it('overdue inline badge uses .notif-overdue-inline', function() {
+    expect(uiSrc).toContain('notif-overdue-inline');
   });
 });
 
@@ -234,9 +261,10 @@ describe('markAllNotificationsRead (source)', function() {
     expect(body).toContain('user_role=eq.');
     expect(body).toContain('_notifRole');
   });
-  it('clears ntab-needs-count and ntab-updates-count', function() {
-    expect(body).toContain('ntab-needs-count');
-    expect(body).toContain('ntab-updates-count');
+  it('clears unread-driven chip counts (approval/comment/overdue)', function() {
+    expect(body).toContain('nchip-approval-count');
+    expect(body).toContain('nchip-comment-count');
+    expect(body).toContain('nchip-overdue-count');
   });
   it('calls logError on catch', function() {
     expect(body).toContain('logError');
@@ -250,7 +278,7 @@ describe('markAllNotificationsRead (source)', function() {
 
 
 // ---------------------------------------------------------------
-// Source analysis: full-page overlay + item tap
+// Source analysis: full-page overlay + item/live-card tap + chips
 // ---------------------------------------------------------------
 describe('openNotifications overlay (source)', function() {
   var body = uiSrc.match(/function openNotifications\(\)[\s\S]*?\n\}/)[0];
@@ -267,44 +295,42 @@ describe('openNotifications overlay (source)', function() {
     expect(body).toContain('height:100%');
     expect(body).toContain('flex-direction:column');
   });
-  it('tap handler targets .notif-item (not .notif-post-card-tap)', function() {
-    expect(body).toContain("closest('.notif-item')");
-    expect(body).not.toContain('notif-post-card-tap');
+  it('tap handler targets .notif-item and .notif-live-card', function() {
+    expect(body).toContain("closest('.notif-item, .notif-live-card')");
   });
   it('tap handler reads data-post-id and data-notif-id from item', function() {
     expect(body).toContain("getAttribute('data-post-id')");
     expect(body).toContain("getAttribute('data-notif-id')");
   });
+  it('wires #notif-chips click delegation with _chipsWired guard', function() {
+    expect(body).toContain('_chipsWired');
+    expect(body).toContain("getElementById('notif-chips')");
+    expect(body).toContain('_notifChipFilter');
+  });
 });
 
 
 // ---------------------------------------------------------------
-// Source analysis: dead code removal
+// Source analysis: dead code removed (PR 1 + PR 2)
 // ---------------------------------------------------------------
 describe('dead code removed', function() {
-  it('loadNotifBadge function is gone', function() {
+  it('PR 1 dead helpers are gone (loadNotifBadge/getActions/parseActor/formatTime/notif-client-badge)', function() {
     expect(uiSrc).not.toMatch(/function\s+loadNotifBadge/);
     expect(uiSrc).not.toContain('window.loadNotifBadge');
-  });
-  it('getActions helper is gone', function() {
     expect(uiSrc).not.toContain('getActions');
-  });
-  it('typeClass map is gone', function() {
-    expect(uiSrc).not.toMatch(/var\s+typeClass\s*=\s*\{/);
-  });
-  it('stagePills map is gone', function() {
-    expect(uiSrc).not.toMatch(/var\s+stagePills\s*=\s*\{/);
-  });
-  it('parseActor regex helper is gone', function() {
     expect(uiSrc).not.toContain('parseActor');
-  });
-  it('formatTime helper is gone (replaced by _notifRelTime)', function() {
     expect(uiSrc).not.toMatch(/function\s+formatTime\(created_at\)/);
-  });
-  it('notif-client-badge reference is gone', function() {
     expect(uiSrc).not.toContain('notif-client-badge');
   });
-  it('old .nftab selector is gone (replaced with .ntab)', function() {
+  it('PR 2 dead APIs are gone (setNotifFilter/.nftab/.ntab-*-count/_NOTIF_NEEDS_TYPES/_NOTIF_UPDATES_TYPES/_notifStagePillClass/notif-summary/chip-urgent)', function() {
+    expect(uiSrc).not.toContain('setNotifFilter');
     expect(uiSrc).not.toContain(".nftab");
+    expect(uiSrc).not.toContain('ntab-needs-count');
+    expect(uiSrc).not.toContain('ntab-updates-count');
+    expect(uiSrc).not.toContain('_NOTIF_NEEDS_TYPES');
+    expect(uiSrc).not.toContain('_NOTIF_UPDATES_TYPES');
+    expect(uiSrc).not.toContain('_notifStagePillClass');
+    expect(uiSrc).not.toContain('notif-summary');
+    expect(uiSrc).not.toContain('chip-urgent');
   });
 });

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -298,14 +298,14 @@ describe('Notification card tap', function() {
   });
 
   it('card tap handler reads data-notif-id and calls markNotifRead', function() {
-    // The delegated click handler targets .notif-item wrappers
-    var match = uiSrc.match(/closest\('\.notif-item'\)[\s\S]{0,800}markNotifRead/);
+    // The delegated click handler targets .notif-item and .notif-live-card
+    var match = uiSrc.match(/closest\('\.notif-item, \.notif-live-card'\)[\s\S]{0,800}markNotifRead/);
     expect(match).not.toBeNull();
   });
 
-  it('tap handler uses closest(.notif-item) to find the row', function() {
-    // Entire row is now tappable, not just inner post card
-    expect(uiSrc).toContain("closest('.notif-item')");
+  it('tap handler uses closest(.notif-item, .notif-live-card) to find the row', function() {
+    // Entire row AND live card are now tappable
+    expect(uiSrc).toContain("closest('.notif-item, .notif-live-card')");
   });
 
 });


### PR DESCRIPTION
Swap the NEEDS YOU / UPDATES bottom tabs for a horizontal scroll of six filter chips at the top, and redraw every notification row at Instagram density (single row, 56px min-height, 11px DM Sans body with inline timestamp + inline OVERDUE badge, 44x44 thumbnail on the right).

styles.css (L4023-4398 rebuilt)
- #panel-updates flex-column scoped under #notif-overlay so .tab-panel hide-on-other-tabs keeps working.
- Two-row header: .notif-topbar-row1 (role + close X) and .notif-topbar-row2 (hey + MARK ALL READ).
- .notif-chips horizontal scroll, scrollbar hidden, 8-digit hex tints via .nchip-red/cyan/amber/green.active.
- .notif-item rebuilt single-row 56px-min: .notif-av 34x34 (nav-* palette), .notif-body with .notif-text (11px, 2-line webkit clamp) + .notif-time-inline + .notif-overdue-inline, .notif-thumb-wrap 44x44 on the right.
- .notif-live-card stays for type:published (green tint #091410, 44x44 thumb, VIEW ON LINKEDIN sub).
- All solid hex with alpha suffixes - zero rgba() added.

index.html
- #panel-updates body rewritten: notif-topbar (two rows) ->
  notif-chips (ALL/APPROVAL/COMMENTS/OVERDUE/LIVE/STAGE MOVES) -> 1px divider -> notif-scroll -> notif-empty.
- Bottom notif-tabs removed.
- All 20 ?v= strings bumped to ?v=20260406c.

10-ui.js
- _notifFilter renamed to _notifChipFilter (default 'all').
- setNotifFilter() removed entirely.
- _NOTIF_NEEDS_TYPES / _NOTIF_UPDATES_TYPES removed.
- _notifStagePillClass removed (post cards carry no pills).
- _notifActorClass rewired av-n-* -> nav-*.
- New _notifChipMatch(filter, n, post) predicate drives chip filtering across all / approval / comment / live / stage / overdue.
- renderNotifications body rewritten for single-row density with inline timestamp; type:published rows render as .notif-live-card. Chip counts (nchip-all/approval/comment/ overdue-count) written after filter application.
- openNotifications click delegation now matches '.notif-item, .notif-live-card' and skips .notif-chips, .mark-all-btn, .notif-close-btn. New _chipsWired guard attaches a delegated listener on #notif-chips that flips active class + _notifChipFilter + re-renders directly (no action-router hop).
- markAllNotificationsRead clears nchip-*-count (unread chips) instead of ntab-*-count.
- Action Router case 'notif-filter' removed.

Tests (net 433, still at 17 files)
- action-router.test.js: dropped the notif-filter router test (36 -> 35).
- notifications.test.js: tap-handler regexes updated for the comma selector .notif-item, .notif-live-card.
- notif-render.test.js: rewritten for the new API (50 tests = _notifRelTime 6, _notifIsOverdue 5, _notifTypeClass 8, _notifActorClass 3, _notifChipMatch 7, renderNotifications wiring 8, markAll audit 5, openNotifications overlay 6, dead-code audit 2).

CLAUDE.md
- Version 20260406b -> 20260406c.
- Section 12: PR 2 rebuild entry added.

Verification:
- grep styles.css for 'font-size: 14px' in notif block -> 0
- grep styles.css for 'rgba(' in new notif block -> 0
- grep index.html for '.nftab' -> 0
- grep index.html for 'NEEDS YOU' -> 0
- Unit: 433/433 passing
- E2E (CI critical): 40/40 passing

Version: ?v=20260406c

https://claude.ai/code/session_01FA6u8CmLY3wtXi6rjyqcXg