### PR TITLE
fix: LinkedIn publish flow — 6 bugs fixed

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -14,10 +14,15 @@ window._sendStageNotif = function(postId, postTitle, stage, recipients, actorNam
     'Client': 'Client'
   };
   var label = (typeof _stageLabel === 'function' && _stageLabel(stage)) || stage;
-  // Guard against double-fire
-  var _notifKey = postId + '|' + stage + '|' + Date.now();
+  // Guard against double-fire (same post + stage within 5 seconds = blocked)
+  var _notifKey = postId + '|' + stage;
   if (window._lastNotifKey === _notifKey) return;
   window._lastNotifKey = _notifKey;
+  setTimeout(function() {
+    if (window._lastNotifKey === _notifKey) {
+      window._lastNotifKey = null;
+    }
+  }, 5000);
   recipients.forEach(function(name) {
     var userRole = roleMap[name] || name;
     apiFetch('/notifications', {
@@ -444,11 +449,19 @@ async function deletePost(postId) {
 
 
 function _confirmPublish(postId) {
-  var input = document.getElementById('publish-li-input-' + postId)
+  var input = document.getElementById('pcs-li-url-input')
+    || document.getElementById('publish-li-input-' + postId)
     || document.getElementById('li-url-input-' + postId);
   var url = input ? (input.value || '').trim() : '';
 
   var btn = document.getElementById('confirm-publish-btn-' + postId);
+
+  // Basic validation - must contain linkedin.com or be empty
+  if (url && !url.includes('linkedin.com')) {
+    showToast('Please enter a valid LinkedIn URL', 'error');
+    return;
+  }
+
   if (btn) { btn.textContent = 'Publishing...'; btn.disabled = true; }
 
   var payload = {
@@ -487,6 +500,7 @@ function _confirmPublish(postId) {
     var _pubPost = getPostById(postId);
     window._sendStageNotif(postId, (_pubPost ? getTitle(_pubPost) : postId), 'published', ['Admin', 'Servicing', 'Creative', 'Client'], window.AppState.user.name || 'Shubham');
     showToast('Published', 'success');
+    if (typeof _removePublishSheet === 'function') _removePublishSheet();
     if (typeof closePCS === 'function') closePCS();
     loadPosts();
   }).catch(function(err) {
@@ -499,6 +513,12 @@ function _confirmPublish(postId) {
 window._confirmPublish = _confirmPublish;
 
 async function _skipPublish(postId) {
+  var skipBtn = document.getElementById('skip-publish-btn-' + postId);
+  if (skipBtn) {
+    if (skipBtn.disabled) return;
+    skipBtn.disabled = true;
+    skipBtn.textContent = 'Skipping...';
+  }
   _removePublishSheet();
   // Change stage without saving URL
   if (typeof quickStage === 'function') {

--- a/09-library.js
+++ b/09-library.js
@@ -1350,24 +1350,6 @@ function libGoToPipeline(postId) {
   }, 500);
 }
 
-// --------------- libSaveLinkedInUrl ---------------
-async function libSaveLinkedInUrl(postId) {
-  var input = document.getElementById('lib-li-url-input');
-  if (!input || !input.value.trim()) return;
-  var url = input.value.trim();
-  try {
-    await apiFetch('/posts?id=eq.' + postId, {
-      method: 'PATCH',
-      body: JSON.stringify({ linkedin_link: url, updated_at: new Date().toISOString() })
-    });
-    if (!_libLinkedIn[postId]) _libLinkedIn[postId] = {};
-    _libLinkedIn[postId].linkedinUrl = url;
-    showToast('LinkedIn URL saved', 'success');
-  } catch(e) {
-    showToast('Failed to save URL', 'error');
-  }
-}
-
 // --------------- attach to window ---------------
 window.libOpenFilterSheet = libOpenFilterSheet;
 window.libCloseFilterSheet = libCloseFilterSheet;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260406h
+Version format: ?v=YYYYMMDDx. Current: ?v=20260406i
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -611,9 +611,40 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Location: 07-post-load.js comment fetch, render/pipeline.js COMMENTED group
    Status: FIXED (PR#640) — enriched with _clientCommentAt, sorted by
    recency, amber dot on cards with client comments
-1. LinkedIn URL not saving from publish dialog
-   Location: actions/pcs.js ~lines 548-580
-   Status: OPEN
+1. LinkedIn publish flow — 6 bugs fixed in one PR
+   (a) linkedin_link never saved on confirm — _confirmPublish
+       (08-post-actions.js:447) looked for input IDs
+       'publish-li-input-{pid}' and 'li-url-input-{pid}' but
+       _showPublishSheet (actions/pcs.js:734) creates
+       id="pcs-li-url-input". Input always null, URL always ''.
+       FIXED: added 'pcs-li-url-input' as first fallback.
+   (b) No URL validation — any string accepted as LinkedIn URL.
+       FIXED: added linkedin.com domain check before save;
+       rejects non-LinkedIn URLs with toast.
+   (c) Ghost overlay — _confirmPublish never called
+       _removePublishSheet(), so the publish sheet stayed in DOM
+       as a floating backdrop after publish completed.
+       FIXED: added _removePublishSheet() call before closePCS().
+   (d) Confirm/Skip buttons had no id attributes — confirm button
+       could not be disabled during publish (btn always null),
+       Skip button had no guard against double-tap.
+       FIXED: added id="confirm-publish-btn-{pid}" and
+       id="skip-publish-btn-{pid}" to _showPublishSheet buttons.
+   (e) _skipPublish had no in-flight guard — rapid taps fired
+       multiple quickStage calls, each sending 4 notifications
+       (N taps = N x 4 notification rows).
+       FIXED: reads skip button, early-returns if disabled,
+       disables + shows "Skipping..." on first tap.
+   (f) _sendStageNotif dedup guard used Date.now() in key —
+       calls >1ms apart bypassed the guard (effectively useless).
+       FIXED: removed Date.now() from key, added 5-second
+       setTimeout to clear the guard. Same post + same stage
+       within 5 seconds = blocked.
+   (g) libSaveLinkedInUrl (09-library.js) was dead code — not
+       exported to window.*, used wrong PK column (id vs post_id).
+       FIXED: deleted entirely.
+   Location: 08-post-actions.js, actions/pcs.js, 09-library.js
+   Status: FIXED (PR#TBD)
 1. Role preview (admin to Chitra/Pranav/Client) not showing
    correct view in all cases
    Status: OPEN

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -740,12 +740,12 @@ window._showPublishSheet = function(postId) {
     'letter-spacing:0.02em;">' +
 
     '<div style="display:flex;gap:10px;">' +
-    '<button onclick="_confirmPublish(\'' + postId + '\')" ' +
+    '<button id="confirm-publish-btn-' + postId + '" onclick="_confirmPublish(\'' + postId + '\')" ' +
     'style="flex:1;font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
     'letter-spacing:0.14em;text-transform:uppercase;color:#3ECF8E;' +
     'background:transparent;border:1px solid rgba(62,207,142,0.4);' +
     'padding:13px 0;cursor:pointer;">Publish + Save URL</button>' +
-    '<button onclick="_skipPublish(\'' + postId + '\')" ' +
+    '<button id="skip-publish-btn-' + postId + '" onclick="_skipPublish(\'' + postId + '\')" ' +
     'style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
     'letter-spacing:0.14em;text-transform:uppercase;color:#333;' +
     'background:transparent;border:1px solid rgba(255,255,255,0.06);' +

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260406h">
+ <link rel="stylesheet" href="styles.css?v=20260406i">
 
 </head>
 <body>
@@ -1064,26 +1064,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260406h"></script>
-<script src="00-appstate-compat.js?v=20260406h"></script>
-<script src="01-config.js?v=20260406h" defer></script>
-<script src="02-session.js?v=20260406h" defer></script>
-<script src="utils.js?v=20260406h" defer></script>
-<script src="03-auth.js?v=20260406h" defer></script>
-<script src="05-api.js?v=20260406h" defer></script>
-<script src="10-ui.js?v=20260406h" defer></script>
+<script src="00-appstate.js?v=20260406i"></script>
+<script src="00-appstate-compat.js?v=20260406i"></script>
+<script src="01-config.js?v=20260406i" defer></script>
+<script src="02-session.js?v=20260406i" defer></script>
+<script src="utils.js?v=20260406i" defer></script>
+<script src="03-auth.js?v=20260406i" defer></script>
+<script src="05-api.js?v=20260406i" defer></script>
+<script src="10-ui.js?v=20260406i" defer></script>
 
-<script src="06-post-create.js?v=20260406h" defer></script>
-<script defer src="render/dashboard.js?v=20260406h"></script>
-<script defer src="render/client.js?v=20260406h"></script>
-<script defer src="render/pipeline.js?v=20260406h"></script>
-<script defer src="render/brief.js?v=20260406h"></script>
-<script defer src="actions/pcs.js?v=20260406h"></script>
-<script src="07-post-load.js?v=20260406h" defer></script>
-<script src="08-post-actions.js?v=20260406h" defer></script>
-<script src="09-library.js?v=20260406h" defer></script>
-<script src="09-approval.js?v=20260406h" defer></script>
-<script src="04-router.js?v=20260406h" defer></script>
+<script src="06-post-create.js?v=20260406i" defer></script>
+<script defer src="render/dashboard.js?v=20260406i"></script>
+<script defer src="render/client.js?v=20260406i"></script>
+<script defer src="render/pipeline.js?v=20260406i"></script>
+<script defer src="render/brief.js?v=20260406i"></script>
+<script defer src="actions/pcs.js?v=20260406i"></script>
+<script src="07-post-load.js?v=20260406i" defer></script>
+<script src="08-post-actions.js?v=20260406i" defer></script>
+<script src="09-library.js?v=20260406i" defer></script>
+<script src="09-approval.js?v=20260406i" defer></script>
+<script src="04-router.js?v=20260406i" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
(a) linkedin_link never saved on confirm — _confirmPublish looked for
    wrong input IDs, now reads pcs-li-url-input correctly
(b) No URL validation — added linkedin.com domain check before save (c) Ghost overlay — _confirmPublish now calls _removePublishSheet()
    before closePCS() so the publish sheet doesn't stay in DOM
(d) Confirm/Skip buttons had no id — added id attributes so btn
    disable logic works and prevents double-tap
(e) _skipPublish had no in-flight guard — now disables Skip button
    on first tap to prevent N × 4 notification spam
(f) _sendStageNotif dedup guard used Date.now() — replaced with
    5-second cooldown window per post+stage combination
(g) Removed dead libSaveLinkedInUrl from 09-library.js

444/444 tests passing. Bumped to ?v=20260406i.

https://claude.ai/code/session_017JGrdNY5QyzkqHCM1GTNtc