### PR TITLE
fix: PCS date picker — showPicker on desktop + clear _isSaving on mobile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408h
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408i
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1527,6 +1527,18 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    input. _pcsDateChange handles cleanup after selection.
    Tapping the chip again closes and reopens correctly.
    508/508 unit passing. Bumped to ?v=20260408h.
+1. PCS date picker — desktop calendar not opening + mobile save silent
+   Location: actions/pcs.js _pcsChipDrop date branch (line 540) and
+   _pcsDateChange (line 609).
+   Desktop: dateInp.focus() does not open Chrome calendar — need
+   showPicker(). Mobile: updatePost has _isSaving guard that silently
+   drops the call if a previous save is in-flight.
+   Status: FIXED (PR#TBD) — added try{dateInp.showPicker()}catch(e){}
+   after focus() to auto-open calendar on desktop. In _pcsDateChange,
+   added dateValue empty guard, _isSaving clear before updatePost,
+   and 300ms setTimeout on openPCS re-render. Test regex window
+   widened from 600→800 chars. 508/508 unit passing.
+   Bumped to ?v=20260408i.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -537,7 +537,10 @@ window._pcsChipDrop = function(chipEl, field, postId) {
     document.body.appendChild(drop);
     setTimeout(function() { window.AppState.pcs.activeMenu = drop; }, 0);
     var dateInp = drop.querySelector('input');
-    if (dateInp) dateInp.focus();
+    if (dateInp) {
+      dateInp.focus();
+      try { dateInp.showPicker(); } catch(e) {}
+    }
     return;
   }
 
@@ -611,8 +614,13 @@ window._pcsDateChange = function(postId, dateValue) {
     window.AppState.pcs.activeMenu = null;
   }
   if (window.AppState && window.AppState.pcs && window.AppState.pcs.open) {
+    if (!dateValue) return;
+    var _postObj = (window.AppState.posts.all || []).find(function(p) {
+      return (p.post_id || p.id) === postId;
+    });
+    if (_postObj) _postObj._isSaving = false;
     if (typeof updatePost === 'function') updatePost(postId, 'targetDate', dateValue);
-    if (typeof openPCS === 'function') openPCS(postId, '');
+    setTimeout(function() { if (typeof openPCS === 'function') openPCS(postId, ''); }, 300);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408h">
+ <link rel="stylesheet" href="styles.css?v=20260408i">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408h"></script>
-<script src="00-appstate-compat.js?v=20260408h"></script>
-<script src="01-config.js?v=20260408h" defer></script>
-<script src="02-session.js?v=20260408h" defer></script>
-<script src="utils.js?v=20260408h" defer></script>
-<script src="03-auth.js?v=20260408h" defer></script>
-<script src="05-api.js?v=20260408h" defer></script>
-<script src="10-ui.js?v=20260408h" defer></script>
+<script src="00-appstate.js?v=20260408i"></script>
+<script src="00-appstate-compat.js?v=20260408i"></script>
+<script src="01-config.js?v=20260408i" defer></script>
+<script src="02-session.js?v=20260408i" defer></script>
+<script src="utils.js?v=20260408i" defer></script>
+<script src="03-auth.js?v=20260408i" defer></script>
+<script src="05-api.js?v=20260408i" defer></script>
+<script src="10-ui.js?v=20260408i" defer></script>
 
-<script src="06-post-create.js?v=20260408h" defer></script>
-<script defer src="render/dashboard.js?v=20260408h"></script>
-<script defer src="render/client.js?v=20260408h"></script>
-<script defer src="render/pipeline.js?v=20260408h"></script>
-<script defer src="render/brief.js?v=20260408h"></script>
-<script defer src="actions/pcs.js?v=20260408h"></script>
-<script src="07-post-load.js?v=20260408h" defer></script>
-<script src="08-post-actions.js?v=20260408h" defer></script>
-<script src="09-library.js?v=20260408h" defer></script>
-<script src="09-approval.js?v=20260408h" defer></script>
-<script src="04-router.js?v=20260408h" defer></script>
+<script src="06-post-create.js?v=20260408i" defer></script>
+<script defer src="render/dashboard.js?v=20260408i"></script>
+<script defer src="render/client.js?v=20260408i"></script>
+<script defer src="render/pipeline.js?v=20260408i"></script>
+<script defer src="render/brief.js?v=20260408i"></script>
+<script defer src="actions/pcs.js?v=20260408i"></script>
+<script src="07-post-load.js?v=20260408i" defer></script>
+<script src="08-post-actions.js?v=20260408i" defer></script>
+<script src="09-library.js?v=20260408i" defer></script>
+<script src="09-approval.js?v=20260408i" defer></script>
+<script src="04-router.js?v=20260408i" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/tests/defensive-guards.test.js
+++ b/tests/defensive-guards.test.js
@@ -73,7 +73,7 @@ describe('FIX 2 — UUID validation before apiFetch', function() {
 describe('FIX 3 — _pcsDateChange guards re-render on closed PCS', function() {
 
   it('_pcsDateChange wraps updatePost+openPCS in pcs.open guard', function() {
-    var match = pcsSrc.match(/_pcsDateChange\s*=\s*function[\s\S]{0,600}/);
+    var match = pcsSrc.match(/_pcsDateChange\s*=\s*function[\s\S]{0,800}/);
     expect(match).toBeTruthy();
     expect(match[0]).toContain('AppState.pcs.open');
     // updatePost and openPCS must be INSIDE the guard, not before it


### PR DESCRIPTION
## Summary
- **Desktop**: `dateInp.focus()` does not open the Chrome calendar popup. Added `try{dateInp.showPicker()}catch(e){}` after focus() so the calendar auto-opens when the date chip dropdown appears. Browsers without showPicker() fall back silently.
- **Mobile**: `updatePost()` has an `_isSaving` guard that silently drops the call if a previous save is in-flight. `_pcsDateChange` now clears `_isSaving` on the post object before calling updatePost, added empty dateValue guard, and delays openPCS re-render by 300ms.

## Test plan
- [x] 508/508 unit tests passing
- [ ] Desktop Chrome: tap date chip → calendar popup should auto-open
- [ ] Desktop Firefox/Safari: tap date chip → input focused, manual click to open picker
- [ ] Mobile iOS: tap date chip → date wheel opens → tap Done → date saves and chip updates
- [ ] Mobile: rapid double-tap on date chip → no duplicate saves
- [ ] Hard refresh after Cloudflare purge

https://claude.ai/code/session_01SZyPE6ir41GZWWxxduyuqN