### PR TITLE
feat: PCS visual redesign Part 1 — topbar, metadata, caption, desktop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408o
+Version format: ?v=YYYYMMDDx. Current: ?v=20260408p
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1621,6 +1621,50 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    actions/pcs.js reduced from 2831 to 2493 lines (−338).
    Status: FIXED (PR#TBD) — 508/508 unit passing, 40/40 e2e.
    Bumped to ?v=20260408o.
+1. PCS visual redesign Part 1 — top section, caption pane, desktop
+   Location: actions/pcs.js, index.html, styles.css
+   Scope:
+   (a) Topbar simplified: stage pill + overdue badge removed from
+       topbar-right. Replaced with WhatsApp icon button (same
+       SVG and handler as _sharePostOnWhatsApp, same visibility
+       condition as _buildWAHtml). Close X, back, back-to-notifs
+       buttons unchanged.
+   (b) Photo header row: stage pill + overdue badge moved here
+       (left side). Same HTML, same onclick handler, same isAdmin
+       check for dropdown arrow. Right side: ADD/EDIT/SAVE text
+       buttons replace the ··· unified menu trigger. ADD calls
+       _pcsAddPhotos, EDIT calls _pcsEnterEditMode (only when
+       imgs.length > 0), SAVE calls _pcsSaveAllPhotos (only when
+       imgs.length > 0). All canManage-gated, same conditions.
+   (c) 3-dot menu trigger button removed from HTML. The
+       _pcsPhotoMenu function itself is NOT deleted — only its
+       trigger button. Caption actions now exposed inline.
+   (d) Chips row replaced with dot-separated metadata text.
+       _buildChipsRow output changed from bordered pill buttons
+       to plain text spans (.pcs-mv) with dot separators (.pcs-dot).
+       Every if/else condition, every canEdit/canManage check,
+       every onclick handler preserved exactly. Owner color mapping:
+       servicing→cyan, creative→purple, client→amber. Date:
+       overdue→red, has date→bright (#F0F0F2). Old .pcs-chip*
+       CSS classes replaced with .pcs-meta-row, .pcs-mv, .pcs-dot.
+   (e) Caption pane: Edit/Copy/Clear action row added below
+       WhatsApp section. Calls _startCaptionEdit, _pcsCopyCaption,
+       _pcsConfirmClearCaption — exact same functions as 3-dot
+       menu used. Clear button only when post.caption truthy.
+       canManage-gated. Done button always rendered, calls
+       closePCS() — same as Close X.
+   (f) Separator normalization: all PCS structural borders
+       changed to 1px solid #323244 (tab bar, metadata row,
+       caption section, photo empty state).
+   (g) Title-metadata coupling: title padding-bottom 4px,
+       metadata padding-top 4px. Only separator is below metadata
+       before tab bar.
+   (h) Desktop max-width: #pcs-screen max-width:480px with
+       margin:0 auto. #pcs-overlay stays full-screen. Bottom
+       confirm sheet (.pcs-bottom-confirm) centered at 480px.
+   Zero business logic changes. Zero data flow changes.
+   508/508 unit passing, 40/40 e2e passing.
+   Status: FIXED (PR#TBD). Bumped to ?v=20260408p.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -206,11 +206,29 @@ window._renderPCS = function(postId) {
   var isAdmin = _pcsRole === 'admin';
   var canManage = canEdit || canEditCreative;
 
-  // a) Stage pill + overdue pill in topbar right
+  // a) WhatsApp icon in topbar right (same condition as _buildWAHtml)
   var topbarRight = document.getElementById('pcs-topbar-right');
   if (topbarRight) {
+    var _showTopWA = post.caption && (
+      _pcsRole === 'client' || stageLC === 'awaiting_approval'
+    );
+    topbarRight.innerHTML = _showTopWA
+      ? '<button class="pcs-topbar-wa" onclick="window._sharePostOnWhatsApp(\'' + esc(id) + '\')">' +
+        '<svg width="18" height="18" viewBox="0 0 24 24" fill="#1a8a4a"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z"/><path d="M12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.66 1.438 5.168L2 22l4.832-1.438A9.955 9.955 0 0012 22c5.523 0 10-4.477 10-10S17.523 2 12 2zm0 18a7.96 7.96 0 01-4.106-1.138l-.294-.176-2.866.852.852-2.866-.176-.294A7.963 7.963 0 014 12c0-4.411 3.589-8 8-8s8 3.589 8 8-3.589 8-8 8z"/></svg>' +
+        '</button>'
+      : '';
+  }
+
+  // b) Photo section
+  var imgs = Array.isArray(post.images) ? post.images : [];
+  var photoHeader = document.getElementById('pcs-photo-header-row');
+  var photoGridWrap = document.getElementById('pcs-photo-grid-wrap');
+  if (photoHeader) {
+    photoHeader.style.display = (canManage || imgs.length > 0) ? 'flex' : 'none';
+    // Left side: stage pill + overdue
     var _stageLabel = (typeof STAGE_DISPLAY !== 'undefined' && STAGE_DISPLAY[stageLC]) || stageLC || 'Unknown';
-    var _pillHtml = '<span class="pcs-stage-pill" id="pcs-stage-pill"' +
+    var _leftHtml = '<div class="pcs-photo-left">' +
+      '<span class="pcs-stage-pill" id="pcs-stage-pill"' +
       (isAdmin ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'stage\',\'' + esc(id) + '\')"' : '') +
       '>' + esc(_stageLabel) +
       (isAdmin ? ' <span class="pcs-pill-arr">&#x25BE;</span>' : '') +
@@ -220,23 +238,21 @@ window._renderPCS = function(postId) {
       var _td = typeof parseDate === 'function' ? parseDate(dateValue) : null;
       var _now = new Date(); _now.setHours(0,0,0,0);
       if (_td && _td < _now) {
-        _pillHtml += '<span class="pcs-od-pill" id="pcs-od-pill"><span class="pcs-od-dot"></span>Overdue</span>';
+        _leftHtml += '<span class="pcs-hdr-dot">\u00B7</span>' +
+          '<span class="pcs-od-pill" id="pcs-od-pill"><span class="pcs-od-dot"></span>Overdue</span>';
       }
     }
-    topbarRight.innerHTML = _pillHtml;
-  }
-
-  // b) Photo section
-  var imgs = Array.isArray(post.images) ? post.images : [];
-  var photoHeader = document.getElementById('pcs-photo-header-row');
-  var photoLabel = document.getElementById('pcs-photo-label');
-  var photoMenuBtn = document.getElementById('pcs-photo-menu-btn');
-  var photoGridWrap = document.getElementById('pcs-photo-grid-wrap');
-  if (photoHeader) photoHeader.style.display = (canManage || imgs.length > 0) ? 'flex' : 'none';
-  if (photoLabel) photoLabel.textContent = 'PHOTOS \u00B7 ' + imgs.length;
-  if (photoMenuBtn) {
-    photoMenuBtn.onclick = function(ev) { window._pcsPhotoMenu(id, ev); };
-    photoMenuBtn.style.display = canManage ? '' : 'none';
+    _leftHtml += '</div>';
+    // Right side: ADD / EDIT / SAVE (canManage only)
+    var _rightHtml = '';
+    if (canManage) {
+      _rightHtml = '<div class="pcs-photo-actions">' +
+        '<button class="pcs-photo-act" onclick="window._pcsAddPhotos(\'' + esc(id) + '\')">ADD</button>' +
+        (imgs.length > 0 ? '<button class="pcs-photo-act" onclick="window._pcsEnterEditMode(\'' + esc(id) + '\')">EDIT</button>' : '') +
+        (imgs.length > 0 ? '<button class="pcs-photo-act" onclick="window._pcsSaveAllPhotos(\'' + esc(id) + '\')">SAVE</button>' : '') +
+        '</div>';
+    }
+    photoHeader.innerHTML = _leftHtml + _rightHtml;
   }
   if (photoGridWrap) photoGridWrap.innerHTML = _buildPhotoGrid(imgs, canEdit, canEditCreative, isAdmin, id);
 
@@ -282,6 +298,21 @@ window._renderPCS = function(postId) {
   var waHtml = _buildWAHtml(post, id, postId, stageLC);
   var waContainer = document.getElementById('pcs-wa-container');
   if (waContainer) waContainer.innerHTML = waHtml;
+
+  // f2) Caption action buttons (canManage only)
+  var capActionsContainer = document.getElementById('pcs-cap-actions-container');
+  if (capActionsContainer) {
+    if (canManage) {
+      capActionsContainer.innerHTML =
+        '<div class="pcs-cap-actions">' +
+        '<button class="pcs-cap-btn" onclick="window._startCaptionEdit(\'' + esc(id) + '\')">Edit</button>' +
+        '<button class="pcs-cap-btn pcs-cap-btn--bright" onclick="window._pcsCopyCaption(\'' + esc(id) + '\')">Copy</button>' +
+        (post.caption ? '<button class="pcs-cap-btn pcs-cap-btn--danger" onclick="window._pcsConfirmClearCaption(\'' + esc(id) + '\')">Clear</button>' : '') +
+        '</div>';
+    } else {
+      capActionsContainer.innerHTML = '';
+    }
+  }
 
   // g) Show comments section (compatibility)
   var commSection = document.getElementById('pcs-comments-section');
@@ -445,27 +476,28 @@ function _buildDriveLinkCard(driveUrl, canManage, postId) {
 }
 window._buildDriveLinkCard = _buildDriveLinkCard;
 
-// -- Chips row builder (stage in topbar, not here) --
+// -- Metadata row builder (dot-separated text values) --
 // Order: Owner → Date → Format → Pillar → Location
 function _buildChipsRow(post, canEdit, canEditCreative, id) {
   var stageLC = post.stage || '';
   var canManage = canEdit || canEditCreative;
-  var arr = canManage ? ' <span class="pcs-chip-arr">&#9662;</span>' : '';
-  var chips = [];
+  var _dot = '<span class="pcs-dot">\u00B7</span>';
+  var items = [];
 
-  // 1. Owner chip (always render if present)
+  // 1. Owner (always render if present)
   if (post.owner) {
-    var ownerColor = ' pcs-chip--dim';
+    var ownerColor = '';
     var ownerLC = (post.owner || '').toLowerCase();
-    if (ownerLC === 'servicing' || ownerLC === 'creative') ownerColor = ' pcs-chip--cyan';
-    else if (ownerLC === 'client') ownerColor = ' pcs-chip--amber';
-    var ownerArr = canEdit ? ' <span class="pcs-chip-arr">&#9662;</span>' : '';
-    chips.push('<button class="pcs-chip' + ownerColor + '"' +
+    if (ownerLC === 'servicing') ownerColor = ' pcs-mv--cyan';
+    else if (ownerLC === 'creative') ownerColor = ' pcs-mv--purple';
+    else if (ownerLC === 'client') ownerColor = ' pcs-mv--amber';
+    items.push('<span class="pcs-mv' + ownerColor + '"' +
       (canEdit ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'owner\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(typeof formatOwner === 'function' ? formatOwner(post.owner) : post.owner) + ownerArr + '</button>');
+      '>' + esc(typeof formatOwner === 'function' ? formatOwner(post.owner) : post.owner) +
+      (canEdit ? ' &#9662;' : '') + '</span>');
   }
 
-  // 2. Date chip (ALWAYS render — never skip)
+  // 2. Date (ALWAYS render — never skip)
   var rawDate = post.targetDate || post.target_date || null;
   var dateDisplay = 'Add Date';
   if (rawDate) {
@@ -478,41 +510,44 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
   }
   var terminalStages = ['published','parked','rejected'];
   var isOverdue = rawDate && terminalStages.indexOf(stageLC) === -1 && new Date(rawDate) < new Date();
-  var dateCls = isOverdue ? ' pcs-chip--red' : rawDate ? ' pcs-chip--dim' : ' pcs-chip--empty';
-  var dateArr = canEdit ? ' <span class="pcs-chip-arr">&#9662;</span>' : '';
-  chips.push('<button class="pcs-chip' + dateCls + '"' +
+  var dateCls = isOverdue ? ' pcs-mv--red' : rawDate ? ' pcs-mv--bright' : '';
+  items.push('<span class="pcs-mv' + dateCls + '"' +
     (canEdit ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'date\',\'' + esc(id) + '\')"' : '') +
-    '>' + esc(dateDisplay) + dateArr + '</button>');
+    '>' + esc(dateDisplay) +
+    (canEdit ? ' &#9662;' : '') + '</span>');
 
-  // 3. Format chip
+  // 3. Format
   if (post.format) {
-    chips.push('<button class="pcs-chip pcs-chip--dim"' +
+    items.push('<span class="pcs-mv"' +
       (canManage ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(post.format) + arr + '</button>');
+      '>' + esc(post.format) +
+      (canManage ? ' &#9662;' : '') + '</span>');
   } else if (canManage) {
-    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="event.stopPropagation();window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')">+ Format' + arr + '</button>');
+    items.push('<span class="pcs-mv" onclick="event.stopPropagation();window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')">+ Format &#9662;</span>');
   }
 
-  // 4. Pillar chip
+  // 4. Pillar
   if (post.contentPillar) {
     var pillarVal = typeof formatPillarDisplay === 'function' ? formatPillarDisplay(post.contentPillar) : post.contentPillar;
-    chips.push('<button class="pcs-chip pcs-chip--dim"' +
+    items.push('<span class="pcs-mv"' +
       (canManage ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(pillarVal) + arr + '</button>');
+      '>' + esc(pillarVal) +
+      (canManage ? ' &#9662;' : '') + '</span>');
   } else if (canManage) {
-    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="event.stopPropagation();window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')">+ Pillar' + arr + '</button>');
+    items.push('<span class="pcs-mv" onclick="event.stopPropagation();window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')">+ Pillar &#9662;</span>');
   }
 
-  // 5. Location chip
+  // 5. Location
   if (post.location) {
-    chips.push('<button class="pcs-chip pcs-chip--dim"' +
+    items.push('<span class="pcs-mv"' +
       (canManage ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(post.location) + arr + '</button>');
+      '>' + esc(post.location) +
+      (canManage ? ' &#9662;' : '') + '</span>');
   } else if (canManage) {
-    chips.push('<button class="pcs-chip pcs-chip--empty" onclick="event.stopPropagation();window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')">+ Location' + arr + '</button>');
+    items.push('<span class="pcs-mv" onclick="event.stopPropagation();window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')">+ Location &#9662;</span>');
   }
 
-  return chips.join('');
+  return items.join(_dot);
 }
 
 // -- Chip dropdown handler (body-appended, getBoundingClientRect positioned) --
@@ -628,7 +663,7 @@ window._pcsDateChange = function(postId, dateValue) {
 // -- Caption section builder --
 function _buildCaptionHtml(post, canEdit, canEditCreative, id) {
   if (!post.caption && !canEdit && !canEditCreative) return '';
-  return '<div id="pcs-caption-section" style="padding:12px 14px 8px;border-bottom:1px solid #1a1a2a;">' +
+  return '<div id="pcs-caption-section" style="padding:12px 14px 8px;border-bottom:1px solid #323244;">' +
     (post.caption ?
       '<div id="pcs-caption-text" data-raw="' + esc(post.caption) + '" style="font-family:\'DM Sans\',sans-serif;' +
       'font-size:13px;color:#888;line-height:1.6;white-space:pre-wrap;word-wrap:break-word;' +
@@ -656,7 +691,7 @@ function _buildLinkedInHtml(post, id, stageLC) {
   var stageForLi = (post.stage || stageLC || '').toLowerCase();
   if (stageForLi !== 'published') return '';
   if (post.linkedinUrl) {
-    return '<div style="padding:12px 18px;border-bottom:1px solid #1a1a2a;background:#0A66C20A;border-top:1px solid #0A66C21A;">' +
+    return '<div style="padding:12px 18px;border-bottom:1px solid #323244;background:#0A66C20A;border-top:1px solid #0A66C21A;">' +
       '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;letter-spacing:0.18em;text-transform:uppercase;color:#0a66c2;margin-bottom:8px;display:flex;align-items:center;gap:6px;">' +
       '<div style="width:6px;height:6px;border-radius:50%;background:#0a66c2;flex-shrink:0;"></div>Live on LinkedIn</div>' +
       '<button onclick="window.open(\'' + esc(post.linkedinUrl) + '\',\'_blank\')" ' +
@@ -667,7 +702,7 @@ function _buildLinkedInHtml(post, id, stageLC) {
       '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;color:#2a2a2a;letter-spacing:0.04em;margin-top:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' +
       esc(post.linkedinUrl.replace('https://','')) + '</div></div>';
   }
-  return '<div style="padding:12px 18px;border-bottom:1px solid #1a1a2a;border-top:1px solid #F6A6231A;background:#F6A62308;">' +
+  return '<div style="padding:12px 18px;border-bottom:1px solid #323244;border-top:1px solid #F6A6231A;background:#F6A62308;">' +
     '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;letter-spacing:0.18em;text-transform:uppercase;color:#444;margin-bottom:8px;">Live Post URL</div>' +
     '<div style="display:flex;gap:8px;align-items:center;">' +
     '<input id="pcs-li-inline-input" type="url" placeholder="Paste LinkedIn post URL..." ' +

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408o">
+ <link rel="stylesheet" href="styles.css?v=20260408p">
 
 </head>
 <body>
@@ -879,18 +879,15 @@
     <div class="pc-scroll-body" id="pcs-scroll">
 
       <!-- Photo section -->
-      <div class="pcs-photo-header" id="pcs-photo-header-row" style="display:none">
-        <span class="pcs-photo-label" id="pcs-photo-label">PHOTOS · 0</span>
-        <button class="pcs-photo-menu-btn" id="pcs-photo-menu-btn">···</button>
-      </div>
+      <div class="pcs-photo-header" id="pcs-photo-header-row" style="display:none"></div>
       <div id="pcs-photo-grid-wrap"></div>
       <div id="pcs-drive-link-wrap" style="display:none;"></div>
 
       <!-- Title -->
       <div id="pcs-topbar-title"></div>
 
-      <!-- Meta chips row -->
-      <div id="pcs-chips-row" class="pcs-chips-row"></div>
+      <!-- Meta row -->
+      <div id="pcs-chips-row" class="pcs-meta-row"></div>
 
       <!-- Tab bar -->
       <div id="pcs-tab-bar" class="pcs-tab-bar">
@@ -903,6 +900,8 @@
       <div id="pcs-pane-caption" class="pcs-tab-pane" style="flex:1;display:flex;flex-direction:column;overflow:hidden">
         <div style="flex:1;overflow-y:auto" id="pcs-fields"></div>
         <div id="pcs-wa-container"></div>
+        <div id="pcs-cap-actions-container"></div>
+        <button class="pcs-close-btn" onclick="closePCS()">Done</button>
       </div>
 
       <!-- Tab pane: Client -->
@@ -1074,26 +1073,26 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408o"></script>
-<script src="00-appstate-compat.js?v=20260408o"></script>
-<script src="01-config.js?v=20260408o" defer></script>
-<script src="02-session.js?v=20260408o" defer></script>
-<script src="utils.js?v=20260408o" defer></script>
-<script src="03-auth.js?v=20260408o" defer></script>
-<script src="05-api.js?v=20260408o" defer></script>
-<script src="10-ui.js?v=20260408o" defer></script>
+<script src="00-appstate.js?v=20260408p"></script>
+<script src="00-appstate-compat.js?v=20260408p"></script>
+<script src="01-config.js?v=20260408p" defer></script>
+<script src="02-session.js?v=20260408p" defer></script>
+<script src="utils.js?v=20260408p" defer></script>
+<script src="03-auth.js?v=20260408p" defer></script>
+<script src="05-api.js?v=20260408p" defer></script>
+<script src="10-ui.js?v=20260408p" defer></script>
 
-<script src="06-post-create.js?v=20260408o" defer></script>
-<script defer src="render/dashboard.js?v=20260408o"></script>
-<script defer src="render/client.js?v=20260408o"></script>
-<script defer src="render/pipeline.js?v=20260408o"></script>
-<script defer src="render/brief.js?v=20260408o"></script>
-<script defer src="actions/pcs.js?v=20260408o"></script>
-<script src="07-post-load.js?v=20260408o" defer></script>
-<script src="08-post-actions.js?v=20260408o" defer></script>
-<script src="09-library.js?v=20260408o" defer></script>
-<script src="09-approval.js?v=20260408o" defer></script>
-<script src="04-router.js?v=20260408o" defer></script>
+<script src="06-post-create.js?v=20260408p" defer></script>
+<script defer src="render/dashboard.js?v=20260408p"></script>
+<script defer src="render/client.js?v=20260408p"></script>
+<script defer src="render/pipeline.js?v=20260408p"></script>
+<script defer src="render/brief.js?v=20260408p"></script>
+<script defer src="actions/pcs.js?v=20260408p"></script>
+<script src="07-post-load.js?v=20260408p" defer></script>
+<script src="08-post-actions.js?v=20260408p" defer></script>
+<script src="09-library.js?v=20260408p" defer></script>
+<script src="09-approval.js?v=20260408p" defer></script>
+<script src="04-router.js?v=20260408p" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -2964,7 +2964,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
   min-height: 100%;
   color: var(--text-primary);
   background: #080808;
@@ -6495,15 +6496,23 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   justify-content: space-between;
   padding: 5px 16px 0;
 }
-.pcs-photo-label {
+.pcs-photo-left {
+  display: flex; align-items: center; gap: 4px;
+}
+.pcs-hdr-dot {
+  color: #505060; padding: 0 4px; font-weight: 600;
   font-family: 'IBM Plex Mono', monospace; font-size: 8px;
-  color: #52525c; letter-spacing: .07em; text-transform: uppercase;
 }
-.pcs-photo-menu-btn {
-  background: none; border: none; color: #52525c;
-  font-size: 14px; letter-spacing: .15em; cursor: pointer;
-  padding: 2px 6px;
+.pcs-photo-actions {
+  display: flex; gap: 0;
 }
+.pcs-photo-act {
+  font-family: 'IBM Plex Mono', monospace; font-size: 7px;
+  letter-spacing: .06em; text-transform: uppercase;
+  color: #505060; background: none; border: none;
+  padding: 10px 8px; cursor: pointer;
+}
+.pcs-photo-act:active { color: #F0F0F2; }
 
 /* PCS PHOTO GRID — hero-driven layout */
 
@@ -6645,7 +6654,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-photo-empty {
   padding: 28px 16px;
   display: flex; flex-direction: column; align-items: center; gap: 8px;
-  cursor: pointer; border-bottom: 1px solid #0d0d12;
+  cursor: pointer; border-bottom: 1px solid #323244;
 }
 
 /* Title */
@@ -6655,49 +6664,36 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   letter-spacing: -0.03em !important;
   line-height: 1.1 !important;
   color: #FFFFFF !important;
-  padding: 11px 16px 7px !important;
+  padding: 11px 16px 4px !important;
 }
 
-/* Chips row */
-.pcs-chips-row {
-  display: flex; gap: 5px;
-  padding: 6px 16px 8px;
-  overflow-x: auto; -webkit-overflow-scrolling: touch;
-  scrollbar-width: none; flex-wrap: nowrap;
-  border-bottom: 1px solid #0d0d12;
-}
-.pcs-chips-row::-webkit-scrollbar { display: none; }
-.pcs-chip {
-  display: flex; align-items: center; gap: 4px;
-  padding: 6px 12px; flex-shrink: 0; white-space: nowrap;
+/* Metadata row (dot-separated text values) */
+.pcs-meta-row {
+  padding: 4px 16px 10px;
+  display: flex; flex-wrap: wrap; align-items: center;
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 12px; font-weight: 600; cursor: pointer;
-  background: linear-gradient(180deg,#191924 0%,#0d0d12 100%);
-  border-top: 1px solid #191924;
-  border-right: 1px solid #16162a;
-  border-bottom: 1px solid #0d0d12;
-  border-left: 1px solid #191924;
-  box-shadow: 0 2px 6px #00000099,
-    inset 0 1px 0 #FFFFFF0A,
-    inset 0 -1px 0 #0000004D;
-  transition: transform .1s, box-shadow .1s;
+  font-size: 8px; letter-spacing: .04em;
+  border-bottom: 1px solid #323244;
 }
-.pcs-chip:active { transform: translateY(1px); box-shadow: 0 1px 3px #00000099; }
-.pcs-chip .pcs-chip-arr { font-size: 8px; opacity: .4; margin-left: 2px; }
-.pcs-chip--cyan  { color: #22D3EE; }
-.pcs-chip--red   { color: #FF4B4B; }
-.pcs-chip--amber { color: #F6A623; }
-.pcs-chip--dim   { color: #AEAEB2; }
-.pcs-chip--empty {
-  color: #52525c; font-weight: 400;
-  border-style: dashed; background: transparent; box-shadow: none;
+.pcs-mv {
+  color: #B8B8C0; cursor: pointer; padding: 3px 0;
+  position: relative; transition: color .12s;
 }
-.pcs-chip--static { cursor: default; }
+.pcs-mv:active { color: #F0F0F2; }
+.pcs-mv--red { color: #FF4B4B; }
+.pcs-mv--cyan { color: #22D3EE; }
+.pcs-mv--purple { color: #9b87f5; }
+.pcs-mv--amber { color: #F6A623; }
+.pcs-mv--bright { color: #F0F0F2; }
+.pcs-dot {
+  color: #505060; padding: 0 7px;
+  font-weight: 600; user-select: none;
+}
 
 /* Tab bar */
 .pcs-tab-bar {
   display: flex;
-  border-bottom: 1px solid #0d0d12;
+  border-bottom: 1px solid #323244;
   flex-shrink: 0;
 }
 .pcs-tab {
@@ -6813,6 +6809,34 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-chip-drop-item:hover, .pcs-chip-drop-item:active { background: #FFFFFF0F; color: #E8E8E8; }
 .pcs-chip-drop-item.selected { color: #F6A623; }
 
+/* Topbar WhatsApp icon */
+.pcs-topbar-wa {
+  background: none; border: none; padding: 4px;
+  cursor: pointer; display: flex; align-items: center;
+}
+
+/* Caption action buttons */
+.pcs-cap-actions {
+  display: flex; gap: 6px; padding: 12px 16px 6px;
+}
+.pcs-cap-btn {
+  flex: 1; font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px; letter-spacing: .06em; text-transform: uppercase;
+  color: #505060; background: none; border: 1px solid #323244;
+  padding: 9px 0; cursor: pointer; text-align: center;
+}
+.pcs-cap-btn--bright { color: #B8B8C0; }
+.pcs-cap-btn--danger { border-color: #3a2222; color: #bb4444; }
+
+/* Done button */
+.pcs-close-btn {
+  display: block; width: calc(100% - 32px); margin: 0 16px 10px;
+  padding: 11px; font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px; letter-spacing: .08em; text-transform: uppercase;
+  color: #505060; background: none; border: 1px solid #323244;
+  cursor: pointer; text-align: center;
+}
+
 /* FIX 5: Pane overflow */
 #pcs-pane-caption, #pcs-pane-client, #pcs-pane-internal { overflow: hidden; }
 
@@ -6827,7 +6851,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* FIX 7: Tight spacing between topbar and photos */
 #pcs-scroll { padding-top: 0; }
-.pcs-photo-header { padding: 4px 16px 0; margin-top: 8px; margin-bottom: 0; }
+.pcs-photo-header { padding: 6px 16px 0; margin-top: 6px; margin-bottom: 0; }
 #pcs-photo-grid-wrap { margin-top: 0; padding-top: 0; }
 
 /* FIX 8: Tighter caption */
@@ -6850,7 +6874,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   letter-spacing: -0.03em !important;
   line-height: 1.1 !important;
   color: #FFFFFF !important;
-  padding: 9px 16px 6px !important;
+  padding: 9px 16px 4px !important;
 }
 
 /* Unified ··· dropdown (Photos + Caption groups) */
@@ -6890,7 +6914,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* Bottom confirm sheet (remove photo / clear caption) */
 .pcs-bottom-confirm {
-  position: fixed; bottom: 0; left: 0; right: 0;
+  position: fixed; bottom: 0; left: 50%; transform: translateX(-50%);
+  width: 100%; max-width: 480px;
   background: #191924; border-top: 1px solid #191924;
   padding: 24px 16px 40px;
 }


### PR DESCRIPTION
## Summary

- **Topbar simplified**: stage pill + overdue badge removed from topbar-right. Replaced with WhatsApp icon button (same SVG and handler as _sharePostOnWhatsApp, same visibility condition as _buildWAHtml). Close X, back, back-to-notifs buttons unchanged.
- **Photo header row**: stage pill + overdue badge moved here (left side). Same HTML, same onclick handler, same isAdmin check for dropdown arrow. Right side: ADD/EDIT/SAVE text buttons replace the ··· unified menu trigger. ADD calls _pcsAddPhotos, EDIT calls _pcsEnterEditMode (only when imgs.length > 0), SAVE calls _pcsSaveAllPhotos (only when imgs.length > 0). All canManage-gated, same conditions.
- **3-dot menu trigger button removed** from HTML. The _pcsPhotoMenu function itself is NOT deleted — only its trigger button. Caption actions now exposed inline.
- **Chips row replaced** with dot-separated metadata text. _buildChipsRow output changed from bordered pill buttons to plain text spans (.pcs-mv) with dot separators (.pcs-dot). Every if/else condition, every canEdit/canManage check, every onclick handler preserved exactly. Owner color mapping: servicing→cyan, creative→purple, client→amber. Date: overdue→red, has date→bright (#F0F0F2). Old .pcs-chip* CSS classes replaced with .pcs-meta-row, .pcs-mv, .pcs-dot.
- **Caption pane**: Edit/Copy/Clear action row added below WhatsApp section. Calls _startCaptionEdit, _pcsCopyCaption, _pcsConfirmClearCaption — exact same functions as 3-dot menu used. Clear button only when post.caption truthy. canManage-gated. Done button always rendered, calls closePCS() — same as Close X.
- **Separator normalization**: all PCS structural borders changed to 1px solid #323244 (tab bar, metadata row, caption section).
- **Title-metadata coupling**: title padding-bottom 4px, metadata padding-top 4px. Only separator is below metadata before tab bar.
- **Desktop max-width**: #pcs-screen max-width:480px with margin:0 auto. #pcs-overlay stays full-screen. Bottom confirm sheet (.pcs-bottom-confirm) centered at 480px.

**Zero business logic changes. Zero data flow changes. Only HTML templates and CSS.**

## Test plan

- [x] 508/508 unit tests passing (npx vitest run)
- [x] 40/40 e2e tests passing (client-flows + pcs + admin-flows)
- [x] Version bump: ?v=20260408p (all 20 resources)
- [x] CLAUDE.md updated in same PR

https://claude.ai/code/session_01Kfx3Cki6vgH4dZwziceD5n