### PR TITLE
fix: permanent silent sessions — typed errors, cross-tab lock, visibilitychange

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -36,35 +36,114 @@ function _normaliseRole(r) {
 
 let _refreshInProgress = null;
 
+// -- Cross-tab token sync: pick up tokens saved by other tabs --
+window.addEventListener('storage', function(e) {
+  if (e.key === 'sb_access_token' && !e.newValue) {
+    // Another tab cleared the token (logged out or auth_expired)
+    if (window._authReady) showLoginOverlay();
+  }
+});
+
+// Helper: clear all session tokens and show login
+function _clearSessionAndLogin() {
+  localStorage.removeItem('sb_access_token');
+  localStorage.removeItem('sb_refresh_token');
+  localStorage.removeItem('hinglish_role');
+  localStorage.removeItem('hinglish_email');
+  localStorage.removeItem('hinglish_name');
+  if (typeof stopRealtime === 'function') stopRealtime();
+  showLoginOverlay();
+}
+window._clearSessionAndLogin = _clearSessionAndLogin;
+
 async function refreshSession() {
   if (_refreshInProgress) return _refreshInProgress;
-  const refreshToken = localStorage.getItem('sb_refresh_token');
-  if (!refreshToken) return null;
-  _refreshInProgress = (async () => {
-    try {
-      const res = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=refresh_token`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_KEY },
-        body: JSON.stringify({ refresh_token: refreshToken }),
-      });
-      if (!res.ok) return null;
-      const data = await res.json();
-      if (data.access_token) {
-        localStorage.setItem('sb_access_token', data.access_token);
-        if (data.refresh_token) localStorage.setItem('sb_refresh_token', data.refresh_token);
-        return data.access_token;
-      }
-    } catch (err) {
-      console.error('[auth] refreshSession failed', err);
-      window.logError && window.logError(err && err.message, err && err.stack, 'refresh-session');
-    }
-    return null;
-  })();
+  var refreshToken = localStorage.getItem('sb_refresh_token');
+  if (!refreshToken) return { error: 'auth_expired' };
+
+  // -- Cross-tab lock: prevent two tabs from using the same refresh token --
+  var lockTs = parseInt(localStorage.getItem('_srtd_refresh_lock') || '0', 10);
+  if (lockTs && (Date.now() - lockTs) < 10000) {
+    // Another tab is refreshing — wait for its result
+    return new Promise(function(resolve) {
+      var oldToken = localStorage.getItem('sb_access_token') || '';
+      var attempts = 0;
+      var pollId = setInterval(function() {
+        attempts++;
+        var current = localStorage.getItem('sb_access_token') || '';
+        if (current && current !== oldToken) {
+          clearInterval(pollId);
+          resolve({ token: current });
+        } else if (attempts >= 33) { // ~10 seconds at 300ms
+          clearInterval(pollId);
+          // Other tab may have crashed — fall through to own refresh
+          _doRefresh(refreshToken).then(resolve);
+        }
+      }, 300);
+    });
+  }
+
+  _refreshInProgress = _doRefresh(refreshToken);
   try {
     return await _refreshInProgress;
   } finally {
     _refreshInProgress = null;
   }
+}
+
+async function _doRefresh(refreshToken) {
+  try {
+    localStorage.setItem('_srtd_refresh_lock', String(Date.now()));
+    var res = await fetch(SUPABASE_URL + '/auth/v1/token?grant_type=refresh_token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_KEY },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+    if (res.status === 400 || res.status === 401 || res.status === 403) {
+      return { error: 'auth_expired' };
+    }
+    if (!res.ok) {
+      return { error: 'server' };
+    }
+    var data = await res.json();
+    if (data.access_token) {
+      localStorage.setItem('sb_access_token', data.access_token);
+      if (data.refresh_token) localStorage.setItem('sb_refresh_token', data.refresh_token);
+      return { token: data.access_token };
+    }
+    return { error: 'server' };
+  } catch (err) {
+    // TypeError = network/DNS/offline failure
+    if (err && err.name === 'TypeError') {
+      console.warn('[auth] refreshSession network error', err.message);
+      return { error: 'network' };
+    }
+    console.error('[auth] refreshSession failed', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'refresh-session');
+    return { error: 'network' };
+  } finally {
+    localStorage.removeItem('_srtd_refresh_lock');
+  }
+}
+
+// -- LAYER 3: visibilitychange — refresh token when app regains focus --
+if (!window._visibilityRefreshBound) {
+  window._visibilityRefreshBound = true;
+  document.addEventListener('visibilitychange', async function() {
+    if (document.visibilityState !== 'visible') return;
+    if (!window._authReady) return;
+    if (window.location.hash.includes('access_token')) return;
+
+    var refreshToken = localStorage.getItem('sb_refresh_token');
+    if (!refreshToken) return;
+
+    var result = await refreshSession();
+    if (result && result.error === 'auth_expired') {
+      _clearSessionAndLogin();
+    }
+    // On network/server error — do nothing, keep existing session
+    // On success — new token already saved by refreshSession()
+  });
 }
 
 function showLoginOverlay() {
@@ -203,7 +282,8 @@ async function handleMagicLinkToken(accessToken, _retried) {
     });
     if (!userRes.ok) {
       if (!_retried) {
-        const newToken = await refreshSession();
+        const result = await refreshSession();
+        var newToken = result && result.token;
         if (newToken) { handleMagicLinkToken(newToken, true); return; }
       }
       showLoginOverlay();
@@ -273,10 +353,11 @@ function activateRole(role) {
     if (!window._clientTokenTimer) {
       window._clientTokenTimer = setInterval(async function() {
         try {
-          var newToken = await refreshSession();
-          if (!newToken) {
-            console.warn('[auth] client token refresh returned null');
-            window.logError && window.logError('Client token refresh returned null', '', 'client-token-refresh');
+          var result = await refreshSession();
+          if (result && result.error === 'auth_expired') {
+            _clearSessionAndLogin();
+          } else if (result && result.error) {
+            console.warn('[auth] client token refresh: ' + result.error);
           }
         } catch(err) {
           console.error('[auth] client token refresh threw', err);

--- a/04-router.js
+++ b/04-router.js
@@ -39,19 +39,39 @@ async function _startRouter() {
     if (savedRole) window.AppState.user.effectiveRole = savedRole;
     // Try to refresh the session silently first
     if (refreshToken) {
-      const newToken = await refreshSession();
-      if (newToken) {
+      const result = await refreshSession();
+      if (result && result.token) {
         activateRole(savedRole);
+        window._authReady = true;
         return;
       }
+      if (result && result.error === 'auth_expired') {
+        // Genuine expiry — clear and show login
+        if (typeof _clearSessionAndLogin === 'function') _clearSessionAndLogin();
+        window._authReady = true;
+        return;
+      }
+      // Network/server error — keep tokens, try with stale token
+      if (savedToken) {
+        activateRole(savedRole);
+        window._authReady = true;
+        return;
+      }
+      // No saved token and refresh failed with network error — show soft banner
+      showErrorBanner('Connection issue', 'Check your internet and try again.');
+      showLoginOverlay();
+      window._authReady = true;
+      return;
     }
     if (savedToken) {
       activateRole(savedRole);
+      window._authReady = true;
       return;
     }
   }
 
   showLoginOverlay();
+  window._authReady = true;
 }
 
 // With defer, DOMContentLoaded may already have fired by the time this script

--- a/05-api.js
+++ b/05-api.js
@@ -27,8 +27,8 @@ async function apiFetch(path, options = {}) {
   // Supabase blip, an RLS policy, or a multi-tab token race. Killing the
   // session on any 401 is the #1 cause of unexpected logouts.
   if (res.status === 401) {
-    const newToken = await refreshSession();
-    if (newToken) {
+    const result = await refreshSession();
+    if (result && result.token) {
       const retry = await fetch(url, {
         ...options,
         headers: getAuthHeaders(options.headers || {}),
@@ -42,15 +42,19 @@ async function apiFetch(path, options = {}) {
       const body = await retry.text().catch(() => '');
       throw new Error(`Supabase ${retry.status}: ${body}`);
     }
-    // Refresh failed  -  token might be genuinely expired.
-    // Show a soft session-expired notification without destroying tokens.
-    // The user can manually log out or refresh the page.
-    console.warn('apiFetch: 401 and refresh failed  -  session may have expired');
+    // Refresh failed  -  branch on error type
+    if (result && result.error === 'auth_expired') {
+      // Genuine auth expiry — clear tokens and force re-login
+      if (typeof _clearSessionAndLogin === 'function') _clearSessionAndLogin();
+      throw new Error('Supabase 401: session expired');
+    }
+    // Network or server error — do NOT clear tokens, show soft banner
+    console.warn('apiFetch: 401 and refresh failed (' + (result && result.error) + ')');
     showErrorBanner(
-      'Your session may have expired.',
-      'Please refresh the page to log in again.'
+      'Connection issue  -  retrying.',
+      'Check your internet and try again.'
     );
-    throw new Error('Supabase 401: session expired');
+    throw new Error('Supabase 401: refresh ' + (result && result.error));
   }
 
   if (!res.ok) {

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -381,9 +381,11 @@ function startRealtime() {
     window.AppState.timers.tokenRefresh = setInterval(async () => {
       if (!localStorage.getItem('sb_refresh_token')) return;
       try {
-        const newToken = await refreshSession();
-        if (!newToken) {
-          console.warn('Background token refresh failed  -  user may need to re-login');
+        var result = await refreshSession();
+        if (result && result.error === 'auth_expired') {
+          if (typeof _clearSessionAndLogin === 'function') _clearSessionAndLogin();
+        } else if (result && result.error) {
+          console.warn('Background token refresh: ' + result.error);
         }
       } catch (e) {
         console.error('[post-load] token refresh failed', e);

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -213,40 +213,42 @@ async function saveAdminEdit() {
 }
 
 async function clientApprove(postId, btn) {
-  const post = getPostById(postId);
+  var post = getPostById(postId);
   if (!post) return;
-  const alreadyApproved = (post.stage||'') === 'scheduled';
+  var alreadyApproved = (post.stage||'') === 'scheduled';
   if (alreadyApproved) { showToast('Already approved ok', 'success'); return; }
-  if (btn) btn.disabled = true;
-  try {
-    // scheduled -> owner remains unchanged (per ownership rules)
-    await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
-      method: 'PATCH',
-      body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: 'Client' }),
-    });
-    await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
-    window._sendStageNotif(postId, getTitle(post), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || 'Client');
-    const confirmEl = document.getElementById(`approved-confirm-${postId}`);
-    if (confirmEl) confirmEl.classList.add('show');
-    var cardEl = document.getElementById('approved-confirm-' + postId);
-    if (cardEl) {
-      var parent = cardEl.parentNode;
-      if (parent) {
-        var actions = parent.querySelector('[style*="display:flex;border-top"]') ||
-          parent.querySelector('.bp-actions');
-        if (actions) {
-          actions.innerHTML =
-            '<div style="flex:1;padding:13px 16px;' +
-            'font-family:\'IBM Plex Mono\',monospace;' +
-            'font-size:10px;letter-spacing:0.1em;text-transform:uppercase;' +
-            'color:#3ECF8E;display:flex;align-items:center;gap:8px;">' +
-            '&#x2713; Approved -- team notified</div>';
+  return window.guardAction('client-approve-' + postId, async function() {
+    if (btn) btn.disabled = true;
+    try {
+      // scheduled -> owner remains unchanged (per ownership rules)
+      await apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
+        method: 'PATCH',
+        body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: 'Client' }),
+      });
+      await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
+      window._sendStageNotif(postId, getTitle(post), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || 'Client');
+      var confirmEl = document.getElementById('approved-confirm-' + postId);
+      if (confirmEl) confirmEl.classList.add('show');
+      var cardEl = document.getElementById('approved-confirm-' + postId);
+      if (cardEl) {
+        var parent = cardEl.parentNode;
+        if (parent) {
+          var actions = parent.querySelector('[style*="display:flex;border-top"]') ||
+            parent.querySelector('.bp-actions');
+          if (actions) {
+            actions.innerHTML =
+              '<div style="flex:1;padding:13px 16px;' +
+              'font-family:\'IBM Plex Mono\',monospace;' +
+              'font-size:10px;letter-spacing:0.1em;text-transform:uppercase;' +
+              'color:#3ECF8E;display:flex;align-items:center;gap:8px;">' +
+              '&#x2713; Approved -- team notified</div>';
+          }
         }
       }
-    }
-    setStage(post, 'scheduled', 'clientApprove');
-    setTimeout(() => loadPostsForClient(), 1200);
-  } catch (err) { if (btn) btn.disabled = false; showToast('Failed  -  try again', 'error'); window.logError && window.logError(err && err.message, err && err.stack, 'client-approve'); }
+      setStage(post, 'scheduled', 'clientApprove');
+      setTimeout(function() { if (typeof loadPostsForClient === 'function') loadPostsForClient(); }, 1200);
+    } catch (err) { if (btn) btn.disabled = false; showToast('Failed  -  try again', 'error'); window.logError && window.logError(err && err.message, err && err.stack, 'client-approve'); }
+  });
 }
 
 async function clientAcknowledge(postId) {

--- a/09-approval.js
+++ b/09-approval.js
@@ -164,7 +164,7 @@ async function submitApproval(type, postId, btn) {
       try {
         await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
           method: 'PATCH',
-          body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString() }),
+          body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: 'Client' }),
         });
         await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
         if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, esc(title), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || window.currentUserName || 'Client');

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260407a
+Version format: ?v=YYYYMMDDx. Current: ?v=20260407b
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -316,8 +316,8 @@ Post-deploy smoke (.github/workflows/smoke.yml):
   than failing the whole suite.
 
 Current (verified 2026-04-06):
-Unit test files: 18
-Unit tests:      454 passing, 0 failing
+Unit test files: 19
+Unit tests:      479 passing, 0 failing
 E2E specs:       9
 
 Files:
@@ -339,6 +339,7 @@ tests/action-router.test.js
 tests/guard-handlers.test.js
 tests/critical-handlers.test.js
 tests/defensive-guards.test.js
+tests/session-resilience.test.js
 
 E2E: tests/e2e/admin-flows.spec.js, client-feed.spec.js, client-flows.spec.js, live-smoke.spec.js, live-smoke-schedule.spec.js, notif-panel.spec.js, pcs.spec.js, role-flows.spec.js, smoke.spec.js
 pcs.spec.js updated for post-redesign selectors: TEST 1 activates Client tab before asserting #pcs-comments-list; TEST 3 activates Client tab before asserting #pcs-comment-input + #pcs-send-btn-client; TEST 4 now asserts the #pcs-stage-pill label (advance button removed); TEST 5 targets #pcs-photo-grid-wrap img and the route handler stubs picsum.photos with a 1×1 PNG; TEST 7 targets #pcs-stage-pill dropdown; TEST 8 invokes window.pcsConfirmDelete() via page.evaluate.
@@ -411,7 +412,7 @@ Pages branch:   main-/-root
 1. 15-second poll interval, 50-minute token refresh
 1. Client DB role takes absolute priority over pcs_role_preview
 1. Silent .catch(function(){}) is a bug — always use window.logError
-1. Vitest must pass 444/444 before every push
+1. Vitest must pass 479/479 before every push
 1. Posts get _commentCount (int) and _clientCommentAt (ISO string or null)
    after loadPosts() — these are runtime-enriched fields, not DB columns
 1. Requests from requests table get _isRequest:true flag after loadPosts().
@@ -461,6 +462,9 @@ window.normalizeRole        — canonical role normalizer (person names → DB r
 window.sendMagicLink        — send OTP email to user
 window.verifyOTPCode        — verify OTP and set session
 window.resetRolePreview     — clear role preview, restore Admin
+window._clearSessionAndLogin — clear all tokens + show login overlay
+window._authReady           — boolean, true after _startRouter completes
+window._visibilityRefreshBound — guard to bind visibilitychange once
 
 01-config.js:
 window.setStage             — stage transition helper
@@ -664,7 +668,8 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    via _isRequest flag.
 1. Session persistence — clients getting logged out
    Check: persistSession in 02-session.js Supabase client config
-   Status: OPEN
+   Status: FIXED (PR#TBD) — resolved by permanent silent sessions
+   (typed errors, cross-tab lock, visibilitychange handler)
 1. Client request form: 15 rgba() violations, multi-select chips,
    no photo size/count limits, fixed-height textarea, dead .nrs-* CSS,
    all inline styles, no field 01 number label
@@ -1267,6 +1272,42 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Status: FIXED (PR#TBD) — wrapped updatePost+openPCS in
    if (window.AppState.pcs.open) guard. 454/454 unit passing.
    Bumped to ?v=20260407a.
+1. Permanent silent sessions — 3 layers + 1 bonus fix
+   LAYER 1: refreshSession() now returns typed error objects:
+     { token } on success, { error: 'auth_expired' } on 400/401/403,
+     { error: 'server' } on 5xx, { error: 'network' } on TypeError.
+     All 5 callers updated to branch on error type. auth_expired →
+     _clearSessionAndLogin(). network/server → keep tokens, soft
+     banner. Never clear tokens on a network error.
+   Location: 03-auth.js (refreshSession, _doRefresh, client timer,
+     handleMagicLinkToken), 05-api.js (apiFetch 401 handler),
+     04-router.js (_startRouter), 07-post-load.js (non-client timer)
+   LAYER 2: Cross-tab refresh lock via localStorage _srtd_refresh_lock.
+     Before calling /auth/v1/token, checks if another tab holds the
+     lock (<10s). If so, polls for new token instead of sending own
+     refresh. Prevents Supabase token reuse revocation. Also added
+     storage event listener for cross-tab logout sync.
+   Location: 03-auth.js
+   LAYER 3: visibilitychange listener with _authReady guard.
+     Fires refreshSession() immediately when tab regains focus.
+     Guarded by window._authReady (set at end of _startRouter).
+     On auth_expired → _clearSessionAndLogin(). On network →
+     do nothing, keep session.
+   Location: 03-auth.js (listener), 04-router.js (_authReady flag)
+   BONUS: clientApprove wrapped in guardAction to prevent double-tap.
+     submitApproval PATCH payload aligned with clientApprove (added
+     status_changed_at + updated_by:'Client').
+   Location: 08-post-actions.js (clientApprove), 09-approval.js
+     (submitApproval)
+   Status: FIXED (PR#TBD) — 479/479 unit passing.
+   Bumped to ?v=20260407b.
+1. Session persistence — clients getting logged out
+   Check: persistSession in 02-session.js Supabase client config
+   Status: FIXED (PR#TBD) — resolved by permanent silent sessions
+   (Layer 1-3 above). No Supabase JS client exists; all auth is
+   hand-rolled. The root cause was: refreshSession returned null
+   for all failures, no visibilitychange handler, no cross-tab
+   lock. All three gaps now closed.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260407a">
+ <link rel="stylesheet" href="styles.css?v=20260407b">
 
 </head>
 <body>
@@ -1064,26 +1064,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260407a"></script>
-<script src="00-appstate-compat.js?v=20260407a"></script>
-<script src="01-config.js?v=20260407a" defer></script>
-<script src="02-session.js?v=20260407a" defer></script>
-<script src="utils.js?v=20260407a" defer></script>
-<script src="03-auth.js?v=20260407a" defer></script>
-<script src="05-api.js?v=20260407a" defer></script>
-<script src="10-ui.js?v=20260407a" defer></script>
+<script src="00-appstate.js?v=20260407b"></script>
+<script src="00-appstate-compat.js?v=20260407b"></script>
+<script src="01-config.js?v=20260407b" defer></script>
+<script src="02-session.js?v=20260407b" defer></script>
+<script src="utils.js?v=20260407b" defer></script>
+<script src="03-auth.js?v=20260407b" defer></script>
+<script src="05-api.js?v=20260407b" defer></script>
+<script src="10-ui.js?v=20260407b" defer></script>
 
-<script src="06-post-create.js?v=20260407a" defer></script>
-<script defer src="render/dashboard.js?v=20260407a"></script>
-<script defer src="render/client.js?v=20260407a"></script>
-<script defer src="render/pipeline.js?v=20260407a"></script>
-<script defer src="render/brief.js?v=20260407a"></script>
-<script defer src="actions/pcs.js?v=20260407a"></script>
-<script src="07-post-load.js?v=20260407a" defer></script>
-<script src="08-post-actions.js?v=20260407a" defer></script>
-<script src="09-library.js?v=20260407a" defer></script>
-<script src="09-approval.js?v=20260407a" defer></script>
-<script src="04-router.js?v=20260407a" defer></script>
+<script src="06-post-create.js?v=20260407b" defer></script>
+<script defer src="render/dashboard.js?v=20260407b"></script>
+<script defer src="render/client.js?v=20260407b"></script>
+<script defer src="render/pipeline.js?v=20260407b"></script>
+<script defer src="render/brief.js?v=20260407b"></script>
+<script defer src="actions/pcs.js?v=20260407b"></script>
+<script src="07-post-load.js?v=20260407b" defer></script>
+<script src="08-post-actions.js?v=20260407b" defer></script>
+<script src="09-library.js?v=20260407b" defer></script>
+<script src="09-approval.js?v=20260407b" defer></script>
+<script src="04-router.js?v=20260407b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/tests/session-resilience.test.js
+++ b/tests/session-resilience.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+var authSrc = readFileSync(resolve(__dirname, '..', '03-auth.js'), 'utf8');
+var apiSrc = readFileSync(resolve(__dirname, '..', '05-api.js'), 'utf8');
+var routerSrc = readFileSync(resolve(__dirname, '..', '04-router.js'), 'utf8');
+var postLoadSrc = readFileSync(resolve(__dirname, '..', '07-post-load.js'), 'utf8');
+var postActionsSrc = readFileSync(resolve(__dirname, '..', '08-post-actions.js'), 'utf8');
+var approvalSrc = readFileSync(resolve(__dirname, '..', '09-approval.js'), 'utf8');
+
+// ── LAYER 1: refreshSession typed errors ────────────────────
+
+describe('LAYER 1 — refreshSession typed error returns', function() {
+
+  it('1. refreshSession returns { error: auth_expired } on 400/401/403', function() {
+    var match = authSrc.match(/async function _doRefresh[\s\S]*?^}/m);
+    expect(match).toBeTruthy();
+    var body = match[0];
+    expect(body).toContain("res.status === 400");
+    expect(body).toContain("res.status === 401");
+    expect(body).toContain("res.status === 403");
+    expect(body).toContain("error: 'auth_expired'");
+  });
+
+  it('2. refreshSession returns { error: server } on non-ok non-auth response', function() {
+    var match = authSrc.match(/async function _doRefresh[\s\S]*?^}/m);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("error: 'server'");
+  });
+
+  it('3. refreshSession returns { error: network } on TypeError', function() {
+    var match = authSrc.match(/async function _doRefresh[\s\S]*?^}/m);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("err.name === 'TypeError'");
+    expect(match[0]).toContain("error: 'network'");
+  });
+
+  it('4. refreshSession returns { token } on success', function() {
+    var match = authSrc.match(/async function _doRefresh[\s\S]*?^}/m);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("token: data.access_token");
+  });
+
+  it('5. refreshSession returns { error: auth_expired } when no refresh token', function() {
+    var match = authSrc.match(/async function refreshSession\(\)[\s\S]{0,300}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("{ error: 'auth_expired' }");
+  });
+
+  it('6. apiFetch handles result.token on 401', function() {
+    expect(apiSrc).toContain('result.token');
+  });
+
+  it('7. apiFetch calls _clearSessionAndLogin on auth_expired', function() {
+    expect(apiSrc).toContain("result.error === 'auth_expired'");
+    expect(apiSrc).toContain('_clearSessionAndLogin');
+  });
+
+  it('8. apiFetch shows soft banner on network error, not session expired', function() {
+    expect(apiSrc).toContain('Connection issue');
+    expect(apiSrc).toContain("result.error");
+  });
+
+  it('9. _startRouter handles typed result from refreshSession', function() {
+    expect(routerSrc).toContain('result.token');
+    expect(routerSrc).toContain("result.error === 'auth_expired'");
+  });
+
+  it('10. client 50-min timer handles auth_expired', function() {
+    var clientTimer = authSrc.match(/_clientTokenTimer[\s\S]{0,400}/);
+    expect(clientTimer).toBeTruthy();
+    expect(clientTimer[0]).toContain("result.error === 'auth_expired'");
+    expect(clientTimer[0]).toContain('_clearSessionAndLogin');
+  });
+
+  it('11. non-client 50-min timer handles auth_expired', function() {
+    var timer = postLoadSrc.match(/tokenRefresh[\s\S]{0,800}50 \* 60/);
+    expect(timer).toBeTruthy();
+    expect(timer[0]).toContain("result.error === 'auth_expired'");
+    expect(timer[0]).toContain('_clearSessionAndLogin');
+  });
+});
+
+// ── LAYER 2: Cross-tab refresh lock ─────────────────────────
+
+describe('LAYER 2 — Cross-tab refresh lock', function() {
+
+  it('12. refreshSession checks _srtd_refresh_lock before refresh', function() {
+    expect(authSrc).toContain('_srtd_refresh_lock');
+    var match = authSrc.match(/async function refreshSession[\s\S]*?_refreshInProgress = _doRefresh/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("localStorage.getItem('_srtd_refresh_lock')");
+  });
+
+  it('13. _doRefresh sets lock before fetch and removes in finally', function() {
+    var match = authSrc.match(/async function _doRefresh[\s\S]*?finally[\s\S]*?\}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("localStorage.setItem('_srtd_refresh_lock'");
+    expect(match[0]).toContain("localStorage.removeItem('_srtd_refresh_lock')");
+  });
+
+  it('14. cross-tab lock polls for new token at 300ms intervals', function() {
+    var match = authSrc.match(/Another tab is refreshing[\s\S]{0,500}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain('300');
+    expect(match[0]).toContain('setInterval');
+  });
+
+  it('15. storage event listener handles token cleared by other tab', function() {
+    expect(authSrc).toContain("addEventListener('storage'");
+    expect(authSrc).toContain("e.key === 'sb_access_token'");
+    expect(authSrc).toContain('!e.newValue');
+    expect(authSrc).toContain('showLoginOverlay');
+  });
+});
+
+// ── LAYER 3: visibilitychange + _authReady ──────────────────
+
+describe('LAYER 3 — visibilitychange with _authReady guard', function() {
+
+  it('16. visibilitychange listener is bound once', function() {
+    expect(authSrc).toContain('_visibilityRefreshBound');
+    expect(authSrc).toContain("addEventListener('visibilitychange'");
+  });
+
+  it('17. visibilitychange checks _authReady before refresh', function() {
+    var match = authSrc.match(/visibilitychange[\s\S]{0,500}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain('_authReady');
+  });
+
+  it('18. visibilitychange only fires when document becomes visible', function() {
+    var match = authSrc.match(/visibilitychange[\s\S]{0,300}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("visibilityState !== 'visible'");
+  });
+
+  it('19. visibilitychange skips if URL has access_token hash', function() {
+    var match = authSrc.match(/visibilitychange[\s\S]{0,500}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain('access_token');
+  });
+
+  it('20. visibilitychange calls _clearSessionAndLogin on auth_expired', function() {
+    var visBlock = authSrc.match(/visibilitychange[\s\S]{0,800}/);
+    expect(visBlock).toBeTruthy();
+    expect(visBlock[0]).toContain("result.error === 'auth_expired'");
+    expect(visBlock[0]).toContain('_clearSessionAndLogin');
+  });
+
+  it('21. _startRouter sets _authReady = true on all exit paths', function() {
+    var paths = routerSrc.match(/_authReady\s*=\s*true/g);
+    // At least 4 exit paths: refresh success, auth_expired, network fallback,
+    // savedToken fallback, showLoginOverlay
+    expect(paths).toBeTruthy();
+    expect(paths.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+// ── BONUS: clientApprove guardAction + payload alignment ────
+
+describe('BONUS — clientApprove guardAction + approval payload', function() {
+
+  it('22. clientApprove is wrapped in guardAction', function() {
+    var match = postActionsSrc.match(/function clientApprove[\s\S]{0,500}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain("window.guardAction('client-approve-'");
+  });
+
+  it('23. submitApproval approved PATCH includes status_changed_at', function() {
+    // Find the 'approved' branch PATCH body
+    var approvedMatch = approvalSrc.match(/type === 'approved'[\s\S]{0,400}/);
+    expect(approvedMatch).toBeTruthy();
+    expect(approvedMatch[0]).toContain('status_changed_at');
+  });
+
+  it('24. submitApproval approved PATCH includes updated_by Client', function() {
+    var approvedMatch = approvalSrc.match(/type === 'approved'[\s\S]{0,400}/);
+    expect(approvedMatch).toBeTruthy();
+    expect(approvedMatch[0]).toContain("updated_by: 'Client'");
+  });
+
+  it('25. _clearSessionAndLogin is exported to window', function() {
+    expect(authSrc).toContain('window._clearSessionAndLogin = _clearSessionAndLogin');
+  });
+});


### PR DESCRIPTION
## Summary
- **LAYER 1 — Typed error returns**: `refreshSession()` now returns `{ token }` on success, `{ error: 'auth_expired' }` on HTTP 400/401/403, `{ error: 'server' }` on 5xx, `{ error: 'network' }` on TypeError. All 5 callers updated. **Never clears tokens on network error** — only on genuine auth expiry.
- **LAYER 2 — Cross-tab refresh lock**: localStorage `_srtd_refresh_lock` prevents two tabs from sending simultaneous refresh requests (which triggers Supabase token reuse revocation). Storage event listener syncs logout across tabs.
- **LAYER 3 — visibilitychange listener**: Fires `refreshSession()` when tab regains focus after backgrounding (iOS Safari, Android Chrome). Guarded by `_authReady` flag set at end of `_startRouter()`. Covers the "client opens app after hours" case that setInterval cannot.
- **BONUS — clientApprove guardAction**: Wrapped in `guardAction` to prevent double-tap. `submitApproval` PATCH payload aligned with `clientApprove` (added `status_changed_at` + `updated_by`).

## Files changed
| File | What changed |
|------|-------------|
| 03-auth.js | LAYER 1: `refreshSession()` rewritten with typed errors + `_doRefresh()` extracted. LAYER 2: cross-tab lock + storage listener. LAYER 3: visibilitychange listener. New `_clearSessionAndLogin()` helper. Client 50-min timer updated. |
| 05-api.js | `apiFetch` 401 handler branches on `result.error` type — `auth_expired` → clear+login, `network` → soft banner |
| 04-router.js | `_startRouter` handles typed result, sets `window._authReady = true` on all exit paths |
| 07-post-load.js | Non-client 50-min timer handles `auth_expired` → `_clearSessionAndLogin()` |
| 08-post-actions.js | `clientApprove` wrapped in `guardAction('client-approve-' + postId)` |
| 09-approval.js | `submitApproval` approved PATCH adds `status_changed_at` + `updated_by: 'Client'` |
| index.html | Version bump `?v=20260407a` → `?v=20260407b` (20/20) |
| CLAUDE.md | Version, test count, test file list, global functions, 2 bug entries updated |
| tests/session-resilience.test.js | NEW — 25 tests covering all 3 layers + bonus fix |

## Test plan
- [x] Full vitest suite: **479/479 passing** (was 454, +25 new)
- [x] 19 test files (was 18, +1 new: session-resilience.test.js)
- [x] Exactly 20 version strings bumped to `?v=20260407b`
- [ ] Manual: Cloudflare cache purge after merge
- [ ] Manual: Hard refresh all devices before testing
- [ ] Manual: Test with 2 tabs open — verify no token revocation on simultaneous 401
- [ ] Manual: Background app on iPhone for 2+ hours, reopen — verify silent refresh
- [ ] Manual: Set Supabase Dashboard → Auth → Settings refresh token lifetime to maximum

https://claude.ai/code/session_011LnsQWvEgoWZcNrK38QM3r