### PR TITLE
fix: notification tap on new_request opens brief sheet instead of PCS

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -664,10 +664,12 @@ function renderNotifications(name, role) {
       }
     }
 
+    var isBriefAttr = n.type === 'new_request' ? ' data-is-brief="1"' : '';
     return '<div class="notif-item ' + tClass + (n.read ? ' read' : '') + '"' +
       ' data-notif-id="' + esc(n.id || '') + '"' +
       ' data-post-id="' + esc(n.post_id || '') + '"' +
-      ' data-notif-type="' + esc(n.type || '') + '">' +
+      ' data-notif-type="' + esc(n.type || '') + '"' +
+      isBriefAttr + '>' +
       '<div class="notif-unread-dot"></div>' +
       '<div class="notif-av ' + avClass + '">' + esc(initial) + '</div>' +
       '<div class="notif-body">' +
@@ -1564,7 +1566,8 @@ function openNotifications() {
       if (!item) return;
       e.stopPropagation();
       var pid = item.getAttribute('data-post-id');
-      var isBrief = item.getAttribute('data-is-brief') === '1';
+      var isBrief = item.getAttribute('data-is-brief') === '1' ||
+        item.getAttribute('data-notif-type') === 'new_request';
       var notifId = item.getAttribute('data-notif-id');
       if (notifId) markNotifRead(notifId);
       // Instant visual mark-as-read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260406i
+Version format: ?v=YYYYMMDDx. Current: ?v=20260406j
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -648,6 +648,19 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
 1. Role preview (admin to Chitra/Pranav/Client) not showing
    correct view in all cases
    Status: OPEN
+1. Notification tap on new_request opens PCS instead of brief sheet
+   Location: 10-ui.js openNotifications() tap handler — notifType
+   'new_request' fell through to openPCS() because data-is-brief
+   was never emitted by _buildItem() and the tap handler did not
+   check notifType. _buildItem only emitted data-notif-type but
+   the routing logic relied on data-is-brief which was always
+   absent.
+   Status: FIXED (PR#TBD) — tap handler isBrief now also matches
+   data-notif-type === 'new_request'. _buildItem emits
+   data-is-brief="1" on new_request notification items so the
+   attribute is present for any code that checks it. Routes to
+   _openBriefSheet(pid) which correctly handles REQ- post_ids
+   via _isRequest flag.
 1. Session persistence — clients getting logged out
    Check: persistSession in 02-session.js Supabase client config
    Status: OPEN

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260406i">
+ <link rel="stylesheet" href="styles.css?v=20260406j">
 
 </head>
 <body>
@@ -1064,26 +1064,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260406i"></script>
-<script src="00-appstate-compat.js?v=20260406i"></script>
-<script src="01-config.js?v=20260406i" defer></script>
-<script src="02-session.js?v=20260406i" defer></script>
-<script src="utils.js?v=20260406i" defer></script>
-<script src="03-auth.js?v=20260406i" defer></script>
-<script src="05-api.js?v=20260406i" defer></script>
-<script src="10-ui.js?v=20260406i" defer></script>
+<script src="00-appstate.js?v=20260406j"></script>
+<script src="00-appstate-compat.js?v=20260406j"></script>
+<script src="01-config.js?v=20260406j" defer></script>
+<script src="02-session.js?v=20260406j" defer></script>
+<script src="utils.js?v=20260406j" defer></script>
+<script src="03-auth.js?v=20260406j" defer></script>
+<script src="05-api.js?v=20260406j" defer></script>
+<script src="10-ui.js?v=20260406j" defer></script>
 
-<script src="06-post-create.js?v=20260406i" defer></script>
-<script defer src="render/dashboard.js?v=20260406i"></script>
-<script defer src="render/client.js?v=20260406i"></script>
-<script defer src="render/pipeline.js?v=20260406i"></script>
-<script defer src="render/brief.js?v=20260406i"></script>
-<script defer src="actions/pcs.js?v=20260406i"></script>
-<script src="07-post-load.js?v=20260406i" defer></script>
-<script src="08-post-actions.js?v=20260406i" defer></script>
-<script src="09-library.js?v=20260406i" defer></script>
-<script src="09-approval.js?v=20260406i" defer></script>
-<script src="04-router.js?v=20260406i" defer></script>
+<script src="06-post-create.js?v=20260406j" defer></script>
+<script defer src="render/dashboard.js?v=20260406j"></script>
+<script defer src="render/client.js?v=20260406j"></script>
+<script defer src="render/pipeline.js?v=20260406j"></script>
+<script defer src="render/brief.js?v=20260406j"></script>
+<script defer src="actions/pcs.js?v=20260406j"></script>
+<script src="07-post-load.js?v=20260406j" defer></script>
+<script src="08-post-actions.js?v=20260406j" defer></script>
+<script src="09-library.js?v=20260406j" defer></script>
+<script src="09-approval.js?v=20260406j" defer></script>
+<script src="04-router.js?v=20260406j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
new_request notifications stored type='new_request' and post_id='REQ-...' but the tap handler ignored the type and always fell through to openPCS(). _buildItem never emitted data-is-brief="1" for these items.

- Tap handler: isBrief now also matches data-notif-type==='new_request'
- _buildItem: emits data-is-brief="1" on new_request notification items
- Bumped all 20 ?v= to 20260406j

https://claude.ai/code/session_016UddYKD1yY9hD1bAzgnjBG