### PR TITLE
feat: add ?open=POST_ID deep-link for email notifications

### DIFF
--- a/04-router.js
+++ b/04-router.js
@@ -17,6 +17,9 @@ async function _startRouter() {
     showApprovalView(ref.replace(/-hinglish$/i, '')); return;
   }
 
+  const openPost = params.get('open');
+  if (openPost) window._pendingOpenPost = openPost;
+
   const hash = window.location.hash;
   if (hash && hash.includes('access_token=')) {
     const hashParams = new URLSearchParams(hash.slice(1));

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -620,6 +620,13 @@ function renderAll() {
   const _libDefault = ['scheduled','published'];
   const libCount = window.AppState.posts.all.filter(p => _libDefault.includes(p.stage || '')).length;
   if (ll) ll.textContent = `${libCount} posts`;
+
+  // Deep-link: open PCS for ?open=POST_ID after posts load
+  if (window._pendingOpenPost && window.AppState.posts.loaded) {
+    var _pid = window._pendingOpenPost;
+    window._pendingOpenPost = null;
+    if (typeof openPCS === 'function') openPCS(_pid);
+  }
 }
 
 function updateStats() {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260407d
+Version format: ?v=YYYYMMDDx. Current: ?v=20260407e
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -316,8 +316,8 @@ Post-deploy smoke (.github/workflows/smoke.yml):
   than failing the whole suite.
 
 Current (verified 2026-04-06):
-Unit test files: 20
-Unit tests:      492 passing, 0 failing
+Unit test files: 21
+Unit tests:      500 passing, 0 failing
 E2E specs:       9
 
 Files:
@@ -341,6 +341,7 @@ tests/critical-handlers.test.js
 tests/defensive-guards.test.js
 tests/session-resilience.test.js
 tests/post-create.test.js
+tests/deeplink.test.js
 
 E2E: tests/e2e/admin-flows.spec.js, client-feed.spec.js, client-flows.spec.js, live-smoke.spec.js, live-smoke-schedule.spec.js, notif-panel.spec.js, pcs.spec.js, role-flows.spec.js, smoke.spec.js
 pcs.spec.js updated for post-redesign selectors: TEST 1 activates Client tab before asserting #pcs-comments-list; TEST 3 activates Client tab before asserting #pcs-comment-input + #pcs-send-btn-client; TEST 4 now asserts the #pcs-stage-pill label (advance button removed); TEST 5 targets #pcs-photo-grid-wrap img and the route handler stubs picsum.photos with a 1×1 PNG; TEST 7 targets #pcs-stage-pill dropdown; TEST 8 invokes window.pcsConfirmDelete() via page.evaluate.
@@ -357,6 +358,7 @@ TEST FILE MAPPING (run targeted tests during development):
   03-auth.js            → npx vitest run tests/role.test.js
   10-ui.js              → npx vitest run tests/notifications.test.js tests/notif-render.test.js
   utils.js              → npx vitest run tests/utils.test.js
+  04-router.js + 07-post-load.js (deep-link) → npx vitest run tests/deeplink.test.js
   Full suite before push: npx vitest run
 
 AppState mock pattern for new test files:
@@ -390,6 +392,12 @@ WhatsApp preview: generated at post creation time (06-post-create.js, render/bri
                   Zero Supabase egress for previews — Worker + KV only
 Resend FROM:    hinglish@srtd.io
 Short URLs:     srtd.io/p/XXXX via Cloudflare Page Rule
+Deep-link:      srtd.io/?open=POST_ID — logs in then opens PCS for that post
+                04-router.js stores in window._pendingOpenPost, renderAll()
+                in 07-post-load.js fires openPCS after posts load + clears flag.
+                Edge functions (notify-comment, notify-stage, notify-request) in
+                Supabase should use https://srtd.io/?open=${postId} for "View Post"
+                button URLs. Edge functions live in Supabase only — not in this repo.
 PREVIEW_SECRET: srtd2026xK9mN3pQ
 Pages branch:   main-/-root
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260407d">
+ <link rel="stylesheet" href="styles.css?v=20260407e">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260407d"></script>
-<script src="00-appstate-compat.js?v=20260407d"></script>
-<script src="01-config.js?v=20260407d" defer></script>
-<script src="02-session.js?v=20260407d" defer></script>
-<script src="utils.js?v=20260407d" defer></script>
-<script src="03-auth.js?v=20260407d" defer></script>
-<script src="05-api.js?v=20260407d" defer></script>
-<script src="10-ui.js?v=20260407d" defer></script>
+<script src="00-appstate.js?v=20260407e"></script>
+<script src="00-appstate-compat.js?v=20260407e"></script>
+<script src="01-config.js?v=20260407e" defer></script>
+<script src="02-session.js?v=20260407e" defer></script>
+<script src="utils.js?v=20260407e" defer></script>
+<script src="03-auth.js?v=20260407e" defer></script>
+<script src="05-api.js?v=20260407e" defer></script>
+<script src="10-ui.js?v=20260407e" defer></script>
 
-<script src="06-post-create.js?v=20260407d" defer></script>
-<script defer src="render/dashboard.js?v=20260407d"></script>
-<script defer src="render/client.js?v=20260407d"></script>
-<script defer src="render/pipeline.js?v=20260407d"></script>
-<script defer src="render/brief.js?v=20260407d"></script>
-<script defer src="actions/pcs.js?v=20260407d"></script>
-<script src="07-post-load.js?v=20260407d" defer></script>
-<script src="08-post-actions.js?v=20260407d" defer></script>
-<script src="09-library.js?v=20260407d" defer></script>
-<script src="09-approval.js?v=20260407d" defer></script>
-<script src="04-router.js?v=20260407d" defer></script>
+<script src="06-post-create.js?v=20260407e" defer></script>
+<script defer src="render/dashboard.js?v=20260407e"></script>
+<script defer src="render/client.js?v=20260407e"></script>
+<script defer src="render/pipeline.js?v=20260407e"></script>
+<script defer src="render/brief.js?v=20260407e"></script>
+<script defer src="actions/pcs.js?v=20260407e"></script>
+<script src="07-post-load.js?v=20260407e" defer></script>
+<script src="08-post-actions.js?v=20260407e" defer></script>
+<script src="09-library.js?v=20260407e" defer></script>
+<script src="09-approval.js?v=20260407e" defer></script>
+<script src="04-router.js?v=20260407e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/tests/deeplink.test.js
+++ b/tests/deeplink.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+var routerSrc = readFileSync(resolve(__dirname, '..', '04-router.js'), 'utf8');
+var postLoadSrc = readFileSync(resolve(__dirname, '..', '07-post-load.js'), 'utf8');
+
+describe('Deep-link ?open=POST_ID', function() {
+
+  it('1. router reads open param from URLSearchParams', function() {
+    expect(routerSrc).toContain("params.get('open')");
+  });
+
+  it('2. router sets window._pendingOpenPost when open param present', function() {
+    expect(routerSrc).toContain('window._pendingOpenPost = openPost');
+  });
+
+  it('3. open param check occurs after approval checks but before hash check', function() {
+    var approveIdx = routerSrc.indexOf("params.get('approve')");
+    var openIdx = routerSrc.indexOf("params.get('open')");
+    var hashIdx = routerSrc.indexOf('window.location.hash');
+    expect(approveIdx).toBeGreaterThan(-1);
+    expect(openIdx).toBeGreaterThan(approveIdx);
+    expect(hashIdx).toBeGreaterThan(openIdx);
+  });
+
+  it('4. open param does NOT return early — auth flow continues', function() {
+    // The open block should set the flag but not return
+    var openLine = routerSrc.indexOf("window._pendingOpenPost = openPost");
+    expect(openLine).toBeGreaterThan(-1);
+    // Get the next 60 chars after the assignment — should not contain 'return'
+    var after = routerSrc.substring(openLine, openLine + 80);
+    // The line ends with semicolon, next meaningful code should be hash check
+    expect(after).not.toMatch(/return\s*;/);
+  });
+
+  it('5. renderAll checks _pendingOpenPost after posts loaded', function() {
+    expect(postLoadSrc).toContain('window._pendingOpenPost');
+    expect(postLoadSrc).toContain('window.AppState.posts.loaded');
+  });
+
+  it('6. renderAll clears _pendingOpenPost before calling openPCS', function() {
+    var clearIdx = postLoadSrc.indexOf('window._pendingOpenPost = null');
+    var openIdx = postLoadSrc.indexOf("openPCS(_pid)");
+    expect(clearIdx).toBeGreaterThan(-1);
+    expect(openIdx).toBeGreaterThan(clearIdx);
+  });
+
+  it('7. renderAll calls openPCS with the stored post ID', function() {
+    // The pattern: save _pid, clear flag, call openPCS(_pid)
+    var match = postLoadSrc.match(/var _pid = window\._pendingOpenPost;\s*window\._pendingOpenPost = null;\s*if \(typeof openPCS === 'function'\) openPCS\(_pid\)/);
+    expect(match).toBeTruthy();
+  });
+
+  it('8. deep-link block is inside renderAll function', function() {
+    var renderAllStart = postLoadSrc.indexOf('function renderAll()');
+    var pendingCheck = postLoadSrc.indexOf('window._pendingOpenPost && window.AppState.posts.loaded');
+    var nextFnStart = postLoadSrc.indexOf('function updateStats()');
+    expect(renderAllStart).toBeGreaterThan(-1);
+    expect(pendingCheck).toBeGreaterThan(renderAllStart);
+    expect(pendingCheck).toBeLessThan(nextFnStart);
+  });
+});


### PR DESCRIPTION
## Summary
- **`04-router.js`**: reads `?open=` URL param, stores in `window._pendingOpenPost` — does NOT return early, auth flow continues normally
- **`07-post-load.js`**: `renderAll()` checks `_pendingOpenPost` after `posts.loaded` is true, calls `openPCS(_pid)`, then clears the flag
- **`index.html`**: version bump `?v=20260407d` → `?v=20260407e` (all 20 resources)
- **`CLAUDE.md`**: documented deep-link URL format, edge function note, test file added, test count 492→500, version updated
- **Edge functions** (notify-comment, notify-stage, notify-request) in Supabase should use `https://srtd.io/?open=${postId}` for "View Post" button URLs — these live in Supabase only, Shubham will update manually

## Files changed
| File | Change |
|------|--------|
| `04-router.js` | Added `params.get('open')` → `window._pendingOpenPost` (2 lines) |
| `07-post-load.js` | Added pending open check at end of `renderAll()` (5 lines) |
| `index.html` | Version bump ?v=20260407e (20 resources) |
| `tests/deeplink.test.js` | **NEW** — 8 tests covering param read, flag set, openPCS call, clear sequence |
| `CLAUDE.md` | Deep-link docs, test file, test count, version |

## Test plan
- [x] 500/500 unit tests passing (8 new in deeplink.test.js)
- [ ] Visit `srtd.io/?open=KNOWN_POST_ID` while logged in → PCS opens for that post
- [ ] Visit `srtd.io/?open=KNOWN_POST_ID` while logged out → login screen → after login PCS opens
- [ ] Visit `srtd.io` with no params → normal dashboard, no PCS auto-open
- [ ] Visit `srtd.io/?open=INVALID_ID` → PCS opens with "post not found" state
- [ ] Purge Cloudflare cache after merge

https://claude.ai/code/session_01MYQqLiP3dr94GmmnRxJpMR