### PR TITLE
fix: PCS photo grid rewrite + reply bar + 4 dashboard bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408e
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408g
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1489,7 +1489,7 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    weight 700 size 22px. .pcs-more-l now IBM Plex Mono.
    Edit mode selector updated to match new cell classes.
    508/508 unit passing. Bumped to ?v=20260408e.
-2. Client feed photo grid — responsive aspect-ratio layout
+1. Client feed photo grid — responsive aspect-ratio layout
    Location: render/client.js _imgGridHtml() + styles.css
    Old system had fixed px heights: img-trio 130px+130px=260px,
    img-quad 150px+150px=300px. Not responsive on narrow screens.
@@ -1502,6 +1502,17 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    n=1 (img-single) and n=2 (img-duo) layouts unchanged.
    wrap() helper, lightbox wiring, border-radius values unchanged.
    508/508 unit passing. Bumped to ?v=20260408f.
+1. PCS reply bar missing cancel/X button
+   Location: actions/pcs.js _pcsSetReply() line 2716 — innerHTML
+   only contained '<span>Replying to {author}</span>' with no way
+   to dismiss the reply bar. _pcsClearReply() existed (line 2739)
+   and worked correctly but had no UI trigger.
+   Status: FIXED (PR#TBD) — added .pcs-reply-cancel X button to
+   _pcsSetReply innerHTML, wired to _pcsClearReply(zone). Added
+   input refocus (pcs-comment-input or pcs-note-input) to
+   _pcsClearReply after clearing state. .pcs-reply-cancel CSS
+   already existed at styles.css:6433. 508/508 unit passing.
+   Bumped to ?v=20260408g.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -2714,7 +2714,7 @@ window._pcsSetReply = function(zone, commentId, author, message) {
   );
   if (indicator) {
     indicator.innerHTML =
-      '<span>Replying to ' + author + '</span>';
+      '<span style="flex:1;">Replying to ' + author + '</span><span class="pcs-reply-cancel" onclick="window._pcsClearReply(\'' + zone + '\')">✕</span>';
     indicator.style.display = 'flex';
   }
   document.querySelectorAll(
@@ -2752,6 +2752,8 @@ window._pcsClearReply = function(zone) {
     .forEach(function(el) {
       el.classList.remove('pcs-comment-replying-to');
     });
+  var inp = document.getElementById(zone === 'client' ? 'pcs-comment-input' : 'pcs-note-input');
+  if (inp) inp.focus();
 };
 
 window._pcsCopyComment = function(message) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408f">
+ <link rel="stylesheet" href="styles.css?v=20260408g">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408f"></script>
-<script src="00-appstate-compat.js?v=20260408f"></script>
-<script src="01-config.js?v=20260408f" defer></script>
-<script src="02-session.js?v=20260408f" defer></script>
-<script src="utils.js?v=20260408f" defer></script>
-<script src="03-auth.js?v=20260408f" defer></script>
-<script src="05-api.js?v=20260408f" defer></script>
-<script src="10-ui.js?v=20260408f" defer></script>
+<script src="00-appstate.js?v=20260408g"></script>
+<script src="00-appstate-compat.js?v=20260408g"></script>
+<script src="01-config.js?v=20260408g" defer></script>
+<script src="02-session.js?v=20260408g" defer></script>
+<script src="utils.js?v=20260408g" defer></script>
+<script src="03-auth.js?v=20260408g" defer></script>
+<script src="05-api.js?v=20260408g" defer></script>
+<script src="10-ui.js?v=20260408g" defer></script>
 
-<script src="06-post-create.js?v=20260408f" defer></script>
-<script defer src="render/dashboard.js?v=20260408f"></script>
-<script defer src="render/client.js?v=20260408f"></script>
-<script defer src="render/pipeline.js?v=20260408f"></script>
-<script defer src="render/brief.js?v=20260408f"></script>
-<script defer src="actions/pcs.js?v=20260408f"></script>
-<script src="07-post-load.js?v=20260408f" defer></script>
-<script src="08-post-actions.js?v=20260408f" defer></script>
-<script src="09-library.js?v=20260408f" defer></script>
-<script src="09-approval.js?v=20260408f" defer></script>
-<script src="04-router.js?v=20260408f" defer></script>
+<script src="06-post-create.js?v=20260408g" defer></script>
+<script defer src="render/dashboard.js?v=20260408g"></script>
+<script defer src="render/client.js?v=20260408g"></script>
+<script defer src="render/pipeline.js?v=20260408g"></script>
+<script defer src="render/brief.js?v=20260408g"></script>
+<script defer src="actions/pcs.js?v=20260408g"></script>
+<script src="07-post-load.js?v=20260408g" defer></script>
+<script src="08-post-actions.js?v=20260408g" defer></script>
+<script src="09-library.js?v=20260408g" defer></script>
+<script src="09-approval.js?v=20260408g" defer></script>
+<script src="04-router.js?v=20260408g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- **PCS photo grid rewrite**: replaced 5 fixed-height layouts with 4 hero-driven aspect-ratio layouts (padding-bottom technique). Removed .pcs-pg-4, .pcs-pg-5, .pcs-pcell. New classes: .pcs-pg-3plus, .pcs-pg-inner, .pcs-pg-hero, .pcs-pg-col, .pcs-pg-sm
- **Reply bar cancel button**: added ✕ button to PCS reply bar wired to existing _pcsClearReply(), with input refocus after cancel
- **Internal notes ALL chip**: now shows all notes regardless of visibility tag (was filtering to visibility=all only)
- **Missing .pcs-reply-bar CSS**: added the rule so reply indicator bars are styled on both tabs
- **Drive link empty state removed**: section hidden when no URL exists
- **Dashboard CLIENT metric row**: added white-space:nowrap to prevent text wrapping

## Test plan
- [x] 508/508 unit tests passing
- [ ] Verify photo grid: 1 img square, 2 imgs side-by-side, 3 imgs hero+2, 4+ imgs hero+2 with +N overlay
- [ ] Verify reply bar shows ✕ when tapping REPLY on a comment, tapping ✕ clears and refocuses input
- [ ] Verify ALL chip in internal notes shows all notes
- [ ] Verify no Add drive link button on posts without drive links
- [ ] Hard refresh after Cloudflare purge

https://claude.ai/code/session_01SZyPE6ir41GZWWxxduyuqN