### PR TITLE
feat: responsive aspect-ratio layout for client feed photo grid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1489,6 +1489,19 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    weight 700 size 22px. .pcs-more-l now IBM Plex Mono.
    Edit mode selector updated to match new cell classes.
    508/508 unit passing. Bumped to ?v=20260408e.
+2. Client feed photo grid — responsive aspect-ratio layout
+   Location: render/client.js _imgGridHtml() + styles.css
+   Old system had fixed px heights: img-trio 130px+130px=260px,
+   img-quad 150px+150px=300px. Not responsive on narrow screens.
+   Status: FIXED — replaced fixed heights with CSS aspect-ratio.
+   img-trio: grid-template-rows:1fr 1fr + aspect-ratio:5/3
+   img-quad: grid-template-rows:1fr 1fr + aspect-ratio:1/1
+   Removed max-height:400px from .img-trio/.img-quad in styles.css
+   (kept on .img-duo). +N overlay updated to rgba(8,8,8,0.72) +
+   backdrop-filter:blur(2px) to match PCS grid overlay style.
+   n=1 (img-single) and n=2 (img-duo) layouts unchanged.
+   wrap() helper, lightbox wiring, border-radius values unchanged.
+   508/508 unit passing. Bumped to ?v=20260408f.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408e">
+ <link rel="stylesheet" href="styles.css?v=20260408f">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408e"></script>
-<script src="00-appstate-compat.js?v=20260408e"></script>
-<script src="01-config.js?v=20260408e" defer></script>
-<script src="02-session.js?v=20260408e" defer></script>
-<script src="utils.js?v=20260408e" defer></script>
-<script src="03-auth.js?v=20260408e" defer></script>
-<script src="05-api.js?v=20260408e" defer></script>
-<script src="10-ui.js?v=20260408e" defer></script>
+<script src="00-appstate.js?v=20260408f"></script>
+<script src="00-appstate-compat.js?v=20260408f"></script>
+<script src="01-config.js?v=20260408f" defer></script>
+<script src="02-session.js?v=20260408f" defer></script>
+<script src="utils.js?v=20260408f" defer></script>
+<script src="03-auth.js?v=20260408f" defer></script>
+<script src="05-api.js?v=20260408f" defer></script>
+<script src="10-ui.js?v=20260408f" defer></script>
 
-<script src="06-post-create.js?v=20260408e" defer></script>
-<script defer src="render/dashboard.js?v=20260408e"></script>
-<script defer src="render/client.js?v=20260408e"></script>
-<script defer src="render/pipeline.js?v=20260408e"></script>
-<script defer src="render/brief.js?v=20260408e"></script>
-<script defer src="actions/pcs.js?v=20260408e"></script>
-<script src="07-post-load.js?v=20260408e" defer></script>
-<script src="08-post-actions.js?v=20260408e" defer></script>
-<script src="09-library.js?v=20260408e" defer></script>
-<script src="09-approval.js?v=20260408e" defer></script>
-<script src="04-router.js?v=20260408e" defer></script>
+<script src="06-post-create.js?v=20260408f" defer></script>
+<script defer src="render/dashboard.js?v=20260408f"></script>
+<script defer src="render/client.js?v=20260408f"></script>
+<script defer src="render/pipeline.js?v=20260408f"></script>
+<script defer src="render/brief.js?v=20260408f"></script>
+<script defer src="actions/pcs.js?v=20260408f"></script>
+<script src="07-post-load.js?v=20260408f" defer></script>
+<script src="08-post-actions.js?v=20260408f" defer></script>
+<script src="09-library.js?v=20260408f" defer></script>
+<script src="09-approval.js?v=20260408f" defer></script>
+<script src="04-router.js?v=20260408f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -258,7 +258,7 @@ console.log('LOADED:', 'render/client.js');
     }
 
     if (n === 3) {
-      return '<div class="img-trio" style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:130px 130px;gap:2px;padding:0 14px;margin-top:10px;height:260px;user-select:none;-webkit-user-select:none;">' +
+      return '<div class="img-trio" style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:1fr 1fr;gap:2px;padding:0 14px;margin-top:10px;aspect-ratio:5/3;user-select:none;-webkit-user-select:none;">' +
         wrap(imgs[0], 0, 'grid-row:1/3;border-radius:8px 0 0 8px;') +
         wrap(imgs[1], 1, 'border-radius:0 8px 0 0;') +
         wrap(imgs[2], 2, 'border-radius:0 0 8px 0;') +
@@ -268,9 +268,9 @@ console.log('LOADED:', 'render/client.js');
     /* 4+ : 2x2 grid with +N overlay on last cell */
     var extra = n > 4 ? n - 4 : 0;
     var overlayHtml = extra > 0
-      ? '<div style="position:absolute;inset:0;background:#0000008C;display:flex;align-items:center;justify-content:center;font-family:\'DM Sans\',sans-serif;font-size:20px;font-weight:700;color:#fff;pointer-events:none;">+' + extra + '</div>'
+      ? '<div style="position:absolute;inset:0;background:rgba(8,8,8,0.72);backdrop-filter:blur(2px);display:flex;align-items:center;justify-content:center;font-family:\'DM Sans\',sans-serif;font-size:20px;font-weight:700;color:#fff;pointer-events:none;">+' + extra + '</div>'
       : '';
-    return '<div class="img-quad" style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:150px 150px;gap:2px;padding:0 14px;margin-top:10px;height:300px;user-select:none;-webkit-user-select:none;">' +
+    return '<div class="img-quad" style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:1fr 1fr;gap:2px;padding:0 14px;margin-top:10px;aspect-ratio:1/1;user-select:none;-webkit-user-select:none;">' +
       wrap(imgs[0], 0, 'border-radius:8px 0 0 0;') +
       wrap(imgs[1], 1, 'border-radius:0 8px 0 0;') +
       wrap(imgs[2], 2, 'border-radius:0 0 0 8px;') +

--- a/styles.css
+++ b/styles.css
@@ -5764,9 +5764,7 @@ body.client-mode .img-single {
   display: block;
 }
 
-body.client-mode .img-duo,
-body.client-mode .img-trio,
-body.client-mode .img-quad {
+body.client-mode .img-duo {
   max-height: 400px;
 }
 


### PR DESCRIPTION
## Summary

- Replace fixed-height photo grid layouts (img-trio, img-quad) with responsive CSS aspect-ratio
- img-trio: `130px+130px` rows → `1fr+1fr` + `aspect-ratio:5/3`
- img-quad: `150px+150px` rows → `1fr+1fr` + `aspect-ratio:1/1`
- Update +N overlay to `rgba(8,8,8,0.72)` + `backdrop-filter:blur(2px)` matching PCS grid style
- Remove `max-height:400px` from `.img-trio`/`.img-quad` CSS (kept on `.img-duo`)

## What is NOT touched

- `wrap()` helper function — unchanged
- `data-action="openLightbox"`, `data-images`, `data-index` — unchanged
- `.lb-trigger-cell` class and CSS — unchanged
- `pointer-events:auto` on all imgs — unchanged
- All border-radius values — unchanged
- `padding:0 14px` and `gap:2px` on containers — unchanged
- n=1 (img-single) and n=2 (img-duo) layouts — unchanged
- Lightbox touch/keyboard handlers — unchanged

## Test plan

- [x] 508/508 unit tests passing — zero regressions
- [ ] Visual check: 3-image grid scales responsively on narrow/wide viewports
- [ ] Visual check: 4-image grid maintains 1:1 square ratio
- [ ] Visual check: +N overlay has subtle blur effect
- [ ] Tap any image → lightbox opens at correct index
- [ ] Swipe left/right in lightbox works

https://claude.ai/code/session_01EchdNtSQU7B2eC3ooZvyPk