### PR TITLE
fix: wire approved notification routing matrix

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -40,11 +40,11 @@ window._sendStageNotif = function(postId, postTitle, stage, recipients, actorNam
 // -- Stage → notification recipients map --
 function _stageRecipients(stage) {
   var map = {
-    'brief':                 ['Creative'],
-    'in_production':         ['Creative'],
-    'ready':                 ['Servicing'],
-    'awaiting_approval':     ['Client'],
-    'awaiting_brand_input':  ['Client'],
+    'brief':                 ['Admin', 'Creative'],
+    'in_production':         ['Admin', 'Creative'],
+    'ready':                 ['Admin', 'Servicing'],
+    'awaiting_approval':     ['Admin', 'Client'],
+    'awaiting_brand_input':  ['Admin', 'Servicing', 'Client'],
     'scheduled':             ['Admin', 'Servicing', 'Creative'],
     'published':             ['Admin', 'Servicing', 'Creative', 'Client']
   };
@@ -364,6 +364,17 @@ async function submitClientRequest() {
         read: false
       })
     }).catch(function(err){ console.error('[post-actions] notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'notification-post'); });
+    apiFetch('/notifications', {
+      method: 'POST',
+      body: JSON.stringify({
+        user_role: 'Admin',
+        post_id: reqId,
+        type: 'new_request',
+        message: (window.AppState.user.name || 'Client') + ' submitted a new request: ' + _reqTitle,
+        actor: window.AppState.user.name || window.currentUserName || 'Client',
+        read: false
+      })
+    }).catch(function(err){ console.error('[post-actions] admin notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'notification-admin-req'); });
 
     // Success: close after 2 seconds
     setTimeout(function() {

--- a/09-approval.js
+++ b/09-approval.js
@@ -146,7 +146,7 @@ async function submitApproval(type, postId, btn) {
           body: JSON.stringify({ stage: 'in_production', client_feedback: text, updated_at: new Date().toISOString() }),
         });
         await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: `Changes requested: ${text.substring(0,80)}` });
-        if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, postId, 'in_production', ['Creative'], 'Client');
+        if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, postId, 'in_production', ['Admin', 'Creative'], window.AppState.user.name || window.currentUserName || 'Client');
         const c = document.getElementById('approval-confirmation');
         if (c) { c.style.display = ''; c.textContent = 'Changes sent  -  the team will review it.'; }
         document.querySelector('.approval-actions')?.remove();
@@ -167,7 +167,7 @@ async function submitApproval(type, postId, btn) {
           body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString() }),
         });
         await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
-        if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, esc(title), 'scheduled', ['Admin', 'Servicing', 'Creative'], 'Client');
+        if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, esc(title), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || window.currentUserName || 'Client');
         const c = document.getElementById('approval-confirmation');
         if (c) { c.style.display = ''; c.textContent = 'ok Approved! The team has been notified.'; }
         document.querySelector('.approval-actions')?.remove();

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,20 @@ Supabase Dashboard SQL Editor after deploy:
   SELECT cron.schedule('cleanup-old-notifications', '0 3 * * *',
     $$DELETE FROM notifications
       WHERE created_at < NOW() - INTERVAL '30 days'$$);
+ROUTING MATRIX (approved 2026-04-06, wired same day):
+  EVENT                     ADMIN  SERV.  CREAT. CLIENT
+  Client comments            YES    YES    YES    NO
+  Client approves            YES    YES    YES    NO
+  Client submits request     YES    YES    NO     NO
+  → Brief                   YES    NO     YES    NO
+  → In Production           YES    NO     YES    NO
+  → Ready                   YES    YES    NO     NO
+  → Awaiting Approval       YES    NO     NO     YES
+  → Awaiting Brand Input    YES    YES    NO     YES
+  → Scheduled               YES    YES    YES    NO
+  → Published               YES    YES    YES    YES
+  Batch stage move           YES    NO     NO     YES
+  Email notifications will be built on top of this matrix.
 
 activity_log: id(uuid PK), post_id(text), actor(text), action(text),
 old_stage(text), new_stage(text), created_at(timestamptz),

--- a/render/client.js
+++ b/render/client.js
@@ -1046,6 +1046,17 @@ console.log('LOADED:', 'render/client.js');
           read: false
         })
       }).catch(function(err){ console.error('[client] notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-notification'); });
+      window.apiFetch('/notifications', {
+        method: 'POST',
+        body: JSON.stringify({
+          user_role: 'Creative',
+          type: 'comment',
+          post_id: realPostId,
+          message: authorName + ' commented on ' + postTitle,
+          actor: window.AppState.user.name || 'Client',
+          read: false
+        })
+      }).catch(function(err){ console.error('[client] creative notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-creative-notification'); });
       var _ROSTER = [
         { name: 'Shubham', role: 'Admin' },
         { name: 'Pranav', role: 'Creative' },

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -345,11 +345,11 @@ describe('No duplicate stage-change notifications from JS', function() {
     expect(hasNotifPost).toBe(false);
   });
 
-  it('08-post-actions.js has exactly 2 notification POSTs (new_request + _sendStageNotif helper)', function() {
+  it('08-post-actions.js has exactly 3 notification POSTs (2x new_request + _sendStageNotif helper)', function() {
     var matches = actionsSrc.match(/apiFetch\('\/notifications',\s*\{[\s\S]*?method:\s*'POST'/g);
-    // 1 = submitClientRequest new_request, 2 = _sendStageNotif helper
+    // 1 = submitClientRequest Servicing, 2 = submitClientRequest Admin, 3 = _sendStageNotif helper
     expect(matches).not.toBeNull();
-    expect(matches.length).toBe(2);
+    expect(matches.length).toBe(3);
   });
 
   it('07-post-load.js has zero notification POSTs', function() {


### PR DESCRIPTION
Implements the exact approved notification routing matrix. Admin (Shubham) now receives every notification type.

render/client.js
  Client comment: added 3rd INSERT for Creative (was only
  Admin + Servicing). Pranav now sees client comments.

08-post-actions.js
  _stageRecipients map updated:
    brief:               +Admin (was Creative only)
    in_production:       +Admin (was Creative only)
    ready:               +Admin (was Servicing only)
    awaiting_approval:   +Admin (was Client only)
    awaiting_brand_input:+Admin +Servicing (was Client only)
    scheduled:           unchanged (Admin+Servicing+Creative)
    published:           unchanged (Admin+Serv+Creative+Client)
  submitClientRequest: added 2nd INSERT for Admin (was
  Servicing only).

09-approval.js
  L149 submitApproval changes: recipients changed from
    ['Creative'] to ['Admin', 'Creative'] per matrix.
    Actor changed from hardcoded 'Client' to
    AppState.user.name || currentUserName || 'Client'
    so notifications say "Manisha" not "Client".
  L170 submitApproval approved: same actor fix.

PART F audit: clientApprove (08-post-actions.js L223) and submitApproval approved (09-approval.js L170) are separate entry points (client feed vs approval overlay). Both fire _sendStageNotif with stage='scheduled' to the same recipients. Not a duplicate — kept both.

tests/notifications.test.js: updated POST count assertion
  from 2 to 3 (new Admin request notification).

CLAUDE.md: documented the full routing matrix in Section 5 under the notifications table entry, noted email
notifications will be built on top.

Tests: 444/444 unit + 40/40 CI e2e passing.
index.html untouched, no version bump.

https://claude.ai/code/session_01FA6u8CmLY3wtXi6rjyqcXg