### PR TITLE
feat: rewrite PCS photo grid — hero-driven responsive layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408d
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408e
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1457,6 +1457,25 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Status: FIXED (PR#TBD) — added white-space:nowrap to both
    approval and input <span> elements. 508/508 unit passing.
    Bumped to ?v=20260408d.
+1. PCS photo grid rewrite — hero-driven responsive layout
+   Location: actions/pcs.js _buildPhotoGrid() + styles.css photo grid
+   rules. Old system had 5 fixed-height layouts (pcs-pg-1 through
+   pcs-pg-5) with .pcs-pcell/.pcs-pcell.hero CSS grid cells.
+   Status: FIXED (PR#TBD) — simplified to 4 layouts using
+   padding-bottom aspect ratio technique instead of fixed px heights.
+   Removed: .pcs-pg-4, .pcs-pg-5, .pcs-pcell, .pcs-pcell.hero,
+   _cell() helper, mobile safari min-height hacks for pg-2/3/4/5.
+   New classes: .pcs-pg-3plus (4+ images), .pcs-pg-inner (absolute
+   positioned flex container), .pcs-pg-hero (60% left column),
+   .pcs-pg-col (right column), .pcs-pg-sm (small cells),
+   .pcs-pg-2-inner/.pcs-pg-2-cell (2-image layout).
+   Layout: 1 img = 100% square, 2 imgs = 50% side-by-side,
+   3 imgs = 60% hero left + 2 stacked right, 4+ = same as 3 with
+   "+N more" overlay on last cell. .pcs-more-ov updated to
+   rgba(8,8,8,0.72) + backdrop-filter:blur(2px). .pcs-more-n
+   weight 700 size 22px. .pcs-more-l now IBM Plex Mono.
+   Edit mode selector updated to match new cell classes.
+   508/508 unit passing. Bumped to ?v=20260408e.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -335,42 +335,50 @@ window._pcsTabSwitch = function(tab) {
 function _buildPhotoGrid(imgs, canEdit, canEditCreative, isAdmin, id) {
   var canManage = canEdit || canEditCreative;
   var count = imgs.length;
-
-  function _cell(idx, heroClass, overlayHtml) {
-    return '<div class="pcs-pcell' + (heroClass ? ' hero' : '') + '" onclick="window._pcsOpenLightbox(\'' + esc(id) + '\',' + idx + ')">' +
-      '<img src="' + esc(imgs[idx]) + '" onerror="this.style.display=\'none\'">' +
-      (overlayHtml || '') +
-      '</div>';
-  }
-
+  var _id = esc(id);
   var gridHtml = '';
 
   if (count === 0) {
     if (canManage) {
-      gridHtml = '<div class="pcs-photo-empty" onclick="window._pcsAddPhotos(\'' + esc(id) + '\')">' +
+      gridHtml = '<div class="pcs-photo-empty" onclick="window._pcsAddPhotos(\'' + _id + '\')">' +
         '<div style="font-size:22px;color:#C8A84B">+</div>' +
         '<div style="font-family:\'Courier New\',monospace;font-size:8px;letter-spacing:.1em;text-transform:uppercase;color:#F6A623">Upload Photos</div>' +
         '<div style="font-family:\'Courier New\',monospace;font-size:7px;color:#333;letter-spacing:.06em">JPG / PNG</div>' +
         '</div>';
     }
   } else if (count === 1) {
-    gridHtml = '<div class="pcs-pg-1">' +
-      '<img src="' + esc(imgs[0]) + '" onclick="window._pcsOpenLightbox(\'' + esc(id) + '\',0)" onerror="this.style.display=\'none\'">' +
+    gridHtml = '<div class="pcs-pg-1" onclick="window._pcsOpenLightbox(\'' + _id + '\',0)">' +
+      '<img src="' + esc(imgs[0]) + '" alt="">' +
       '</div>';
   } else if (count === 2) {
-    gridHtml = '<div class="pcs-pg-2">' + _cell(0) + _cell(1) + '</div>';
+    gridHtml = '<div class="pcs-pg-2"><div class="pcs-pg-2-inner">' +
+      '<div class="pcs-pg-2-cell" onclick="window._pcsOpenLightbox(\'' + _id + '\',0)"><img src="' + esc(imgs[0]) + '" alt=""></div>' +
+      '<div class="pcs-pg-2-cell" onclick="window._pcsOpenLightbox(\'' + _id + '\',1)"><img src="' + esc(imgs[1]) + '" alt=""></div>' +
+      '</div></div>';
   } else if (count === 3) {
-    gridHtml = '<div class="pcs-pg-3">' + _cell(0, true) + _cell(1) + _cell(2) + '</div>';
-  } else if (count === 4) {
-    gridHtml = '<div class="pcs-pg-4">' + _cell(0) + _cell(1) + _cell(2) + _cell(3) + '</div>';
+    gridHtml = '<div class="pcs-pg-3"><div class="pcs-pg-inner">' +
+      '<div class="pcs-pg-hero" onclick="window._pcsOpenLightbox(\'' + _id + '\',0)"><img src="' + esc(imgs[0]) + '" alt=""></div>' +
+      '<div class="pcs-pg-col">' +
+        '<div class="pcs-pg-sm" onclick="window._pcsOpenLightbox(\'' + _id + '\',1)"><img src="' + esc(imgs[1]) + '" alt=""></div>' +
+        '<div class="pcs-pg-sm" onclick="window._pcsOpenLightbox(\'' + _id + '\',2)"><img src="' + esc(imgs[2]) + '" alt=""></div>' +
+      '</div>' +
+      '</div></div>';
   } else {
     var extra = count - 3;
-    var ov = '<div class="pcs-more-ov"><div class="pcs-more-n">+' + extra + '</div><div class="pcs-more-l">more</div></div>';
-    gridHtml = '<div class="pcs-pg-5">' + _cell(0, true) + _cell(1) + _cell(2, false, ov) + '</div>';
+    gridHtml = '<div class="pcs-pg-3plus"><div class="pcs-pg-inner">' +
+      '<div class="pcs-pg-hero" onclick="window._pcsOpenLightbox(\'' + _id + '\',0)"><img src="' + esc(imgs[0]) + '" alt=""></div>' +
+      '<div class="pcs-pg-col">' +
+        '<div class="pcs-pg-sm" onclick="window._pcsOpenLightbox(\'' + _id + '\',1)"><img src="' + esc(imgs[1]) + '" alt=""></div>' +
+        '<div class="pcs-pg-sm" onclick="window._pcsOpenLightbox(\'' + _id + '\',2)">' +
+          '<img src="' + esc(imgs[2]) + '" alt="">' +
+          '<div class="pcs-more-ov"><div class="pcs-more-n">+' + extra + '</div><div class="pcs-more-l">more</div></div>' +
+        '</div>' +
+      '</div>' +
+      '</div></div>';
   }
 
   var inputHtml = canManage
-    ? '<input type="file" id="pcs-photo-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandlePhotoInput(\'' + esc(id) + '\',this)">'
+    ? '<input type="file" id="pcs-photo-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandlePhotoInput(\'' + _id + '\',this)">'
     : '';
 
   return gridHtml + inputHtml;
@@ -1757,7 +1765,7 @@ window._pcsEnterEditMode = function(postId) {
   // Add X overlays to photos
   var wrap = document.getElementById('pcs-photo-grid-wrap');
   if (!wrap) return;
-  var cells = wrap.querySelectorAll('.pcs-pcell, .pcs-pg-1');
+  var cells = wrap.querySelectorAll('.pcs-pg-1, .pcs-pg-2-cell, .pcs-pg-hero, .pcs-pg-sm');
   cells.forEach(function(cell, idx) {
     if (cell.querySelector('.pcs-edit-x')) return;
     var xBtn = document.createElement('button');

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408d">
+ <link rel="stylesheet" href="styles.css?v=20260408e">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408d"></script>
-<script src="00-appstate-compat.js?v=20260408d"></script>
-<script src="01-config.js?v=20260408d" defer></script>
-<script src="02-session.js?v=20260408d" defer></script>
-<script src="utils.js?v=20260408d" defer></script>
-<script src="03-auth.js?v=20260408d" defer></script>
-<script src="05-api.js?v=20260408d" defer></script>
-<script src="10-ui.js?v=20260408d" defer></script>
+<script src="00-appstate.js?v=20260408e"></script>
+<script src="00-appstate-compat.js?v=20260408e"></script>
+<script src="01-config.js?v=20260408e" defer></script>
+<script src="02-session.js?v=20260408e" defer></script>
+<script src="utils.js?v=20260408e" defer></script>
+<script src="03-auth.js?v=20260408e" defer></script>
+<script src="05-api.js?v=20260408e" defer></script>
+<script src="10-ui.js?v=20260408e" defer></script>
 
-<script src="06-post-create.js?v=20260408d" defer></script>
-<script defer src="render/dashboard.js?v=20260408d"></script>
-<script defer src="render/client.js?v=20260408d"></script>
-<script defer src="render/pipeline.js?v=20260408d"></script>
-<script defer src="render/brief.js?v=20260408d"></script>
-<script defer src="actions/pcs.js?v=20260408d"></script>
-<script src="07-post-load.js?v=20260408d" defer></script>
-<script src="08-post-actions.js?v=20260408d" defer></script>
-<script src="09-library.js?v=20260408d" defer></script>
-<script src="09-approval.js?v=20260408d" defer></script>
-<script src="04-router.js?v=20260408d" defer></script>
+<script src="06-post-create.js?v=20260408e" defer></script>
+<script defer src="render/dashboard.js?v=20260408e"></script>
+<script defer src="render/client.js?v=20260408e"></script>
+<script defer src="render/pipeline.js?v=20260408e"></script>
+<script defer src="render/brief.js?v=20260408e"></script>
+<script defer src="actions/pcs.js?v=20260408e"></script>
+<script src="07-post-load.js?v=20260408e" defer></script>
+<script src="08-post-actions.js?v=20260408e" defer></script>
+<script src="09-library.js?v=20260408e" defer></script>
+<script src="09-approval.js?v=20260408e" defer></script>
+<script src="04-router.js?v=20260408e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6507,24 +6507,142 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   padding: 2px 6px;
 }
 
-/* Photo grids */
-.pcs-pg-1 { width:100%; height:312px; overflow:hidden; cursor:pointer; position:relative; }
-.pcs-pg-1 img { width:100%; height:100%; object-fit:cover; object-position:center center; display:block; background:#080808; }
-.pcs-pg-2 { display:grid; grid-template-columns:1fr 1fr; gap:2px; height:272px; }
-.pcs-pg-3, .pcs-pg-5 { display:grid; grid-template-columns:62% 38%; grid-template-rows:1fr 1fr; gap:2px; height:272px; }
-.pcs-pg-4 { display:grid; grid-template-columns:1fr 1fr; grid-template-rows:1fr 1fr; gap:2px; height:292px; }
-.pcs-pcell { position:relative; overflow:hidden; cursor:pointer; background:#080808; flex-shrink:0; }
-.pcs-pcell.hero { grid-row:span 2; }
-.pcs-pcell img { width:100%; height:100%; object-fit:cover; object-position:center center; display:block; background:#080808; }
-.pcs-more-ov {
-  position:absolute; inset:0; background:rgba(0,0,0,0.62); /* approved rgba exception — must show photo underneath */
-  display:flex; flex-direction:column;
-  align-items:center; justify-content:center; gap:3px;
+/* PCS PHOTO GRID — hero-driven layout */
+
+.pcs-pg-1 {
+  width: 100%;
+  padding-bottom: 100%;
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+  background: #080808;
 }
-.pcs-more-n { font-size:26px; font-weight:300; color:#fff; line-height:1; }
+
+.pcs-pg-1 img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+
+.pcs-pg-2 {
+  width: 100%;
+  padding-bottom: 50%;
+  position: relative;
+  overflow: hidden;
+  background: #080808;
+}
+
+.pcs-pg-2-inner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  gap: 2px;
+}
+
+.pcs-pg-2-cell {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: #0d0d12;
+  cursor: pointer;
+}
+
+.pcs-pg-2-cell img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+
+.pcs-pg-3 {
+  width: 100%;
+  padding-bottom: 60%;
+  position: relative;
+  overflow: hidden;
+  background: #080808;
+}
+
+.pcs-pg-3plus {
+  width: 100%;
+  padding-bottom: 60%;
+  position: relative;
+  overflow: hidden;
+  background: #080808;
+}
+
+.pcs-pg-inner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  gap: 2px;
+}
+
+.pcs-pg-hero {
+  flex: 0 0 calc(60% - 1px);
+  position: relative;
+  overflow: hidden;
+  background: #0d0d12;
+  cursor: pointer;
+}
+
+.pcs-pg-hero img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+
+.pcs-pg-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.pcs-pg-sm {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: #0d0d12;
+  cursor: pointer;
+}
+
+.pcs-pg-sm img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+
+.pcs-more-ov {
+  position: absolute;
+  inset: 0;
+  background: rgba(8,8,8,0.72); /* approved rgba exception — photo must show through */
+  backdrop-filter: blur(2px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  cursor: pointer;
+}
+.pcs-more-n { font-size: 22px; font-weight: 700; color: #ffffff; line-height: 1; }
 .pcs-more-l {
-  font-family:'Courier New',monospace; font-size:7px;
-  color:rgba(255,255,255,0.6); letter-spacing:.08em; text-transform:uppercase; /* approved rgba exception — overlay text */
+  font-family: 'IBM Plex Mono', monospace; font-size: 7px;
+  color: rgba(255,255,255,0.5); letter-spacing: 0.14em; text-transform: uppercase; /* approved rgba exception — overlay text */
 }
 .pcs-photo-empty {
   padding: 28px 16px;
@@ -6717,12 +6835,11 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   word-break: break-word;
 }
 
-/* FIX 10: Photo grid min-height (mobile Safari) */
-.pcs-pg-1 { flex-shrink:0; min-height:312px; }
-.pcs-pg-2 { flex-shrink:0; min-height:272px; }
-.pcs-pg-3 { flex-shrink:0; min-height:272px; }
-.pcs-pg-4 { flex-shrink:0; min-height:292px; }
-.pcs-pg-5 { flex-shrink:0; min-height:272px; }
+/* FIX 10: Photo grid flex-shrink (mobile Safari) */
+.pcs-pg-1 { flex-shrink:0; }
+.pcs-pg-2 { flex-shrink:0; }
+.pcs-pg-3 { flex-shrink:0; }
+.pcs-pg-3plus { flex-shrink:0; }
 
 /* FIX 11: Title size */
 #pcs-topbar-title, .pc-title {


### PR DESCRIPTION
Replaced 5 fixed-height grid layouts with 4 aspect-ratio-driven layouts:
- 1 img: 100% square (padding-bottom:100%)
- 2 imgs: side-by-side (padding-bottom:50%)
- 3 imgs: 60% hero left + 2 stacked right (padding-bottom:60%)
- 4+ imgs: same as 3 with "+N more" overlay

Removed: .pcs-pg-4, .pcs-pg-5, .pcs-pcell, .pcs-pcell.hero, _cell() helper
Added: .pcs-pg-3plus, .pcs-pg-inner, .pcs-pg-hero, .pcs-pg-col, .pcs-pg-sm
Updated: .pcs-more-ov to translucent rgba(8,8,8,0.72) + backdrop-filter blur
Updated: edit mode selector for new cell classes

508/508 tests passing. Bumped to ?v=20260408e.

https://claude.ai/code/session_01SZyPE6ir41GZWWxxduyuqN