### PR TITLE
fix: replace 100vh with 100dvh on iOS Safari overflow views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408a
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408b
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1394,7 +1394,14 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    _hexToRgb() deleted (dead code after conversion). Approved exceptions
    kept: .pcs-more-ov, .pcs-more-l, SVG fill in index.html L1140,
    mockup photo overlay. 508/508 unit passing.
-   Bumped to ?v=20260408a.
+   Bumped to ?v=20260408b.
+1. 100vh causes overflow on iOS Safari — address bar not excluded
+   Location: styles.css — #dashboard-view height:100vh (L711),
+   #dashboard-view min-height:100vh (L716), #client-view
+   min-height:100vh (L1317), #approval-view min-height:100vh (L1524)
+   Status: FIXED (PR#TBD) — changed all four values from 100vh to
+   100dvh (dynamic viewport height). 508/508 unit passing.
+   Bumped to ?v=20260408b.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408a">
+ <link rel="stylesheet" href="styles.css?v=20260408b">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408a"></script>
-<script src="00-appstate-compat.js?v=20260408a"></script>
-<script src="01-config.js?v=20260408a" defer></script>
-<script src="02-session.js?v=20260408a" defer></script>
-<script src="utils.js?v=20260408a" defer></script>
-<script src="03-auth.js?v=20260408a" defer></script>
-<script src="05-api.js?v=20260408a" defer></script>
-<script src="10-ui.js?v=20260408a" defer></script>
+<script src="00-appstate.js?v=20260408b"></script>
+<script src="00-appstate-compat.js?v=20260408b"></script>
+<script src="01-config.js?v=20260408b" defer></script>
+<script src="02-session.js?v=20260408b" defer></script>
+<script src="utils.js?v=20260408b" defer></script>
+<script src="03-auth.js?v=20260408b" defer></script>
+<script src="05-api.js?v=20260408b" defer></script>
+<script src="10-ui.js?v=20260408b" defer></script>
 
-<script src="06-post-create.js?v=20260408a" defer></script>
-<script defer src="render/dashboard.js?v=20260408a"></script>
-<script defer src="render/client.js?v=20260408a"></script>
-<script defer src="render/pipeline.js?v=20260408a"></script>
-<script defer src="render/brief.js?v=20260408a"></script>
-<script defer src="actions/pcs.js?v=20260408a"></script>
-<script src="07-post-load.js?v=20260408a" defer></script>
-<script src="08-post-actions.js?v=20260408a" defer></script>
-<script src="09-library.js?v=20260408a" defer></script>
-<script src="09-approval.js?v=20260408a" defer></script>
-<script src="04-router.js?v=20260408a" defer></script>
+<script src="06-post-create.js?v=20260408b" defer></script>
+<script defer src="render/dashboard.js?v=20260408b"></script>
+<script defer src="render/client.js?v=20260408b"></script>
+<script defer src="render/pipeline.js?v=20260408b"></script>
+<script defer src="render/brief.js?v=20260408b"></script>
+<script defer src="actions/pcs.js?v=20260408b"></script>
+<script src="07-post-load.js?v=20260408b" defer></script>
+<script src="08-post-actions.js?v=20260408b" defer></script>
+<script src="09-library.js?v=20260408b" defer></script>
+<script src="09-approval.js?v=20260408b" defer></script>
+<script src="04-router.js?v=20260408b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -708,12 +708,12 @@ a:hover { text-decoration: underline; }
  */
 #dashboard-view {
   flex-direction: column;
-  height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   max-width: 480px;
   margin: 0 auto;
   width: 100%;
-  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 /* Tab panels fill remaining height and scroll internally */
@@ -1314,7 +1314,7 @@ tr:hover td { background: var(--surface2); }
 }
 #client-view {
   flex-direction: column;
-  min-height: 100vh;
+  min-height: 100dvh;
   background: #0a0a0f;
   max-width: 640px;
   width: 100%;
@@ -1521,7 +1521,7 @@ textarea.cp-form-input {
    PUBLIC APPROVAL VIEW
  */
 #approval-view {
-  min-height: 100vh;
+  min-height: 100dvh;
   flex-direction: column;
   align-items: center;
   padding: var(--sp-6) var(--sp-4);


### PR DESCRIPTION
## Summary
- Changed 4 `100vh` values to `100dvh` in styles.css to fix iOS Safari overflow
- `100vh` on iOS Safari includes the address bar height, causing content to overflow past the visible area
- `100dvh` (dynamic viewport height) correctly excludes the address bar

### Changes:
| Location | Property | Before | After |
|----------|----------|--------|-------|
| styles.css L711 `#dashboard-view` | height | 100vh | 100dvh |
| styles.css L716 `#dashboard-view` | min-height | 100vh | 100dvh |
| styles.css L1317 `#client-view` | min-height | 100vh | 100dvh |
| styles.css L1524 `#approval-view` | min-height | 100vh | 100dvh |

## Test plan
- [x] 508/508 unit tests passing
- [ ] Hard refresh iPhone Safari — dashboard, client feed, approval view should no longer overflow
- [ ] Purge Cloudflare cache after merge

https://claude.ai/code/session_01E3gLeDKYXtfah2h3oHsZWD