### PR TITLE
fix: PCS date picker — flag guards dropdown from premature close

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408i
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408k
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1539,6 +1539,20 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    and 300ms setTimeout on openPCS re-render. Test regex window
    widened from 600→800 chars. 508/508 unit passing.
    Bumped to ?v=20260408i.
+1. PCS date picker onchange never fires — dropdown destroyed mid-selection
+   Location: actions/pcs.js document click listener (line 27) and
+   _pcsChipDrop date branch (line 540).
+   Root cause: showPicker() opens Chrome calendar. When user clicks
+   a date, Chrome fires document click BEFORE firing onchange on the
+   input. The document click listener destroyed the dropdown, detaching
+   the input, so onchange never reached _pcsDateChange.
+   Status: FIXED (PR#TBD) — added _pcsDatePickerOpen flag (var at
+   line 23). showPicker() and input click set flag true. Document
+   click listener returns early when flag is true. change event
+   listener (once:true) and _pcsDateChange both clear the flag.
+   Tapping the chip again to dismiss still works because the chip
+   onclick calls _pcsChipDrop which removes activeMenu directly.
+   508/508 unit passing. Bumped to ?v=20260408k.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -20,6 +20,7 @@ window._pcsNoteImgs = [];
 window._pcsReplyTo = null;
 window._pcsReplyToAuthor = null;
 window._pcsActiveTab = 'caption';
+var _pcsDatePickerOpen = false;
 window.AppState.pcs.activeMenu = null;
 window.AppState.ui.modalOpen = window.AppState.ui.modalOpen || false;
 
@@ -27,7 +28,7 @@ document.addEventListener('click', function(e) {
   var menu = window.AppState && window.AppState.pcs && window.AppState.pcs.activeMenu;
   if (!menu) return;
   if (e.target.closest('.pcs-confirm-overlay')) return;
-  if (menu.querySelector('input[type="date"]')) return;
+  if (_pcsDatePickerOpen) return;
   if (!menu.contains(e.target)) {
     menu.remove();
     window.AppState.pcs.activeMenu = null;
@@ -539,7 +540,14 @@ window._pcsChipDrop = function(chipEl, field, postId) {
     var dateInp = drop.querySelector('input');
     if (dateInp) {
       dateInp.focus();
-      try { dateInp.showPicker(); } catch(e) {}
+      _pcsDatePickerOpen = false;
+      dateInp.addEventListener('change', function() {
+        _pcsDatePickerOpen = false;
+      }, { once: true });
+      dateInp.addEventListener('click', function() {
+        _pcsDatePickerOpen = true;
+      }, { once: false });
+      try { dateInp.showPicker(); _pcsDatePickerOpen = true; } catch(e) {}
     }
     return;
   }
@@ -607,6 +615,7 @@ window._pcsChipDrop = function(chipEl, field, postId) {
 
 // -- Date change from inline date picker --
 window._pcsDateChange = function(postId, dateValue) {
+  _pcsDatePickerOpen = false;
   if (window.AppState.pcs.activeMenu) {
     if (window.AppState.pcs.activeMenu.parentNode) {
       window.AppState.pcs.activeMenu.remove();

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408i">
+ <link rel="stylesheet" href="styles.css?v=20260408k">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408i"></script>
-<script src="00-appstate-compat.js?v=20260408i"></script>
-<script src="01-config.js?v=20260408i" defer></script>
-<script src="02-session.js?v=20260408i" defer></script>
-<script src="utils.js?v=20260408i" defer></script>
-<script src="03-auth.js?v=20260408i" defer></script>
-<script src="05-api.js?v=20260408i" defer></script>
-<script src="10-ui.js?v=20260408i" defer></script>
+<script src="00-appstate.js?v=20260408k"></script>
+<script src="00-appstate-compat.js?v=20260408k"></script>
+<script src="01-config.js?v=20260408k" defer></script>
+<script src="02-session.js?v=20260408k" defer></script>
+<script src="utils.js?v=20260408k" defer></script>
+<script src="03-auth.js?v=20260408k" defer></script>
+<script src="05-api.js?v=20260408k" defer></script>
+<script src="10-ui.js?v=20260408k" defer></script>
 
-<script src="06-post-create.js?v=20260408i" defer></script>
-<script defer src="render/dashboard.js?v=20260408i"></script>
-<script defer src="render/client.js?v=20260408i"></script>
-<script defer src="render/pipeline.js?v=20260408i"></script>
-<script defer src="render/brief.js?v=20260408i"></script>
-<script defer src="actions/pcs.js?v=20260408i"></script>
-<script src="07-post-load.js?v=20260408i" defer></script>
-<script src="08-post-actions.js?v=20260408i" defer></script>
-<script src="09-library.js?v=20260408i" defer></script>
-<script src="09-approval.js?v=20260408i" defer></script>
-<script src="04-router.js?v=20260408i" defer></script>
+<script src="06-post-create.js?v=20260408k" defer></script>
+<script defer src="render/dashboard.js?v=20260408k"></script>
+<script defer src="render/client.js?v=20260408k"></script>
+<script defer src="render/pipeline.js?v=20260408k"></script>
+<script defer src="render/brief.js?v=20260408k"></script>
+<script defer src="actions/pcs.js?v=20260408k"></script>
+<script src="07-post-load.js?v=20260408k" defer></script>
+<script src="08-post-actions.js?v=20260408k" defer></script>
+<script src="09-library.js?v=20260408k" defer></script>
+<script src="09-approval.js?v=20260408k" defer></script>
+<script src="04-router.js?v=20260408k" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- **Root cause**: `showPicker()` opens Chrome calendar. When user clicks a date, Chrome fires a `document click` event BEFORE firing `onchange` on the input. The document click listener destroyed the dropdown (detaching the input from DOM), so `onchange` never reached `_pcsDateChange`. Date was never saved.
- **Fix**: Added `_pcsDatePickerOpen` flag variable. `showPicker()` and input `click` set it `true`. Document click listener returns early when flag is `true`. The input's `change` event listener (`once:true`) and `_pcsDateChange` both clear the flag as safety net.

## Test plan
- [x] 508/508 unit tests passing
- [ ] Desktop Chrome: tap date chip → calendar auto-opens → pick a date → date saves and chip updates
- [ ] Desktop Chrome: tap date chip → calendar opens → click outside to dismiss → dropdown stays, tap chip again to close
- [ ] Mobile iOS: tap date chip → date wheel opens → tap Done → date saves
- [ ] Other chip dropdowns (owner, format, pillar, location) still close on outside click
- [ ] Hard refresh after Cloudflare purge

https://claude.ai/code/session_01SZyPE6ir41GZWWxxduyuqN