### PR TITLE
fix: replace date chip dropdown with hidden input — no race condition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408l
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408m
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1546,13 +1546,16 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    a date, Chrome fires document click BEFORE firing onchange on the
    input. The document click listener destroyed the dropdown, detaching
    the input, so onchange never reached _pcsDateChange.
-   Status: FIXED (PR#TBD) — deferred dropdown teardown in the
-   document click listener to next tick via setTimeout(0) so the
-   browser completes its event queue and onchange fires on the
-   input before the dropdown is removed. Added parentNode guard
-   inside the deferred callback. Removed _pcsDatePickerOpen flag
-   (no longer needed — setTimeout alone is sufficient).
-   508/508 unit passing. Bumped to ?v=20260408l.
+   Status: FIXED (PR#TBD) — replaced dropdown approach entirely
+   with a hidden input appended directly to document.body
+   (position:fixed off-screen, opacity:0). showPicker() opens
+   the native calendar without any visible dropdown. change
+   listener calls _pcsDateChange and removes input. blur
+   listener removes input after 200ms delay. No dropdown means
+   no document click listener race condition. Removed dropdown
+   div, activeMenu assignment, and all related wiring from the
+   date branch. _pcsDatePickerOpen flag also removed.
+   508/508 unit passing. Bumped to ?v=20260408m.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -529,23 +529,24 @@ window._pcsChipDrop = function(chipEl, field, postId) {
 
   var post = typeof getPostById === 'function' ? getPostById(postId) : null;
 
-  // DATE: inline date input in dropdown
+  // DATE: hidden input — no dropdown (avoids Chrome calendar race condition)
   if (field === 'date') {
-    var rect = chipEl.getBoundingClientRect();
-    var drop = document.createElement('div');
-    drop.className = 'pcs-chip-drop';
-    drop.style.cssText = 'position:fixed;top:' + (rect.bottom + 4) + 'px;left:' + rect.left + 'px;z-index:9700;';
-    drop.innerHTML = '<div style="padding:12px 16px;background:#141420">' +
-      '<input type="date" value="' + esc(post ? (post.targetDate || '') : '') + '" ' +
-      'style="width:100%;padding:10px 12px;background:#0f0f1a;border:1px solid #1c1c26;color:#fff;font-size:14px;outline:none;color-scheme:dark;font-family:inherit" ' +
-      'onchange="window._pcsDateChange(\'' + esc(postId) + '\',this.value)"/></div>';
-    document.body.appendChild(drop);
-    setTimeout(function() { window.AppState.pcs.activeMenu = drop; }, 0);
-    var dateInp = drop.querySelector('input');
-    if (dateInp) {
-      dateInp.focus();
-      try { dateInp.showPicker(); } catch(e) {}
-    }
+    var existingPicker = document.getElementById('pcs-hidden-date-picker');
+    if (existingPicker) existingPicker.remove();
+    var hiddenInp = document.createElement('input');
+    hiddenInp.type = 'date';
+    hiddenInp.id = 'pcs-hidden-date-picker';
+    hiddenInp.value = post ? (post.targetDate || '') : '';
+    hiddenInp.style.cssText = 'position:fixed;top:-200px;left:-200px;opacity:0;pointer-events:none;';
+    hiddenInp.addEventListener('change', function() {
+      window._pcsDateChange(postId, hiddenInp.value);
+      hiddenInp.remove();
+    });
+    hiddenInp.addEventListener('blur', function() {
+      setTimeout(function() { hiddenInp.remove(); }, 200);
+    });
+    document.body.appendChild(hiddenInp);
+    try { hiddenInp.showPicker(); } catch(e) {}
     return;
   }
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408l">
+ <link rel="stylesheet" href="styles.css?v=20260408m">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408l"></script>
-<script src="00-appstate-compat.js?v=20260408l"></script>
-<script src="01-config.js?v=20260408l" defer></script>
-<script src="02-session.js?v=20260408l" defer></script>
-<script src="utils.js?v=20260408l" defer></script>
-<script src="03-auth.js?v=20260408l" defer></script>
-<script src="05-api.js?v=20260408l" defer></script>
-<script src="10-ui.js?v=20260408l" defer></script>
+<script src="00-appstate.js?v=20260408m"></script>
+<script src="00-appstate-compat.js?v=20260408m"></script>
+<script src="01-config.js?v=20260408m" defer></script>
+<script src="02-session.js?v=20260408m" defer></script>
+<script src="utils.js?v=20260408m" defer></script>
+<script src="03-auth.js?v=20260408m" defer></script>
+<script src="05-api.js?v=20260408m" defer></script>
+<script src="10-ui.js?v=20260408m" defer></script>
 
-<script src="06-post-create.js?v=20260408l" defer></script>
-<script defer src="render/dashboard.js?v=20260408l"></script>
-<script defer src="render/client.js?v=20260408l"></script>
-<script defer src="render/pipeline.js?v=20260408l"></script>
-<script defer src="render/brief.js?v=20260408l"></script>
-<script defer src="actions/pcs.js?v=20260408l"></script>
-<script src="07-post-load.js?v=20260408l" defer></script>
-<script src="08-post-actions.js?v=20260408l" defer></script>
-<script src="09-library.js?v=20260408l" defer></script>
-<script src="09-approval.js?v=20260408l" defer></script>
-<script src="04-router.js?v=20260408l" defer></script>
+<script src="06-post-create.js?v=20260408m" defer></script>
+<script defer src="render/dashboard.js?v=20260408m"></script>
+<script defer src="render/client.js?v=20260408m"></script>
+<script defer src="render/pipeline.js?v=20260408m"></script>
+<script defer src="render/brief.js?v=20260408m"></script>
+<script defer src="actions/pcs.js?v=20260408m"></script>
+<script src="07-post-load.js?v=20260408m" defer></script>
+<script src="08-post-actions.js?v=20260408m" defer></script>
+<script src="09-library.js?v=20260408m" defer></script>
+<script src="09-approval.js?v=20260408m" defer></script>
+<script src="04-router.js?v=20260408m" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Replaced the date chip dropdown entirely with a hidden `<input type="date">` appended directly to `document.body` (positioned off-screen, opacity:0)
- `showPicker()` opens the native calendar without any visible dropdown
- `change` listener calls `_pcsDateChange` and removes the input
- `blur` listener removes the input after 200ms delay on cancel
- **Root cause**: The dropdown approach was unfixable — Chrome fires `document click` before `onchange` when user picks a date from native calendar, destroying the dropdown and detaching the input before `onchange` can fire. No dropdown = no race condition.
- Confirmed working via live console test: `DATE SELECTED: 2026-04-08`

## Test plan
- [x] 508/508 unit tests passing
- [ ] Desktop Chrome: tap date chip → native calendar opens → pick date → saves correctly
- [ ] Desktop Chrome: tap date chip → dismiss calendar → no stale input left in DOM
- [ ] Mobile iOS: tap date chip → date wheel → Done → saves correctly
- [ ] Other chip dropdowns (owner, format, pillar, location) unaffected
- [ ] Hard refresh after Cloudflare purge

https://claude.ai/code/session_01SZyPE6ir41GZWWxxduyuqN