### PR TITLE
fix: hide PCS close ✕ when ← NOTIFS button is shown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260406g
+Version format: ?v=YYYYMMDDx. Current: ?v=20260406h
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -91,6 +91,9 @@ window.openPCS = function(postId, listKey) {
 window.closePCS = function() {
   var returnToNotif = !!window._notifOpenedPCS;
   window._notifOpenedPCS = false;
+  // Restore ✕ close button if it was hidden for ← NOTIFS
+  var pcsCloseX = document.querySelector('#pcs-overlay .pc-topbar [aria-label="Close"]');
+  if (pcsCloseX) pcsCloseX.style.display = '';
   forcePCSReset();
   // Safety: re-verify after animations settle (catches mobile compositor lag).
   // Store the timer so openPCS can cancel it if the user reopens quickly.
@@ -164,7 +167,12 @@ window._renderPCS = function(postId) {
   // Back-to-notifications button (shows when PCS opened from notif panel)
   var existingNb = document.querySelector('.pcs-back-notif-btn');
   if (existingNb && existingNb.parentNode) existingNb.parentNode.removeChild(existingNb);
+  // Restore close button visibility (may have been hidden on previous notif open)
+  var pcsCloseX = document.querySelector('#pcs-overlay .pc-topbar [aria-label="Close"]');
+  if (pcsCloseX) pcsCloseX.style.display = '';
   if (window._notifOpenedPCS) {
+    // Hide the ✕ close button — ← NOTIFS replaces it
+    if (pcsCloseX) pcsCloseX.style.display = 'none';
     var nbBtn = document.createElement('button');
     nbBtn.className = 'pcs-back-notif-btn';
     nbBtn.textContent = '\u2190 NOTIFS';

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260406g">
+ <link rel="stylesheet" href="styles.css?v=20260406h">
 
 </head>
 <body>
@@ -1064,26 +1064,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260406g"></script>
-<script src="00-appstate-compat.js?v=20260406g"></script>
-<script src="01-config.js?v=20260406g" defer></script>
-<script src="02-session.js?v=20260406g" defer></script>
-<script src="utils.js?v=20260406g" defer></script>
-<script src="03-auth.js?v=20260406g" defer></script>
-<script src="05-api.js?v=20260406g" defer></script>
-<script src="10-ui.js?v=20260406g" defer></script>
+<script src="00-appstate.js?v=20260406h"></script>
+<script src="00-appstate-compat.js?v=20260406h"></script>
+<script src="01-config.js?v=20260406h" defer></script>
+<script src="02-session.js?v=20260406h" defer></script>
+<script src="utils.js?v=20260406h" defer></script>
+<script src="03-auth.js?v=20260406h" defer></script>
+<script src="05-api.js?v=20260406h" defer></script>
+<script src="10-ui.js?v=20260406h" defer></script>
 
-<script src="06-post-create.js?v=20260406g" defer></script>
-<script defer src="render/dashboard.js?v=20260406g"></script>
-<script defer src="render/client.js?v=20260406g"></script>
-<script defer src="render/pipeline.js?v=20260406g"></script>
-<script defer src="render/brief.js?v=20260406g"></script>
-<script defer src="actions/pcs.js?v=20260406g"></script>
-<script src="07-post-load.js?v=20260406g" defer></script>
-<script src="08-post-actions.js?v=20260406g" defer></script>
-<script src="09-library.js?v=20260406g" defer></script>
-<script src="09-approval.js?v=20260406g" defer></script>
-<script src="04-router.js?v=20260406g" defer></script>
+<script src="06-post-create.js?v=20260406h" defer></script>
+<script defer src="render/dashboard.js?v=20260406h"></script>
+<script defer src="render/client.js?v=20260406h"></script>
+<script defer src="render/pipeline.js?v=20260406h"></script>
+<script defer src="render/brief.js?v=20260406h"></script>
+<script defer src="actions/pcs.js?v=20260406h"></script>
+<script src="07-post-load.js?v=20260406h" defer></script>
+<script src="08-post-actions.js?v=20260406h" defer></script>
+<script src="09-library.js?v=20260406h" defer></script>
+<script src="09-approval.js?v=20260406h" defer></script>
+<script src="04-router.js?v=20260406h" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
When PCS is opened from the notification panel, the ✕ close button is now hidden (display:none) so only the ← NOTIFS button is visible. This removes the ambiguous dual-button state where both competed for the same "close" action.

actions/pcs.js _renderPCS (L164-180):
  Queries the close button via
    '#pcs-overlay .pc-topbar [aria-label="Close"]'
  When _notifOpenedPCS is true: hides it before prepending
  the ← NOTIFS button.
  When _notifOpenedPCS is false: restores display (covers
  the case where the previous PCS open hid it).

actions/pcs.js closePCS (L91-110):
  Restores the close button display before forcePCSReset
  so the next normal PCS open sees it.

index.html: all 20 ?v= bumped to ?v=20260406h.
CLAUDE.md: version bumped.

Tests: 444/444 unit + 50/50 e2e passing.
Version: ?v=20260406h

https://claude.ai/code/session_01FA6u8CmLY3wtXi6rjyqcXg