### PR TITLE
fix: new post form — add drive_link, fix format, replace rgba

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -162,7 +162,7 @@ const hasDraft = loadDraft();
 
 if (!hasDraft) {
 
-['new-post-title','new-post-link'].forEach(id => {
+['new-post-title','new-post-link','new-post-drive-link'].forEach(id => {
 const el = document.getElementById(id);
 if (el) el.value = '';
 });
@@ -262,6 +262,9 @@ const createBtn = _s('nps-create-btn');
 
 if (createBtn) createBtn.disabled = true;
 
+var formatVal = (_s('new-post-format')?.value || '').trim() || null;
+var driveLinkVal = (_s('new-post-drive-link')?.value || '').trim() || null;
+
 const payload = {
 post_id: 'POST-' + Date.now(),
 title,
@@ -270,6 +273,8 @@ content_pillar: sanitizePillar(pillar) || null,
 location: location || null,
 stage: 'in_production',
 target_date: date || null,
+format: formatVal,
+drive_link: driveLinkVal,
 };
 if (captionVal) payload.caption = captionVal;
 // Defensive: remove any invalid field names that must never reach DB

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260407b
+Version format: ?v=YYYYMMDDx. Current: ?v=20260407c
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -316,8 +316,8 @@ Post-deploy smoke (.github/workflows/smoke.yml):
   than failing the whole suite.
 
 Current (verified 2026-04-06):
-Unit test files: 19
-Unit tests:      479 passing, 0 failing
+Unit test files: 20
+Unit tests:      487 passing, 0 failing
 E2E specs:       9
 
 Files:
@@ -340,6 +340,7 @@ tests/guard-handlers.test.js
 tests/critical-handlers.test.js
 tests/defensive-guards.test.js
 tests/session-resilience.test.js
+tests/post-create.test.js
 
 E2E: tests/e2e/admin-flows.spec.js, client-feed.spec.js, client-flows.spec.js, live-smoke.spec.js, live-smoke-schedule.spec.js, notif-panel.spec.js, pcs.spec.js, role-flows.spec.js, smoke.spec.js
 pcs.spec.js updated for post-redesign selectors: TEST 1 activates Client tab before asserting #pcs-comments-list; TEST 3 activates Client tab before asserting #pcs-comment-input + #pcs-send-btn-client; TEST 4 now asserts the #pcs-stage-pill label (advance button removed); TEST 5 targets #pcs-photo-grid-wrap img and the route handler stubs picsum.photos with a 1×1 PNG; TEST 7 targets #pcs-stage-pill dropdown; TEST 8 invokes window.pcsConfirmDelete() via page.evaluate.
@@ -412,7 +413,7 @@ Pages branch:   main-/-root
 1. 15-second poll interval, 50-minute token refresh
 1. Client DB role takes absolute priority over pcs_role_preview
 1. Silent .catch(function(){}) is a bug — always use window.logError
-1. Vitest must pass 479/479 before every push
+1. Vitest must pass 487/487 before every push
 1. Posts get _commentCount (int) and _clientCommentAt (ISO string or null)
    after loadPosts() — these are runtime-enriched fields, not DB columns
 1. Requests from requests table get _isRequest:true flag after loadPosts().
@@ -1308,6 +1309,14 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    hand-rolled. The root cause was: refreshSession returned null
    for all failures, no visibilitychange handler, no cross-tab
    lock. All three gaps now closed.
+1. New post form: format field never sent to DB, drive_link field
+   missing entirely, 17 rgba violations in NPS CSS block
+   Location: 06-post-create.js submitNewPost() payload, index.html
+   new-post-overlay, styles.css NPS block (L4880-5111)
+   Status: FIXED (PR#TBD) — format added to payload, drive_link
+   field added to form HTML + payload + draft clear, all 17 rgba
+   replaced with solid hex in NPS CSS + 1 in HTML. 487/487 unit
+   passing. Bumped to ?v=20260407c.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260407b">
+ <link rel="stylesheet" href="styles.css?v=20260407c">
 
 </head>
 <body>
@@ -589,7 +589,7 @@
     monospace;font-size:7px;letter-spacing:0.12em;
     text-transform:uppercase;color:#F6A623;
     background:transparent;
-    border:1px dashed rgba(246,166,35,0.25);
+    border:1px dashed #3d2e0a;
     padding:11px 0;text-align:center;
     cursor:pointer;width:100%;margin-top:4px;">
     + Upload Photos
@@ -598,6 +598,26 @@
     font-size:6px;color:#2a2a2a;letter-spacing:0.06em;
     text-align:center;margin-top:4px;">
     JPG / PNG -- original quality stored in Supabase
+  </div>
+</div>
+
+<div class="nps-full">
+  <div class="nps-label">Drive Link
+    <span style="color:#2a2a2a;font-size:6px;
+    letter-spacing:0.06em;text-transform:none;">
+    (optional)</span>
+  </div>
+  <div style="font-family:'IBM Plex Mono',monospace;
+    font-size:6px;color:#555;letter-spacing:0.06em;
+    text-transform:uppercase;margin-bottom:4px;">
+    OPTIONAL &middot; FOR VIDEO, CAROUSEL DECK, PDF OR RAW ASSETS
+  </div>
+  <input type="url" id="new-post-drive-link" class="nps-select"
+    placeholder="Google Drive, Dropbox, WeTransfer...">
+  <div style="font-family:'IBM Plex Mono',monospace;
+    font-size:6px;color:#3ECF8E;letter-spacing:0.06em;
+    text-transform:uppercase;margin-top:4px;">
+    PASTE ANY LINK -- WE'LL ACCESS IT
   </div>
 </div>
 
@@ -1064,26 +1084,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260407b"></script>
-<script src="00-appstate-compat.js?v=20260407b"></script>
-<script src="01-config.js?v=20260407b" defer></script>
-<script src="02-session.js?v=20260407b" defer></script>
-<script src="utils.js?v=20260407b" defer></script>
-<script src="03-auth.js?v=20260407b" defer></script>
-<script src="05-api.js?v=20260407b" defer></script>
-<script src="10-ui.js?v=20260407b" defer></script>
+<script src="00-appstate.js?v=20260407c"></script>
+<script src="00-appstate-compat.js?v=20260407c"></script>
+<script src="01-config.js?v=20260407c" defer></script>
+<script src="02-session.js?v=20260407c" defer></script>
+<script src="utils.js?v=20260407c" defer></script>
+<script src="03-auth.js?v=20260407c" defer></script>
+<script src="05-api.js?v=20260407c" defer></script>
+<script src="10-ui.js?v=20260407c" defer></script>
 
-<script src="06-post-create.js?v=20260407b" defer></script>
-<script defer src="render/dashboard.js?v=20260407b"></script>
-<script defer src="render/client.js?v=20260407b"></script>
-<script defer src="render/pipeline.js?v=20260407b"></script>
-<script defer src="render/brief.js?v=20260407b"></script>
-<script defer src="actions/pcs.js?v=20260407b"></script>
-<script src="07-post-load.js?v=20260407b" defer></script>
-<script src="08-post-actions.js?v=20260407b" defer></script>
-<script src="09-library.js?v=20260407b" defer></script>
-<script src="09-approval.js?v=20260407b" defer></script>
-<script src="04-router.js?v=20260407b" defer></script>
+<script src="06-post-create.js?v=20260407c" defer></script>
+<script defer src="render/dashboard.js?v=20260407c"></script>
+<script defer src="render/client.js?v=20260407c"></script>
+<script defer src="render/pipeline.js?v=20260407c"></script>
+<script defer src="render/brief.js?v=20260407c"></script>
+<script defer src="actions/pcs.js?v=20260407c"></script>
+<script src="07-post-load.js?v=20260407c" defer></script>
+<script src="08-post-actions.js?v=20260407c" defer></script>
+<script src="09-library.js?v=20260407c" defer></script>
+<script src="09-approval.js?v=20260407c" defer></script>
+<script src="04-router.js?v=20260407c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4891,7 +4891,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   align-items: center;
   justify-content: space-between;
   padding: 14px 18px;
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+  border-bottom: 1px solid #191919;
   flex-shrink: 0;
 }
 .nps-title {
@@ -4900,7 +4900,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   color:var(--text2);
 }
 .nps-close {
-  width:28px; height:28px; border:1px dotted var(--dotline);
+  width:28px; height:28px; border:1px dotted #1a1a1a;
   background:transparent; color:var(--muted); font-size:13px;
   cursor:pointer; display:flex; align-items:center;
   justify-content:center; font-family:var(--mono);
@@ -4916,7 +4916,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 .nps-body::-webkit-scrollbar { display: none; }
 .nps-title-field {
   padding: 10px 18px;
-  border-bottom: 1px dashed rgba(255,255,255,0.07);
+  border-bottom: 1px dashed #191919;
 }
 .nps-req { color:var(--red); }
 .nps-label {
@@ -4938,7 +4938,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   width: 100%;
   background: transparent;
   border: none;
-  border-bottom: 1px solid rgba(255,255,255,0.1);
+  border-bottom: 1px solid #1a1a1a;
   color: var(--text1, #e8e2d9);
   font-family: var(--sans);
   font-size: 17px;
@@ -4950,7 +4950,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 }
 .nps-title-input::placeholder { color: #2a2a2a; }
 .nps-title-input:focus {
-  border-bottom-color: rgba(200,168,75,0.4);
+  border-bottom-color: #5a4a1a;
 }
 .nps-grid {
   display: grid;
@@ -4958,8 +4958,8 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 }
 .nps-cell {
   padding: 10px 18px;
-  border-bottom: 1px dashed rgba(255,255,255,0.07);
-  border-right: 1px dashed rgba(255,255,255,0.07);
+  border-bottom: 1px dashed #191919;
+  border-right: 1px dashed #191919;
 }
 .nps-cell:nth-child(even) {
   border-right: none;
@@ -4970,7 +4970,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: #9b87f5;
-  border: 1px solid rgba(155,135,245,0.25);
+  border: 1px solid #302a4a;
   padding: 4px 10px;
   display: inline-block;
   margin-top: 4px;
@@ -4979,7 +4979,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   width: 100%;
   background: transparent;
   border: none;
-  border-bottom: 1px solid rgba(255,255,255,0.1);
+  border-bottom: 1px solid #1a1a1a;
   color: var(--text1, #e8e2d9);
   font-family: var(--mono);
   font-size: 11px;
@@ -5000,7 +5000,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   background-image: none;
   background-position: unset;
   border: none;
-  border-bottom: 1px solid rgba(255,255,255,0.1);
+  border-bottom: 1px solid #1a1a1a;
   color: var(--text1);
   font-family: var(--mono);
   font-size: 11px;
@@ -5012,12 +5012,12 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 }
 .nps-full {
   padding: 10px 18px;
-  border-bottom: 1px dashed rgba(255,255,255,0.07);
+  border-bottom: 1px dashed #191919;
 }
 .nps-textarea {
   width: 100%;
-  background: rgba(255,255,255,0.02);
-  border: 1px solid rgba(255,255,255,0.07);
+  background: #0d0d0d;
+  border: 1px solid #191919;
   color: var(--text1, #e8e2d9);
   font-family: var(--sans);
   font-size: 13px;
@@ -5029,14 +5029,14 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   border-radius: 0;
   box-shadow: none;
 }
-.nps-textarea:focus { border-color: rgba(246,166,35,0.25); }
+.nps-textarea:focus { border-color: #3d2e0a; }
 .nps-textarea::placeholder { color: #2a2a2a; }
 .nps-caption-area {
   overflow: hidden;
   height: auto;
   min-height: 120px;
   resize: none;
-  border-color: rgba(246,166,35,0.15);
+  border-color: #2a1f05;
 }
 .nps-notes-area {
   min-height: 52px;
@@ -5049,7 +5049,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   text-transform: uppercase;
   color: #F6A623;
   background: transparent;
-  border: 1px dashed rgba(246,166,35,0.25);
+  border: 1px dashed #3d2e0a;
   padding: 11px 0;
   text-align: center;
   cursor: pointer;
@@ -5069,7 +5069,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   display: flex;
   gap: 10px;
   padding: 12px 18px 16px;
-  border-top: 1px solid rgba(255,255,255,0.07);
+  border-top: 1px solid #191919;
   background: #0a0a0f;
 }
 .nps-btn-cancel {
@@ -5079,7 +5079,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   text-transform: uppercase;
   color: #555;
   background: transparent;
-  border: 1px solid rgba(255,255,255,0.07);
+  border: 1px solid #191919;
   padding: 13px 16px;
   cursor: pointer;
   border-radius: 0;
@@ -5092,7 +5092,7 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   letter-spacing: 0.2em;
   text-transform: uppercase;
   background: transparent;
-  border: 1px solid rgba(255,255,255,0.07);
+  border: 1px solid #191919;
   padding: 13px 0;
   cursor: pointer;
   color: #333;
@@ -5101,12 +5101,12 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 }
 .nps-btn-create:not(:disabled) {
   color: #3ECF8E;
-  background: rgba(62,207,142,0.08);
-  border-color: rgba(62,207,142,0.35);
+  background: #0a1f14;
+  border-color: #1a5c36;
 }
 .nps-btn-create:disabled {
   color: #333;
-  border-color: rgba(255,255,255,0.06);
+  border-color: #0f0f0f;
   cursor: not-allowed;
 }
 /* ===============================================

--- a/tests/post-create.test.js
+++ b/tests/post-create.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+var src = readFileSync(resolve(__dirname, '..', '06-post-create.js'), 'utf8');
+var htmlSrc = readFileSync(resolve(__dirname, '..', 'index.html'), 'utf8');
+
+describe('New Post Form — payload fields', function() {
+
+  it('1. drive_link is read from #new-post-drive-link and included in payload', function() {
+    expect(src).toContain("'new-post-drive-link'");
+    expect(src).toContain('drive_link:');
+  });
+
+  it('2. drive_link is null when input is empty (not empty string)', function() {
+    // The pattern: .trim() || null ensures null on empty
+    var match = src.match(/driveLinkVal\s*=[\s\S]{0,100}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain('|| null');
+  });
+
+  it('3. format is read from #new-post-format and included in payload', function() {
+    expect(src).toContain("'new-post-format'");
+    var payloadMatch = src.match(/const payload[\s\S]{0,500}/);
+    expect(payloadMatch).toBeTruthy();
+    expect(payloadMatch[0]).toContain('format:');
+  });
+
+  it('4. format is null when not selected (not empty string)', function() {
+    var match = src.match(/formatVal\s*=[\s\S]{0,100}/);
+    expect(match).toBeTruthy();
+    expect(match[0]).toContain('|| null');
+  });
+
+  it('5. new-post-drive-link input exists in HTML', function() {
+    expect(htmlSrc).toContain('id="new-post-drive-link"');
+  });
+
+  it('6. drive_link input is cleared on form open when no draft', function() {
+    expect(src).toContain("'new-post-drive-link'");
+    // It should be in the array that gets cleared
+    var clearMatch = src.match(/\['new-post-title'[^\]]*\]/);
+    expect(clearMatch).toBeTruthy();
+    expect(clearMatch[0]).toContain('new-post-drive-link');
+  });
+});
+
+describe('New Post Form — NPS rgba violations removed', function() {
+
+  var cssSrc = readFileSync(resolve(__dirname, '..', 'styles.css'), 'utf8');
+  // Extract only the NPS block
+  var npsStart = cssSrc.indexOf('/* -- New Post Sheet (NPS)');
+  var npsEnd = cssSrc.indexOf('/* =', npsStart + 1);
+  var npsBlock = cssSrc.slice(npsStart, npsEnd > 0 ? npsEnd : npsStart + 5000);
+
+  it('7. no rgba() in NPS CSS block', function() {
+    var rgbaMatches = npsBlock.match(/rgba\(/g);
+    expect(rgbaMatches).toBeNull();
+  });
+
+  it('8. upload photos dashed border in HTML uses solid hex', function() {
+    var uploadMatch = htmlSrc.match(/new-post-asset[\s\S]{0,300}dashed/);
+    expect(uploadMatch).toBeTruthy();
+    expect(uploadMatch[0]).not.toContain('rgba');
+  });
+});


### PR DESCRIPTION
## Summary
- **FIX 1 — Drive link field**: Added `drive_link` URL input to new post form between Post Photos and Brief/Internal Notes. Uses existing `nps-full`/`nps-label`/`nps-select` classes. Green helper text matches client request form.
- **FIX 2 — drive_link in payload**: `submitNewPost()` now reads `#new-post-drive-link` and sends `drive_link` to DB. Sends `null` when empty. Field cleared on form open.
- **FIX 3 — format field fix**: `format` was never included in submit payload despite the `<select>` existing in HTML. Now included. Sends `null` when not selected.
- **FIX 4 — rgba cleanup**: Replaced all 17 `rgba()` values in NPS CSS block + 1 in index.html with solid hex equivalents. Zero rgba remains in new post form styles.

## Files changed
| File | What changed |
|------|-------------|
| index.html | Drive link field added, upload border rgba→hex, version bump `?v=20260407b` → `?v=20260407c` (20/20) |
| 06-post-create.js | `format` + `drive_link` added to payload, drive_link cleared on form open |
| styles.css | All 17 rgba in NPS block replaced with solid hex |
| CLAUDE.md | Version, test count, test file list, bug entry updated |
| tests/post-create.test.js | NEW — 8 tests covering payload fields + rgba removal |

## Test plan
- [x] Full vitest suite: **487/487 passing** (was 479, +8 new)
- [x] 20 test files (was 19, +1 new: post-create.test.js)
- [x] 20/20 version strings bumped to `?v=20260407c`
- [x] Zero rgba in NPS CSS block
- [ ] Manual: Cloudflare cache purge after merge
- [ ] Manual: Hard refresh all devices before testing

https://claude.ai/code/session_011LnsQWvEgoWZcNrK38QM3r