### PR TITLE
fix: remove updated_at from requests PATCH in assign brief

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1318,6 +1318,12 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    field added to form HTML + payload + draft clear, all 17 rgba
    replaced with solid hex in NPS CSS + 1 in HTML. 487/487 unit
    passing. Bumped to ?v=20260407c.
+1. Assign brief PATCH sends updated_at to requests table
+   Location: render/brief.js line 367 — _assignBriefToPranav()
+   PATCH to /requests included updated_at which does not exist
+   on the requests table. PostgREST rejected with PGRST204.
+   Status: FIXED (PR#TBD) — removed updated_at from the PATCH
+   payload. Only { status: 'assigned' } is sent now.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -364,7 +364,7 @@ window._assignBriefToPranav = function(postId) {
     // 1. PATCH request status to assigned
     apiFetch('/requests?id=eq.' + encodeURIComponent(postId), {
       method: 'PATCH',
-      body: JSON.stringify({ status: 'assigned', updated_at: nowISO })
+      body: JSON.stringify({ status: 'assigned' })
     }).then(function() {
       // 2. Create new post linked to this request
       return apiFetch('/posts', {


### PR DESCRIPTION
## Summary
One line fix. `_assignBriefToPranav()` was PATCHing `/requests` with `{ status: 'assigned', updated_at: nowISO }` but the `requests` table has no `updated_at` column. PostgREST rejected with PGRST204. Removed `updated_at` from the payload.

## Files changed
| File | What changed |
|------|-------------|
| render/brief.js | Line 367: removed `updated_at: nowISO` from requests PATCH payload |
| CLAUDE.md | Bug entry added |

## Test plan
- [x] Full vitest suite: **492/492 passing**
- No version bump needed (JS-only fix, no index.html change)

https://claude.ai/code/session_011LnsQWvEgoWZcNrK38QM3r