### PR TITLE
fix: PCS back-to-notifications button polish + close returns to panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260406f
+Version format: ?v=YYYYMMDDx. Current: ?v=20260406g
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -89,6 +89,7 @@ window.openPCS = function(postId, listKey) {
 }
 
 window.closePCS = function() {
+  var returnToNotif = !!window._notifOpenedPCS;
   window._notifOpenedPCS = false;
   forcePCSReset();
   // Safety: re-verify after animations settle (catches mobile compositor lag).
@@ -98,6 +99,12 @@ window.closePCS = function() {
     window._pcsCloseTimer = null;
     forcePCSReset();
   }, 300);
+  // If PCS was opened from the notification panel, return there
+  if (returnToNotif) {
+    setTimeout(function() {
+      if (typeof openNotifications === 'function') openNotifications();
+    }, 150);
+  }
 }
 
 // ===============================================
@@ -160,13 +167,9 @@ window._renderPCS = function(postId) {
   if (window._notifOpenedPCS) {
     var nbBtn = document.createElement('button');
     nbBtn.className = 'pcs-back-notif-btn';
-    nbBtn.textContent = '\u2190 NOTIFICATIONS';
+    nbBtn.textContent = '\u2190 NOTIFS';
     nbBtn.onclick = function() {
-      window._notifOpenedPCS = false;
       if (typeof closePCS === 'function') closePCS();
-      setTimeout(function() {
-        if (typeof openNotifications === 'function') openNotifications();
-      }, 150);
     };
     var pcsTopbar = document.querySelector('#pcs-overlay .pc-topbar') ||
                     document.getElementById('pcs-topbar');

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260406f">
+ <link rel="stylesheet" href="styles.css?v=20260406g">
 
 </head>
 <body>
@@ -1064,26 +1064,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260406f"></script>
-<script src="00-appstate-compat.js?v=20260406f"></script>
-<script src="01-config.js?v=20260406f" defer></script>
-<script src="02-session.js?v=20260406f" defer></script>
-<script src="utils.js?v=20260406f" defer></script>
-<script src="03-auth.js?v=20260406f" defer></script>
-<script src="05-api.js?v=20260406f" defer></script>
-<script src="10-ui.js?v=20260406f" defer></script>
+<script src="00-appstate.js?v=20260406g"></script>
+<script src="00-appstate-compat.js?v=20260406g"></script>
+<script src="01-config.js?v=20260406g" defer></script>
+<script src="02-session.js?v=20260406g" defer></script>
+<script src="utils.js?v=20260406g" defer></script>
+<script src="03-auth.js?v=20260406g" defer></script>
+<script src="05-api.js?v=20260406g" defer></script>
+<script src="10-ui.js?v=20260406g" defer></script>
 
-<script src="06-post-create.js?v=20260406f" defer></script>
-<script defer src="render/dashboard.js?v=20260406f"></script>
-<script defer src="render/client.js?v=20260406f"></script>
-<script defer src="render/pipeline.js?v=20260406f"></script>
-<script defer src="render/brief.js?v=20260406f"></script>
-<script defer src="actions/pcs.js?v=20260406f"></script>
-<script src="07-post-load.js?v=20260406f" defer></script>
-<script src="08-post-actions.js?v=20260406f" defer></script>
-<script src="09-library.js?v=20260406f" defer></script>
-<script src="09-approval.js?v=20260406f" defer></script>
-<script src="04-router.js?v=20260406f" defer></script>
+<script src="06-post-create.js?v=20260406g" defer></script>
+<script defer src="render/dashboard.js?v=20260406g"></script>
+<script defer src="render/client.js?v=20260406g"></script>
+<script defer src="render/pipeline.js?v=20260406g"></script>
+<script defer src="render/brief.js?v=20260406g"></script>
+<script defer src="actions/pcs.js?v=20260406g"></script>
+<script src="07-post-load.js?v=20260406g" defer></script>
+<script src="08-post-actions.js?v=20260406g" defer></script>
+<script src="09-library.js?v=20260406g" defer></script>
+<script src="09-approval.js?v=20260406g" defer></script>
+<script src="04-router.js?v=20260406g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4439,8 +4439,12 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   background: none;
   border: none;
   cursor: pointer;
-  padding: 4px 0;
+  padding: 6px 0;
   text-transform: uppercase;
+  display: block;
+  width: 100%;
+  text-align: left;
+  margin-bottom: 6px;
 }
 .pcs-back-notif-btn:hover { color: #F0F0F2; }
 


### PR DESCRIPTION
Two targeted fixes for the PCS ← NOTIFS button.

FIX 1 — Button layout (actions/pcs.js + styles.css)
- Text shortened from "← NOTIFICATIONS" to "← NOTIFS".
- CSS updated: display:block, width:100%, text-align:left, padding 6px 0, margin-bottom 6px. Button now renders as a full-width line above the topbar controls, not inline.

FIX 2 — Close ✕ returns to notifications (actions/pcs.js)
- closePCS() now captures window._notifOpenedPCS BEFORE resetting it. If the flag was true, a 150ms setTimeout reopens the notification panel after PCS teardown.
- This means both "← NOTIFS" AND the ✕ close button return to the notification panel when PCS was opened from it. Natural "back" behavior.
- When PCS was opened normally (not from notifications), the flag is false and closing just stays on main feed.
- The back button onclick simplified to just closePCS() since closePCS now handles the return-to-notif logic.

index.html: all 20 ?v= bumped to ?v=20260406g.
CLAUDE.md: version bumped.

Tests: 444/444 unit + 50/50 e2e passing.
Version: ?v=20260406g

https://claude.ai/code/session_01FA6u8CmLY3wtXi6rjyqcXg