### PR TITLE
fix: 4 low-risk PCS/dashboard bugs — notes filter, reply bar, drive l…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408c
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408d
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1424,6 +1424,39 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    #6e6e80/#302a4a/#333344 (specialized UI accents), all 8-digit hex
    alpha values, rgba() approved exceptions, SVG values, mockups, tests.
    508/508 unit passing. Bumped to ?v=20260408c.
+1. Internal notes ALL chip shows only visibility=all notes
+   Location: actions/pcs.js line 1198-1199 — filteredNotes filter
+   used strict equality (visibility === 'all') when ALL chip active,
+   hiding notes with visibility admin/servicing/creative.
+   Status: FIXED (PR#TBD) — changed to bypass filter entirely when
+   _activeVis === 'all', so ALL chip shows every note regardless of
+   visibility tag. 508/508 unit passing.
+   Bumped to ?v=20260408d.
+1. Missing .pcs-reply-bar CSS class — reply bar unstyled
+   Location: index.html:913 and :939 use class="pcs-reply-bar" on
+   #pcs-client-reply-indicator and #pcs-note-reply-indicator, but
+   styles.css had no .pcs-reply-bar rule. The class name did not
+   match .pcs-reply-indicator-bar (the only styled variant).
+   Status: FIXED (PR#TBD) — added .pcs-reply-bar rule to styles.css
+   (display:none default, flex when JS sets display:flex, gold left
+   border, dark background, mono font). 508/508 unit passing.
+   Bumped to ?v=20260408d.
+1. Drive link empty state shown when no URL exists
+   Location: actions/pcs.js lines 248-250 — showed "+ Add drive link"
+   empty state to agency users (canManage) even when post had no
+   drive_link. Drive links should only be added at post creation.
+   Status: FIXED (PR#TBD) — removed the else-if canManage branch.
+   #pcs-drive-link-wrap now only shows when driveUrl is truthy;
+   otherwise display:none regardless of role. 508/508 unit passing.
+   Bumped to ?v=20260408d.
+1. Dashboard CLIENT metric row text wraps on narrow screens
+   Location: render/dashboard.js lines 358-365 — the clickable
+   approval/input count spans lacked white-space:nowrap, causing
+   the CLIENT row to be taller than other metric rows on narrow
+   viewports.
+   Status: FIXED (PR#TBD) — added white-space:nowrap to both
+   approval and input <span> elements. 508/508 unit passing.
+   Bumped to ?v=20260408d.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -245,9 +245,6 @@ window._renderPCS = function(postId) {
     if (driveUrl) {
       driveLinkWrap.style.display = 'block';
       driveLinkWrap.innerHTML = _buildDriveLinkCard(driveUrl, canManage, post.post_id || post.id);
-    } else if (canManage) {
-      driveLinkWrap.style.display = 'block';
-      driveLinkWrap.innerHTML = _buildDriveLinkCard(null, canManage, post.post_id || post.id);
     } else {
       driveLinkWrap.style.display = 'none';
     }
@@ -1195,9 +1192,11 @@ window.loadPcsComments = async function(postId) {
 
     if (notesList && _roleLower !== 'client') {
       var _activeVis = window._pcsNoteVisibility || 'all';
-      var filteredNotes = internalRows.filter(function(c) {
-        return (c.visibility || 'all') === _activeVis;
-      });
+      var filteredNotes = _activeVis === 'all'
+        ? internalRows
+        : internalRows.filter(function(c) {
+            return (c.visibility || 'all') === _activeVis;
+          });
       var resolvedRows = filteredNotes.filter(function(c) { return c.resolved; });
       var activeRows = filteredNotes.filter(function(c) { return !c.resolved; });
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408c">
+ <link rel="stylesheet" href="styles.css?v=20260408d">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408c"></script>
-<script src="00-appstate-compat.js?v=20260408c"></script>
-<script src="01-config.js?v=20260408c" defer></script>
-<script src="02-session.js?v=20260408c" defer></script>
-<script src="utils.js?v=20260408c" defer></script>
-<script src="03-auth.js?v=20260408c" defer></script>
-<script src="05-api.js?v=20260408c" defer></script>
-<script src="10-ui.js?v=20260408c" defer></script>
+<script src="00-appstate.js?v=20260408d"></script>
+<script src="00-appstate-compat.js?v=20260408d"></script>
+<script src="01-config.js?v=20260408d" defer></script>
+<script src="02-session.js?v=20260408d" defer></script>
+<script src="utils.js?v=20260408d" defer></script>
+<script src="03-auth.js?v=20260408d" defer></script>
+<script src="05-api.js?v=20260408d" defer></script>
+<script src="10-ui.js?v=20260408d" defer></script>
 
-<script src="06-post-create.js?v=20260408c" defer></script>
-<script defer src="render/dashboard.js?v=20260408c"></script>
-<script defer src="render/client.js?v=20260408c"></script>
-<script defer src="render/pipeline.js?v=20260408c"></script>
-<script defer src="render/brief.js?v=20260408c"></script>
-<script defer src="actions/pcs.js?v=20260408c"></script>
-<script src="07-post-load.js?v=20260408c" defer></script>
-<script src="08-post-actions.js?v=20260408c" defer></script>
-<script src="09-library.js?v=20260408c" defer></script>
-<script src="09-approval.js?v=20260408c" defer></script>
-<script src="04-router.js?v=20260408c" defer></script>
+<script src="06-post-create.js?v=20260408d" defer></script>
+<script defer src="render/dashboard.js?v=20260408d"></script>
+<script defer src="render/client.js?v=20260408d"></script>
+<script defer src="render/pipeline.js?v=20260408d"></script>
+<script defer src="render/brief.js?v=20260408d"></script>
+<script defer src="actions/pcs.js?v=20260408d"></script>
+<script src="07-post-load.js?v=20260408d" defer></script>
+<script src="08-post-actions.js?v=20260408d" defer></script>
+<script src="09-library.js?v=20260408d" defer></script>
+<script src="09-approval.js?v=20260408d" defer></script>
+<script src="04-router.js?v=20260408d" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/dashboard.js
+++ b/render/dashboard.js
@@ -356,11 +356,11 @@ window.renderScoreboard = function() {
     if (elClMsg) {
       if (approvalOnly > 0 || inputOnly > 0) {
         elClMsg.innerHTML =
-          '<span style="cursor:pointer;color:var(--c-red);"' +
+          '<span style="cursor:pointer;color:var(--c-red);white-space:nowrap;"' +
           ' onclick="event.stopPropagation();openStageSheet(\'awaiting_approval\')">' +
           dashPad(approvalOnly) + ' APPROVAL</span>' +
           ' <span style="color:#555;">\u00b7</span> ' +
-          '<span style="cursor:pointer;color:#888;"' +
+          '<span style="cursor:pointer;color:#888;white-space:nowrap;"' +
           ' onclick="event.stopPropagation();openStageSheet(\'awaiting_brand_input\')">' +
           dashPad(inputOnly) + ' INPUT</span>';
       } else {

--- a/styles.css
+++ b/styles.css
@@ -6396,6 +6396,19 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   padding-left: 10px;
 }
 
+.pcs-reply-bar {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: #191924;
+  border-left: 2px solid #C8A84B;
+  margin: 0 8px 4px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: #AEAEB2;
+}
+
 .pcs-reply-indicator {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 9px;


### PR DESCRIPTION
…ink, metric wrap

1. Internal notes ALL chip now shows all notes (was filtering to visibility=all only)
2. Added missing .pcs-reply-bar CSS class for reply indicator bars
3. Drive link section hidden when no URL exists (removed empty state)
4. Dashboard CLIENT metric row spans use white-space:nowrap

508/508 tests passing. Bumped to ?v=20260408d.

https://claude.ai/code/session_01SZyPE6ir41GZWWxxduyuqN