### PR TITLE
feat: PCS comment redesign Part 2A — Instagram-style rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,8 @@ Root config files:
 
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
-19 script tags + 1 stylesheet = 20 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260408p
+20 script tags + 1 stylesheet = 21 versioned resources total.
+Version format: ?v=YYYYMMDDx. Current: ?v=20260409a
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -51,6 +51,7 @@ render/client.js         — client feed render (defer)
 render/pipeline.js       — pipeline render (defer)
 render/brief.js          — brief render (defer)
 actions/pcs.js           — Post Card System overlay (defer)
+actions/pcs-longpress.js — Long-press menu for PCS comments (defer)
 07-post-load.js          — post fetching (defer)
 08-post-actions.js       — stage changes, admin edit (defer)
 09-library.js            — library view (defer)
@@ -62,6 +63,7 @@ CRITICAL:
 - 00-appstate.js + 00-appstate-compat.js have NO defer — load synchronously
 - 09-library.js calls _renderPCS() directly — must stay on window.*
 - 04-router.js must always be the LAST script tag
+- actions/pcs-longpress.js must load AFTER actions/pcs.js (wraps openPCS)
 
 ## SECTION 4 — APPSTATE
 
@@ -264,7 +266,7 @@ PCS overlay: full page (not bottom sheet), slides right-to-left
 
 1. Bump ALL 20 ?v= strings in index.html together
    Format: ?v=YYYYMMDDx (e.g. ?v=20260401f)
-   Count: 20 total (1 stylesheet + 19 scripts). Never change just one.
+   Count: 21 total (1 stylesheet + 20 scripts). Never change just one.
 1. After EVERY merge purge Cloudflare immediately:
    dash.cloudflare.com -> srtd.io -> Caching -> Purge Everything
 1. Hard refresh all devices BEFORE testing
@@ -327,7 +329,7 @@ Post-deploy smoke (.github/workflows/smoke.yml):
   Schedule: '*/30 * * * *' (every 30 min) + workflow_dispatch.
   Spec: tests/e2e/live-smoke-schedule.spec.js (6 tests) hits the
     real srtd.io + Supabase. Checks: site reachable, expected
-    version served, all 20 versioned assets return 200, Supabase
+    version served, all 21 versioned assets return 200, Supabase
     REST reachable, client can open a post + comments render,
     error_log has <3 rows in last 30 min.
   Required GitHub secrets for smoke workflow:
@@ -338,7 +340,7 @@ Post-deploy smoke (.github/workflows/smoke.yml):
   required env vars are missing skip with a console.warn rather
   than failing the whole suite.
 
-Current (verified 2026-04-06):
+Current (verified 2026-04-09):
 Unit test files: 21
 Unit tests:      508 passing, 0 failing
 E2E specs:       9
@@ -429,7 +431,7 @@ Pages branch:   main-/-root
 1. Never raw fetch() — always apiFetch()
 1. Never mutate AppState.posts.all — always setAll()
 1. Never reference /sorted/ — does not exist, files are at root
-1. All 20 ?v= strings must bump together — never just one file
+1. All 21 ?v= strings must bump together — never just one file
 1. 00-appstate.js + 00-appstate-compat.js have NO defer attribute
 1. Client comment input only renders for awaiting_approval
    and awaiting_brand_input — not all stages
@@ -585,6 +587,7 @@ window._pcsLbDownload, window._startCaptionEdit, window._cancelCaptionEdit,
 window._saveCaptionEdit, window._sharePostOnWhatsApp, window.submitPcsComment,
 window._doSubmitComment, window.toggleTaskResolve, window._initMentionDropup,
 window._showTaskAssign, window.submitPcsTask, window._pcsHandleCommentImg,
+window._pcsTogglePlusMenu, window._pcsLongpressRemoveMenu,
 window._pcsRenderImgPreviews, window._pcsRemoveCommentImg,
 window._pcsSetReply, window._pcsClearReply, window._pcsCopyComment,
 window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
@@ -1665,6 +1668,58 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Zero business logic changes. Zero data flow changes.
    508/508 unit passing, 40/40 e2e passing.
    Status: FIXED (PR#TBD). Bumped to ?v=20260408p.
+1. PCS comment visual redesign Part 2A — Instagram-style rendering
+   Location: actions/pcs.js, actions/pcs-longpress.js (new),
+   index.html, styles.css
+   Scope:
+   (a) _renderClientThread and _renderNoteThread rewritten:
+       DELETE/COPY action row removed from comment HTML. Only
+       visible "Reply" text remains below each comment (calls
+       exact same _pcsSetReply function). Heart SVG placeholder
+       added on right side (visual only, not wired to DB).
+       data-comment-id and data-author attributes added to
+       comment div for long-press handler to read.
+   (b) Thread grouping: comments grouped by parent_id. Top-level
+       comment + last reply always visible. Middle replies hidden
+       behind "View N more replies" expand link. Orphaned replies
+       render as top-level. Uses .pcs-thread-group wrapper.
+   (c) Same changes applied to internal notes (_renderNoteThread).
+       All note-specific features preserved: .pcs-vis-tag,
+       .pcs-mention-badge, .pcs-task-assignee, resolved accordion.
+   (d) Task checkbox: ☐/☑ emoji replaced with SVG dotted circles.
+       Unchecked = hollow dotted circle. Checked = green dotted
+       circle with checkmark polyline. onclick calls exact same
+       toggleTaskResolve(). "Resolved by" label added below done
+       tasks when resolved_by is truthy.
+   (e) Long-press bottom sheet: new file actions/pcs-longpress.js.
+       500ms touch-hold on .pcs-comment-item/.pcs-note-item shows
+       bottom sheet with Copy/Reply/Delete + Resolve task (for
+       tasks only). All buttons call exact same existing functions.
+       Delete permission: author === name || admin. Desktop
+       fallback via contextmenu event. Haptic vibrate(12).
+   (f) Plus button menu: + button in both input bars now shows
+       Task/Image popover instead of directly opening file picker.
+       Image calls exact same file input click. Task calls exact
+       same submitPcsComment(isTask=true) or _showTaskAssign().
+   (g) Reply tag moved inside input pill: old .pcs-reply-bar
+       removed from HTML. New .pcs-reply-tag inline element added
+       inside .pcs-ibar-pill showing "Author ·" with X dismiss.
+       _pcsSetReply and _pcsClearReply updated for new element IDs.
+   (h) CSS overhaul: comment items no border-bottom (whitespace
+       only). Avatar 30px (up from 28). Author 13px/700 #F0F0F2.
+       Text 13.5px #C0C0C8. Avatar colors solid hex backgrounds
+       (no alpha). .pcs-comment-reply no border-left. New classes:
+       .pcs-thread-group, .pcs-expand-link, .pcs-expand-line,
+       .pcs-expand-text, .pcs-comment-reply-btn, .pcs-comment-react,
+       .pcs-react-icon, .pcs-resolved-label, .pcs-lp-backdrop,
+       .pcs-lp-menu, .pcs-lp-item, .pcs-lp-cancel, .pcs-lp-delete,
+       .pcs-lp-resolve, .pcs-plus-menu, .pcs-plus-item,
+       .pcs-reply-tag, .pcs-reply-tag-x. Zero rgba(). All hex.
+   New file: actions/pcs-longpress.js. Script count: 21 (20+1).
+   Zero business logic changes. Zero new DB calls. Zero new API
+   endpoints. All onclick handlers call exact same functions.
+   508/508 unit passing, 40/40 e2e passing.
+   Status: FIXED (PR#TBD). Bumped to ?v=20260409a.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs-longpress.js
+++ b/actions/pcs-longpress.js
@@ -1,0 +1,222 @@
+/* ===============================================
+   actions/pcs-longpress.js  -  Long-press menu for PCS comments
+   Visual redesign Part 2A — no new DB calls
+=============================================== */
+console.log("LOADED:", "actions/pcs-longpress.js");
+
+(function() {
+  var _lpTimer = null;
+  var _lpTarget = null;
+  var _lpStartX = 0;
+  var _lpStartY = 0;
+  var _MOVE_THRESHOLD = 10;
+  var _LP_DELAY = 500;
+
+  // Elements we should NOT trigger long-press on
+  var _SKIP_SELECTORS = '.pcs-comment-react, .pcs-comment-reply-btn, .pcs-task-check, .pcs-expand-link, .pcs-comment-img-thumb, a, button, input, textarea';
+
+  function _findCommentItem(el) {
+    return el.closest('.pcs-comment-item, .pcs-note-item');
+  }
+
+  function _getZone(item) {
+    if (!item) return 'client';
+    if (item.closest('#pcs-notes-list')) return 'note';
+    return 'client';
+  }
+
+  function _getPostId() {
+    var el = document.getElementById('pcs-post-id');
+    return el ? el.value : '';
+  }
+
+  function _isTask(item) {
+    return item && !!item.querySelector('.pcs-task-check');
+  }
+
+  function _showMenu(item) {
+    // Remove existing menu
+    _removeMenu();
+
+    var zone = _getZone(item);
+    var commentId = item.getAttribute('data-comment-id') || '';
+    var author = item.getAttribute('data-author') || '';
+    var postId = _getPostId();
+    var isInternalNote = zone === 'note';
+    var hasTask = _isTask(item);
+    var textEl = item.querySelector('.pcs-comment-text');
+    var message = textEl ? textEl.textContent : '';
+
+    // Check delete permission: author match or admin
+    var _name = (window.AppState && window.AppState.user && window.AppState.user.name) || '';
+    var _roleLower = ((window.AppState && window.AppState.user && window.AppState.user.effectiveRole) || 'Admin').toLowerCase();
+    var canDelete = (author === _name || _roleLower === 'admin');
+
+    // Check if deleted comment
+    if (item.querySelector('.pcs-deleted-msg')) return;
+
+    var backdrop = document.createElement('div');
+    backdrop.id = 'pcs-longpress-backdrop';
+    backdrop.className = 'pcs-lp-backdrop';
+
+    var menu = document.createElement('div');
+    menu.id = 'pcs-longpress-menu';
+    menu.className = 'pcs-lp-menu';
+
+    var html = '';
+
+    // Resolve task button (only for task comments)
+    if (hasTask) {
+      html += '<button class="pcs-lp-item pcs-lp-resolve" id="pcs-lp-resolve">Resolve task</button>';
+    }
+
+    html += '<button class="pcs-lp-item" id="pcs-lp-copy">Copy text</button>';
+    html += '<button class="pcs-lp-item" id="pcs-lp-reply">Reply</button>';
+
+    if (canDelete) {
+      html += '<button class="pcs-lp-item pcs-lp-delete" id="pcs-lp-delete">Delete</button>';
+    }
+
+    html += '<button class="pcs-lp-cancel" id="pcs-lp-cancel">Cancel</button>';
+    menu.innerHTML = html;
+
+    backdrop.appendChild(menu);
+    var overlay = document.getElementById('pcs-overlay');
+    if (overlay) {
+      overlay.appendChild(backdrop);
+    } else {
+      document.body.appendChild(backdrop);
+    }
+
+    // Wire handlers
+    backdrop.addEventListener('click', function(e) {
+      if (e.target === backdrop) _removeMenu();
+    });
+
+    var cancelBtn = document.getElementById('pcs-lp-cancel');
+    if (cancelBtn) cancelBtn.addEventListener('click', _removeMenu);
+
+    var copyBtn = document.getElementById('pcs-lp-copy');
+    if (copyBtn) copyBtn.addEventListener('click', function() {
+      _removeMenu();
+      if (typeof window._pcsCopyComment === 'function') {
+        window._pcsCopyComment(message);
+      }
+    });
+
+    var replyBtn = document.getElementById('pcs-lp-reply');
+    if (replyBtn) replyBtn.addEventListener('click', function() {
+      _removeMenu();
+      if (typeof window._pcsSetReply === 'function') {
+        window._pcsSetReply(zone, commentId, author, message);
+      }
+    });
+
+    var deleteBtn = document.getElementById('pcs-lp-delete');
+    if (deleteBtn) deleteBtn.addEventListener('click', function() {
+      _removeMenu();
+      if (typeof window._pcsConfirmDeleteComment === 'function') {
+        window._pcsConfirmDeleteComment(commentId, postId, isInternalNote);
+      }
+    });
+
+    var resolveBtn = document.getElementById('pcs-lp-resolve');
+    if (resolveBtn) resolveBtn.addEventListener('click', function() {
+      _removeMenu();
+      if (typeof window.toggleTaskResolve === 'function') {
+        window.toggleTaskResolve(commentId, postId);
+      }
+    });
+  }
+
+  function _removeMenu() {
+    var existing = document.getElementById('pcs-longpress-backdrop');
+    if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
+  }
+
+  function _cancelTimer() {
+    if (_lpTimer) {
+      clearTimeout(_lpTimer);
+      _lpTimer = null;
+    }
+    _lpTarget = null;
+  }
+
+  function _onTouchStart(e) {
+    var target = e.target;
+    // Skip interactive elements
+    if (target.closest && target.closest(_SKIP_SELECTORS)) return;
+
+    var item = _findCommentItem(target);
+    if (!item) return;
+
+    _lpStartX = e.touches[0].clientX;
+    _lpStartY = e.touches[0].clientY;
+    _lpTarget = item;
+
+    _lpTimer = setTimeout(function() {
+      if (_lpTarget) {
+        // Haptic feedback
+        if (navigator.vibrate) navigator.vibrate(12);
+        _showMenu(_lpTarget);
+        _lpTarget = null;
+      }
+    }, _LP_DELAY);
+  }
+
+  function _onTouchMove(e) {
+    if (!_lpTimer) return;
+    var dx = Math.abs(e.touches[0].clientX - _lpStartX);
+    var dy = Math.abs(e.touches[0].clientY - _lpStartY);
+    if (dx > _MOVE_THRESHOLD || dy > _MOVE_THRESHOLD) {
+      _cancelTimer();
+    }
+  }
+
+  function _onTouchEnd() {
+    _cancelTimer();
+  }
+
+  // Desktop: right-click on comment items
+  function _onContextMenu(e) {
+    var target = e.target;
+    if (target.closest && target.closest(_SKIP_SELECTORS)) return;
+    var item = _findCommentItem(target);
+    if (!item) return;
+    e.preventDefault();
+    _showMenu(item);
+  }
+
+  // Attach listeners to #pcs-overlay once it exists
+  function _wireListeners() {
+    var overlay = document.getElementById('pcs-overlay');
+    if (!overlay) return;
+    if (overlay._lpWired) return;
+    overlay._lpWired = true;
+
+    overlay.addEventListener('touchstart', _onTouchStart, { passive: true });
+    overlay.addEventListener('touchmove', _onTouchMove, { passive: true });
+    overlay.addEventListener('touchend', _onTouchEnd, { passive: true });
+    overlay.addEventListener('touchcancel', _onTouchEnd, { passive: true });
+    overlay.addEventListener('contextmenu', _onContextMenu);
+  }
+
+  // Wire on DOMContentLoaded and also when PCS opens
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _wireListeners);
+  } else {
+    _wireListeners();
+  }
+
+  // Re-wire on each openPCS (overlay may be re-created)
+  var _origOpenPCS = window.openPCS;
+  if (_origOpenPCS) {
+    window.openPCS = function() {
+      _origOpenPCS.apply(this, arguments);
+      _wireListeners();
+    };
+  }
+
+  // Expose remove for cleanup
+  window._pcsLongpressRemoveMenu = _removeMenu;
+})();

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1021,163 +1021,247 @@ window.loadPcsComments = async function(postId) {
       return null;
     }
 
+    function _renderSingleClient(c) {
+      if (c.deleted) {
+        return '<div class="pcs-comment-item">' +
+          '<div class="pcs-avatar av-muted">?</div>' +
+          '<div class="pcs-comment-body">' +
+          '<div class="pcs-deleted-msg">This message was deleted.</div>' +
+          '</div></div>';
+      }
+      var _initial = (c.author||'?').charAt(0).toUpperCase();
+      var _taskObj = _parseTask(c);
+      var _isTask = !!_taskObj;
+      var _taskPrefix = _isTask
+        ? '<span class="pcs-task-check' + (c.resolved ? ' pcs-task-done' : '') +
+          '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\')">' +
+          (c.resolved
+            ? '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="8 12 11 15 16 9"/></svg>'
+            : '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>') +
+          '</span> '
+        : '';
+      var _att = (function() {
+        try {
+          return typeof c.attachments === 'string'
+            ? JSON.parse(c.attachments)
+            : c.attachments;
+        } catch(e) { return null; }
+      })();
+      var _imgHtml = '';
+      if (_att && _att.type === 'images' && _att.urls) {
+        _imgHtml = '<div class="pcs-comment-imgs">' +
+          _att.urls.map(function(u) {
+            return '<img src="' + esc(u) + '" class="pcs-comment-img-thumb" ' +
+              'onclick="window._pcsOpenLightbox(\'' + esc(postId) + '\',[' +
+              _att.urls.map(function(x){ return '\'' + esc(x) + '\''; }).join(',') +
+              '],' + _att.urls.indexOf(u) + ')">';
+          }).join('') +
+        '</div>';
+      }
+      var _resolvedLabel = (_isTask && c.resolved && c.resolved_by)
+        ? '<div class="pcs-resolved-label">Resolved by ' + esc(c.resolved_by) + '</div>'
+        : '';
+      var _escapedMsg = esc(c.message).replace(/'/g, '&#39;');
+      return '<div class="pcs-comment-item' +
+        (c.reply_to ? ' pcs-comment-reply' : '') + '" data-comment-id="' + esc(c.id) + '" data-author="' + esc(c.author) + '">' +
+        (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
+        '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>' +
+        '<div class="pcs-comment-body">' +
+          '<div class="pcs-comment-meta">' +
+            '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
+            '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
+          '</div>' +
+          (c.reply_to && c.reply_to_author ?
+            '<div class="pcs-reply-indicator">' +
+            '&#8629; ' + esc(c.reply_to_author) + '</div>'
+            : '') +
+          '<div class="pcs-comment-text' + (_isTask ? ' pcs-task-text' : '') +
+          ((_isTask && c.resolved) ? ' pcs-task-done' : '') + '">' +
+          _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
+          _imgHtml +
+          _resolvedLabel +
+          '<div class="pcs-comment-reply-btn" ' +
+            'onclick="window._pcsSetReply(\'client\',\'' +
+            esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
+            _escapedMsg + '\')">Reply</div>' +
+        '</div>' +
+        '<div class="pcs-comment-react" data-comment-id="' + esc(c.id) + '">' +
+          '<span class="pcs-react-icon"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg></span>' +
+        '</div>' +
+      '</div>';
+    }
+
     function _renderClientThread(threadRows, isEmpty) {
       if (!threadRows.length) return isEmpty;
-      return threadRows.map(function(c) {
-        if (c.deleted) {
-          return '<div class="pcs-comment-item">' +
-            '<div class="pcs-avatar av-muted">?</div>' +
-            '<div class="pcs-comment-body">' +
-            '<div class="pcs-deleted-msg">This message was deleted.</div>' +
-            '</div></div>';
+      // Build thread groups: top-level comments + their replies
+      var _topLevel = [];
+      var _replyMap = {};
+      threadRows.forEach(function(c) {
+        if (!c.reply_to) {
+          _topLevel.push(c);
+        } else {
+          if (!_replyMap[c.reply_to]) _replyMap[c.reply_to] = [];
+          _replyMap[c.reply_to].push(c);
         }
-        var _initial = (c.author||'?').charAt(0).toUpperCase();
-        var _taskObj = _parseTask(c);
-        var _isTask = !!_taskObj;
-        var _taskPrefix = _isTask
-          ? '<span class="pcs-task-check' + (c.resolved ? ' pcs-task-done' : '') +
-            '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\')">' +
-            (c.resolved ? '&#x2611;' : '&#x2610;') + '</span> '
-          : '';
-        var _att = (function() {
-          try {
-            return typeof c.attachments === 'string'
-              ? JSON.parse(c.attachments)
-              : c.attachments;
-          } catch(e) { return null; }
-        })();
-        var _imgHtml = '';
-        if (_att && _att.type === 'images' && _att.urls) {
-          _imgHtml = '<div class="pcs-comment-imgs">' +
-            _att.urls.map(function(u) {
-              return '<img src="' + esc(u) + '" class="pcs-comment-img-thumb" ' +
-                'onclick="window._pcsOpenLightbox(\'' + esc(postId) + '\',[' +
-                _att.urls.map(function(x){ return '\'' + esc(x) + '\''; }).join(',') +
-                '],' + _att.urls.indexOf(u) + ')">';
-            }).join('') +
-          '</div>';
+      });
+      // Orphaned replies (parent not in this batch) become top-level
+      Object.keys(_replyMap).forEach(function(pid) {
+        var parentExists = threadRows.some(function(c) { return c.id === pid; });
+        if (!parentExists) {
+          _replyMap[pid].forEach(function(c) { _topLevel.push(c); });
+          delete _replyMap[pid];
         }
-        return '<div class="pcs-comment-item' +
-          (c.reply_to ? ' pcs-comment-reply' : '') + '" data-comment-id="' + esc(c.id) + '">' +
-          (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
-          '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>' +
-          '<div class="pcs-comment-body">' +
-            '<div class="pcs-comment-meta">' +
-              '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
-              '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
-            '</div>' +
-            (c.reply_to && c.reply_to_author ?
-              '<div class="pcs-reply-indicator">' +
-              '&#8629; ' + esc(c.reply_to_author) + '</div>'
-              : '') +
-            '<div class="pcs-comment-text' + (_isTask ? ' pcs-task-text' : '') +
-            ((_isTask && c.resolved) ? ' pcs-task-done' : '') + '">' +
-            _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
-            _imgHtml +
-            '<div class="pcs-comment-actions">' +
-            (c.author === _name || _roleLower === 'admin' ?
-              '<span class="pcs-comment-action pcs-comment-delete-btn" ' +
-              'onclick="window._pcsConfirmDeleteComment(\'' +
-              esc(c.id) + '\',\'' + esc(postId) + '\')">DELETE</span>'
-              : '') +
-            '<span class="pcs-comment-action" ' +
-              'onclick="window._pcsSetReply(\'client\',\'' +
-              esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
-              esc(c.message) + '\')">REPLY</span>' +
-            '<span class="pcs-comment-action" ' +
-              'onclick="window._pcsCopyComment(\'' +
-              esc(c.message) + '\')">COPY</span>' +
-            '</div>' +
-          '</div>' +
-        '</div>';
+      });
+      return _topLevel.map(function(parent) {
+        var replies = _replyMap[parent.id] || [];
+        var groupHtml = '<div class="pcs-thread-group">';
+        groupHtml += _renderSingleClient(parent);
+        if (replies.length === 1) {
+          groupHtml += _renderSingleClient(replies[0]);
+        } else if (replies.length > 1) {
+          var middle = replies.slice(0, replies.length - 1);
+          var last = replies[replies.length - 1];
+          groupHtml += '<div class="pcs-expand-link" onclick="this.nextElementSibling.style.display=\'block\';this.style.display=\'none\'">' +
+            '<span class="pcs-expand-line"></span>' +
+            '<span class="pcs-expand-text">View ' + middle.length + ' more repl' + (middle.length === 1 ? 'y' : 'ies') + '</span>' +
+            '</div>';
+          groupHtml += '<div class="pcs-hidden-replies" style="display:none">';
+          middle.forEach(function(r) { groupHtml += _renderSingleClient(r); });
+          groupHtml += '</div>';
+          groupHtml += _renderSingleClient(last);
+        }
+        groupHtml += '</div>';
+        return groupHtml;
       }).join('');
+    }
+
+    function _renderSingleNote(c) {
+      if (c.deleted) {
+        return '<div class="pcs-note-item">' +
+          '<div class="pcs-avatar av-muted">?</div>' +
+          '<div class="pcs-comment-body">' +
+          '<div class="pcs-deleted-msg">This message was deleted.</div>' +
+          '</div></div>';
+      }
+      var _initial = (c.author||'?').charAt(0).toUpperCase();
+      var _mu = Array.isArray(c.mentioned_users) ? c.mentioned_users : [];
+      var _mentionBadge = _mu.length
+        ? '<span class="pcs-mention-badge">@' + esc(_mu.join(', @')) + '</span>'
+        : '';
+      var _vis = (c.visibility||'all').toUpperCase();
+      if (_vis === 'SERVICING') _vis = 'SERV';
+      var _visTag = '<span class="pcs-vis-tag">' + _vis + '</span>';
+      var _taskObj = _parseTask(c);
+      var _isTask = !!_taskObj;
+      var _assignedTo = (_taskObj && _taskObj.assigned_to) ? _taskObj.assigned_to : null;
+      var _assignedLabel = _assignedTo
+        ? '<span class="pcs-task-assignee">@' + esc(_assignedTo) + '</span> '
+        : '';
+      var _taskPrefix = _isTask
+        ? '<span class="pcs-task-check' + (c.resolved ? ' pcs-task-done' : '') +
+          '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\')">' +
+          (c.resolved
+            ? '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="8 12 11 15 16 9"/></svg>'
+            : '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>') +
+          '</span> '
+          + _assignedLabel
+        : '';
+
+      var _att = (function() {
+        try {
+          return typeof c.attachments === 'string'
+            ? JSON.parse(c.attachments)
+            : c.attachments;
+        } catch(e) { return null; }
+      })();
+      var _imgHtml = '';
+      if (_att && _att.type === 'images' && _att.urls) {
+        _imgHtml = '<div class="pcs-comment-imgs">' +
+          _att.urls.map(function(u) {
+            return '<img src="' + esc(u) + '" class="pcs-comment-img-thumb" ' +
+              'onclick="window._pcsOpenLightbox(\'' + esc(postId) + '\',[' +
+              _att.urls.map(function(x){ return '\'' + esc(x) + '\''; }).join(',') +
+              '],' + _att.urls.indexOf(u) + ')">';
+          }).join('') +
+        '</div>';
+      }
+      var _resolvedLabel = (_isTask && c.resolved && c.resolved_by)
+        ? '<div class="pcs-resolved-label">Resolved by ' + esc(c.resolved_by) + '</div>'
+        : '';
+      var _escapedMsg = esc(c.message).replace(/'/g, '&#39;');
+      return '<div class="pcs-note-item' +
+        (c.reply_to ? ' pcs-comment-reply' : '') +
+        (c.resolved ? ' pcs-resolved' : '') + '" data-comment-id="' + esc(c.id) + '" data-author="' + esc(c.author) + '">' +
+        (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
+        '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>' +
+        '<div class="pcs-comment-body">' +
+          '<div class="pcs-comment-meta">' +
+            '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
+            '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
+            _mentionBadge +
+            _visTag +
+          '</div>' +
+          (c.reply_to && c.reply_to_author ?
+            '<div class="pcs-reply-indicator">' +
+            '&#8629; ' + esc(c.reply_to_author) + '</div>'
+            : '') +
+          '<div class="pcs-comment-text' + (_isTask ? ' pcs-task-text' : '') +
+          ((_isTask && c.resolved) ? ' pcs-task-done' : '') + '">' +
+          _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
+          _imgHtml +
+          _resolvedLabel +
+          '<div class="pcs-comment-reply-btn" ' +
+            'onclick="window._pcsSetReply(\'note\',\'' +
+            esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
+            _escapedMsg + '\')">Reply</div>' +
+        '</div>' +
+        '<div class="pcs-comment-react" data-comment-id="' + esc(c.id) + '">' +
+          '<span class="pcs-react-icon"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg></span>' +
+        '</div>' +
+      '</div>';
     }
 
     function _renderNoteThread(threadRows, isEmpty) {
       if (!threadRows.length) return isEmpty;
-      return threadRows.map(function(c) {
-        if (c.deleted) {
-          return '<div class="pcs-note-item">' +
-            '<div class="pcs-avatar av-muted">?</div>' +
-            '<div class="pcs-comment-body">' +
-            '<div class="pcs-deleted-msg">This message was deleted.</div>' +
-            '</div></div>';
+      // Build thread groups: top-level notes + their replies
+      var _topLevel = [];
+      var _replyMap = {};
+      threadRows.forEach(function(c) {
+        if (!c.reply_to) {
+          _topLevel.push(c);
+        } else {
+          if (!_replyMap[c.reply_to]) _replyMap[c.reply_to] = [];
+          _replyMap[c.reply_to].push(c);
         }
-        var _initial = (c.author||'?').charAt(0).toUpperCase();
-        var _mu = Array.isArray(c.mentioned_users) ? c.mentioned_users : [];
-        var _mentionBadge = _mu.length
-          ? '<span class="pcs-mention-badge">@' + esc(_mu.join(', @')) + '</span>'
-          : '';
-        var _vis = (c.visibility||'all').toUpperCase();
-        if (_vis === 'SERVICING') _vis = 'SERV';
-        var _visTag = '<span class="pcs-vis-tag">' + _vis + '</span>';
-        var _taskObj = _parseTask(c);
-        var _isTask = !!_taskObj;
-        var _assignedTo = (_taskObj && _taskObj.assigned_to) ? _taskObj.assigned_to : null;
-        var _assignedLabel = _assignedTo
-          ? '<span class="pcs-task-assignee">@' + esc(_assignedTo) + '</span> '
-          : '';
-        var _taskPrefix = _isTask
-          ? '<span class="pcs-task-check' + (c.resolved ? ' pcs-task-done' : '') +
-            '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\')">' +
-            (c.resolved ? '&#x2611;' : '&#x2610;') + '</span> '
-            + _assignedLabel
-          : '';
-
-        var _att = (function() {
-          try {
-            return typeof c.attachments === 'string'
-              ? JSON.parse(c.attachments)
-              : c.attachments;
-          } catch(e) { return null; }
-        })();
-        var _imgHtml = '';
-        if (_att && _att.type === 'images' && _att.urls) {
-          _imgHtml = '<div class="pcs-comment-imgs">' +
-            _att.urls.map(function(u) {
-              return '<img src="' + esc(u) + '" class="pcs-comment-img-thumb" ' +
-                'onclick="window._pcsOpenLightbox(\'' + esc(postId) + '\',[' +
-                _att.urls.map(function(x){ return '\'' + esc(x) + '\''; }).join(',') +
-                '],' + _att.urls.indexOf(u) + ')">';
-            }).join('') +
-          '</div>';
+      });
+      // Orphaned replies become top-level
+      Object.keys(_replyMap).forEach(function(pid) {
+        var parentExists = threadRows.some(function(c) { return c.id === pid; });
+        if (!parentExists) {
+          _replyMap[pid].forEach(function(c) { _topLevel.push(c); });
+          delete _replyMap[pid];
         }
-        return '<div class="pcs-note-item' +
-          (c.reply_to ? ' pcs-comment-reply' : '') +
-          (c.resolved ? ' pcs-resolved' : '') + '" data-comment-id="' + esc(c.id) + '">' +
-          (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
-          '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>' +
-          '<div class="pcs-comment-body">' +
-            '<div class="pcs-comment-meta">' +
-              '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
-              '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
-              _mentionBadge +
-              _visTag +
-            '</div>' +
-            (c.reply_to && c.reply_to_author ?
-              '<div class="pcs-reply-indicator">' +
-              '&#8629; ' + esc(c.reply_to_author) + '</div>'
-              : '') +
-            '<div class="pcs-comment-text' + (_isTask ? ' pcs-task-text' : '') +
-            ((_isTask && c.resolved) ? ' pcs-task-done' : '') + '">' +
-            _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
-            _imgHtml +
-            '<div class="pcs-comment-actions">' +
-            (c.author === _name || _roleLower === 'admin' ?
-              '<span class="pcs-comment-action pcs-comment-delete-btn" ' +
-              'onclick="window._pcsConfirmDeleteComment(\'' +
-              esc(c.id) + '\',\'' + esc(postId) + '\',true)">DELETE</span>'
-              : '') +
-            '<span class="pcs-comment-action" ' +
-              'onclick="window._pcsSetReply(\'note\',\'' +
-              esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
-              esc(c.message) + '\')">REPLY</span>' +
-            '<span class="pcs-comment-action" ' +
-              'onclick="window._pcsCopyComment(\'' +
-              esc(c.message) + '\')">COPY</span>' +
-            '</div>' +
-          '</div>' +
-        '</div>';
+      });
+      return _topLevel.map(function(parent) {
+        var replies = _replyMap[parent.id] || [];
+        var groupHtml = '<div class="pcs-thread-group">';
+        groupHtml += _renderSingleNote(parent);
+        if (replies.length === 1) {
+          groupHtml += _renderSingleNote(replies[0]);
+        } else if (replies.length > 1) {
+          var middle = replies.slice(0, replies.length - 1);
+          var last = replies[replies.length - 1];
+          groupHtml += '<div class="pcs-expand-link" onclick="this.nextElementSibling.style.display=\'block\';this.style.display=\'none\'">' +
+            '<span class="pcs-expand-line"></span>' +
+            '<span class="pcs-expand-text">View ' + middle.length + ' more repl' + (middle.length === 1 ? 'y' : 'ies') + '</span>' +
+            '</div>';
+          groupHtml += '<div class="pcs-hidden-replies" style="display:none">';
+          middle.forEach(function(r) { groupHtml += _renderSingleNote(r); });
+          groupHtml += '</div>';
+          groupHtml += _renderSingleNote(last);
+        }
+        groupHtml += '</div>';
+        return groupHtml;
       }).join('');
     }
 
@@ -2408,6 +2492,61 @@ window._pcsRemoveCommentImg = function(zone, idx) {
   _pcsRenderImgPreviews(zone);
 };
 
+// -- Plus button menu (Task / Image) --
+window._pcsTogglePlusMenu = function(btn, zone) {
+  // Remove any existing plus menu
+  var existing = document.querySelector('.pcs-plus-menu');
+  if (existing) { existing.remove(); return; }
+
+  var menu = document.createElement('div');
+  menu.className = 'pcs-plus-menu';
+
+  var taskBtn = document.createElement('button');
+  taskBtn.className = 'pcs-plus-item';
+  taskBtn.textContent = 'Task';
+  taskBtn.addEventListener('click', function() {
+    menu.remove();
+    if (zone === 'client') {
+      // Same flow as #pcs-task-btn-client onclick
+      var pid = document.getElementById('pcs-post-id');
+      var inp = document.getElementById('pcs-comment-input');
+      if (pid && inp && inp.value.trim()) {
+        window.submitPcsComment(pid.value, inp.value, 'all', true, false);
+      }
+    } else {
+      // Same flow as #pcs-task-btn-note onclick
+      if (typeof window._showTaskAssign === 'function') {
+        window._showTaskAssign('pcs-note-input', 'pcs-task-btn-note');
+      }
+    }
+  });
+
+  var imgBtn = document.createElement('button');
+  imgBtn.className = 'pcs-plus-item';
+  imgBtn.textContent = 'Image';
+  imgBtn.addEventListener('click', function() {
+    menu.remove();
+    // Same as original plus button — trigger file input
+    var inputId = zone === 'client' ? 'pcs-client-img-input' : 'pcs-note-img-input';
+    var fileInput = document.getElementById(inputId);
+    if (fileInput) fileInput.click();
+  });
+
+  menu.appendChild(taskBtn);
+  menu.appendChild(imgBtn);
+  btn.parentNode.appendChild(menu);
+
+  // Close on outside click
+  setTimeout(function() {
+    document.addEventListener('click', function _dismiss(e) {
+      if (!menu.contains(e.target) && e.target !== btn) {
+        menu.remove();
+        document.removeEventListener('click', _dismiss);
+      }
+    });
+  }, 10);
+};
+
 window._pcsSetReply = function(zone, commentId, author, message) {
   window._pcsReplyTo = commentId;
   window._pcsReplyToAuthor = author;
@@ -2415,16 +2554,17 @@ window._pcsSetReply = function(zone, commentId, author, message) {
     ? 'pcs-comment-input'
     : 'pcs-note-input';
   var input = document.getElementById(inputId);
-  var indicator = document.getElementById(
-    zone === 'client'
-      ? 'pcs-client-reply-indicator'
-      : 'pcs-note-reply-indicator'
-  );
-  if (indicator) {
-    indicator.innerHTML =
-      '<span style="flex:1;">Replying to ' + author + '</span><span class="pcs-reply-cancel" onclick="window._pcsClearReply(\'' + zone + '\')">✕</span>';
-    indicator.style.display = 'flex';
+
+  // Show reply tag inside input pill
+  var tagId = zone === 'client' ? 'pcs-client-reply-tag' : 'pcs-note-reply-tag';
+  var nameId = zone === 'client' ? 'pcs-client-reply-name' : 'pcs-note-reply-name';
+  var tag = document.getElementById(tagId);
+  var nameEl = document.getElementById(nameId);
+  if (tag && nameEl) {
+    nameEl.textContent = author + ' \u00B7';
+    tag.style.display = 'inline-flex';
   }
+
   document.querySelectorAll(
     '.pcs-comment-item, .pcs-note-item'
   ).forEach(function(el) {
@@ -2447,15 +2587,14 @@ window._pcsSetReply = function(zone, commentId, author, message) {
 window._pcsClearReply = function(zone) {
   window._pcsReplyTo = null;
   window._pcsReplyToAuthor = null;
-  var indicator = document.getElementById(
-    zone === 'client'
-      ? 'pcs-client-reply-indicator'
-      : 'pcs-note-reply-indicator'
-  );
-  if (indicator) {
-    indicator.style.display = 'none';
-    indicator.textContent = '';
+
+  // Hide reply tag
+  var tagId = zone === 'client' ? 'pcs-client-reply-tag' : 'pcs-note-reply-tag';
+  var tag = document.getElementById(tagId);
+  if (tag) {
+    tag.style.display = 'none';
   }
+
   document.querySelectorAll('.pcs-comment-replying-to')
     .forEach(function(el) {
       el.classList.remove('pcs-comment-replying-to');

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260408p">
+ <link rel="stylesheet" href="styles.css?v=20260409a">
 
 </head>
 <body>
@@ -909,10 +909,12 @@
         <span id="pcs-comments-count" style="display:none">0</span>
         <div id="pcs-comments-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:12px 16px;scrollbar-width:none;min-height:0"></div>
         <div class="pcs-ibar-wrap client">
-          <div id="pcs-client-reply-indicator" class="pcs-reply-bar" style="display:none"></div>
           <div id="pcs-client-img-previews"></div>
           <div class="pcs-ibar-pill">
-            <button class="pcs-ibar-plus" onclick="var i=document.getElementById('pcs-client-img-input');if(i)i.click()">+</button>
+            <div style="position:relative">
+              <button class="pcs-ibar-plus" onclick="window._pcsTogglePlusMenu(this,'client')">+</button>
+            </div>
+            <span class="pcs-reply-tag" id="pcs-client-reply-tag" style="display:none"><span id="pcs-client-reply-name"></span><button class="pcs-reply-tag-x" onclick="window._pcsClearReply('client')">&#x2715;</button></span>
             <textarea id="pcs-comment-input" class="pcs-ibar-input" placeholder="Reply to client..." rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.45'"></textarea>
             <button id="pcs-send-btn-client" class="pcs-ibar-send" onclick="window.submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',false)">&#x2191;</button>
           </div>
@@ -935,11 +937,13 @@
           <div id="pcs-notes-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:12px 16px;background:#080806;scrollbar-width:none;min-height:0"></div>
         </div>
         <div class="pcs-ibar-wrap notes">
-          <div id="pcs-note-reply-indicator" class="pcs-reply-bar" style="display:none"></div>
           <div id="pcs-note-img-previews"></div>
           <div id="pcs-mention-dropup" style="display:none"></div>
           <div class="pcs-ibar-pill">
-            <button class="pcs-ibar-plus" onclick="var i=document.getElementById('pcs-note-img-input');if(i)i.click()">+</button>
+            <div style="position:relative">
+              <button class="pcs-ibar-plus" onclick="window._pcsTogglePlusMenu(this,'note')">+</button>
+            </div>
+            <span class="pcs-reply-tag" id="pcs-note-reply-tag" style="display:none"><span id="pcs-note-reply-name"></span><button class="pcs-reply-tag-x" onclick="window._pcsClearReply('note')">&#x2715;</button></span>
             <textarea id="pcs-note-input" class="pcs-ibar-input" placeholder="Add note... @mention" rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.45'"></textarea>
             <button id="pcs-send-btn-note" class="pcs-ibar-send" onclick="submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-note-input')?document.getElementById('pcs-note-input').value:'',window._pcsNoteVisibility||'all',false,true)">&#x2191;</button>
           </div>
@@ -1073,26 +1077,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260408p"></script>
-<script src="00-appstate-compat.js?v=20260408p"></script>
-<script src="01-config.js?v=20260408p" defer></script>
-<script src="02-session.js?v=20260408p" defer></script>
-<script src="utils.js?v=20260408p" defer></script>
-<script src="03-auth.js?v=20260408p" defer></script>
-<script src="05-api.js?v=20260408p" defer></script>
-<script src="10-ui.js?v=20260408p" defer></script>
+<script src="00-appstate.js?v=20260409a"></script>
+<script src="00-appstate-compat.js?v=20260409a"></script>
+<script src="01-config.js?v=20260409a" defer></script>
+<script src="02-session.js?v=20260409a" defer></script>
+<script src="utils.js?v=20260409a" defer></script>
+<script src="03-auth.js?v=20260409a" defer></script>
+<script src="05-api.js?v=20260409a" defer></script>
+<script src="10-ui.js?v=20260409a" defer></script>
 
-<script src="06-post-create.js?v=20260408p" defer></script>
-<script defer src="render/dashboard.js?v=20260408p"></script>
-<script defer src="render/client.js?v=20260408p"></script>
-<script defer src="render/pipeline.js?v=20260408p"></script>
-<script defer src="render/brief.js?v=20260408p"></script>
-<script defer src="actions/pcs.js?v=20260408p"></script>
-<script src="07-post-load.js?v=20260408p" defer></script>
-<script src="08-post-actions.js?v=20260408p" defer></script>
-<script src="09-library.js?v=20260408p" defer></script>
-<script src="09-approval.js?v=20260408p" defer></script>
-<script src="04-router.js?v=20260408p" defer></script>
+<script src="06-post-create.js?v=20260409a" defer></script>
+<script defer src="render/dashboard.js?v=20260409a"></script>
+<script defer src="render/client.js?v=20260409a"></script>
+<script defer src="render/pipeline.js?v=20260409a"></script>
+<script defer src="render/brief.js?v=20260409a"></script>
+<script defer src="actions/pcs.js?v=20260409a"></script>
+<script defer src="actions/pcs-longpress.js?v=20260409a"></script>
+<script src="07-post-load.js?v=20260409a" defer></script>
+<script src="08-post-actions.js?v=20260409a" defer></script>
+<script src="09-library.js?v=20260409a" defer></script>
+<script src="09-approval.js?v=20260409a" defer></script>
+<script src="04-router.js?v=20260409a" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5887,35 +5887,31 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   margin-top: -4px;
 }
 
-/* SHARED COMMENT ITEMS */
+/* SHARED COMMENT ITEMS — Instagram-style (Part 2A) */
 .pcs-comment-item {
   display: flex;
   gap: 10px;
-  padding: 10px 16px;
+  padding: 14px 16px 0;
   position: relative;
-  border-bottom: 1px solid #FFFFFF08;
 }
-.pcs-comment-item:last-child { border-bottom: none; }
 .pcs-note-item {
   display: flex;
   gap: 10px;
-  padding: 10px 16px;
+  padding: 14px 16px 0;
   position: relative;
-  border-bottom: 1px solid #A872FF0F;
 }
-.pcs-note-item:last-child { border-bottom: none; }
 .pcs-unread-dot {
   position: absolute;
   left: 6px;
-  top: 14px;
+  top: 16px;
   width: 4px;
   height: 4px;
   border-radius: 50%;
   background: #C8A84B;
 }
 .pcs-avatar {
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   flex-shrink: 0;
   display: flex;
@@ -5926,24 +5922,24 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-weight: 500;
 }
 .av-client {
-  background: #FF4B4B1F;
+  background: #2a1212;
   color: #FF4B4B;
-  border: 1px solid #FF4B4B33;
+  border: 1px solid #3a1818;
 }
 .av-servicing {
-  background: #22D3EE1F;
+  background: #0a1a1e;
   color: #22D3EE;
-  border: 1px solid #22D3EE33;
+  border: 1px solid #143a44;
 }
 .av-creative {
-  background: #9B87F51F;
+  background: #1a162a;
   color: #9b87f5;
-  border: 1px solid #9B87F533;
+  border: 1px solid #2a2244;
 }
 .av-admin {
-  background: #C8A84B1F;
+  background: #2a2210;
   color: #C8A84B;
-  border: 1px solid #C8A84B33;
+  border: 1px solid #3a3018;
 }
 .pcs-comment-body { flex: 1; min-width: 0; }
 .pcs-comment-meta {
@@ -5954,14 +5950,14 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   flex-wrap: wrap;
 }
 .pcs-comment-author {
-  font-size: 11px;
-  font-weight: 600;
-  color: #E8E8E8;
+  font-size: 13px;
+  font-weight: 700;
+  color: #F0F0F2;
 }
 .pcs-comment-time {
   font-family: var(--mono);
-  font-size: 7px;
-  color: #AEAEB2;
+  font-size: 8px;
+  color: #8E8E93;
 }
 .pcs-vis-tag {
   font-family: var(--mono);
@@ -5982,9 +5978,9 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   padding: 1px 4px;
 }
 .pcs-comment-text {
-  font-size: 13px;
-  color: #E8E8E8;
-  line-height: 1.5;
+  font-size: 13.5px;
+  color: #C0C0C8;
+  line-height: 1.55;
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -6345,6 +6341,198 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   cursor: pointer;
 }
 
+/* Reply button (visible inline text) */
+.pcs-comment-reply-btn {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #8E8E93;
+  font-weight: 500;
+  padding: 2px 0 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.pcs-comment-reply-btn:active {
+  color: #AEAEB2;
+}
+
+/* Heart placeholder (visual only) */
+.pcs-comment-react {
+  position: absolute;
+  right: 16px;
+  top: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  cursor: pointer;
+}
+.pcs-react-icon {
+  font-size: 12px;
+  line-height: 1;
+}
+.pcs-react-icon svg {
+  width: 14px;
+  height: 14px;
+  stroke: #606070;
+  fill: none;
+  stroke-width: 1.8;
+}
+
+/* Resolved label for tasks */
+.pcs-resolved-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  color: #3ECF8E;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  margin-top: 3px;
+}
+
+/* Thread grouping */
+.pcs-thread-group { padding: 0; }
+.pcs-thread-group + .pcs-thread-group { padding-top: 20px; }
+.pcs-expand-link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 16px 0 56px;
+  cursor: pointer;
+}
+.pcs-expand-line {
+  width: 20px;
+  height: 1px;
+  background: #8E8E93;
+}
+.pcs-expand-text {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #8E8E93;
+  font-weight: 500;
+}
+
+/* Task checkbox SVG */
+.pcs-task-check svg {
+  width: 18px;
+  height: 18px;
+  stroke: #606070;
+  fill: none;
+  stroke-width: 1.5;
+  stroke-dasharray: 3 2;
+}
+.pcs-task-check.pcs-task-done svg {
+  stroke: #3ECF8E;
+}
+.pcs-task-check.pcs-task-done svg polyline {
+  stroke-dasharray: none;
+}
+
+/* Long-press bottom sheet */
+.pcs-lp-backdrop {
+  position: fixed;
+  inset: 0;
+  background: #000000AA;
+  z-index: 9600;
+}
+.pcs-lp-menu {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  max-width: 480px;
+  margin: 0 auto;
+  background: #16161f;
+  border-top: 1px solid #323244;
+  z-index: 9601;
+  padding: 8px 0;
+}
+.pcs-lp-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  color: #C0C0C8;
+  cursor: pointer;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+}
+.pcs-lp-item:active {
+  background: #1c1c28;
+}
+.pcs-lp-delete {
+  color: #FF4B4B;
+}
+.pcs-lp-cancel {
+  padding: 14px 20px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: #8E8E93;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  cursor: pointer;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: center;
+  border-top: 1px solid #323244;
+  margin-top: 4px;
+}
+
+/* Plus button menu */
+.pcs-plus-menu {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 0;
+  background: #16161f;
+  border: 1px solid #323244;
+  z-index: 200;
+  min-width: 120px;
+}
+.pcs-plus-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 10px 14px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: #C0C0C8;
+  cursor: pointer;
+  background: none;
+  border: none;
+}
+.pcs-plus-item:active {
+  background: #1c1c28;
+}
+.pcs-plus-item + .pcs-plus-item {
+  border-top: 1px solid #323244;
+}
+
+/* Reply tag inside input pill */
+.pcs-reply-tag {
+  display: none;
+  align-items: center;
+  gap: 4px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  color: #C8A84B;
+  white-space: nowrap;
+  padding-right: 4px;
+  flex-shrink: 0;
+}
+.pcs-reply-tag-x {
+  background: none;
+  border: none;
+  color: #8E8E93;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+}
+
 .pcs-menu-item {
   padding: 10px 14px;
   font-family: 'IBM Plex Mono', monospace;
@@ -6369,10 +6557,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 .pcs-comment-actions {
-  display: flex;
-  gap: 12px;
-  margin-top: 5px;
-  justify-content: flex-end;
+  display: none;
 }
 
 .pcs-comment-action {
@@ -6391,8 +6576,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 .pcs-comment-reply {
   margin-left: 20px;
-  border-left: 2px solid #FFFFFF14;
-  padding-left: 10px;
+  padding-left: 0;
 }
 
 .pcs-reply-bar {


### PR DESCRIPTION
## Summary

- **Instagram-style comment rendering**: DELETE/COPY removed from visible comment HTML, replaced with inline "Reply" text and heart SVG placeholder. Thread grouping by parent_id with collapsible middle replies ("View N more replies").
- **Long-press bottom sheet**: New file `actions/pcs-longpress.js` — 500ms touch-hold shows Copy/Reply/Delete menu (+ Resolve for tasks). Desktop right-click fallback.
- **Plus button menu**: + button now shows Task/Image popover instead of directly opening file picker. Same underlying functions called.
- **Reply tag in input pill**: Reply indicator moved inside the input row as an inline tag with author name and dismiss X.
- **Task checkbox SVG**: Emoji ☐/☑ replaced with dotted SVG circles (green when resolved). "Resolved by" label added.
- **CSS overhaul**: No separators between comments (whitespace only), avatar 30px, author 13px/700, text 13.5px #C0C0C8, all solid hex. New classes for threads, expand links, long-press sheet, plus menu, reply tag.

**Zero business logic changes. Zero new DB calls. Zero new API endpoints. All onclick handlers call the exact same functions with the exact same parameters.**

### Files changed

| File | What changed |
|------|-------------|
| `actions/pcs.js` | `_renderClientThread` + `_renderNoteThread` rewritten for new HTML structure + thread grouping. `_pcsSetReply`/`_pcsClearReply` updated for reply tag. `_pcsTogglePlusMenu` added. Task checkbox SVG. |
| `actions/pcs-longpress.js` | **NEW** — Long-press/right-click bottom sheet for comment actions |
| `index.html` | Input bars restructured (reply tag inside pill, plus menu). Script tag added for pcs-longpress.js. All 21 `?v=` bumped to `20260409a`. |
| `styles.css` | Comment item CSS overhauled. 20+ new classes added. All hex, zero rgba. |
| `CLAUDE.md` | Updated: file list, script count (21), version string, global functions, new bug entry |

## Test plan

- [x] `npx vitest run` — 508/508 passing
- [x] `npx playwright test` (3 critical specs) — 40/40 passing
- [ ] Manual: Open PCS client tab, verify Instagram-style comments (no separators, Reply text visible, heart on right)
- [ ] Manual: Long-press a comment → bottom sheet with Copy/Reply/Delete
- [ ] Manual: Long-press a task comment → Resolve task option appears
- [ ] Manual: Tap plus button → Task/Image menu appears
- [ ] Manual: Reply tag shows inside input pill with author name + dismiss X
- [ ] Manual: Thread grouping — 3+ reply thread shows "View N more replies" expand
- [ ] Manual: Task checkbox is dotted SVG circle, green when resolved
- [ ] Manual: Internal notes tab — vis tags, mention badges, assignee labels all render
- [ ] Manual: Desktop right-click on comment → same bottom sheet

https://claude.ai/code/session_01G8J4Nvj1Nkcu4o11U4uQA6