### PR TITLE
fix: 3 defensive guards for error-log issues + resolve merge conflicts

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -358,6 +358,7 @@ function startRealtime() {
   // Data polling  -  every 15 seconds (was 8s; reduces API calls & DOM churn)
   window.AppState.timers.realtimeTimer = setInterval(async () => {
     if (document.hidden) return;
+    if (!localStorage.getItem('sb_access_token')) return;
     // Skip poll while user is in a modal  -  they'll get fresh data on close
     if (window.AppState.ui.modalOpen) return;
     try {

--- a/10-ui.js
+++ b/10-ui.js
@@ -22,6 +22,7 @@ window._clickBuffer = [];
 
 function _flushClickBuffer() {
   if (!window._clickBuffer.length) return;
+  if (!localStorage.getItem('sb_access_token')) return;
   var batch = window._clickBuffer.splice(0);
   var user = AppState.user || {};
   var payload = batch.map(function(entry) {
@@ -400,6 +401,7 @@ var roleDisplayMap = {
 };
 
 async function loadNotifications() {
+  if (!localStorage.getItem('sb_access_token')) return;
   try {
     var _notifRole = window.AppState.user.effectiveRole || window.AppState.user.role || 'Admin';
     _notifRole = _notifRole.charAt(0).toUpperCase() + _notifRole.slice(1).toLowerCase();
@@ -789,6 +791,7 @@ async function markAllNotificationsRead() {
 }
 
 function updateNotifBadge() {
+  if (!localStorage.getItem('sb_access_token')) return;
   var role = (window.AppState.user.effectiveRole || 'Admin');
   var _badgeRole = role.charAt(0).toUpperCase() +
     role.slice(1).toLowerCase();

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-<<<<<<< claude/audit-email-system-Ixq0c
-Version format: ?v=YYYYMMDDx. Current: ?v=20260406k
-=======
-Version format: ?v=YYYYMMDDx. Current: ?v=20260406j
->>>>>>> main-/-root
+Version format: ?v=YYYYMMDDx. Current: ?v=20260407a
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -320,8 +316,8 @@ Post-deploy smoke (.github/workflows/smoke.yml):
   than failing the whole suite.
 
 Current (verified 2026-04-06):
-Unit test files: 17
-Unit tests:      444 passing, 0 failing
+Unit test files: 18
+Unit tests:      454 passing, 0 failing
 E2E specs:       9
 
 Files:
@@ -342,6 +338,7 @@ tests/utils.test.js
 tests/action-router.test.js
 tests/guard-handlers.test.js
 tests/critical-handlers.test.js
+tests/defensive-guards.test.js
 
 E2E: tests/e2e/admin-flows.spec.js, client-feed.spec.js, client-flows.spec.js, live-smoke.spec.js, live-smoke-schedule.spec.js, notif-panel.spec.js, pcs.spec.js, role-flows.spec.js, smoke.spec.js
 pcs.spec.js updated for post-redesign selectors: TEST 1 activates Client tab before asserting #pcs-comments-list; TEST 3 activates Client tab before asserting #pcs-comment-input + #pcs-send-btn-client; TEST 4 now asserts the #pcs-stage-pill label (advance button removed); TEST 5 targets #pcs-photo-grid-wrap img and the route handler stubs picsum.photos with a 1×1 PNG; TEST 7 targets #pcs-stage-pill dropdown; TEST 8 invokes window.pcsConfirmDelete() via page.evaluate.
@@ -1246,6 +1243,30 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Status: FIXED (PR#TBD) — added document.body.style.overflow=''
    to all 8 close handlers. 444/444 unit passing.
    Bumped to ?v=20260406k.
+1. updateNotifBadge fires apiFetch with no session token check
+   Location: 10-ui.js updateNotifBadge() — called from timers
+   and direct invocations with no guard for valid session token.
+   Same pattern in _flushClickBuffer (5s interval),
+   loadNotifications, and startRealtime 15s poll callback.
+   Status: FIXED (PR#TBD) — added
+   if (!localStorage.getItem('sb_access_token')) return;
+   to updateNotifBadge, _flushClickBuffer, loadNotifications
+   (all in 10-ui.js), and startRealtime poll callback
+   (07-post-load.js). 454/454 unit passing.
+1. _pcsDoDeleteComment passes empty UUID to Supabase
+   Location: actions/pcs.js _pcsDoDeleteComment() — no validation
+   that commentId is non-empty before PATCH call. Same pattern in
+   toggleTaskResolve (pcs.js), _saveLiUrlInline (pcs.js),
+   _closeBrief (brief.js), _reopenBrief (brief.js).
+   Status: FIXED (PR#TBD) — added type+empty validation guards
+   to all 5 functions. 454/454 unit passing.
+1. _pcsDateChange re-renders PCS during closePCS teardown
+   Location: actions/pcs.js _pcsDateChange() line 533-534 —
+   updatePost() and openPCS() fire even when PCS is closing,
+   causing NotFoundError on detached DOM.
+   Status: FIXED (PR#TBD) — wrapped updatePost+openPCS in
+   if (window.AppState.pcs.open) guard. 454/454 unit passing.
+   Bumped to ?v=20260407a.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -530,8 +530,10 @@ window._pcsDateChange = function(postId, dateValue) {
     }
     window.AppState.pcs.activeMenu = null;
   }
-  if (typeof updatePost === 'function') updatePost(postId, 'targetDate', dateValue);
-  if (typeof openPCS === 'function') openPCS(postId, '');
+  if (window.AppState && window.AppState.pcs && window.AppState.pcs.open) {
+    if (typeof updatePost === 'function') updatePost(postId, 'targetDate', dateValue);
+    if (typeof openPCS === 'function') openPCS(postId, '');
+  }
 }
 
 // -- Caption section builder --
@@ -780,6 +782,10 @@ window._saveLiUrlInline = function(postId) {
            (p.id && p.id === postId);
   });
   var _liPostId = _liPost ? _liPost.post_id : postId;
+  if (!_liPostId) {
+    console.warn('_saveLiUrlInline: missing postId, aborting');
+    return;
+  }
 
   var btn = document.getElementById('li-save-btn-' + postId);
   if (btn) {
@@ -2405,6 +2411,10 @@ window._doSubmitComment = async function(opts) {
 };
 
 window.toggleTaskResolve = function(commentId, postId) {
+  if (!commentId || typeof commentId !== 'string' || commentId.trim() === '') {
+    console.warn('toggleTaskResolve: missing or invalid commentId, aborting');
+    return;
+  }
   apiFetch('/post_comments?id=eq.' + commentId, {
     method: 'PATCH',
     headers: {'Prefer': 'return=minimal'},
@@ -2698,6 +2708,10 @@ window._pcsConfirmDeleteComment = function(commentId, postId, isInternalNote) {
 };
 
 window._pcsDoDeleteComment = async function(commentId, postId, isInternalNote) {
+  if (!commentId || typeof commentId !== 'string' || commentId.trim() === '') {
+    console.warn('_pcsDoDeleteComment: missing or invalid commentId, aborting');
+    return;
+  }
   return window.guardAction('pcs-delete-comment-' + commentId, async function() {
     _removePcsConfirm();
     try {

--- a/index.html
+++ b/index.html
@@ -56,11 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
-<<<<<<< claude/audit-email-system-Ixq0c
- <link rel="stylesheet" href="styles.css?v=20260406k">
-=======
- <link rel="stylesheet" href="styles.css?v=20260406j">
->>>>>>> main-/-root
+ <link rel="stylesheet" href="styles.css?v=20260407a">
 
 </head>
 <body>
@@ -1068,49 +1064,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<<<<<<< claude/audit-email-system-Ixq0c
-<script src="00-appstate.js?v=20260406k"></script>
-<script src="00-appstate-compat.js?v=20260406k"></script>
-<script src="01-config.js?v=20260406k" defer></script>
-<script src="02-session.js?v=20260406k" defer></script>
-<script src="utils.js?v=20260406k" defer></script>
-<script src="03-auth.js?v=20260406k" defer></script>
-<script src="05-api.js?v=20260406k" defer></script>
-<script src="10-ui.js?v=20260406k" defer></script>
+<script src="00-appstate.js?v=20260407a"></script>
+<script src="00-appstate-compat.js?v=20260407a"></script>
+<script src="01-config.js?v=20260407a" defer></script>
+<script src="02-session.js?v=20260407a" defer></script>
+<script src="utils.js?v=20260407a" defer></script>
+<script src="03-auth.js?v=20260407a" defer></script>
+<script src="05-api.js?v=20260407a" defer></script>
+<script src="10-ui.js?v=20260407a" defer></script>
 
-<script src="06-post-create.js?v=20260406k" defer></script>
-<script defer src="render/dashboard.js?v=20260406k"></script>
-<script defer src="render/client.js?v=20260406k"></script>
-<script defer src="render/pipeline.js?v=20260406k"></script>
-<script defer src="render/brief.js?v=20260406k"></script>
-<script defer src="actions/pcs.js?v=20260406k"></script>
-<script src="07-post-load.js?v=20260406k" defer></script>
-<script src="08-post-actions.js?v=20260406k" defer></script>
-<script src="09-library.js?v=20260406k" defer></script>
-<script src="09-approval.js?v=20260406k" defer></script>
-<script src="04-router.js?v=20260406k" defer></script>
-=======
-<script src="00-appstate.js?v=20260406j"></script>
-<script src="00-appstate-compat.js?v=20260406j"></script>
-<script src="01-config.js?v=20260406j" defer></script>
-<script src="02-session.js?v=20260406j" defer></script>
-<script src="utils.js?v=20260406j" defer></script>
-<script src="03-auth.js?v=20260406j" defer></script>
-<script src="05-api.js?v=20260406j" defer></script>
-<script src="10-ui.js?v=20260406j" defer></script>
-
-<script src="06-post-create.js?v=20260406j" defer></script>
-<script defer src="render/dashboard.js?v=20260406j"></script>
-<script defer src="render/client.js?v=20260406j"></script>
-<script defer src="render/pipeline.js?v=20260406j"></script>
-<script defer src="render/brief.js?v=20260406j"></script>
-<script defer src="actions/pcs.js?v=20260406j"></script>
-<script src="07-post-load.js?v=20260406j" defer></script>
-<script src="08-post-actions.js?v=20260406j" defer></script>
-<script src="09-library.js?v=20260406j" defer></script>
-<script src="09-approval.js?v=20260406j" defer></script>
-<script src="04-router.js?v=20260406j" defer></script>
->>>>>>> main-/-root
+<script src="06-post-create.js?v=20260407a" defer></script>
+<script defer src="render/dashboard.js?v=20260407a"></script>
+<script defer src="render/client.js?v=20260407a"></script>
+<script defer src="render/pipeline.js?v=20260407a"></script>
+<script defer src="render/brief.js?v=20260407a"></script>
+<script defer src="actions/pcs.js?v=20260407a"></script>
+<script src="07-post-load.js?v=20260407a" defer></script>
+<script src="08-post-actions.js?v=20260407a" defer></script>
+<script src="09-library.js?v=20260407a" defer></script>
+<script src="09-approval.js?v=20260407a" defer></script>
+<script src="04-router.js?v=20260407a" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -501,6 +501,10 @@ window._closeBriefConfirm = function(postId) {
 }
 
 window._closeBrief = function(postId) {
+  if (!postId) {
+    console.warn('_closeBrief: missing postId, aborting');
+    return;
+  }
   document.getElementById('brief-confirm-overlay') &&
     document.getElementById('brief-confirm-overlay').remove();
 
@@ -553,6 +557,10 @@ window._closeBrief = function(postId) {
 }
 
 window._reopenBrief = function(postId) {
+  if (!postId) {
+    console.warn('_reopenBrief: missing postId, aborting');
+    return;
+  }
   var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
 
   if (post && post._isRequest) {

--- a/tests/defensive-guards.test.js
+++ b/tests/defensive-guards.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+var uiSrc = readFileSync(resolve(__dirname, '..', '10-ui.js'), 'utf8');
+var pcsSrc = readFileSync(resolve(__dirname, '..', 'actions', 'pcs.js'), 'utf8');
+var postLoadSrc = readFileSync(resolve(__dirname, '..', '07-post-load.js'), 'utf8');
+var briefSrc = readFileSync(resolve(__dirname, '..', 'render', 'brief.js'), 'utf8');
+
+describe('FIX 1 — session token guards on apiFetch callers', function() {
+
+  it('updateNotifBadge has session token guard', function() {
+    var match = uiSrc.match(/function updateNotifBadge\(\)\s*\{[^}]{0,200}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("localStorage.getItem('sb_access_token')");
+  });
+
+  it('_flushClickBuffer has session token guard', function() {
+    var match = uiSrc.match(/function _flushClickBuffer\(\)\s*\{[^}]{0,300}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("localStorage.getItem('sb_access_token')");
+  });
+
+  it('loadNotifications has session token guard', function() {
+    var match = uiSrc.match(/async function loadNotifications\(\)\s*\{[^}]{0,200}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("localStorage.getItem('sb_access_token')");
+  });
+
+  it('startRealtime polling callback has session token guard', function() {
+    var realtimeBlock = postLoadSrc.match(/realtimeTimer\s*=\s*setInterval[\s\S]{0,400}/);
+    expect(realtimeBlock).toBeTruthy();
+    expect(realtimeBlock[0]).toContain("localStorage.getItem('sb_access_token')");
+  });
+});
+
+describe('FIX 2 — UUID validation before apiFetch', function() {
+
+  it('_pcsDoDeleteComment validates commentId before guardAction', function() {
+    var match = pcsSrc.match(/_pcsDoDeleteComment\s*=\s*async function\(commentId[\s\S]{0,400}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("!commentId");
+    expect(match[0]).toContain("typeof commentId !== 'string'");
+    expect(match[0]).toContain("commentId.trim()");
+  });
+
+  it('toggleTaskResolve validates commentId before apiFetch', function() {
+    var match = pcsSrc.match(/toggleTaskResolve\s*=\s*function\(commentId[\s\S]{0,400}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("!commentId");
+    expect(match[0]).toContain("typeof commentId !== 'string'");
+  });
+
+  it('_saveLiUrlInline validates _liPostId before apiFetch', function() {
+    var match = pcsSrc.match(/_liPostId\s*=\s*_liPost[\s\S]{0,200}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("!_liPostId");
+  });
+
+  it('_closeBrief validates postId before apiFetch', function() {
+    var match = briefSrc.match(/_closeBrief\s*=\s*function\(postId\)\s*\{[^}]{0,300}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("!postId");
+  });
+
+  it('_reopenBrief validates postId before apiFetch', function() {
+    var match = briefSrc.match(/_reopenBrief\s*=\s*function\(postId\)\s*\{[^}]{0,300}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("!postId");
+  });
+});
+
+describe('FIX 3 — _pcsDateChange guards re-render on closed PCS', function() {
+
+  it('_pcsDateChange wraps updatePost+openPCS in pcs.open guard', function() {
+    var match = pcsSrc.match(/_pcsDateChange\s*=\s*function[\s\S]{0,600}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain('AppState.pcs.open');
+    // updatePost and openPCS must be INSIDE the guard, not before it
+    var guardIdx = match[0].indexOf('AppState.pcs.open');
+    var updateIdx = match[0].indexOf('updatePost(postId');
+    var openIdx = match[0].indexOf('openPCS(postId');
+    expect(updateIdx).toBeGreaterThan(guardIdx);
+    expect(openIdx).toBeGreaterThan(guardIdx);
+  });
+});


### PR DESCRIPTION
FIX 1 — Session token guards on apiFetch callers:
  - updateNotifBadge (10-ui.js) — added token check before apiFetch
  - _flushClickBuffer (10-ui.js) — added token check on 5s interval
  - loadNotifications (10-ui.js) — added token check before fetch
  - startRealtime poll (07-post-load.js) — added token check on 15s interval

FIX 2 — UUID validation before apiFetch:
  - _pcsDoDeleteComment (actions/pcs.js) — validate commentId before guardAction
  - toggleTaskResolve (actions/pcs.js) — validate commentId before apiFetch
  - _saveLiUrlInline (actions/pcs.js) — validate _liPostId before apiFetch
  - _closeBrief (render/brief.js) — validate postId before apiFetch
  - _reopenBrief (render/brief.js) — validate postId before apiFetch

FIX 3 — _pcsDateChange PCS teardown guard:
  - Wrapped updatePost+openPCS in AppState.pcs.open check (actions/pcs.js)

Also: resolved merge conflict markers in index.html and CLAUDE.md.
Version bump: ?v=20260406k → ?v=20260407a (all 20 resources).
Tests: 454/454 passing (was 444, +10 new in defensive-guards.test.js).

https://claude.ai/code/session_011LnsQWvEgoWZcNrK38QM3r