### PR TITLE
fix: add Manisha + Shivangini to PCS @mention roster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1368,6 +1368,16 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Self-filter at line 905 already works by name comparison.
    Notification user_role is read from _member.role which is
    'Client' for both — correct for the notifications table.
+1. PCS @mention dropdown missing client users (agency cannot tag clients)
+   Location: actions/pcs.js _AGENCY_MEMBERS at line 2509 —
+   hardcoded to 3 agency members only. Mention notifications
+   at line 2435 also used _AGENCY_MEMBERS so @Manisha and
+   @Shivangini were silently ignored in PCS comments.
+   Status: FIXED (PR#TBD) — added { name:'Manisha', role:'Client' }
+   and { name:'Shivangini', role:'Client' } to _AGENCY_MEMBERS.
+   _showTaskAssign (line 2584) filtered to exclude role 'Client'
+   so task assignment remains agency-only. Notification user_role
+   at line 2446 reads _member.role ('Client') — correct.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -2509,7 +2509,9 @@ window.toggleTaskResolve = function(commentId, postId) {
 var _AGENCY_MEMBERS = [
   { name: 'Shubham', role: 'Admin' },
   { name: 'Pranav', role: 'Creative' },
-  { name: 'Chitra', role: 'Servicing' }
+  { name: 'Chitra', role: 'Servicing' },
+  { name: 'Manisha', role: 'Client' },
+  { name: 'Shivangini', role: 'Client' }
 ];
 
 function _hideMentionDropup() {
@@ -2581,7 +2583,9 @@ window._showTaskAssign = function(inputId, taskBtnId) {
 
   var dropup = document.createElement('div');
   dropup.id = 'pcs-task-assign-dropup';
-  dropup.innerHTML = _AGENCY_MEMBERS.map(function(m) {
+  dropup.innerHTML = _AGENCY_MEMBERS.filter(function(m) {
+    return m.role !== 'Client';
+  }).map(function(m) {
     return '<div class="pcs-mention-item" data-name="' + m.name + '">' +
       '<span class="pcs-mention-name">@' + m.name + '</span>' +
       '<span class="pcs-mention-role">' + m.role + '</span>' +


### PR DESCRIPTION
actions/pcs.js _AGENCY_MEMBERS was hardcoded to 3 agency members. Agency users could not @mention Manisha or Shivangini in PCS client or internal note comments, and mention notifications were silently skipped for them.

Added { name:'Manisha', role:'Client' } and
{ name:'Shivangini', role:'Client' } to _AGENCY_MEMBERS. _showTaskAssign (line 2584) now filters out role 'Client' so task assignment remains agency-only. Notification user_role at line 2446 reads _member.role ('Client') — correct.

render/client.js was already fixed in a prior commit (both _ROSTER arrays have Manisha + Shivangini).

- actions/pcs.js: _AGENCY_MEMBERS expanded + task assign filtered.
- CLAUDE.md: new FIXED bug entry.

Tests: 508/508 passing. Version: ?v=20260407h.

https://claude.ai/code/session_01RQSSfFwKcHqN5FBcxxbcE8