### PR TITLE
fix: set AppState.pcs.open flag — date picker save was dead code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408m
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408n
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1564,6 +1564,21 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    menu.remove() + activeMenu = null for non-date dropdowns.
    showPicker() (line 542) retained from prior fix for desktop.
    508/508 unit passing. Bumped to ?v=20260408m.
+1. PCS date picker — date never saved (pcs.open flag never set)
+   Location: actions/pcs.js _pcsDateChange() line 618 guards the
+   updatePost + openPCS calls behind window.AppState.pcs.open.
+   But pcs.open was initialized false in 00-appstate.js:32 and
+   NEVER set to true anywhere. openPCS() set ui.modalOpen = true
+   (line 70) but never set pcs.open = true. The entire save block
+   inside _pcsDateChange was dead code — dropdown closed, date
+   value silently dropped every time.
+   Status: FIXED (PR#TBD) — added window.AppState.pcs.open = true
+   in openPCS() (line 71, right after modalOpen = true), and
+   window.AppState.pcs.open = false in forcePCSReset() (line 151,
+   right after modalOpen = false). closePCS() delegates to
+   forcePCSReset so both paths are covered. _pcsDateChange guard
+   unchanged — it was correct, the flag was just never set.
+   508/508 unit passing. Bumped to ?v=20260408n.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -68,6 +68,7 @@ window.openPCS = function(postId, listKey) {
   overlay.style.pointerEvents = '';
 
   window.AppState.ui.modalOpen = true;
+  window.AppState.pcs.open = true;
   document.body.style.overflow = 'hidden';
 
   try {
@@ -147,6 +148,7 @@ window.forcePCSReset = function() {
 
   // 5. Reset all state flags
   window.AppState.ui.modalOpen = false;
+  window.AppState.pcs.open = false;
 
   // 6. Clear PCS context
   window._pcs.postId = null;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408m">
+ <link rel="stylesheet" href="styles.css?v=20260408n">
 
 </head>
 <body>
@@ -1077,26 +1077,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408m"></script>
-<script src="00-appstate-compat.js?v=20260408m"></script>
-<script src="01-config.js?v=20260408m" defer></script>
-<script src="02-session.js?v=20260408m" defer></script>
-<script src="utils.js?v=20260408m" defer></script>
-<script src="03-auth.js?v=20260408m" defer></script>
-<script src="05-api.js?v=20260408m" defer></script>
-<script src="10-ui.js?v=20260408m" defer></script>
+<script src="00-appstate.js?v=20260408n"></script>
+<script src="00-appstate-compat.js?v=20260408n"></script>
+<script src="01-config.js?v=20260408n" defer></script>
+<script src="02-session.js?v=20260408n" defer></script>
+<script src="utils.js?v=20260408n" defer></script>
+<script src="03-auth.js?v=20260408n" defer></script>
+<script src="05-api.js?v=20260408n" defer></script>
+<script src="10-ui.js?v=20260408n" defer></script>
 
-<script src="06-post-create.js?v=20260408m" defer></script>
-<script defer src="render/dashboard.js?v=20260408m"></script>
-<script defer src="render/client.js?v=20260408m"></script>
-<script defer src="render/pipeline.js?v=20260408m"></script>
-<script defer src="render/brief.js?v=20260408m"></script>
-<script defer src="actions/pcs.js?v=20260408m"></script>
-<script src="07-post-load.js?v=20260408m" defer></script>
-<script src="08-post-actions.js?v=20260408m" defer></script>
-<script src="09-library.js?v=20260408m" defer></script>
-<script src="09-approval.js?v=20260408m" defer></script>
-<script src="04-router.js?v=20260408m" defer></script>
+<script src="06-post-create.js?v=20260408n" defer></script>
+<script defer src="render/dashboard.js?v=20260408n"></script>
+<script defer src="render/client.js?v=20260408n"></script>
+<script defer src="render/pipeline.js?v=20260408n"></script>
+<script defer src="render/brief.js?v=20260408n"></script>
+<script defer src="actions/pcs.js?v=20260408n"></script>
+<script src="07-post-load.js?v=20260408n" defer></script>
+<script src="08-post-actions.js?v=20260408n" defer></script>
+<script src="09-library.js?v=20260408n" defer></script>
+<script src="09-approval.js?v=20260408n" defer></script>
+<script src="04-router.js?v=20260408n" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- **actions/pcs.js line 71**: Added `window.AppState.pcs.open = true` in `openPCS()` right after `modalOpen = true`
- **actions/pcs.js line 151**: Added `window.AppState.pcs.open = false` in `forcePCSReset()` right after `modalOpen = false` (covers both closePCS and forcePCSReset paths)
- **index.html**: Bumped all 20 `?v=` strings from `20260408m` → `20260408n`
- **CLAUDE.md**: Updated version + added bug entry documenting root cause

**Root cause**: `_pcsDateChange()` guards `updatePost()` + `openPCS()` behind `AppState.pcs.open`. But `pcs.open` was initialized `false` in `00-appstate.js:32` and never set to `true` anywhere. The entire save block was dead code — dropdown closed, date value silently dropped every time.

## Test plan
- [x] 508/508 unit tests passing (`npx vitest run`)
- [ ] Tap date chip → select date → confirm toast "Saved" appears
- [ ] PCS re-renders with new date after 300ms
- [ ] Close PCS → reopen → date persists (saved to Supabase)
- [ ] Test on iOS Safari (native wheel picker)
- [ ] Hard refresh after Cloudflare purge

https://claude.ai/code/session_01TrcBUYfdW9aSrQsh1UBrXz