### PR TITLE
fix: scroll hijacking — reset body overflow on sheet close

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -1408,13 +1408,13 @@ function openRunwaySheet() {
     sheet = document.createElement('div');
     sheet.id = 'runway-sheet';
     sheet.style.cssText = 'position:fixed;inset:0;z-index:1300;background:rgba(0,0,0,0.75);display:flex;align-items:flex-end;justify-content:center;';
-    sheet.onclick = function(e) { if (e.target === sheet) sheet.style.display = 'none'; };
+    sheet.onclick = function(e) { if (e.target === sheet) { sheet.style.display = 'none'; document.body.style.overflow = ''; } };
     document.body.appendChild(sheet);
   }
   var html = '<div style="width:100%;max-width:480px;max-height:88vh;overflow-y:auto;background:#141414;border-top:1px solid rgba(255,255,255,0.1);padding-bottom:30px;">';
   html += '<div style="display:flex;align-items:center;justify-content:space-between;padding:14px 18px;border-bottom:1px solid var(--dotline);">';
   html += '<span style="font-family:var(--mono);font-size:9px;letter-spacing:0.2em;text-transform:uppercase;color:var(--text1);">Runway - ' + posts.length + ' scheduled</span>';
-  html += '<button onclick="document.getElementById(\'runway-sheet\').style.display=\'none\'" style="background:none;border:none;color:var(--c-text3);font-size:18px;cursor:pointer;line-height:1;">x</button>';
+  html += '<button onclick="document.getElementById(\'runway-sheet\').style.display=\'none\';document.body.style.overflow=\'\'" style="background:none;border:none;color:var(--c-text3);font-size:18px;cursor:pointer;line-height:1;">x</button>';
   html += '</div>';
   if (!posts.length) {
     html += '<div style="padding:24px 18px;font-family:var(--mono);font-size:11px;color:var(--c-text3);">Nothing scheduled yet.</div>';
@@ -1542,7 +1542,7 @@ function openStageSheet(stage) {
       'background:rgba(0,0,0,0.75);display:flex;'+
       'align-items:flex-end;justify-content:center;';
     sheet.onclick = function(e) {
-      if (e.target===sheet) sheet.style.display='none';
+      if (e.target===sheet) { sheet.style.display='none'; document.body.style.overflow=''; }
     };
     document.body.appendChild(sheet);
   }
@@ -1557,7 +1557,7 @@ function openStageSheet(stage) {
     'letter-spacing:0.2em;text-transform:uppercase;'+
     'color:#e8e2d9;">'+esc(sheetTitle)+' \u00b7 '+posts.length+'</span>'+
     '<button onclick="document.getElementById('+
-    '\'stage-sheet-overlay\').style.display=\'none\'"'+
+    '\'stage-sheet-overlay\').style.display=\'none\';document.body.style.overflow=\'\'"'+
     ' style="background:none;border:none;color:#555;'+
     'font-size:18px;cursor:pointer;">\u00d7</button></div>';
   if (!posts.length) {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260406h
+Version format: ?v=YYYYMMDDx. Current: ?v=20260406k
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1184,6 +1184,20 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
        .pcs-back-notif-btn added. Zero rgba, all solid hex.
    Status: FIXED (PR#TBD) — 433/433 unit + 40/40 CI e2e
    passing. Bumped to ?v=20260406e.
+1. Scroll hijacking on mobile — body stays locked after
+   closing runway-sheet or stage-sheet bottom sheets
+   Location: 07-post-load.js openRunwaySheet() and
+   openStageSheet() set document.body.style.overflow =
+   'hidden' on open, but the close handlers (X button
+   onclick and backdrop click) only set display='none'
+   on the sheet without resetting body overflow.
+   Same bug duplicated in render/dashboard.js for the
+   identical openRunwaySheet() and openStageSheet().
+   Total: 8 close paths missing overflow reset across
+   2 files (4 in 07-post-load.js, 4 in dashboard.js).
+   Status: FIXED (PR#TBD) — added document.body.style.overflow=''
+   to all 8 close handlers. 444/444 unit passing.
+   Bumped to ?v=20260406k.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260406h">
+ <link rel="stylesheet" href="styles.css?v=20260406k">
 
 </head>
 <body>
@@ -1064,26 +1064,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260406h"></script>
-<script src="00-appstate-compat.js?v=20260406h"></script>
-<script src="01-config.js?v=20260406h" defer></script>
-<script src="02-session.js?v=20260406h" defer></script>
-<script src="utils.js?v=20260406h" defer></script>
-<script src="03-auth.js?v=20260406h" defer></script>
-<script src="05-api.js?v=20260406h" defer></script>
-<script src="10-ui.js?v=20260406h" defer></script>
+<script src="00-appstate.js?v=20260406k"></script>
+<script src="00-appstate-compat.js?v=20260406k"></script>
+<script src="01-config.js?v=20260406k" defer></script>
+<script src="02-session.js?v=20260406k" defer></script>
+<script src="utils.js?v=20260406k" defer></script>
+<script src="03-auth.js?v=20260406k" defer></script>
+<script src="05-api.js?v=20260406k" defer></script>
+<script src="10-ui.js?v=20260406k" defer></script>
 
-<script src="06-post-create.js?v=20260406h" defer></script>
-<script defer src="render/dashboard.js?v=20260406h"></script>
-<script defer src="render/client.js?v=20260406h"></script>
-<script defer src="render/pipeline.js?v=20260406h"></script>
-<script defer src="render/brief.js?v=20260406h"></script>
-<script defer src="actions/pcs.js?v=20260406h"></script>
-<script src="07-post-load.js?v=20260406h" defer></script>
-<script src="08-post-actions.js?v=20260406h" defer></script>
-<script src="09-library.js?v=20260406h" defer></script>
-<script src="09-approval.js?v=20260406h" defer></script>
-<script src="04-router.js?v=20260406h" defer></script>
+<script src="06-post-create.js?v=20260406k" defer></script>
+<script defer src="render/dashboard.js?v=20260406k"></script>
+<script defer src="render/client.js?v=20260406k"></script>
+<script defer src="render/pipeline.js?v=20260406k"></script>
+<script defer src="render/brief.js?v=20260406k"></script>
+<script defer src="actions/pcs.js?v=20260406k"></script>
+<script src="07-post-load.js?v=20260406k" defer></script>
+<script src="08-post-actions.js?v=20260406k" defer></script>
+<script src="09-library.js?v=20260406k" defer></script>
+<script src="09-approval.js?v=20260406k" defer></script>
+<script src="04-router.js?v=20260406k" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/dashboard.js
+++ b/render/dashboard.js
@@ -622,13 +622,13 @@ window.openRunwaySheet = function() {
     sheet = document.createElement('div');
     sheet.id = 'runway-sheet';
     sheet.style.cssText = 'position:fixed;inset:0;z-index:1300;background:rgba(0,0,0,0.75);display:flex;align-items:flex-end;justify-content:center;';
-    sheet.onclick = function(e) { if (e.target === sheet) sheet.style.display = 'none'; };
+    sheet.onclick = function(e) { if (e.target === sheet) { sheet.style.display = 'none'; document.body.style.overflow = ''; } };
     document.body.appendChild(sheet);
   }
   var html = '<div style="width:100%;max-width:480px;max-height:88vh;overflow-y:auto;background:#141414;border-top:1px solid rgba(255,255,255,0.1);padding-bottom:30px;">';
   html += '<div style="display:flex;align-items:center;justify-content:space-between;padding:14px 18px;border-bottom:1px solid var(--dotline);">';
   html += '<span style="font-family:var(--mono);font-size:9px;letter-spacing:0.2em;text-transform:uppercase;color:var(--text1);">Runway - ' + posts.length + ' scheduled</span>';
-  html += '<button onclick="document.getElementById(\'runway-sheet\').style.display=\'none\'" style="background:none;border:none;color:var(--c-text3);font-size:18px;cursor:pointer;line-height:1;">x</button>';
+  html += '<button onclick="document.getElementById(\'runway-sheet\').style.display=\'none\';document.body.style.overflow=\'\'" style="background:none;border:none;color:var(--c-text3);font-size:18px;cursor:pointer;line-height:1;">x</button>';
   html += '</div>';
   if (!posts.length) {
     html += '<div style="padding:24px 18px;font-family:var(--mono);font-size:11px;color:var(--c-text3);">Nothing scheduled yet.</div>';
@@ -751,7 +751,7 @@ window.openStageSheet = function(stage) {
       'background:rgba(0,0,0,0.75);display:flex;'+
       'align-items:flex-end;justify-content:center;';
     sheet.onclick = function(e) {
-      if (e.target===sheet) sheet.style.display='none';
+      if (e.target===sheet) { sheet.style.display='none'; document.body.style.overflow=''; }
     };
     document.body.appendChild(sheet);
   }
@@ -766,7 +766,7 @@ window.openStageSheet = function(stage) {
     'letter-spacing:0.2em;text-transform:uppercase;'+
     'color:#e8e2d9;">'+esc(sheetTitle)+' \u00b7 '+posts.length+'</span>'+
     '<button onclick="document.getElementById('+
-    '\'stage-sheet-overlay\').style.display=\'none\'"'+
+    '\'stage-sheet-overlay\').style.display=\'none\';document.body.style.overflow=\'\'"'+
     ' style="background:none;border:none;color:#555;'+
     'font-size:18px;cursor:pointer;">\u00d7</button></div>';
   if (!posts.length) {


### PR DESCRIPTION
## Summary
- **Root cause**: `openRunwaySheet()` and `openStageSheet()` set `document.body.style.overflow = 'hidden'` on open, but all 8 close handlers (X button onclick + backdrop click) only set `display='none'` on the sheet without resetting body overflow — leaving the page permanently frozen until refresh
- Added `document.body.style.overflow = ''` to all 8 close paths across 2 files (4 in `07-post-load.js`, 4 in `render/dashboard.js`)
- Version bump `?v=20260406h` → `?v=20260406k` across all 20 resources
- CLAUDE.md updated with bug entry and version

## Files changed
| File | Change |
|------|--------|
| `07-post-load.js` | Added overflow reset to runway-sheet backdrop click (L1411), runway-sheet X button (L1417), stage-sheet backdrop click (L1544), stage-sheet X button (L1559) |
| `render/dashboard.js` | Added overflow reset to runway-sheet backdrop click (L625), runway-sheet X button (L631), stage-sheet backdrop click (L753), stage-sheet X button (L768) |
| `index.html` | Version bump ?v=20260406k (20 resources) |
| `CLAUDE.md` | Bug entry added, version updated |

## Test plan
- [x] 444/444 unit tests passing
- [ ] Open Dashboard → tap runway count → close via X → verify scroll works
- [ ] Open Dashboard → tap runway count → close via backdrop tap → verify scroll works
- [ ] Open Dashboard → tap any stage count → close via X → verify scroll works
- [ ] Open Dashboard → tap any stage count → close via backdrop tap → verify scroll works
- [ ] Repeat all 4 on mobile Safari / Chrome
- [ ] Purge Cloudflare cache after merge

https://claude.ai/code/session_01MYQqLiP3dr94GmmnRxJpMR