### PR TITLE
chore: PCS dead code cleanup — delete 12 unused functions, fix stray …

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -820,16 +820,6 @@ function updateNotifBadge() {
   }).catch(function(err){ console.error('[10-ui] updateNotifBadge', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'update-notif-badge'); });
 }
 
-// -- PCS Activity toggle -----------------------
-function togglePCSActivity() {
-  var body = document.getElementById('pcs-activity-body');
-  if (!body) return;
-  var isOpen = body.style.display !== 'none';
-  body.style.display = isOpen ? 'none' : 'block';
-  var trigger = document.getElementById('pc-activity-trigger');
-  if (trigger) trigger.classList.toggle('expanded', !isOpen);
-}
-
 // -- Zen mode ----------------------------------
 function openZen(title, comments) {
   const overlay = document.getElementById('zen-overlay');

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Sorted (srtd.io)
 
-# Last updated: 2026-04-08
+# Last updated: 2026-04-09
 
 # All facts verified from actual codebase
 
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408n
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408o
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -568,20 +568,17 @@ actions/pcs.js:
 window._pcsLbImages, window._pcsLbIdx, window._pcsActiveTab, window._pcsDateChange,
 window.openPCS, window.closePCS, window.forcePCSReset,
 window._renderPCS, window._pcsTabSwitch, window._pcsChipDrop,
-window._updateSubtitle, window._pcsTitleEdit,
+window._pcsTitleEdit,
 window.changeStage, window._showPublishSheet, window._removePublishSheet,
 window._saveLiUrlInline, window.loadPcsComments, window._showStageConfirm,
-window._buildStageProgress, window._buildInlineActions, window._buildDriveLinkCard,
-window._pcsEditLink,
-window.pcsCloseAttach, window.pcsSaveAttach, window._loadPCSActivity,
-window._buildInfoGrid, window._buildNotes, window._renderAdvanceButton,
-window._renderActivityCount, window._removePcsConfirm, window.pcsConfirmDelete,
+window._buildDriveLinkCard,
+window._removePcsConfirm, window.pcsConfirmDelete,
 window.pcsDoDelete, window._pcsAddPhotos, window._pcsHandlePhotoInput,
 window._pcsRemovePhoto, window._pcsPhotoMenu, window._pcsSaveAllPhotos,
 window._pcsCloseUnifiedMenu, window._pcsEnterEditMode, window._pcsExitEditMode,
 window._pcsConfirmRemovePhoto, window._pcsDoRemovePhotoEdit,
 window._pcsConfirmClearCaption, window._pcsDoClearing,
-window._pcsCaptionMenu, window._pcsCopyCaption, window._pcsConfirmReplace,
+window._pcsCopyCaption, window._pcsConfirmReplace,
 window._pcsDoReplace, window._pcsOpenLightbox, window._pcsLbRender,
 window._pcsLbNext, window._pcsLbPrev, window._pcsLbClose,
 window._pcsLbDownload, window._startCaptionEdit, window._cancelCaptionEdit,
@@ -1579,6 +1576,51 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    forcePCSReset so both paths are covered. _pcsDateChange guard
    unchanged — it was correct, the flag was just never set.
    508/508 unit passing. Bumped to ?v=20260408n.
+1. PCS dead code cleanup — 12 dead functions, 347 net lines removed
+   Location: actions/pcs.js, 10-ui.js, index.html, styles.css
+   Scope:
+   (a) Deleted 12 dead functions from actions/pcs.js that were
+       defined but never called from _renderPCS or any live code
+       path: _buildStageProgress, _buildInfoGrid,
+       _buildInlineActions, _buildNotes, _renderAdvanceButton,
+       _renderActivityCount, _updateSubtitle, _pcsCaptionMenu,
+       _pcsEditLink, pcsCloseAttach, pcsSaveAttach,
+       _loadPCSActivity. Also deleted _ADVANCE_SEQ,
+       _ADVANCE_LABELS, _ADVANCE_CLS constants and
+       _pcsEditingTarget state variable.
+   (b) Deleted togglePCSActivity dead function from 10-ui.js.
+   (c) Deleted #pcs-activity-body div from index.html (was
+       display:none permanently, nothing wrote to it).
+   (d) Removed 2 dead pcsCloseAttach calls from live code:
+       _pcsTitleEdit L757 and _showStageConfirm L1277 — both
+       were no-ops since the attach editor elements (created by
+       _buildInlineActions) were never in the DOM.
+   (e) Fixed stray "11" count badge — #pcs-comments-count and
+       #pcs-notes-count spans were being set to display:inline
+       by loadPcsComments, making them visible as standalone
+       elements in the client/internal panes. Removed the
+       display toggle so they stay display:none always. Tab
+       badges (#pcs-tab-client-count, #pcs-tab-notes-count)
+       already show the count inside the tab label.
+   (f) Normalized chip fonts — added font-family:'IBM Plex
+       Mono',monospace to .pcs-chip (had none, was inheriting).
+       Changed .pcs-chip-drop-item and .pcs-photo-label from
+       'Courier New' to 'IBM Plex Mono'. Changed .pcs-ibar-hint
+       from 'Courier New' to 'IBM Plex Mono'. 5 remaining
+       Courier New refs in styles.css: .pcs-stage-pill,
+       .pcs-od-pill, .pcs-tab, .pcs-wa-btn (not changed, will
+       be addressed in font consolidation PR).
+   (g) Replaced inline styles on PCS input bars with CSS
+       classes. Client and internal note input bars in
+       index.html now use .pcs-ibar-wrap/.client/.notes,
+       .pcs-ibar-pill, .pcs-ibar-plus, .pcs-ibar-input,
+       .pcs-ibar-send, .pcs-ibar-hint CSS classes. Updated
+       CSS class values to exactly match previous inline styles
+       (border colors, backgrounds, box-shadows, scrollbar,
+       opacity, transition). Zero visual change.
+   actions/pcs.js reduced from 2831 to 2493 lines (−338).
+   Status: FIXED (PR#TBD) — 508/508 unit passing, 40/40 e2e.
+   Bumped to ?v=20260408o.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -12,7 +12,6 @@ window._pcs = {
   idx:     0,
 };
 window._pcsCloseTimer = null;
-window._pcsEditingTarget = null;
 window._pcsLbImages = [];
 window._pcsLbIdx = 0;
 window._pcsClientImgs = [];
@@ -712,49 +711,11 @@ function _buildWAHtml(post, id, postId, stageLC) {
     '</div>';
 }
 
-// -- Subtitle sync — now shows stage pill + owner + date summary --
-window._updateSubtitle = function(post) {
-  var el = document.getElementById('pcs-subtitle');
-  if (!el || !post) return;
-  var stLC = post.stage || '';
-  var stageLabel = (typeof STAGE_DISPLAY !== 'undefined' && STAGE_DISPLAY[stLC]) || stLC || '';
-  var stageColor = '#AEAEB2';
-  if (stLC === 'in_production' || stLC === 'awaiting_brand_input') stageColor = '#F6A623';
-  else if (stLC === 'ready') stageColor = '#3ECF8E';
-  else if (stLC === 'awaiting_approval') stageColor = '#FF4B4B';
-  else if (stLC === 'scheduled') stageColor = '#22D3EE';
-  else if (stLC === 'published') stageColor = '#8E8E93';
-
-  var pLabel = post.contentPillar ? (typeof getPillarShort === 'function' ? getPillarShort(post.contentPillar) : post.contentPillar) : '';
-  var dVal = post.targetDate || '';
-  var dDisp = (typeof formatDate === 'function' ? formatDate(dVal) : dVal) || '';
-  var ownerDisp = typeof formatOwner === 'function' ? formatOwner(post.owner) : (post.owner || '');
-
-  var parts = [];
-  if (pLabel) parts.push(esc(pLabel));
-  if (ownerDisp && ownerDisp !== '--') parts.push(esc(ownerDisp));
-  if (dDisp) parts.push(esc(dDisp));
-  var html = '<span class="pcs-stage-pill" style="color:' + stageColor + ';border-color:' + stageColor + ';">' + esc(stageLabel) + '</span>';
-  if (parts.length) html += '<span class="pc-sub-dot"></span>' + parts.join('<span class="pc-sub-dot"></span>');
-
-  // Overdue badge
-  var _noOverdue = ['published', 'parked', 'rejected'];
-  if (_noOverdue.indexOf(stLC) === -1 && dVal) {
-    var td = typeof parseDate === 'function' ? parseDate(dVal) : null;
-    var now = new Date(); now.setHours(0,0,0,0);
-    if (td && td < now) {
-      html += '<span class="pc-sub-dot"></span><span class="pc-overdue-badge">Overdue</span>';
-    }
-  }
-  el.innerHTML = html;
-}
-
 // -- Inline title editing --------------
 window._pcsTitleEdit = function(el, postId) {
   if (el.querySelector('input')) return; // already editing
   // Close other interactive layers  -  only one at a time
   _removePcsConfirm();
-  pcsCloseAttach(postId);
   const current = el.textContent;
   const input = document.createElement('input');
   input.type = 'text';
@@ -1195,12 +1156,7 @@ window.loadPcsComments = async function(postId) {
 
     var countEl = document.getElementById('pcs-comments-count');
     if (countEl) {
-      if (clientRows.length) {
-        countEl.textContent = clientRows.length;
-        countEl.style.display = 'inline';
-      } else {
-        countEl.style.display = 'none';
-      }
+      countEl.textContent = clientRows.length;
     }
 
     // Update tab count badge
@@ -1242,12 +1198,7 @@ window.loadPcsComments = async function(postId) {
 
       var notesCountEl = document.getElementById('pcs-notes-count');
       if (notesCountEl) {
-        if (filteredNotes.length) {
-          notesCountEl.textContent = activeRows.length;
-          notesCountEl.style.display = 'inline';
-        } else {
-          notesCountEl.style.display = 'none';
-        }
+        notesCountEl.textContent = activeRows.length;
       }
 
       // Update tab count badge
@@ -1273,8 +1224,6 @@ window.loadPcsComments = async function(postId) {
 
 window._showStageConfirm = function(postId, newStage) {
   _removePcsConfirm();
-  // Close any open attach editor  -  only one interactive layer at a time
-  if (window._pcs.postId) pcsCloseAttach(window._pcs.postId);
   const displayName = (typeof STAGE_DISPLAY !== 'undefined' && STAGE_DISPLAY[newStage]) || newStage;
   const overlay = document.createElement('div');
   overlay.className = 'pcs-confirm-overlay';
@@ -1290,262 +1239,6 @@ window._showStageConfirm = function(postId, newStage) {
     </div>`;
   document.body.appendChild(overlay);
   setTimeout(function() { overlay.classList.add('open'); }, 10);
-}
-
-window._buildStageProgress = function(stageLC) {
-  const steps = [
-    { key: 'in_production',      label: 'Production' },
-    { key: 'ready',              label: 'Ready' },
-    { key: 'awaiting_approval',  label: 'Approval' },
-    { key: 'scheduled',          label: 'Scheduled' },
-    { key: 'published',          label: 'Published' },
-  ];
-  // Normalise variant stages to a progress step
-  const norm =
-    (stageLC === 'awaiting_brand_input') ? 'in_production'     :
-    (stageLC === 'parked')               ? 'scheduled'         :
-    (stageLC === 'rejected')             ? 'in_production'     :
-    stageLC;
-
-  const activeIdx = steps.findIndex(function(s) { return s.key === norm; });
-
-  var html = steps.map(function(s, i) {
-    var isDone    = activeIdx !== -1 && i < activeIdx;
-    var isCurrent = i === activeIdx;
-    var dotCls = isDone ? 'pc-pipe-dot done' : isCurrent ? 'pc-pipe-dot current' : 'pc-pipe-dot future';
-    var lblCls = isDone ? 'pc-pipe-lbl done' : isCurrent ? 'pc-pipe-lbl current' : 'pc-pipe-lbl future';
-    return '<div class="pc-pipe-step">' +
-      '<div class="' + dotCls + '"></div>' +
-      '<div class="' + lblCls + '">' + s.label + '</div>' +
-    '</div>';
-  }).join('');
-
-  return '<div class="pc-pipeline">' + html + '</div>';
-}
-
-window._buildInlineActions = function(canvaUrl, linkedinUrl, isPublished, canEdit, postId, stageLC) {
-  // URL-aware label for the design link
-  var designLabel = canvaUrl
-    ? (canvaUrl.includes('canva.com') ? 'Canva' : canvaUrl.includes('linkedin.com') ? 'LinkedIn' : 'Design')
-    : '';
-
-  var links = '';
-  if (canvaUrl) {
-    links += '<a href="' + esc(canvaUrl) + '" target="_blank" rel="noopener" class="pc-action-link canva" onclick="closePCS()">' +
-      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>' +
-      esc(designLabel) + '</a>';
-  }
-  if (linkedinUrl) {
-    links += '<a href="' + esc(linkedinUrl) + '" target="_blank" rel="noopener" class="pc-action-link linkedin" onclick="closePCS()">' +
-      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>' +
-      'LinkedIn</a>';
-  }
-  if (!canvaUrl && canEdit) {
-    links += '<button class="pc-action-link canva" onclick="_pcsEditLink(\'' + esc(postId) + '\',\'canva\')">+ Design</button>';
-  }
-  if (!linkedinUrl && canEdit) {
-    links += '<button class="pc-action-link linkedin" onclick="_pcsEditLink(\'' + esc(postId) + '\',\'linkedin\')">LinkedIn</button>';
-  }
-
-  // Attach URL editor
-  var attachRow = canEdit
-    ? '<div class="pcs-attach-row" id="pcs-attach-row-' + esc(postId) + '" style="display:none">' +
-        '<input type="url" class="pcs-attach-input" id="pcs-attach-input-' + esc(postId) + '" placeholder="Paste link...">' +
-        '<button class="pcs-attach-save" onclick="pcsSaveAttach(\'' + esc(postId) + '\')">Save</button>' +
-      '</div>' +
-      '<button class="pcs-attach-cancel" id="pcs-attach-cancel-' + esc(postId) + '" style="display:none" onclick="pcsCloseAttach(\'' + esc(postId) + '\')">Cancel</button>'
-    : '';
-
-  return '<div class="pc-actions-block">' + links + attachRow + '</div>';
-}
-
-window._pcsEditLink = function(postId, target) {
-  window._pcsEditingTarget = target; // 'canva' or 'linkedin'
-  const row = document.getElementById(`pcs-attach-row-${postId}`);
-  const cancel = document.getElementById(`pcs-attach-cancel-${postId}`);
-  if (!row) return;
-  row.style.display = 'flex';
-  if (cancel) cancel.style.display = '';
-  // Close any confirm overlay first  -  only one interactive layer at a time
-  _removePcsConfirm();
-  const input = document.getElementById(`pcs-attach-input-${postId}`);
-  if (input) {
-    input.value = '';
-    input.placeholder = target === 'linkedin' ? 'Paste LinkedIn link...' : 'Paste Canva link...';
-    input.focus();
-    input.onkeydown = function(e) {
-      if (e.key === 'Escape') { pcsCloseAttach(postId); }
-    };
-  }
-}
-
-window.pcsCloseAttach = function(postId) {
-  window._pcsEditingTarget = null;
-  const row = document.getElementById(`pcs-attach-row-${postId}`);
-  const cancel = document.getElementById(`pcs-attach-cancel-${postId}`);
-  if (row) row.style.display = 'none';
-  if (cancel) cancel.style.display = 'none';
-}
-
-window.pcsSaveAttach = async function(postId) {
-  const input = document.getElementById(`pcs-attach-input-${postId}`);
-  const url = (input?.value || '').trim();
-  if (!url || !url.startsWith('http')) { showToast('Enter a valid URL', 'error'); return; }
-  try {
-  // Save to the field that matches the editing target  -  never infer from stage
-  const field = window._pcsEditingTarget === 'linkedin' ? 'linkedinUrl' : 'postLink';
-  await updatePost(postId, field, url);
-  // Clear editing state and hide attach row (auto-disappear)
-  window._pcsEditingTarget = null;
-  pcsCloseAttach(postId);
-  // Re-render photo grid (not the old inline actions layout)
-  var _attachPost = (window.AppState.posts.all || []).find(function(p) {
-    return p.post_id === postId || (p.id && p.id === postId);
-  });
-  if (_attachPost) {
-    var _attachImgs = Array.isArray(_attachPost.images) ? _attachPost.images : [];
-    var _attachRole = (window.AppState.user.effectiveRole || '').toLowerCase();
-    var _attachIsPranav = _attachRole === 'creative' || _attachRole === 'pranav' ||
-      (window.AppState.user.email || '').toLowerCase().includes('pranav');
-    var _attachCanEdit = _attachRole !== 'client' && !_attachIsPranav;
-    var _attachCanEditCreative = _attachIsPranav;
-    var _attachIsAdmin = _attachRole === 'admin';
-    var _attachWrap = document.getElementById('pcs-photo-grid-wrap');
-    if (_attachWrap) {
-      _attachWrap.innerHTML = _buildPhotoGrid(_attachImgs, _attachCanEdit, _attachCanEditCreative, _attachIsAdmin, postId);
-    }
-  }
-  } catch(err) {
-    console.error('[pcs] save attachment failed', err);
-    window.logError && window.logError(err && err.message, err && err.stack, 'pcs-save-attach');
-    showToast && showToast('Failed to save attachment', 'error');
-  }
-}
-
-window._loadPCSActivity = function(postId, bodyEl) {
-  // READ from activity_log removed - activity_log contains system noise.
-  // Use notifications table for user-facing messages instead.
-  bodyEl.innerHTML = '<div class="pcs-activity-empty">No activity yet.</div>';
-}
-
-window._buildInfoGrid = function(post, canEdit, canEditCreative, id) {
-  var LOCS     = ['Mumbai','Sakarwadi','Sameerwadi','Other'];
-  var OWNERS   = ALLOWED_OWNERS;
-  var FORMATS  = ['Creative','Photo','Carousel','Video','Text'];
-
-  var stageLC     = post.stage || '';
-  var isPublished = stageLC === 'published';
-  var dateLabel   = isPublished ? 'Published Date' : 'Target Date';
-  var dateValue   = isPublished
-    ? (post.targetDate || '')
-    : (post.targetDate || '');
-
-  // Stage color class
-  var stageColorCls = '';
-  if (stageLC === 'in_production' || stageLC === 'awaiting_brand_input') stageColorCls = ' pc-meta-val--production';
-  else if (stageLC === 'ready') stageColorCls = ' pc-meta-val--ready';
-  else if (stageLC === 'awaiting_approval') stageColorCls = ' pc-meta-val--approval';
-  else if (stageLC === 'scheduled') stageColorCls = ' pc-meta-val--scheduled';
-  else if (stageLC === 'published') stageColorCls = ' pc-meta-val--published';
-
-  // Overdue date class
-  var dateColorCls = '';
-  if (!isPublished && dateValue) {
-    var td = parseDate(dateValue);
-    var now = new Date(); now.setHours(0,0,0,0);
-    if (td && td < now) dateColorCls = ' pc-meta-val--overdue';
-  }
-
-  function mkSel(field, opts, val, dbField, displayMap) {
-    var options = opts.map(function(o) {
-      var label = displayMap ? (displayMap[o] || o) : o;
-      return '<option value="' + esc(o) + '"' + (o === val ? ' selected' : '') + '>' + esc(label) + '</option>';
-    }).join('');
-    return '<select' + (canEdit ? ' onchange="updatePost(\'' + esc(id) + '\',\'' + (dbField||field) + '\',this.value)"' : ' disabled') + '>' + options + '</select>';
-  }
-
-  function mkRo(val) { return '<span>' + esc(val || ' - ') + '</span>'; }
-
-  // Stage selector
-  var stageSel = canEdit
-    ? (function() {
-        var opts = STAGES_DB.map(function(o) {
-          var dl = STAGE_DISPLAY ? (STAGE_DISPLAY[o] || o) : o;
-          return '<option value="' + esc(o) + '"' + (o === (post.stage||'') ? ' selected' : '') + '>' + esc(dl) + '</option>';
-        }).join('');
-        return '<select onchange="changeStage(this.value)">' + opts + '</select>';
-      })()
-    : '<span>' + esc(stageStyle(post.stage).label || post.stage || ' - ') + '</span>';
-
-  // Date field
-  var dateInput = canEdit
-    ? '<label class="pcs-date-tap"><span class="pcs-date-text">' + esc(displayDate(dateValue)) + '</span>' +
-      '<input type="date" class="pcs-date-input-native" value="' + esc(dateValue) + '"' +
-      ' onchange="this.closest(\'.pcs-date-tap\').querySelector(\'.pcs-date-text\').textContent=displayDate(this.value);updatePost(\'' + esc(id) + '\',\'targetDate\',this.value)"' +
-      ' style="position:absolute;opacity:0;width:100%;height:100%;cursor:pointer"></label>'
-    : '<span>' + esc(formatDate(dateValue) || ' - ') + '</span>';
-
-  function cell(label, content, extraCls) {
-    return '<div class="pc-meta-cell">' +
-      '<div class="pc-meta-lbl">' + label + '</div>' +
-      '<div class="pc-meta-val' + (extraCls || '') + '">' + content + '</div>' +
-    '</div>';
-  }
-
-  return '<div class="pc-meta-block"><div class="pc-meta-grid">' +
-    cell('Stage', stageSel, stageColorCls) +
-    cell('Owner', canEdit
-      ? (function() {
-          var opts = OWNERS.map(function(o) {
-            return '<option value="' + esc(o) + '"' + (o === (post.owner||'') ? ' selected' : '') + '>' + esc(o) + '</option>';
-          }).join('');
-          return '<select onchange="handleOwnerChange(\'' + esc(id) + '\',this.value)">' + opts + '</select>';
-        })()
-      : mkRo(formatOwner(post.owner))) +
-    cell('Pillar', (canEdit || canEditCreative) ? mkSel('contentPillar', PILLARS_DB, post.contentPillar||'', 'contentPillar', PILLAR_DISPLAY) : mkRo(formatPillarDisplay(post.contentPillar) || ' - ')) +
-    cell('Location', (canEdit || canEditCreative) ? mkSel('location', LOCS, post.location||'', 'location') : mkRo(post.location)) +
-    cell('Format', (canEdit || canEditCreative) ? mkSel('format', FORMATS, post.format||'', 'format') : mkRo(post.format)) +
-    cell(dateLabel, dateInput, dateColorCls) +
-  '</div></div>';
-}
-
-window._buildNotes = function() {
-  return '';
-}
-
-// -- Stage advance button (FIX 7) --
-window._ADVANCE_SEQ = ['in_production', 'ready', 'awaiting_approval', 'scheduled', 'published'];
-window._ADVANCE_LABELS = {
-  'ready': 'Move to Ready',
-  'awaiting_approval': 'Send for Approval',
-  'scheduled': 'Mark Scheduled',
-  'published': 'Mark Published'
-};
-window._ADVANCE_CLS = {
-  'ready': 'to-ready',
-  'awaiting_approval': 'to-approval',
-  'scheduled': 'to-scheduled',
-  'published': 'to-published'
-};
-
-window._renderAdvanceButton = function(stageLC) {
-  // Advance button removed from redesign — stage changes via topbar pill dropdown only.
-  // Keep function signature intact (called from _renderPCS), just always hide the block.
-  var block = document.getElementById('pc-advance-block');
-  if (block) block.style.display = 'none';
-}
-
-// -- Activity count (FIX 9) --
-window._renderActivityCount = function(postId) {
-  var countEl = document.getElementById('pc-activity-count');
-  if (!countEl) return;
-  countEl.textContent = '';
-  // Attempt to count from already-loaded activity body
-  var body = document.getElementById('pcs-activity-body');
-  if (body && body.dataset.loadedFor === postId) {
-    var rows = body.querySelectorAll('.pcs-activity-row');
-    if (rows.length) countEl.textContent = rows.length;
-  }
 }
 
 window._removePcsConfirm = function() {
@@ -1919,37 +1612,6 @@ window._pcsSaveAllPhotos = async function(postId) {
     a.click();
     document.body.removeChild(a);
     await new Promise(function(resolve) { setTimeout(resolve, 300); });
-  }
-};
-
-window._pcsCaptionMenu = function(postId, e) {
-  if (e) e.stopPropagation();
-  if (window.AppState.pcs.activeMenu) {
-    window.AppState.pcs.activeMenu.remove();
-    window.AppState.pcs.activeMenu = null;
-    return;
-  }
-  var menu = document.createElement('div');
-  menu.id = 'pcs-caption-menu-drop';
-  menu.style.cssText = 'position:absolute;right:18px;' +
-    'background:#1e1e26;border:1px solid #2a2a36;' +
-    'z-index:200;min-width:140px;overflow:hidden;';
-  menu.innerHTML =
-    '<div class="pcs-menu-item" onclick="window._pcsCopyCaption(\'' +
-      postId + '\');if(window.AppState.pcs.activeMenu){window.AppState.pcs.activeMenu.remove();window.AppState.pcs.activeMenu=null;}">' +
-      'Copy</div>' +
-    '<div class="pcs-menu-item" onclick="_startCaptionEdit(\'' +
-      postId + '\');if(window.AppState.pcs.activeMenu){window.AppState.pcs.activeMenu.remove();window.AppState.pcs.activeMenu=null;}">' +
-      'Edit</div>' +
-    '<div class="pcs-menu-item pcs-menu-item-danger" ' +
-      'onclick="if(window.AppState.pcs.activeMenu){window.AppState.pcs.activeMenu.remove();window.AppState.pcs.activeMenu=null;}window._pcsConfirmReplace(\'' +
-      postId + '\');">' +
-      'Replace</div>';
-  var section = document.getElementById('pcs-caption-section');
-  if (section) {
-    section.style.position = 'relative';
-    section.appendChild(menu);
-    window.AppState.pcs.activeMenu = menu;
   }
 };
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408n">
+ <link rel="stylesheet" href="styles.css?v=20260408o">
 
 </head>
 <body>
@@ -909,15 +909,15 @@
       <div id="pcs-pane-client" class="pcs-tab-pane" style="display:none;flex:1;flex-direction:column;overflow:hidden">
         <span id="pcs-comments-count" style="display:none">0</span>
         <div id="pcs-comments-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:12px 16px;scrollbar-width:none;min-height:0"></div>
-        <div style="flex-shrink:0;padding:8px 14px 14px;background:#08080c;border-top:1px solid #141420">
+        <div class="pcs-ibar-wrap client">
           <div id="pcs-client-reply-indicator" class="pcs-reply-bar" style="display:none"></div>
           <div id="pcs-client-img-previews"></div>
-          <div style="display:flex;align-items:center;gap:8px;background:#0f0f1a;border:1px solid #1c1c28;padding:6px 6px 6px 14px;border-radius:24px;margin-bottom:6px">
-            <button style="width:32px;height:32px;border-radius:50%;background:linear-gradient(180deg,#2a2a3a,#1a1a28);border:none;color:#fff;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;box-shadow:0 2px 4px #00000066,inset 0 1px 0 #FFFFFF1A" onclick="var i=document.getElementById('pcs-client-img-input');if(i)i.click()">+</button>
-            <textarea id="pcs-comment-input" placeholder="Reply to client..." rows="1" style="flex:1;background:none;border:none;font-size:14px;color:#F0F0F2;outline:none;resize:none;max-height:100px;overflow-y:auto;font-family:-apple-system,sans-serif;line-height:1.4;padding:4px 0;scrollbar-width:none" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.45'"></textarea>
-            <button id="pcs-send-btn-client" style="width:32px;height:32px;border-radius:50%;background:linear-gradient(180deg,#d4b050,#b8922e);border:none;color:#000;font-size:15px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;opacity:0.45;box-shadow:0 2px 6px #00000080,inset 0 1px 0 #FFFFFF33;transition:transform .1s,box-shadow .1s,opacity .15s" onclick="window.submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',false)">&#x2191;</button>
+          <div class="pcs-ibar-pill">
+            <button class="pcs-ibar-plus" onclick="var i=document.getElementById('pcs-client-img-input');if(i)i.click()">+</button>
+            <textarea id="pcs-comment-input" class="pcs-ibar-input" placeholder="Reply to client..." rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.45'"></textarea>
+            <button id="pcs-send-btn-client" class="pcs-ibar-send" onclick="window.submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',false)">&#x2191;</button>
           </div>
-          <div style="font-family:'Courier New',monospace;font-size:7px;color:#1c1c2c;letter-spacing:.06em;text-transform:uppercase;padding-left:4px">Client + Agency · Visible to all</div>
+          <div class="pcs-ibar-hint">Client + Agency · Visible to all</div>
           <input type="file" id="pcs-client-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg&&_pcsHandleCommentImg('client')">
           <button id="pcs-task-btn-client" style="display:none" onclick="window.submitPcsComment&&submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',true,false)"></button>
         </div>
@@ -935,16 +935,16 @@
         <div id="pcs-notes-section" style="flex:1;display:flex;flex-direction:column;min-height:0">
           <div id="pcs-notes-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:12px 16px;background:#080806;scrollbar-width:none;min-height:0"></div>
         </div>
-        <div style="flex-shrink:0;padding:8px 14px 14px;background:#090808;border-top:1px solid #151208">
+        <div class="pcs-ibar-wrap notes">
           <div id="pcs-note-reply-indicator" class="pcs-reply-bar" style="display:none"></div>
           <div id="pcs-note-img-previews"></div>
           <div id="pcs-mention-dropup" style="display:none"></div>
-          <div style="display:flex;align-items:center;gap:8px;background:#100e04;border:1px solid #26200a;padding:6px 6px 6px 14px;border-radius:24px;margin-bottom:6px">
-            <button style="width:32px;height:32px;border-radius:50%;background:linear-gradient(180deg,#2a2208,#1a1408);border:none;color:#fff;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;box-shadow:0 2px 4px #00000066,inset 0 1px 0 #FFFFFF14" onclick="var i=document.getElementById('pcs-note-img-input');if(i)i.click()">+</button>
-            <textarea id="pcs-note-input" placeholder="Add note... @mention" rows="1" style="flex:1;background:none;border:none;font-size:14px;color:#F0F0F2;outline:none;resize:none;max-height:100px;overflow-y:auto;font-family:-apple-system,sans-serif;line-height:1.4;padding:4px 0;scrollbar-width:none" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.45'"></textarea>
-            <button id="pcs-send-btn-note" style="width:32px;height:32px;border-radius:50%;background:linear-gradient(180deg,#fdb030,#e09218);border:none;color:#000;font-size:15px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;opacity:0.45;box-shadow:0 2px 6px #00000080,inset 0 1px 0 #FFFFFF33;transition:transform .1s,box-shadow .1s,opacity .15s" onclick="submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-note-input')?document.getElementById('pcs-note-input').value:'',window._pcsNoteVisibility||'all',false,true)">&#x2191;</button>
+          <div class="pcs-ibar-pill">
+            <button class="pcs-ibar-plus" onclick="var i=document.getElementById('pcs-note-img-input');if(i)i.click()">+</button>
+            <textarea id="pcs-note-input" class="pcs-ibar-input" placeholder="Add note... @mention" rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.45'"></textarea>
+            <button id="pcs-send-btn-note" class="pcs-ibar-send" onclick="submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-note-input')?document.getElementById('pcs-note-input').value:'',window._pcsNoteVisibility||'all',false,true)">&#x2191;</button>
           </div>
-          <div style="font-family:'Courier New',monospace;font-size:7px;color:#1c1c2c;letter-spacing:.06em;text-transform:uppercase;padding-left:4px">Agency only · Visibility set above</div>
+          <div class="pcs-ibar-hint">Agency only · Visibility set above</div>
           <input type="file" id="pcs-note-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg&&_pcsHandleCommentImg('note')">
           <button id="pcs-task-btn-note" style="display:none" onclick="window._showTaskAssign&&_showTaskAssign('pcs-note-input','pcs-task-btn-note')"></button>
         </div>
@@ -966,9 +966,6 @@
           </div>
         </div>
       </div>
-
-      <!-- Hidden activity (kept for compatibility) -->
-      <div id="pcs-activity-body" style="display:none"></div>
 
     </div>
   </div>
@@ -1077,26 +1074,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408n"></script>
-<script src="00-appstate-compat.js?v=20260408n"></script>
-<script src="01-config.js?v=20260408n" defer></script>
-<script src="02-session.js?v=20260408n" defer></script>
-<script src="utils.js?v=20260408n" defer></script>
-<script src="03-auth.js?v=20260408n" defer></script>
-<script src="05-api.js?v=20260408n" defer></script>
-<script src="10-ui.js?v=20260408n" defer></script>
+<script src="00-appstate.js?v=20260408o"></script>
+<script src="00-appstate-compat.js?v=20260408o"></script>
+<script src="01-config.js?v=20260408o" defer></script>
+<script src="02-session.js?v=20260408o" defer></script>
+<script src="utils.js?v=20260408o" defer></script>
+<script src="03-auth.js?v=20260408o" defer></script>
+<script src="05-api.js?v=20260408o" defer></script>
+<script src="10-ui.js?v=20260408o" defer></script>
 
-<script src="06-post-create.js?v=20260408n" defer></script>
-<script defer src="render/dashboard.js?v=20260408n"></script>
-<script defer src="render/client.js?v=20260408n"></script>
-<script defer src="render/pipeline.js?v=20260408n"></script>
-<script defer src="render/brief.js?v=20260408n"></script>
-<script defer src="actions/pcs.js?v=20260408n"></script>
-<script src="07-post-load.js?v=20260408n" defer></script>
-<script src="08-post-actions.js?v=20260408n" defer></script>
-<script src="09-library.js?v=20260408n" defer></script>
-<script src="09-approval.js?v=20260408n" defer></script>
-<script src="04-router.js?v=20260408n" defer></script>
+<script src="06-post-create.js?v=20260408o" defer></script>
+<script defer src="render/dashboard.js?v=20260408o"></script>
+<script defer src="render/client.js?v=20260408o"></script>
+<script defer src="render/pipeline.js?v=20260408o"></script>
+<script defer src="render/brief.js?v=20260408o"></script>
+<script defer src="actions/pcs.js?v=20260408o"></script>
+<script src="07-post-load.js?v=20260408o" defer></script>
+<script src="08-post-actions.js?v=20260408o" defer></script>
+<script src="09-library.js?v=20260408o" defer></script>
+<script src="09-approval.js?v=20260408o" defer></script>
+<script src="04-router.js?v=20260408o" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6496,7 +6496,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   padding: 5px 16px 0;
 }
 .pcs-photo-label {
-  font-family: 'Courier New', monospace; font-size: 8px;
+  font-family: 'IBM Plex Mono', monospace; font-size: 8px;
   color: #52525c; letter-spacing: .07em; text-transform: uppercase;
 }
 .pcs-photo-menu-btn {
@@ -6670,6 +6670,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-chip {
   display: flex; align-items: center; gap: 4px;
   padding: 6px 12px; flex-shrink: 0; white-space: nowrap;
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 12px; font-weight: 600; cursor: pointer;
   background: linear-gradient(180deg,#191924 0%,#0d0d12 100%);
   border-top: 1px solid #191924;
@@ -6735,7 +6736,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   border-top: 1px solid;
 }
 .pcs-ibar-wrap.client {
-  background: #08080c; border-top-color: #0d0d12;
+  background: #08080c; border-top-color: #141420;
 }
 .pcs-ibar-wrap.notes {
   background: #090808; border-top-color: #151208;
@@ -6747,7 +6748,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   margin-bottom: 6px;
 }
 .pcs-ibar-wrap.client .pcs-ibar-pill {
-  background: #0d0d12; border-color: #191924;
+  background: #0f0f1a; border-color: #1c1c28;
 }
 .pcs-ibar-wrap.notes .pcs-ibar-pill {
   background: #100e04; border-color: #26200a;
@@ -6757,13 +6758,14 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   border: none; color: #fff; font-size: 20px; cursor: pointer;
   display: flex; align-items: center; justify-content: center;
   flex-shrink: 0; line-height: 1;
-  box-shadow: 0 2px 4px #00000066, inset 0 1px 0 #FFFFFF1A;
 }
 .pcs-ibar-wrap.client .pcs-ibar-plus {
-  background: linear-gradient(180deg,#191924,#191924);
+  background: linear-gradient(180deg,#2a2a3a,#1a1a28);
+  box-shadow: 0 2px 4px #00000066, inset 0 1px 0 #FFFFFF1A;
 }
 .pcs-ibar-wrap.notes .pcs-ibar-plus {
   background: linear-gradient(180deg,#2a2208,#1a1408);
+  box-shadow: 0 2px 4px #00000066, inset 0 1px 0 #FFFFFF14;
 }
 .pcs-ibar-input {
   flex: 1; background: none; border: none;
@@ -6771,15 +6773,17 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-family: -apple-system, sans-serif;
   line-height: 1.4; padding: 4px 0;
   resize: none; max-height: 100px; overflow-y: auto;
+  scrollbar-width: none;
 }
+.pcs-ibar-input::-webkit-scrollbar { display: none; }
 .pcs-ibar-input::placeholder { color: #191924; }
 .pcs-ibar-send {
   width: 32px; height: 32px; border-radius: 50%;
   border: none; color: #000; font-size: 15px; cursor: pointer;
   display: flex; align-items: center; justify-content: center;
-  flex-shrink: 0;
+  flex-shrink: 0; opacity: 0.45;
   box-shadow: 0 2px 6px #00000080, inset 0 1px 0 #FFFFFF33;
-  transition: transform .1s, box-shadow .1s;
+  transition: transform .1s, box-shadow .1s, opacity .15s;
 }
 .pcs-ibar-send:active { transform: translateY(1px); }
 .pcs-ibar-wrap.client .pcs-ibar-send {
@@ -6789,8 +6793,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   background: linear-gradient(180deg,#fdb030,#e09218);
 }
 .pcs-ibar-hint {
-  font-family: 'Courier New', monospace; font-size: 7px;
-  color: #191924; letter-spacing: .06em;
+  font-family: 'IBM Plex Mono', monospace; font-size: 7px;
+  color: #1c1c2c; letter-spacing: .06em;
   text-transform: uppercase; padding-left: 4px;
 }
 
@@ -6802,7 +6806,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .pcs-chip-drop-item {
   padding: 9px 14px;
-  font-family: 'Courier New', monospace; font-size: 11px;
+  font-family: 'IBM Plex Mono', monospace; font-size: 11px;
   color: #AEAEB2; cursor: pointer; border-bottom: 1px solid #191924;
 }
 .pcs-chip-drop-item:last-child { border-bottom: none; }


### PR DESCRIPTION
…count badge, normalize fonts, replace inline styles

Delete 12 dead functions from actions/pcs.js that were defined but never called: _buildStageProgress, _buildInfoGrid, _buildInlineActions, _buildNotes, _renderAdvanceButton, _renderActivityCount, _updateSubtitle, _pcsCaptionMenu, _pcsEditLink, pcsCloseAttach, pcsSaveAttach, _loadPCSActivity. Also delete _ADVANCE_SEQ/_LABELS/_CLS constants and _pcsEditingTarget state variable. Delete togglePCSActivity from 10-ui.js. Delete #pcs-activity-body from HTML.

Fix stray count badge: #pcs-comments-count and #pcs-notes-count were set to display:inline, rendering as visible text in the panes. Keep them hidden.

Normalize chip fonts: add IBM Plex Mono to .pcs-chip, change Courier New to IBM Plex Mono on .pcs-chip-drop-item, .pcs-photo-label, .pcs-ibar-hint.

Replace inline styles on PCS input bars with .pcs-ibar-* CSS classes. Updated CSS class values to exactly match previous inline styles. Zero visual change.

actions/pcs.js: 2831 → 2493 lines (−338). Net −347 lines across all files. 508/508 unit tests passing. 40/40 e2e tests passing. Bumped to ?v=20260408o.

https://claude.ai/code/session_01Kfx3Cki6vgH4dZwziceD5n