### PR TITLE
fix: PCS chip dropdown closes immediately on iOS — defer activeMenu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260407e
+Version format: ?v=YYYYMMDDx. Current: ?v=20260407f
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1332,6 +1332,16 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    on the requests table. PostgREST rejected with PGRST204.
    Status: FIXED (PR#TBD) — removed updated_at from the PATCH
    payload. Only { status: 'assigned' } is sent now.
+1. PCS chip dropdown closes immediately on iOS Safari
+   Location: actions/pcs.js lines 532 and 596 — _pcsChipDrop()
+   set window.AppState.pcs.activeMenu synchronously. The
+   document-level click listener (line 26) saw activeMenu as
+   non-null in the same tick and closed it because the chip
+   button is not inside the dropdown.
+   Status: FIXED (PR#TBD) — wrapped both activeMenu assignments
+   in setTimeout(0) so activeMenu is set after the click event
+   finishes bubbling. 508/508 unit passing.
+   Bumped to ?v=20260407f.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260407f
+Version format: ?v=YYYYMMDDx. Current: ?v=20260407g
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -529,7 +529,7 @@ window._pcsChipDrop = function(chipEl, field, postId) {
       'style="width:100%;padding:10px 12px;background:#0f0f1a;border:1px solid #1c1c26;color:#fff;font-size:14px;outline:none;color-scheme:dark;font-family:inherit" ' +
       'onchange="window._pcsDateChange(\'' + esc(postId) + '\',this.value)"/></div>';
     document.body.appendChild(drop);
-    window.AppState.pcs.activeMenu = drop;
+    setTimeout(function() { window.AppState.pcs.activeMenu = drop; }, 0);
     var dateInp = drop.querySelector('input');
     if (dateInp) dateInp.focus();
     return;
@@ -593,7 +593,7 @@ window._pcsChipDrop = function(chipEl, field, postId) {
   });
 
   document.body.appendChild(drop);
-  window.AppState.pcs.activeMenu = drop;
+  setTimeout(function() { window.AppState.pcs.activeMenu = drop; }, 0);
 }
 
 // -- Date change from inline date picker --

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260407e">
+ <link rel="stylesheet" href="styles.css?v=20260407f">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260407e"></script>
-<script src="00-appstate-compat.js?v=20260407e"></script>
-<script src="01-config.js?v=20260407e" defer></script>
-<script src="02-session.js?v=20260407e" defer></script>
-<script src="utils.js?v=20260407e" defer></script>
-<script src="03-auth.js?v=20260407e" defer></script>
-<script src="05-api.js?v=20260407e" defer></script>
-<script src="10-ui.js?v=20260407e" defer></script>
+<script src="00-appstate.js?v=20260407f"></script>
+<script src="00-appstate-compat.js?v=20260407f"></script>
+<script src="01-config.js?v=20260407f" defer></script>
+<script src="02-session.js?v=20260407f" defer></script>
+<script src="utils.js?v=20260407f" defer></script>
+<script src="03-auth.js?v=20260407f" defer></script>
+<script src="05-api.js?v=20260407f" defer></script>
+<script src="10-ui.js?v=20260407f" defer></script>
 
-<script src="06-post-create.js?v=20260407e" defer></script>
-<script defer src="render/dashboard.js?v=20260407e"></script>
-<script defer src="render/client.js?v=20260407e"></script>
-<script defer src="render/pipeline.js?v=20260407e"></script>
-<script defer src="render/brief.js?v=20260407e"></script>
-<script defer src="actions/pcs.js?v=20260407e"></script>
-<script src="07-post-load.js?v=20260407e" defer></script>
-<script src="08-post-actions.js?v=20260407e" defer></script>
-<script src="09-library.js?v=20260407e" defer></script>
-<script src="09-approval.js?v=20260407e" defer></script>
-<script src="04-router.js?v=20260407e" defer></script>
+<script src="06-post-create.js?v=20260407f" defer></script>
+<script defer src="render/dashboard.js?v=20260407f"></script>
+<script defer src="render/client.js?v=20260407f"></script>
+<script defer src="render/pipeline.js?v=20260407f"></script>
+<script defer src="render/brief.js?v=20260407f"></script>
+<script defer src="actions/pcs.js?v=20260407f"></script>
+<script src="07-post-load.js?v=20260407f" defer></script>
+<script src="08-post-actions.js?v=20260407f" defer></script>
+<script src="09-library.js?v=20260407f" defer></script>
+<script src="09-approval.js?v=20260407f" defer></script>
+<script src="04-router.js?v=20260407f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260407f">
+ <link rel="stylesheet" href="styles.css?v=20260407g">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260407f"></script>
-<script src="00-appstate-compat.js?v=20260407f"></script>
-<script src="01-config.js?v=20260407f" defer></script>
-<script src="02-session.js?v=20260407f" defer></script>
-<script src="utils.js?v=20260407f" defer></script>
-<script src="03-auth.js?v=20260407f" defer></script>
-<script src="05-api.js?v=20260407f" defer></script>
-<script src="10-ui.js?v=20260407f" defer></script>
+<script src="00-appstate.js?v=20260407g"></script>
+<script src="00-appstate-compat.js?v=20260407g"></script>
+<script src="01-config.js?v=20260407g" defer></script>
+<script src="02-session.js?v=20260407g" defer></script>
+<script src="utils.js?v=20260407g" defer></script>
+<script src="03-auth.js?v=20260407g" defer></script>
+<script src="05-api.js?v=20260407g" defer></script>
+<script src="10-ui.js?v=20260407g" defer></script>
 
-<script src="06-post-create.js?v=20260407f" defer></script>
-<script defer src="render/dashboard.js?v=20260407f"></script>
-<script defer src="render/client.js?v=20260407f"></script>
-<script defer src="render/pipeline.js?v=20260407f"></script>
-<script defer src="render/brief.js?v=20260407f"></script>
-<script defer src="actions/pcs.js?v=20260407f"></script>
-<script src="07-post-load.js?v=20260407f" defer></script>
-<script src="08-post-actions.js?v=20260407f" defer></script>
-<script src="09-library.js?v=20260407f" defer></script>
-<script src="09-approval.js?v=20260407f" defer></script>
-<script src="04-router.js?v=20260407f" defer></script>
+<script src="06-post-create.js?v=20260407g" defer></script>
+<script defer src="render/dashboard.js?v=20260407g"></script>
+<script defer src="render/client.js?v=20260407g"></script>
+<script defer src="render/pipeline.js?v=20260407g"></script>
+<script defer src="render/brief.js?v=20260407g"></script>
+<script defer src="actions/pcs.js?v=20260407g"></script>
+<script src="07-post-load.js?v=20260407g" defer></script>
+<script src="08-post-actions.js?v=20260407g" defer></script>
+<script src="09-library.js?v=20260407g" defer></script>
+<script src="09-approval.js?v=20260407g" defer></script>
+<script src="04-router.js?v=20260407g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
One surgical fix. PCS chip dropdowns (date, format, pillar, location, owner) were closing immediately after opening on iOS Safari because the document-level click listener destroyed the dropdown in the same tick as the opening click.

## Root cause
`_pcsChipDrop()` set `window.AppState.pcs.activeMenu = drop` synchronously. The document-level click listener (line 26) saw `activeMenu` as non-null, checked `!menu.contains(e.target)` (the chip button is outside the dropdown), and removed it — all in the same event propagation cycle. `event.stopPropagation()` in the inline onclick did not reliably prevent this on iOS Safari.

## Fix
Wrapped both `activeMenu` assignments in `setTimeout(0)`:
- Line 532 (date dropdown)
- Line 596 (other chip dropdowns)

This ensures `activeMenu` is `null` during the opening click's bubble phase, so the document listener exits early. By the next tick, the click is done and the dropdown stays open.

## Files changed
| File | What changed |
|------|-------------|
| actions/pcs.js | Two `activeMenu = drop` → `setTimeout(function() { activeMenu = drop; }, 0)` |
| index.html | Version bump `?v=20260407e` → `?v=20260407f` (20/20) |
| CLAUDE.md | Version, bug entry added |

## Test plan
- [x] Full vitest suite: **508/508 passing**
- [x] 20/20 version strings bumped
- [ ] Manual: Purge Cloudflare cache after merge
- [ ] Manual: Test on iPhone — tap date chip, confirm dropdown stays open

https://claude.ai/code/session_011LnsQWvEgoWZcNrK38QM3r