### PR TITLE
fix: notification panel polish — WhatsApp msg, dots, comment tab, cli…

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -612,7 +612,8 @@ function renderNotifications(name, role) {
     if (n.type === 'published') {
       return '<div class="notif-live-card"' +
           ' data-notif-id="' + esc(n.id || '') + '"' +
-          ' data-post-id="' + esc(n.post_id || '') + '">' +
+          ' data-post-id="' + esc(n.post_id || '') + '"' +
+          ' data-notif-type="published">' +
           '<div class="notif-unread-dot"></div>' +
           '<div class="notif-live-av">' + esc(initial) + '</div>' +
           '<div class="notif-live-body">' +
@@ -665,7 +666,8 @@ function renderNotifications(name, role) {
 
     return '<div class="notif-item ' + tClass + (n.read ? ' read' : '') + '"' +
       ' data-notif-id="' + esc(n.id || '') + '"' +
-      ' data-post-id="' + esc(n.post_id || '') + '">' +
+      ' data-post-id="' + esc(n.post_id || '') + '"' +
+      ' data-notif-type="' + esc(n.type || '') + '">' +
       '<div class="notif-unread-dot"></div>' +
       '<div class="notif-av ' + avClass + '">' + esc(initial) + '</div>' +
       '<div class="notif-body">' +
@@ -755,6 +757,12 @@ async function markAllNotificationsRead() {
       el.classList.add('read');
       var dot = el.querySelector('.notif-unread-dot');
       if (dot && dot.parentNode) dot.parentNode.removeChild(dot);
+    });
+    var liveEls = document.querySelectorAll(
+      '#panel-updates .notif-live-card');
+    liveEls.forEach(function(el) {
+      var dot = el.querySelector('.notif-unread-dot');
+      if (dot) dot.style.display = 'none';
     });
     ['notif-bell-badge','notif-pipeline-badge',
      'notif-lib-badge','notif-ins-badge'].forEach(function(id) {
@@ -1561,7 +1569,10 @@ function openNotifications() {
       if (notifId) markNotifRead(notifId);
       // Instant visual mark-as-read
       item.classList.add('read');
+      var _tapDot = item.querySelector('.notif-unread-dot');
+      if (_tapDot) _tapDot.style.display = 'none';
       if (!pid) return;
+      var notifType = item.getAttribute('data-notif-type') || '';
       window._notifOpenedPCS = true;
       closeNotifications();
       setTimeout(function() {
@@ -1575,6 +1586,12 @@ function openNotifications() {
             window._openClientPostOverlay(pid);
         } else {
           openPCS(pid, '');
+          if (notifType === 'comment') {
+            setTimeout(function() {
+              if (typeof window._pcsTabSwitch === 'function')
+                window._pcsTabSwitch('client');
+            }, 300);
+          }
         }
       }, 150);
     });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260406e
+Version format: ?v=YYYYMMDDx. Current: ?v=20260406f
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -2148,9 +2148,7 @@ window._sharePostOnWhatsApp = function(postId) {
   if (!shortId) shortId = postIdRaw.slice(-4);
   var previewUrl = 'https://srtd.io/p/' + shortId;
 
-  var message = title
-    + ' -- Awaiting your approval.\n\n'
-    + previewUrl;
+  var message = title + '\n\n' + previewUrl;
 
   location.href = 'https://wa.me/?text='
     + encodeURIComponent(message);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260406e">
+ <link rel="stylesheet" href="styles.css?v=20260406f">
 
 </head>
 <body>
@@ -1064,26 +1064,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260406e"></script>
-<script src="00-appstate-compat.js?v=20260406e"></script>
-<script src="01-config.js?v=20260406e" defer></script>
-<script src="02-session.js?v=20260406e" defer></script>
-<script src="utils.js?v=20260406e" defer></script>
-<script src="03-auth.js?v=20260406e" defer></script>
-<script src="05-api.js?v=20260406e" defer></script>
-<script src="10-ui.js?v=20260406e" defer></script>
+<script src="00-appstate.js?v=20260406f"></script>
+<script src="00-appstate-compat.js?v=20260406f"></script>
+<script src="01-config.js?v=20260406f" defer></script>
+<script src="02-session.js?v=20260406f" defer></script>
+<script src="utils.js?v=20260406f" defer></script>
+<script src="03-auth.js?v=20260406f" defer></script>
+<script src="05-api.js?v=20260406f" defer></script>
+<script src="10-ui.js?v=20260406f" defer></script>
 
-<script src="06-post-create.js?v=20260406e" defer></script>
-<script defer src="render/dashboard.js?v=20260406e"></script>
-<script defer src="render/client.js?v=20260406e"></script>
-<script defer src="render/pipeline.js?v=20260406e"></script>
-<script defer src="render/brief.js?v=20260406e"></script>
-<script defer src="actions/pcs.js?v=20260406e"></script>
-<script src="07-post-load.js?v=20260406e" defer></script>
-<script src="08-post-actions.js?v=20260406e" defer></script>
-<script src="09-library.js?v=20260406e" defer></script>
-<script src="09-approval.js?v=20260406e" defer></script>
-<script src="04-router.js?v=20260406e" defer></script>
+<script src="06-post-create.js?v=20260406f" defer></script>
+<script defer src="render/dashboard.js?v=20260406f"></script>
+<script defer src="render/client.js?v=20260406f"></script>
+<script defer src="render/pipeline.js?v=20260406f"></script>
+<script defer src="render/brief.js?v=20260406f"></script>
+<script defer src="actions/pcs.js?v=20260406f"></script>
+<script src="07-post-load.js?v=20260406f" defer></script>
+<script src="08-post-actions.js?v=20260406f" defer></script>
+<script src="09-library.js?v=20260406f" defer></script>
+<script src="09-approval.js?v=20260406f" defer></script>
+<script src="04-router.js?v=20260406f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1697,10 +1697,28 @@ console.log('LOADED:', 'render/client.js');
         _wireEvents(lbEl);
         lbEl.dataset.clickWired = '1';
       }
+      // Back-to-notifications button (when opened from notif panel)
+      if (window._notifOpenedPCS) {
+        var nbBtn = document.createElement('button');
+        nbBtn.className = 'pcs-back-notif-btn';
+        nbBtn.textContent = '\u2190 NOTIFICATIONS';
+        nbBtn.onclick = function() {
+          window._notifOpenedPCS = false;
+          _self_overlay.remove();
+          window.AppState.ui.modalOpen = false;
+          document.body.style.overflow = '';
+          setTimeout(function() {
+            if (typeof window.openNotifications === 'function') window.openNotifications();
+          }, 150);
+        };
+        var clientHeader = _self_overlay.querySelector('[id="client-overlay-close"]');
+        if (clientHeader && clientHeader.parentNode) clientHeader.parentNode.prepend(nbBtn);
+      }
       var closeBtn =
         document.getElementById('client-overlay-close');
       if (closeBtn) {
         closeBtn.addEventListener('click', function() {
+          window._notifOpenedPCS = false;
           _self_overlay.remove();
           window.AppState.ui.modalOpen = false;
           document.body.style.overflow = '';


### PR DESCRIPTION
…ent back

Four targeted fixes, no new features.

FIX 1 — WhatsApp message cleaned (actions/pcs.js L2151)
  Replaced "title -- Awaiting your approval.\n\nurl" with
  just "title\n\nurl". Works for any notification context
  (comment, approval, live, stage move) without misleading
  stage text.

FIX 2 — Gold dot not clearing (10-ui.js)
  (a) markAllNotificationsRead DOM pass (L752-762) now also
      walks .notif-live-card elements and hides their
      .notif-unread-dot. Previously only .notif-item was
      targeted; live cards kept their dot.
  (b) Individual tap handler (L1563) now hides the dot on
      the tapped item immediately:
        item.querySelector('.notif-unread-dot').style.display = 'none'
      This gives instant feedback without a full re-render.

FIX 3 — Comment tap opens PCS to comments tab (10-ui.js)
  (a) _buildItem now emits data-notif-type="{n.type}" on
      both .notif-item and .notif-live-card wrappers.
  (b) Tap handler reads notifType before closeNotifications,
      and after openPCS(pid, '') fires a delayed
      _pcsTabSwitch('client') (300ms, after PCS render
      settles) so comment/mention taps land directly on
      the comments tab.

FIX 4 — Back button extended to client overlay (render/client.js)
  (a) _notifOpenedPCS flag verified: set BEFORE the
      closeNotifications/setTimeout chain (L1565), so
      _renderPCS reads it in time.
  (b) _openClientPostOverlay: after appending the overlay,
      checks _notifOpenedPCS and prepends a
      .pcs-back-notif-btn ("← NOTIFICATIONS") to the
      sticky header. Button removes overlay + reopens
      notif panel after 150ms.
  (c) Client overlay close button (X) now also resets
      _notifOpenedPCS = false so the back button doesn't
      persist on next open.

index.html: all 20 ?v= strings bumped to ?v=20260406f.
CLAUDE.md: version bumped.

Tests: 433/433 unit + 40/40 CI e2e passing.
Version: ?v=20260406f

https://claude.ai/code/session_01FA6u8CmLY3wtXi6rjyqcXg