### PR TITLE
feat: custom calendar date picker replaces native input[type=date]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408l
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408n
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -560,6 +560,7 @@ window._reopenBrief, window._createPostFromBrief
 
 actions/pcs.js:
 window._pcsLbImages, window._pcsLbIdx, window._pcsActiveTab, window._pcsDateChange,
+window._pcsShowCalendar,
 window.openPCS, window.closePCS, window.forcePCSReset,
 window._renderPCS, window._pcsTabSwitch, window._pcsChipDrop,
 window._updateSubtitle, window._pcsTitleEdit,
@@ -1546,13 +1547,22 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    a date, Chrome fires document click BEFORE firing onchange on the
    input. The document click listener destroyed the dropdown, detaching
    the input, so onchange never reached _pcsDateChange.
-   Status: FIXED (PR#TBD) — deferred dropdown teardown in the
-   document click listener to next tick via setTimeout(0) so the
-   browser completes its event queue and onchange fires on the
-   input before the dropdown is removed. Added parentNode guard
-   inside the deferred callback. Removed _pcsDatePickerOpen flag
-   (no longer needed — setTimeout alone is sufficient).
-   508/508 unit passing. Bumped to ?v=20260408l.
+   Status: FIXED (PR#TBD) — replaced native input[type=date]
+   entirely with custom HTML/CSS/JS calendar picker
+   (window._pcsShowCalendar). No native date inputs in this
+   feature. Calendar is a fixed-position div appended to body,
+   set as activeMenu so document click listener closes it.
+   Date cells emit YYYY-MM-DD string to _pcsDateChange.
+   Clear button sends '' to clear target_date. Today button
+   navigates to current month and highlights today. Month
+   nav via ← → arrows. Monday-start week. Prev/next month
+   days shown in muted color. Design: #111118 bg, #C8A84B
+   gold for selected + today, IBM Plex Mono headers, DM Sans
+   day numbers. New CSS classes: .pcs-cal, .pcs-cal-header,
+   .pcs-cal-title, .pcs-cal-nav, .pcs-cal-daynames, .pcs-cal-dn,
+   .pcs-cal-grid, .pcs-cal-cell (.is-today/.is-selected/.is-other),
+   .pcs-cal-footer, .pcs-cal-clear, .pcs-cal-today-btn.
+   508/508 unit passing. Bumped to ?v=20260408n.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -529,23 +529,13 @@ window._pcsChipDrop = function(chipEl, field, postId) {
 
   var post = typeof getPostById === 'function' ? getPostById(postId) : null;
 
-  // DATE: inline date input in dropdown
+  // DATE: custom calendar picker (avoids native input race condition)
   if (field === 'date') {
-    var rect = chipEl.getBoundingClientRect();
-    var drop = document.createElement('div');
-    drop.className = 'pcs-chip-drop';
-    drop.style.cssText = 'position:fixed;top:' + (rect.bottom + 4) + 'px;left:' + rect.left + 'px;z-index:9700;';
-    drop.innerHTML = '<div style="padding:12px 16px;background:#141420">' +
-      '<input type="date" value="' + esc(post ? (post.targetDate || '') : '') + '" ' +
-      'style="width:100%;padding:10px 12px;background:#0f0f1a;border:1px solid #1c1c26;color:#fff;font-size:14px;outline:none;color-scheme:dark;font-family:inherit" ' +
-      'onchange="window._pcsDateChange(\'' + esc(postId) + '\',this.value)"/></div>';
-    document.body.appendChild(drop);
-    setTimeout(function() { window.AppState.pcs.activeMenu = drop; }, 0);
-    var dateInp = drop.querySelector('input');
-    if (dateInp) {
-      dateInp.focus();
-      try { dateInp.showPicker(); } catch(e) {}
-    }
+    var postObj = (window.AppState.posts.all || []).find(function(p) {
+      return (p.post_id || p.id) === postId;
+    });
+    var currentDate = postObj ? (postObj.targetDate || '') : '';
+    window._pcsShowCalendar(chipEl, postId, currentDate);
     return;
   }
 
@@ -610,7 +600,161 @@ window._pcsChipDrop = function(chipEl, field, postId) {
   setTimeout(function() { window.AppState.pcs.activeMenu = drop; }, 0);
 }
 
-// -- Date change from inline date picker --
+// -- Custom calendar date picker --
+window._pcsShowCalendar = function(chipEl, postId, currentDate) {
+  // Remove any existing calendar
+  var existing = document.getElementById('pcs-cal-root');
+  if (existing) existing.remove();
+  if (window.AppState && window.AppState.pcs) window.AppState.pcs.activeMenu = null;
+
+  // Parse current date
+  var today = new Date();
+  var todayY = today.getFullYear();
+  var todayM = today.getMonth();
+  var todayD = today.getDate();
+
+  var selYear = null, selMonth = null, selDay = null;
+  if (currentDate && currentDate.length === 10) {
+    var parts = currentDate.split('-');
+    selYear = parseInt(parts[0]);
+    selMonth = parseInt(parts[1]) - 1;
+    selDay = parseInt(parts[2]);
+  }
+
+  var viewYear = selYear !== null ? selYear : todayY;
+  var viewMonth = selMonth !== null ? selMonth : todayM;
+
+  var MONTH_NAMES = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+  var DAY_NAMES = ['Mo','Tu','We','Th','Fr','Sa','Su'];
+
+  // Build calendar element
+  var cal = document.createElement('div');
+  cal.id = 'pcs-cal-root';
+  cal.className = 'pcs-cal';
+  cal.addEventListener('click', function(e) { e.stopPropagation(); });
+
+  function buildGrid() {
+    var firstDay = new Date(viewYear, viewMonth, 1).getDay();
+    var startOffset = (firstDay + 6) % 7;
+    var daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+    var daysInPrev = new Date(viewYear, viewMonth, 0).getDate();
+
+    var titleEl = cal.querySelector('.pcs-cal-title');
+    if (titleEl) titleEl.textContent = MONTH_NAMES[viewMonth] + ' ' + viewYear;
+
+    var grid = cal.querySelector('.pcs-cal-grid');
+    grid.innerHTML = '';
+
+    var totalCells = Math.ceil((startOffset + daysInMonth) / 7) * 7;
+
+    for (var i = 0; i < totalCells; i++) {
+      var cell = document.createElement('div');
+      cell.className = 'pcs-cal-cell';
+      var cellDay, cellMonth, cellYear;
+
+      if (i < startOffset) {
+        cellDay = daysInPrev - startOffset + i + 1;
+        cellMonth = viewMonth - 1;
+        cellYear = viewYear;
+        if (cellMonth < 0) { cellMonth = 11; cellYear--; }
+        cell.classList.add('is-other');
+      } else if (i >= startOffset + daysInMonth) {
+        cellDay = i - startOffset - daysInMonth + 1;
+        cellMonth = viewMonth + 1;
+        cellYear = viewYear;
+        if (cellMonth > 11) { cellMonth = 0; cellYear++; }
+        cell.classList.add('is-other');
+      } else {
+        cellDay = i - startOffset + 1;
+        cellMonth = viewMonth;
+        cellYear = viewYear;
+      }
+
+      cell.textContent = cellDay;
+
+      if (cellYear === todayY && cellMonth === todayM && cellDay === todayD) {
+        cell.classList.add('is-today');
+      }
+
+      if (selYear !== null && cellYear === selYear && cellMonth === selMonth && cellDay === selDay) {
+        cell.classList.add('is-selected');
+      }
+
+      (function(y, m, d) {
+        cell.addEventListener('click', function(e) {
+          e.stopPropagation();
+          var mm = String(m + 1).padStart(2, '0');
+          var dd = String(d).padStart(2, '0');
+          var dateStr = y + '-' + mm + '-' + dd;
+          cal.remove();
+          if (window.AppState && window.AppState.pcs) window.AppState.pcs.activeMenu = null;
+          window._pcsDateChange(postId, dateStr);
+        });
+      })(cellYear, cellMonth, cellDay);
+
+      grid.appendChild(cell);
+    }
+  }
+
+  // Build full HTML structure
+  cal.innerHTML =
+    '<div class="pcs-cal-header">' +
+      '<div class="pcs-cal-title"></div>' +
+      '<div class="pcs-cal-nav">' +
+        '<button class="pcs-cal-prev">&#8592;</button>' +
+        '<button class="pcs-cal-next">&#8594;</button>' +
+      '</div>' +
+    '</div>' +
+    '<div class="pcs-cal-daynames">' +
+      DAY_NAMES.map(function(d) { return '<div class="pcs-cal-dn">' + d + '</div>'; }).join('') +
+    '</div>' +
+    '<div class="pcs-cal-grid"></div>' +
+    '<div class="pcs-cal-footer">' +
+      '<button class="pcs-cal-clear">Clear</button>' +
+      '<button class="pcs-cal-today-btn">Today</button>' +
+    '</div>';
+
+  cal.querySelector('.pcs-cal-prev').addEventListener('click', function(e) {
+    e.stopPropagation();
+    viewMonth--;
+    if (viewMonth < 0) { viewMonth = 11; viewYear--; }
+    buildGrid();
+  });
+  cal.querySelector('.pcs-cal-next').addEventListener('click', function(e) {
+    e.stopPropagation();
+    viewMonth++;
+    if (viewMonth > 11) { viewMonth = 0; viewYear++; }
+    buildGrid();
+  });
+
+  cal.querySelector('.pcs-cal-clear').addEventListener('click', function(e) {
+    e.stopPropagation();
+    cal.remove();
+    if (window.AppState && window.AppState.pcs) window.AppState.pcs.activeMenu = null;
+    window._pcsDateChange(postId, '');
+  });
+
+  cal.querySelector('.pcs-cal-today-btn').addEventListener('click', function(e) {
+    e.stopPropagation();
+    viewYear = todayY;
+    viewMonth = todayM;
+    selYear = todayY;
+    selMonth = todayM;
+    selDay = todayD;
+    buildGrid();
+  });
+
+  var rect = chipEl.getBoundingClientRect();
+  cal.style.top = (rect.bottom + 4) + 'px';
+  cal.style.left = rect.left + 'px';
+
+  document.body.appendChild(cal);
+  buildGrid();
+
+  window.AppState.pcs.activeMenu = cal;
+};
+
+// -- Date change from date picker --
 window._pcsDateChange = function(postId, dateValue) {
   if (window.AppState.pcs.activeMenu) {
     if (window.AppState.pcs.activeMenu.parentNode) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408l">
+ <link rel="stylesheet" href="styles.css?v=20260408n">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408l"></script>
-<script src="00-appstate-compat.js?v=20260408l"></script>
-<script src="01-config.js?v=20260408l" defer></script>
-<script src="02-session.js?v=20260408l" defer></script>
-<script src="utils.js?v=20260408l" defer></script>
-<script src="03-auth.js?v=20260408l" defer></script>
-<script src="05-api.js?v=20260408l" defer></script>
-<script src="10-ui.js?v=20260408l" defer></script>
+<script src="00-appstate.js?v=20260408n"></script>
+<script src="00-appstate-compat.js?v=20260408n"></script>
+<script src="01-config.js?v=20260408n" defer></script>
+<script src="02-session.js?v=20260408n" defer></script>
+<script src="utils.js?v=20260408n" defer></script>
+<script src="03-auth.js?v=20260408n" defer></script>
+<script src="05-api.js?v=20260408n" defer></script>
+<script src="10-ui.js?v=20260408n" defer></script>
 
-<script src="06-post-create.js?v=20260408l" defer></script>
-<script defer src="render/dashboard.js?v=20260408l"></script>
-<script defer src="render/client.js?v=20260408l"></script>
-<script defer src="render/pipeline.js?v=20260408l"></script>
-<script defer src="render/brief.js?v=20260408l"></script>
-<script defer src="actions/pcs.js?v=20260408l"></script>
-<script src="07-post-load.js?v=20260408l" defer></script>
-<script src="08-post-actions.js?v=20260408l" defer></script>
-<script src="09-library.js?v=20260408l" defer></script>
-<script src="09-approval.js?v=20260408l" defer></script>
-<script src="04-router.js?v=20260408l" defer></script>
+<script src="06-post-create.js?v=20260408n" defer></script>
+<script defer src="render/dashboard.js?v=20260408n"></script>
+<script defer src="render/client.js?v=20260408n"></script>
+<script defer src="render/pipeline.js?v=20260408n"></script>
+<script defer src="render/brief.js?v=20260408n"></script>
+<script defer src="actions/pcs.js?v=20260408n"></script>
+<script src="07-post-load.js?v=20260408n" defer></script>
+<script src="08-post-actions.js?v=20260408n" defer></script>
+<script src="09-library.js?v=20260408n" defer></script>
+<script src="09-approval.js?v=20260408n" defer></script>
+<script src="04-router.js?v=20260408n" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6809,6 +6809,111 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-chip-drop-item:hover, .pcs-chip-drop-item:active { background: #FFFFFF0F; color: #E8E8E8; }
 .pcs-chip-drop-item.selected { color: #F6A623; }
 
+/* Custom calendar date picker */
+.pcs-cal {
+  position: fixed;
+  z-index: 9700;
+  background: #111118;
+  border: 1px solid #222230;
+  width: 240px;
+  box-shadow: 0 8px 32px #00000099;
+}
+.pcs-cal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid #191924;
+}
+.pcs-cal-title {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: #E8E8E8;
+}
+.pcs-cal-nav { display: flex; gap: 4px; }
+.pcs-cal-nav button {
+  background: none;
+  border: none;
+  color: #AEAEB2;
+  cursor: pointer;
+  padding: 2px 6px;
+  font-size: 12px;
+  font-family: 'IBM Plex Mono', monospace;
+}
+.pcs-cal-nav button:hover { color: #E8E8E8; background: #191924; }
+.pcs-cal-daynames {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  padding: 8px 8px 4px;
+  gap: 2px;
+}
+.pcs-cal-dn {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-align: center;
+  color: #555566;
+  text-transform: uppercase;
+}
+.pcs-cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  padding: 4px 8px 10px;
+  gap: 2px;
+}
+.pcs-cal-cell {
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  cursor: pointer;
+  color: #AEAEB2;
+}
+.pcs-cal-cell:hover { background: #191924; color: #E8E8E8; }
+.pcs-cal-cell.is-today { color: #C8A84B; font-weight: 700; }
+.pcs-cal-cell.is-selected { background: #C8A84B; color: #000000; font-weight: 700; }
+.pcs-cal-cell.is-selected:hover { background: #C8A84B; }
+.pcs-cal-cell.is-other { color: #333344; }
+.pcs-cal-cell.is-other:hover { background: #191924; color: #555566; }
+.pcs-cal-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  border-top: 1px solid #191924;
+}
+.pcs-cal-clear {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #555566;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 4px 0;
+}
+.pcs-cal-clear:hover { color: #AEAEB2; }
+.pcs-cal-today-btn {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #C8A84B;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 4px 0;
+}
+.pcs-cal-today-btn:hover { color: #E8E8E8; }
+
 /* FIX 5: Pane overflow */
 #pcs-pane-caption, #pcs-pane-client, #pcs-pane-internal { overflow: hidden; }
 


### PR DESCRIPTION
Native input[type=date] had unfixable race condition: Chrome fires document click before onchange, destroying the dropdown before the date selection reaches _pcsDateChange.

Built custom HTML/CSS/JS calendar (window._pcsShowCalendar):
- Monday-start week grid with prev/next month navigation
- Today highlight (gold), selected date highlight (gold bg)
- Previous/next month days shown in muted color
- Clear button (sends '' to clear target_date)
- Today button (navigates to current month)
- Closes on outside click via activeMenu pattern
- Date cells emit YYYY-MM-DD to _pcsDateChange
- Design: #111118 bg, IBM Plex Mono headers, DM Sans numbers

Zero native date inputs in _pcsChipDrop.

508/508 tests passing. Bumped to ?v=20260408n.

https://claude.ai/code/session_01SZyPE6ir41GZWWxxduyuqN