### PR TITLE
ci: skip e2e on CSS/template-only PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,26 @@ jobs:
           TZ: Asia/Kolkata
         run: npm test
 
+  check-e2e-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.core }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - '03-auth.js'
+              - '05-api.js'
+              - '06-post-create.js'
+              - '08-post-actions.js'
+              - '09-approval.js'
+
   e2e-critical:
-    needs: [test]
+    needs: [test, check-e2e-paths]
+    if: needs.check-e2e-paths.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,8 +294,11 @@ E2E: npx playwright test
 
 CI (.github/workflows/test.yml):
   Job 1 `test`          — vitest unit suite on every push/PR to
-                          main + main-/-root.
-  Job 2 `e2e-critical`  — runs after unit job passes; executes 3
+                          main + main-/-root. Always runs.
+  Job 2 `check-e2e-paths` — uses dorny/paths-filter@v3 to detect
+                          changes in core logic files.
+  Job 3 `e2e-critical`  — runs after unit job passes AND only when
+                          core logic files changed; executes 3
                           critical Playwright specs headless in
                           Chromium with a 2-minute cap:
                             tests/e2e/client-flows.spec.js
@@ -303,6 +306,16 @@ CI (.github/workflows/test.yml):
                             tests/e2e/admin-flows.spec.js
                           live-smoke.spec.js (real creds) and
                           role-flows/smoke are NOT run in CI.
+
+Test tiers (CI path filtering):
+  CSS-only changes (styles.css)        → unit tests only (vitest)
+  JS template changes (render/*.js,    → unit tests only (vitest)
+    actions/pcs.js, index.html bumps)
+  Core logic changes (03-auth.js,      → full suite: unit + e2e
+    05-api.js, 06-post-create.js,
+    08-post-actions.js, 09-approval.js)
+  E2e-critical is SKIPPED when none of the 5 core files are in
+  the PR diff. This saves ~2 min CI time on CSS/template PRs.
 
 Post-deploy smoke (.github/workflows/smoke.yml):
   Schedule: '*/30 * * * *' (every 30 min) + workflow_dispatch.


### PR DESCRIPTION
## Summary
- Added `dorny/paths-filter@v3` to detect changes in 5 core logic files (03-auth.js, 05-api.js, 06-post-create.js, 08-post-actions.js, 09-approval.js)
- `e2e-critical` job now only runs when those core files change — skipped for CSS, render/*.js, actions/pcs.js, and index.html version bumps
- Unit tests (`vitest`) still run on every push/PR — no change there
- Updated CLAUDE.md Section 8 to document the test tier rules

## Files changed
- `.github/workflows/test.yml` — added `check-e2e-paths` job with path filter, added `if` condition on `e2e-critical`
- `CLAUDE.md` — documented test tiers and new CI job structure in Section 8

## Test count
508/508 unit passing

## Test plan
- [ ] Push a CSS-only PR and verify e2e-critical is skipped
- [ ] Push a PR touching 03-auth.js and verify e2e-critical runs
- [ ] Confirm unit tests still run on all PRs

https://claude.ai/code/session_01BzVv6uSCAD7t7FteUjwEkU