### PR TITLE
Notification panel final PR: unread dot, delete, WhatsApp, response t…

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -557,9 +557,6 @@ function renderNotifications(name, role) {
     if (post && post.title) {
       postTitle = post.title;
     } else if (n.message) {
-      // Fallback: extract title from message
-      // Message format is typically "Actor published Post Title"
-      // or "Post Title is now live"
       var msgLower = (n.message || '').toLowerCase();
       var pubIdx = msgLower.indexOf('published ');
       if (pubIdx !== -1) {
@@ -574,16 +571,49 @@ function renderNotifications(name, role) {
       }
     }
     var actor = n.actor || '';
-    var actorLower = (actor || 'system').toLowerCase();
     var avClass = _notifActorClass(actor);
     var initial = actor ? actor.charAt(0).toUpperCase() : '?';
     var ts = _notifRelTime(n.created_at);
+
+    // Action buttons
+    var actionsHtml = '';
+    if (n.post_id) {
+      actionsHtml = '<div class="notif-actions">' +
+        '<button class="notif-action-btn nab-wa" data-action="notif-wa" data-post-id="' + esc(n.post_id) + '">\u2197 WHATSAPP</button>' +
+        '<span class="notif-action-sep">\xB7</span>' +
+        '<button class="notif-action-btn nab-del" data-action="notif-delete" data-notif-id="' + esc(n.id || '') + '">DELETE</button>' +
+        '</div>';
+    } else {
+      actionsHtml = '<div class="notif-actions">' +
+        '<button class="notif-action-btn nab-del" data-action="notif-delete" data-notif-id="' + esc(n.id || '') + '">DELETE</button>' +
+        '</div>';
+    }
+
+    // Response time for approval-resolved notifications
+    var respTimeHtml = '';
+    if (n.post_id && n.type === 'scheduled') {
+      var sentRow = _notifData.find(function(x) {
+        return x.post_id === n.post_id && x.type === 'awaiting_approval';
+      });
+      if (sentRow && sentRow.created_at && n.created_at) {
+        var diffMs = new Date(n.created_at) - new Date(sentRow.created_at);
+        if (diffMs > 0) {
+          var diffMin = Math.floor(diffMs / 60000);
+          if (diffMin < 60) {
+            respTimeHtml = '<span class="notif-resp-time"> \xB7 replied in ' + diffMin + ' min</span>';
+          } else {
+            respTimeHtml = '<span class="notif-resp-time"> \xB7 replied in ' + Math.floor(diffMin / 60) + ' hr</span>';
+          }
+        }
+      }
+    }
 
     // Live card (published)
     if (n.type === 'published') {
       return '<div class="notif-live-card"' +
           ' data-notif-id="' + esc(n.id || '') + '"' +
           ' data-post-id="' + esc(n.post_id || '') + '">' +
+          '<div class="notif-unread-dot"></div>' +
           '<div class="notif-live-av">' + esc(initial) + '</div>' +
           '<div class="notif-live-body">' +
             '<div class="notif-live-tag">\u2713 POST IS LIVE</div>' +
@@ -593,6 +623,7 @@ function renderNotifications(name, role) {
                 .filter(function(s) { return s && s.length > 0; })
                 .join(' \xB7 ') +
             '</div>' +
+            actionsHtml +
           '</div>' +
           '<div class="notif-thumb-wrap">' +
             (postThumb
@@ -635,13 +666,16 @@ function renderNotifications(name, role) {
     return '<div class="notif-item ' + tClass + (n.read ? ' read' : '') + '"' +
       ' data-notif-id="' + esc(n.id || '') + '"' +
       ' data-post-id="' + esc(n.post_id || '') + '">' +
+      '<div class="notif-unread-dot"></div>' +
       '<div class="notif-av ' + avClass + '">' + esc(initial) + '</div>' +
       '<div class="notif-body">' +
         '<div class="notif-text">' +
           '<strong>' + esc(actor) + '</strong> ' + esc(actionText) +
+          respTimeHtml +
           '<span class="notif-time-inline"> \xB7 ' + esc(ts) + '</span>' +
         '</div>' +
         previewHtml +
+        actionsHtml +
       '</div>' +
       '<div class="notif-thumb-wrap">' +
         (postThumb
@@ -676,6 +710,35 @@ async function markNotifRead(id) {
       body: JSON.stringify({ read: true }),
     });
   } catch(e) { console.error('markNotifRead error:', e); }
+}
+
+async function deleteNotification(id) {
+  try {
+    _notifData = _notifData.filter(function(n) { return n.id !== id; });
+    var el = document.querySelector(
+      '[data-notif-id="' + id + '"].notif-item,' +
+      '[data-notif-id="' + id + '"].notif-live-card'
+    );
+    if (el) {
+      el.style.transition = 'opacity .25s, max-height .3s, padding .3s';
+      el.style.opacity = '0';
+      el.style.maxHeight = '0';
+      el.style.overflow = 'hidden';
+      el.style.padding = '0';
+      el.style.borderBottom = 'none';
+      setTimeout(function() {
+        if (el.parentNode) el.parentNode.removeChild(el);
+      }, 320);
+    }
+    updateNotifBadge();
+    await apiFetch('/notifications?id=eq.' + encodeURIComponent(id), {
+      method: 'DELETE'
+    });
+  } catch(e) {
+    console.error('deleteNotification error:', e);
+    window.logError && window.logError(e && e.message, e && e.stack, 'delete-notification');
+    if (typeof showToast === 'function') showToast('Could not delete notification', 'error');
+  }
 }
 
 async function markAllNotificationsRead() {
@@ -1484,10 +1547,11 @@ function openNotifications() {
   if (!panel._notifTapWired) {
     panel._notifTapWired = true;
     panel.addEventListener('click', function(e) {
-      // Chips, mark-all, close button handle their own clicks.
+      // Skip elements that handle their own clicks.
       if (e.target.closest('.notif-chips')) return;
       if (e.target.closest('.mark-all-btn')) return;
       if (e.target.closest('.notif-close-btn')) return;
+      if (e.target.closest('.notif-action-btn')) return;
       var item = e.target.closest('.notif-item, .notif-live-card');
       if (!item) return;
       e.stopPropagation();
@@ -1495,7 +1559,10 @@ function openNotifications() {
       var isBrief = item.getAttribute('data-is-brief') === '1';
       var notifId = item.getAttribute('data-notif-id');
       if (notifId) markNotifRead(notifId);
+      // Instant visual mark-as-read
+      item.classList.add('read');
       if (!pid) return;
+      window._notifOpenedPCS = true;
       closeNotifications();
       setTimeout(function() {
         var _role = (window.AppState.user.effectiveRole || '').toLowerCase();
@@ -1774,6 +1841,21 @@ if (!window._routerBound) {
         case 'ins-main-tab': return guardAction('ins-main-tab-' + actionEl.dataset.tab, () => insSetMainTab(actionEl.dataset.tab, actionEl));
         case 'close-notifications': return guardAction('close-notifications', () => closeNotifications());
         case 'mark-all-read':       return guardAction('mark-all-read', () => markAllNotificationsRead());
+        case 'notif-wa':
+          return guardAction('notif-wa-' + (actionEl.dataset.postId || ''), function() {
+            var pid = actionEl.dataset.postId;
+            if (!pid) return;
+            if (typeof window._sharePostOnWhatsApp === 'function') {
+              window._sharePostOnWhatsApp(pid);
+            } else if (typeof showToast === 'function') {
+              showToast('WhatsApp share not available', 'error');
+            }
+          });
+        case 'notif-delete':
+          return guardAction('notif-delete-' + (actionEl.dataset.notifId || ''), function() {
+            var nid = actionEl.dataset.notifId;
+            if (nid) deleteNotification(nid);
+          });
         case 'overlay-close':
           if (e.target !== actionEl) return;
           return guardAction('overlay-close-' + actionEl.dataset.close, () => {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260406d
+Version format: ?v=YYYYMMDDx. Current: ?v=20260406e
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -131,6 +131,12 @@ notifications: id(uuid PK), user_role(text), post_id(text),
 type(text), message(text), read(boolean), created_at(timestamptz),
 actor(text)
 RLS: DISABLED
+CLEANUP: pg_cron job 'cleanup-old-notifications' should run daily
+at 3 AM UTC to DELETE rows older than 30 days. Run this SQL in
+Supabase Dashboard SQL Editor after deploy:
+  SELECT cron.schedule('cleanup-old-notifications', '0 3 * * *',
+    $$DELETE FROM notifications
+      WHERE created_at < NOW() - INTERVAL '30 days'$$);
 
 activity_log: id(uuid PK), post_id(text), actor(text), action(text),
 old_stage(text), new_stage(text), created_at(timestamptz),
@@ -1106,6 +1112,64 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    index.html untouched, no version bump.
    Status: FIXED (PR#TBD) — 433/433 unit + 40/40 CI e2e
    passing. Same ?v=20260406d.
+1. Notification panel — final PR. Five wired features,
+   zero dummy buttons.
+   (a) Read/unread state: opacity:0.45 on .notif-item.read
+       deleted entirely. Read/unread difference is now ONLY
+       the gold unread dot (position:absolute top-right,
+       7px circle, display:none when .read). Zero visual
+       dimming. CSS .notif-unread-dot with pointer-events:
+       none so it never intercepts taps.
+   (b) Individual mark as read: tap handler in
+       openNotifications (10-ui.js) now calls
+       item.classList.add('read') immediately after
+       markNotifRead(notifId) for instant dot removal
+       without re-render.
+   (c) WhatsApp share: each notification item with a
+       post_id gets a "↗ WHATSAPP" action button wired
+       via data-action="notif-wa" through the Action Router
+       to window._sharePostOnWhatsApp(pid) (existing
+       function in actions/pcs.js:2115). Builds the
+       srtd.io/p/XXXX preview URL and opens wa.me.
+   (d) Individual delete: new deleteNotification(id) in
+       10-ui.js — optimistic removal from _notifData,
+       fade-out DOM animation (opacity+maxHeight 320ms),
+       updateNotifBadge(), then DELETE /notifications?id=
+       eq.{id}. Wired via data-action="notif-delete"
+       through the Action Router with guardAction.
+   (e) Response time: for type=scheduled notifications
+       (client approved), finds the paired
+       awaiting_approval row in _notifData for the same
+       post_id and diffs created_at timestamps. Renders
+       as <span class="notif-resp-time"> · replied in
+       X min</span> in green inline with the action text.
+   (f) Back to notifications from PCS: tap handler sets
+       window._notifOpenedPCS = true before opening PCS.
+       actions/pcs.js _renderPCS prepends a
+       .pcs-back-notif-btn ("← NOTIFICATIONS") to the
+       PCS topbar when the flag is true. Button closes
+       PCS and reopens notification panel after 150ms.
+       closePCS() resets the flag so the button doesn't
+       persist on next normal PCS open.
+   (g) pg_cron auto cleanup: NOT a code change — requires
+       manual SQL in Supabase Dashboard:
+         SELECT cron.schedule(
+           'cleanup-old-notifications',
+           '0 3 * * *',
+           $$DELETE FROM notifications
+             WHERE created_at < NOW() - INTERVAL '30 days'$$
+         );
+       Documented in CLAUDE.md Section 5 and here for
+       Shubham to run after merge.
+   (h) Action Router: two new cases added —
+       notif-wa (guardAction → _sharePostOnWhatsApp) and
+       notif-delete (guardAction → deleteNotification).
+   (i) CSS: .notif-unread-dot, .notif-actions,
+       .notif-action-btn (.nab-wa, .nab-del),
+       .notif-action-sep, .notif-resp-time,
+       .pcs-back-notif-btn added. Zero rgba, all solid hex.
+   Status: FIXED (PR#TBD) — 433/433 unit + 40/40 CI e2e
+   passing. Bumped to ?v=20260406e.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -89,6 +89,7 @@ window.openPCS = function(postId, listKey) {
 }
 
 window.closePCS = function() {
+  window._notifOpenedPCS = false;
   forcePCSReset();
   // Safety: re-verify after animations settle (catches mobile compositor lag).
   // Store the timer so openPCS can cancel it if the user reopens quickly.
@@ -151,6 +152,25 @@ window._renderPCS = function(postId) {
   var backBtn = document.getElementById('pcs-back-btn');
   if (backBtn) {
     backBtn.style.display = (window.AppState.pcs.openedFrom === 'sheet') ? 'block' : 'none';
+  }
+
+  // Back-to-notifications button (shows when PCS opened from notif panel)
+  var existingNb = document.querySelector('.pcs-back-notif-btn');
+  if (existingNb && existingNb.parentNode) existingNb.parentNode.removeChild(existingNb);
+  if (window._notifOpenedPCS) {
+    var nbBtn = document.createElement('button');
+    nbBtn.className = 'pcs-back-notif-btn';
+    nbBtn.textContent = '\u2190 NOTIFICATIONS';
+    nbBtn.onclick = function() {
+      window._notifOpenedPCS = false;
+      if (typeof closePCS === 'function') closePCS();
+      setTimeout(function() {
+        if (typeof openNotifications === 'function') openNotifications();
+      }, 150);
+    };
+    var pcsTopbar = document.getElementById('pcs-topbar') ||
+                    document.querySelector('#pcs-overlay .pcs-top');
+    if (pcsTopbar) pcsTopbar.prepend(nbBtn);
   }
 
   // 1. Fetch post

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260406d">
+ <link rel="stylesheet" href="styles.css?v=20260406e">
 
 </head>
 <body>
@@ -1064,26 +1064,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260406d"></script>
-<script src="00-appstate-compat.js?v=20260406d"></script>
-<script src="01-config.js?v=20260406d" defer></script>
-<script src="02-session.js?v=20260406d" defer></script>
-<script src="utils.js?v=20260406d" defer></script>
-<script src="03-auth.js?v=20260406d" defer></script>
-<script src="05-api.js?v=20260406d" defer></script>
-<script src="10-ui.js?v=20260406d" defer></script>
+<script src="00-appstate.js?v=20260406e"></script>
+<script src="00-appstate-compat.js?v=20260406e"></script>
+<script src="01-config.js?v=20260406e" defer></script>
+<script src="02-session.js?v=20260406e" defer></script>
+<script src="utils.js?v=20260406e" defer></script>
+<script src="03-auth.js?v=20260406e" defer></script>
+<script src="05-api.js?v=20260406e" defer></script>
+<script src="10-ui.js?v=20260406e" defer></script>
 
-<script src="06-post-create.js?v=20260406d" defer></script>
-<script defer src="render/dashboard.js?v=20260406d"></script>
-<script defer src="render/client.js?v=20260406d"></script>
-<script defer src="render/pipeline.js?v=20260406d"></script>
-<script defer src="render/brief.js?v=20260406d"></script>
-<script defer src="actions/pcs.js?v=20260406d"></script>
-<script src="07-post-load.js?v=20260406d" defer></script>
-<script src="08-post-actions.js?v=20260406d" defer></script>
-<script src="09-library.js?v=20260406d" defer></script>
-<script src="09-approval.js?v=20260406d" defer></script>
-<script src="04-router.js?v=20260406d" defer></script>
+<script src="06-post-create.js?v=20260406e" defer></script>
+<script defer src="render/dashboard.js?v=20260406e"></script>
+<script defer src="render/client.js?v=20260406e"></script>
+<script defer src="render/pipeline.js?v=20260406e"></script>
+<script defer src="render/brief.js?v=20260406e"></script>
+<script defer src="actions/pcs.js?v=20260406e"></script>
+<script src="07-post-load.js?v=20260406e" defer></script>
+<script src="08-post-actions.js?v=20260406e" defer></script>
+<script src="09-library.js?v=20260406e" defer></script>
+<script src="09-approval.js?v=20260406e" defer></script>
+<script src="04-router.js?v=20260406e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4209,7 +4209,24 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   min-height: 56px;
 }
 .notif-item:hover { background: #141420; }
-.notif-item.read  { opacity: 0.45; }
+
+/* READ state — ONLY difference is dot visibility. Zero opacity changes. */
+.notif-item.read { background: #0e0e16; }
+.notif-item:not(.read) { background: #0e0e16; }
+
+/* Unread dot - absolute positioned, never affects flex layout */
+.notif-unread-dot {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #C8A84B;
+  pointer-events: none;
+  display: block;
+}
+.notif-item.read .notif-unread-dot { display: none; }
 
 /* LEFT COLOR BAR */
 .notif-item::before {
@@ -4386,6 +4403,46 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 .notif-empty-title { font-family: 'DM Sans', sans-serif; font-size: 15px; font-weight: 600; color: #F0F0F2; }
 .notif-empty-sub   { font-family: 'IBM Plex Mono', monospace; font-size: 9px; color: #555566; letter-spacing: .06em; line-height: 1.6; }
 .notif-empty-stat  { font-family: 'IBM Plex Mono', monospace; font-size: 9px; color: #3ECF8E; letter-spacing: .06em; margin-top: 4px; }
+
+/* Action buttons row */
+.notif-actions {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-top: 6px;
+}
+.notif-action-btn {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .06em;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  text-transform: uppercase;
+}
+.notif-action-btn.nab-wa  { color: #3ECF8E; }
+.notif-action-btn.nab-wa:hover { color: #5EFFA8; }
+.notif-action-btn.nab-del { color: #555566; margin-left: 10px; }
+.notif-action-btn.nab-del:hover { color: #FF4B4B; }
+.notif-action-sep { color: #333344; margin: 0 6px; font-size: 8px; font-family: 'IBM Plex Mono', monospace; }
+
+/* Response time inline */
+.notif-resp-time { color: #3ECF8E; font-size: 11px; }
+
+/* PCS back-to-notifications button */
+.pcs-back-notif-btn {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .08em;
+  color: #C8A84B;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 0;
+  text-transform: uppercase;
+}
+.pcs-back-notif-btn:hover { color: #F0F0F2; }
 
 /* ===================================================
    DASHBOARD REDESIGN


### PR DESCRIPTION
…ime, back-to-notif

Five wired features, zero dummy buttons.

styles.css
- Removed opacity:0.45 on .notif-item.read. Read/unread is now ONLY the gold unread dot (position:absolute top-right, 7px circle, hidden via display:none on .read parent).
- New .notif-unread-dot, .notif-actions, .notif-action-btn (.nab-wa green, .nab-del gray→red on hover), .notif-action-sep, .notif-resp-time (green 11px), .pcs-back-notif-btn (gold mono 8px).

10-ui.js
- renderNotifications _buildItem: every item now has a position:absolute .notif-unread-dot as first child (CSS hides it on .read rows). Action buttons row with ↗ WHATSAPP + DELETE (or just DELETE when no post_id) wired via data-action="notif-wa" / "notif-delete".
- Response time: for type=scheduled, finds paired awaiting_approval row in _notifData for same post_id, diffs created_at → "replied in X min/hr" in green.
- New deleteNotification(id): optimistic _notifData filter, fade-out DOM animation (opacity+maxHeight 320ms → remove), updateNotifBadge(), DELETE /notifications?id=eq.{id}, logError + error toast on failure.
- Tap handler: (a) skips .notif-action-btn clicks so WhatsApp/Delete buttons don't also open PCS. (b) Adds item.classList.add('read') immediately after markNotifRead for instant dot removal. (c) Sets window._notifOpenedPCS = true before opening PCS.
- Action Router: new notif-wa case (guardAction → _sharePostOnWhatsApp) and notif-delete case (guardAction → deleteNotification).

actions/pcs.js
- _renderPCS: after existing pcs-back-btn handling, checks window._notifOpenedPCS flag. When true, prepends a .pcs-back-notif-btn ("← NOTIFICATIONS") to #pcs-topbar. Button click resets flag, closes PCS, reopens notif panel after 150ms.
- closePCS: resets window._notifOpenedPCS = false so the button doesn't persist on next normal PCS open.

index.html
- All 20 ?v= strings bumped to ?v=20260406e.

CLAUDE.md
- Version 20260406d → 20260406e.
- Section 5 notifications table: added pg_cron cleanup job SQL (manual run in Supabase Dashboard after deploy).
- Section 12: final PR entry with per-feature breakdown.

Tests: 433/433 unit + 40/40 CI e2e passing.
Version: ?v=20260406e

https://claude.ai/code/session_01FA6u8CmLY3wtXi6rjyqcXg