### PR TITLE
fix: add date input guard to PCS document click listener

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Root files: rollback.sql — DB rollback for role standardization (run if produc
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408l
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408m
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1540,19 +1540,24 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    widened from 600→800 chars. 508/508 unit passing.
    Bumped to ?v=20260408i.
 1. PCS date picker onchange never fires — dropdown destroyed mid-selection
-   Location: actions/pcs.js document click listener (line 27) and
-   _pcsChipDrop date branch (line 540).
+   Location: actions/pcs.js document click listener (line 26) and
+   _pcsChipDrop date branch (line 533).
    Root cause: showPicker() opens Chrome calendar. When user clicks
    a date, Chrome fires document click BEFORE firing onchange on the
    input. The document click listener destroyed the dropdown, detaching
    the input, so onchange never reached _pcsDateChange.
-   Status: FIXED (PR#TBD) — deferred dropdown teardown in the
-   document click listener to next tick via setTimeout(0) so the
-   browser completes its event queue and onchange fires on the
-   input before the dropdown is removed. Added parentNode guard
-   inside the deferred callback. Removed _pcsDatePickerOpen flag
-   (no longer needed — setTimeout alone is sufficient).
-   508/508 unit passing. Bumped to ?v=20260408l.
+   Previous fix (setTimeout(0) deferral) masked the problem — the
+   date input guard from the first fix was never actually merged.
+   Status: FIXED (PR#TBD) — replaced the setTimeout(0) deferral
+   with a proper date input guard:
+   if (menu.querySelector('input[type="date"]')) return;
+   When the active dropdown contains a date input, the document
+   click listener exits immediately — no removal, no deferral.
+   _pcsDateChange (line 614) handles dropdown cleanup after
+   selection. Removed setTimeout(0) wrapper entirely — direct
+   menu.remove() + activeMenu = null for non-date dropdowns.
+   showPicker() (line 542) retained from prior fix for desktop.
+   508/508 unit passing. Bumped to ?v=20260408m.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -27,15 +27,10 @@ document.addEventListener('click', function(e) {
   var menu = window.AppState && window.AppState.pcs && window.AppState.pcs.activeMenu;
   if (!menu) return;
   if (e.target.closest('.pcs-confirm-overlay')) return;
+  if (menu.querySelector('input[type="date"]')) return;
   if (!menu.contains(e.target)) {
-    setTimeout(function() {
-      if (menu && menu.parentNode) {
-        menu.remove();
-      }
-      if (window.AppState && window.AppState.pcs) {
-        window.AppState.pcs.activeMenu = null;
-      }
-    }, 0);
+    menu.remove();
+    window.AppState.pcs.activeMenu = null;
   }
 });
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408l">
+ <link rel="stylesheet" href="styles.css?v=20260408m">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408l"></script>
-<script src="00-appstate-compat.js?v=20260408l"></script>
-<script src="01-config.js?v=20260408l" defer></script>
-<script src="02-session.js?v=20260408l" defer></script>
-<script src="utils.js?v=20260408l" defer></script>
-<script src="03-auth.js?v=20260408l" defer></script>
-<script src="05-api.js?v=20260408l" defer></script>
-<script src="10-ui.js?v=20260408l" defer></script>
+<script src="00-appstate.js?v=20260408m"></script>
+<script src="00-appstate-compat.js?v=20260408m"></script>
+<script src="01-config.js?v=20260408m" defer></script>
+<script src="02-session.js?v=20260408m" defer></script>
+<script src="utils.js?v=20260408m" defer></script>
+<script src="03-auth.js?v=20260408m" defer></script>
+<script src="05-api.js?v=20260408m" defer></script>
+<script src="10-ui.js?v=20260408m" defer></script>
 
-<script src="06-post-create.js?v=20260408l" defer></script>
-<script defer src="render/dashboard.js?v=20260408l"></script>
-<script defer src="render/client.js?v=20260408l"></script>
-<script defer src="render/pipeline.js?v=20260408l"></script>
-<script defer src="render/brief.js?v=20260408l"></script>
-<script defer src="actions/pcs.js?v=20260408l"></script>
-<script src="07-post-load.js?v=20260408l" defer></script>
-<script src="08-post-actions.js?v=20260408l" defer></script>
-<script src="09-library.js?v=20260408l" defer></script>
-<script src="09-approval.js?v=20260408l" defer></script>
-<script src="04-router.js?v=20260408l" defer></script>
+<script src="06-post-create.js?v=20260408m" defer></script>
+<script defer src="render/dashboard.js?v=20260408m"></script>
+<script defer src="render/client.js?v=20260408m"></script>
+<script defer src="render/pipeline.js?v=20260408m"></script>
+<script defer src="render/brief.js?v=20260408m"></script>
+<script defer src="actions/pcs.js?v=20260408m"></script>
+<script src="07-post-load.js?v=20260408m" defer></script>
+<script src="08-post-actions.js?v=20260408m" defer></script>
+<script src="09-library.js?v=20260408m" defer></script>
+<script src="09-approval.js?v=20260408m" defer></script>
+<script src="04-router.js?v=20260408m" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- **actions/pcs.js**: Added `menu.querySelector('input[type="date"]')` guard to the document click listener (line 30). When the active dropdown contains a date input, the listener exits immediately — no removal, no deferral. Removed the `setTimeout(0)` wrapper that was masking the problem. `_pcsDateChange` handles dropdown cleanup after date selection. `showPicker()` at line 542 retained from prior fix for desktop Chrome.
- **index.html**: Bumped all 20 `?v=` strings from `20260408l` → `20260408m`.
- **CLAUDE.md**: Updated version to `?v=20260408m`. Updated date picker bug entry #3 to reflect actual fix (guard merged, setTimeout removed).

## Test plan
- [x] 508/508 unit tests passing (`npx vitest run`)
- [ ] Verify date chip tap opens native picker on iOS Safari
- [ ] Verify date selection fires onchange and saves to Supabase
- [ ] Verify PCS re-renders with new date after 300ms
- [ ] Verify non-date chip dropdowns (format, pillar, location, owner, stage) still close on outside click
- [ ] Hard refresh after Cloudflare purge on all devices

https://claude.ai/code/session_01TrcBUYfdW9aSrQsh1UBrXz