### PR TITLE
feat: PCS comment wiring Part 2B — reactions + toggleTaskResolve fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260409a
+Version format: ?v=YYYYMMDDx. Current: ?v=20260409b
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -588,6 +588,7 @@ window._saveCaptionEdit, window._sharePostOnWhatsApp, window.submitPcsComment,
 window._doSubmitComment, window.toggleTaskResolve, window._initMentionDropup,
 window._showTaskAssign, window.submitPcsTask, window._pcsHandleCommentImg,
 window._pcsTogglePlusMenu, window._pcsLongpressRemoveMenu,
+window._pcsShowEmojiPicker, window._pcsAddReaction, window._pcsRemoveReaction,
 window._pcsRenderImgPreviews, window._pcsRemoveCommentImg,
 window._pcsSetReply, window._pcsClearReply, window._pcsCopyComment,
 window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
@@ -1720,6 +1721,39 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    endpoints. All onclick handlers call exact same functions.
    508/508 unit passing, 40/40 e2e passing.
    Status: FIXED (PR#TBD). Bumped to ?v=20260409a.
+1. PCS comment wiring Part 2B — reactions DB + toggleTaskResolve fix
+   Location: actions/pcs.js, actions/pcs-longpress.js, styles.css
+   Scope:
+   (a) loadPcsComments now fetches /post_comment_reactions for the
+       post in a third API call. Results stored in window._pcsReactions
+       keyed by comment_id. Fetch is try/catch wrapped — failure does
+       not break comment loading.
+   (b) _renderSingleClient and _renderSingleNote now check
+       window._pcsReactions[commentId]. If user has reacted: show
+       their emoji instead of heart SVG, add .pcs-reacted class.
+       If reactions exist: show count via .pcs-react-count span.
+   (c) New function window._pcsShowEmojiPicker(reactEl): if user
+       already reacted, unreacts (removes). Otherwise shows inline
+       5-emoji picker (❤️ 👍 🎯 👀 ✅) positioned above the react
+       div. Click outside closes picker.
+   (d) New function window._pcsAddReaction(commentId, emoji, reactEl):
+       POST to /post_comment_reactions, optimistic DOM update, no
+       full re-fetch. Wrapped in guardAction.
+   (e) New function window._pcsRemoveReaction(commentId, reactEl):
+       DELETE from /post_comment_reactions by reaction id, optimistic
+       DOM update. Wrapped in guardAction.
+   (f) BUG FIX: toggleTaskResolve now accepts third parameter
+       isInternalNote (boolean). Routes PATCH to /internal_notes
+       when true, /post_comments when false. Previously always
+       patched /post_comments causing silent failure for internal
+       note tasks. All callers updated: _renderSingleClient passes
+       false, _renderSingleNote passes true, pcs-longpress.js
+       passes isInternalNote based on zone detection.
+   (g) CSS: .pcs-react-emoji, .pcs-reacted, .pcs-react-count,
+       .pcs-emoji-picker, .pcs-emoji-btn added. All solid hex.
+   Zero visual layout changes from Part 2A. Zero new HTML structure.
+   508/508 unit passing, 40/40 e2e passing.
+   Status: FIXED (PR#TBD). Bumped to ?v=20260409b.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs-longpress.js
+++ b/actions/pcs-longpress.js
@@ -124,7 +124,7 @@ console.log("LOADED:", "actions/pcs-longpress.js");
     if (resolveBtn) resolveBtn.addEventListener('click', function() {
       _removeMenu();
       if (typeof window.toggleTaskResolve === 'function') {
-        window.toggleTaskResolve(commentId, postId);
+        window.toggleTaskResolve(commentId, postId, isInternalNote);
       }
     });
   }

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -941,6 +941,24 @@ window.loadPcsComments = async function(postId) {
     );
     if (!Array.isArray(internalData)) internalData = [];
 
+    // Fetch reactions for this post
+    var _reactData = [];
+    try {
+      var _reactRes = await apiFetch(
+        '/post_comment_reactions?post_id=eq.' +
+        encodeURIComponent(postId) +
+        '&select=*'
+      );
+      if (Array.isArray(_reactRes)) _reactData = _reactRes;
+    } catch(e) {
+      console.warn('[pcs] reactions fetch failed, continuing:', e);
+    }
+    window._pcsReactions = {};
+    _reactData.forEach(function(r) {
+      if (!window._pcsReactions[r.comment_id]) window._pcsReactions[r.comment_id] = [];
+      window._pcsReactions[r.comment_id].push(r);
+    });
+
     var _allRows = rows.concat(internalData);
     var _commentMap = {};
     _allRows.forEach(function(c) {
@@ -1034,7 +1052,7 @@ window.loadPcsComments = async function(postId) {
       var _isTask = !!_taskObj;
       var _taskPrefix = _isTask
         ? '<span class="pcs-task-check' + (c.resolved ? ' pcs-task-done' : '') +
-          '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\')">' +
+          '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\',false)">' +
           (c.resolved
             ? '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="8 12 11 15 16 9"/></svg>'
             : '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>') +
@@ -1062,6 +1080,16 @@ window.loadPcsComments = async function(postId) {
         ? '<div class="pcs-resolved-label">Resolved by ' + esc(c.resolved_by) + '</div>'
         : '';
       var _escapedMsg = esc(c.message).replace(/'/g, '&#39;');
+      // Build reaction display
+      var _cReactions = (window._pcsReactions && window._pcsReactions[c.id]) || [];
+      var _myReact = _cReactions.find(function(r) { return r.author === _name; });
+      var _reactCount = _cReactions.length;
+      var _reactInner = _myReact
+        ? '<span class="pcs-react-icon pcs-react-emoji">' + esc(_myReact.emoji) + '</span>'
+        : '<span class="pcs-react-icon"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg></span>';
+      _reactInner += _reactCount > 0
+        ? '<span class="pcs-react-count">' + _reactCount + '</span>'
+        : '';
       return '<div class="pcs-comment-item' +
         (c.reply_to ? ' pcs-comment-reply' : '') + '" data-comment-id="' + esc(c.id) + '" data-author="' + esc(c.author) + '">' +
         (!c.read ? '<div class="pcs-unread-dot"></div>' : '') +
@@ -1085,8 +1113,8 @@ window.loadPcsComments = async function(postId) {
             esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
             _escapedMsg + '\')">Reply</div>' +
         '</div>' +
-        '<div class="pcs-comment-react" data-comment-id="' + esc(c.id) + '">' +
-          '<span class="pcs-react-icon"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg></span>' +
+        '<div class="pcs-comment-react' + (_myReact ? ' pcs-reacted' : '') + '" data-comment-id="' + esc(c.id) + '" onclick="window._pcsShowEmojiPicker(this)">' +
+          _reactInner +
         '</div>' +
       '</div>';
     }
@@ -1159,7 +1187,7 @@ window.loadPcsComments = async function(postId) {
         : '';
       var _taskPrefix = _isTask
         ? '<span class="pcs-task-check' + (c.resolved ? ' pcs-task-done' : '') +
-          '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\')">' +
+          '" onclick="toggleTaskResolve(\'' + (c.id||'') + '\',\'' + postId + '\',true)">' +
           (c.resolved
             ? '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="8 12 11 15 16 9"/></svg>'
             : '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>') +
@@ -1189,6 +1217,16 @@ window.loadPcsComments = async function(postId) {
         ? '<div class="pcs-resolved-label">Resolved by ' + esc(c.resolved_by) + '</div>'
         : '';
       var _escapedMsg = esc(c.message).replace(/'/g, '&#39;');
+      // Build reaction display
+      var _cReactions = (window._pcsReactions && window._pcsReactions[c.id]) || [];
+      var _myReact = _cReactions.find(function(r) { return r.author === _name; });
+      var _reactCount = _cReactions.length;
+      var _reactInner = _myReact
+        ? '<span class="pcs-react-icon pcs-react-emoji">' + esc(_myReact.emoji) + '</span>'
+        : '<span class="pcs-react-icon"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg></span>';
+      _reactInner += _reactCount > 0
+        ? '<span class="pcs-react-count">' + _reactCount + '</span>'
+        : '';
       return '<div class="pcs-note-item' +
         (c.reply_to ? ' pcs-comment-reply' : '') +
         (c.resolved ? ' pcs-resolved' : '') + '" data-comment-id="' + esc(c.id) + '" data-author="' + esc(c.author) + '">' +
@@ -1215,8 +1253,8 @@ window.loadPcsComments = async function(postId) {
             esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
             _escapedMsg + '\')">Reply</div>' +
         '</div>' +
-        '<div class="pcs-comment-react" data-comment-id="' + esc(c.id) + '">' +
-          '<span class="pcs-react-icon"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg></span>' +
+        '<div class="pcs-comment-react' + (_myReact ? ' pcs-reacted' : '') + '" data-comment-id="' + esc(c.id) + '" onclick="window._pcsShowEmojiPicker(this)">' +
+          _reactInner +
         '</div>' +
       '</div>';
     }
@@ -2283,12 +2321,13 @@ window._doSubmitComment = async function(opts) {
   }
 };
 
-window.toggleTaskResolve = function(commentId, postId) {
+window.toggleTaskResolve = function(commentId, postId, isInternalNote) {
   if (!commentId || typeof commentId !== 'string' || commentId.trim() === '') {
     console.warn('toggleTaskResolve: missing or invalid commentId, aborting');
     return;
   }
-  apiFetch('/post_comments?id=eq.' + commentId, {
+  var _endpoint = (isInternalNote ? '/internal_notes' : '/post_comments') + '?id=eq.' + commentId;
+  apiFetch(_endpoint, {
     method: 'PATCH',
     headers: {'Prefer': 'return=minimal'},
     body: JSON.stringify({
@@ -2490,6 +2529,139 @@ window._pcsRemoveCommentImg = function(zone, idx) {
     window._pcsNoteImgs.splice(idx, 1);
   }
   _pcsRenderImgPreviews(zone);
+};
+
+// -- Emoji reactions --
+var _PCS_EMOJIS = ['\u2764\uFE0F', '\uD83D\uDC4D', '\uD83C\uDFAF', '\uD83D\uDC40', '\u2705'];
+
+window._pcsShowEmojiPicker = function(reactEl) {
+  if (!reactEl) return;
+  var commentId = reactEl.getAttribute('data-comment-id');
+  if (!commentId) return;
+  var _name = (window.AppState && window.AppState.user && window.AppState.user.name) || '';
+  var _reactions = (window._pcsReactions && window._pcsReactions[commentId]) || [];
+  var _mine = _reactions.find(function(r) { return r.author === _name; });
+
+  // If already reacted, unreact
+  if (_mine) {
+    window._pcsRemoveReaction(commentId, reactEl);
+    return;
+  }
+
+  // Remove existing picker
+  var old = document.querySelector('.pcs-emoji-picker');
+  if (old) old.remove();
+
+  var picker = document.createElement('div');
+  picker.className = 'pcs-emoji-picker';
+  _PCS_EMOJIS.forEach(function(emoji) {
+    var btn = document.createElement('button');
+    btn.className = 'pcs-emoji-btn';
+    btn.textContent = emoji;
+    btn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      picker.remove();
+      window._pcsAddReaction(commentId, emoji, reactEl);
+    });
+    picker.appendChild(btn);
+  });
+  reactEl.style.position = 'relative';
+  reactEl.appendChild(picker);
+
+  // Close on outside click
+  setTimeout(function() {
+    document.addEventListener('click', function _dismiss(e) {
+      if (!picker.contains(e.target)) {
+        picker.remove();
+        document.removeEventListener('click', _dismiss);
+      }
+    });
+  }, 10);
+};
+
+window._pcsAddReaction = function(commentId, emoji, reactEl) {
+  return window.guardAction('pcs-react-' + commentId, async function() {
+    try {
+      var _postIdEl = document.getElementById('pcs-post-id');
+      var _postId = _postIdEl ? _postIdEl.value : '';
+      var _name = (window.AppState.user.name || '');
+      var _role = (window.AppState.user.effectiveRole || 'Admin');
+      var _normalRole = _role.charAt(0).toUpperCase() + _role.slice(1).toLowerCase();
+
+      var result = await apiFetch('/post_comment_reactions', {
+        method: 'POST',
+        body: JSON.stringify({
+          comment_id: commentId,
+          post_id: _postId,
+          author: _name,
+          author_role: _normalRole,
+          emoji: emoji
+        })
+      });
+
+      // Optimistic update
+      var newReaction = {
+        id: (Array.isArray(result) && result[0]) ? result[0].id : null,
+        comment_id: commentId,
+        post_id: _postId,
+        author: _name,
+        author_role: _normalRole,
+        emoji: emoji
+      };
+      if (!window._pcsReactions) window._pcsReactions = {};
+      if (!window._pcsReactions[commentId]) window._pcsReactions[commentId] = [];
+      window._pcsReactions[commentId].push(newReaction);
+
+      // Update DOM
+      if (reactEl) {
+        var count = window._pcsReactions[commentId].length;
+        reactEl.classList.add('pcs-reacted');
+        reactEl.innerHTML =
+          '<span class="pcs-react-icon pcs-react-emoji">' + emoji + '</span>' +
+          (count > 0 ? '<span class="pcs-react-count">' + count + '</span>' : '');
+      }
+    } catch(e) {
+      console.error('[pcs] addReaction failed:', e);
+      window.logError && window.logError(e && e.message, e && e.stack, 'pcs-add-reaction');
+      showToast('Failed to react', 'error');
+    }
+  });
+};
+
+window._pcsRemoveReaction = function(commentId, reactEl) {
+  return window.guardAction('pcs-unreact-' + commentId, async function() {
+    try {
+      var _name = (window.AppState.user.name || '');
+      var _reactions = (window._pcsReactions && window._pcsReactions[commentId]) || [];
+      var _mine = _reactions.find(function(r) { return r.author === _name; });
+      if (!_mine || !_mine.id) return;
+
+      await apiFetch('/post_comment_reactions?id=eq.' + _mine.id, {
+        method: 'DELETE'
+      });
+
+      // Remove from local state
+      window._pcsReactions[commentId] = _reactions.filter(function(r) { return r.id !== _mine.id; });
+
+      // Update DOM
+      if (reactEl) {
+        var count = window._pcsReactions[commentId].length;
+        reactEl.classList.remove('pcs-reacted');
+        if (count > 0) {
+          reactEl.innerHTML =
+            '<span class="pcs-react-icon"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg></span>' +
+            '<span class="pcs-react-count">' + count + '</span>';
+        } else {
+          reactEl.innerHTML =
+            '<span class="pcs-react-icon"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg></span>';
+        }
+      }
+    } catch(e) {
+      console.error('[pcs] removeReaction failed:', e);
+      window.logError && window.logError(e && e.message, e && e.stack, 'pcs-remove-reaction');
+      showToast('Failed to remove reaction', 'error');
+    }
+  });
 };
 
 // -- Plus button menu (Task / Image) --

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260409a">
+ <link rel="stylesheet" href="styles.css?v=20260409b">
 
 </head>
 <body>
@@ -1077,27 +1077,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260409a"></script>
-<script src="00-appstate-compat.js?v=20260409a"></script>
-<script src="01-config.js?v=20260409a" defer></script>
-<script src="02-session.js?v=20260409a" defer></script>
-<script src="utils.js?v=20260409a" defer></script>
-<script src="03-auth.js?v=20260409a" defer></script>
-<script src="05-api.js?v=20260409a" defer></script>
-<script src="10-ui.js?v=20260409a" defer></script>
+<script src="00-appstate.js?v=20260409b"></script>
+<script src="00-appstate-compat.js?v=20260409b"></script>
+<script src="01-config.js?v=20260409b" defer></script>
+<script src="02-session.js?v=20260409b" defer></script>
+<script src="utils.js?v=20260409b" defer></script>
+<script src="03-auth.js?v=20260409b" defer></script>
+<script src="05-api.js?v=20260409b" defer></script>
+<script src="10-ui.js?v=20260409b" defer></script>
 
-<script src="06-post-create.js?v=20260409a" defer></script>
-<script defer src="render/dashboard.js?v=20260409a"></script>
-<script defer src="render/client.js?v=20260409a"></script>
-<script defer src="render/pipeline.js?v=20260409a"></script>
-<script defer src="render/brief.js?v=20260409a"></script>
-<script defer src="actions/pcs.js?v=20260409a"></script>
-<script defer src="actions/pcs-longpress.js?v=20260409a"></script>
-<script src="07-post-load.js?v=20260409a" defer></script>
-<script src="08-post-actions.js?v=20260409a" defer></script>
-<script src="09-library.js?v=20260409a" defer></script>
-<script src="09-approval.js?v=20260409a" defer></script>
-<script src="04-router.js?v=20260409a" defer></script>
+<script src="06-post-create.js?v=20260409b" defer></script>
+<script defer src="render/dashboard.js?v=20260409b"></script>
+<script defer src="render/client.js?v=20260409b"></script>
+<script defer src="render/pipeline.js?v=20260409b"></script>
+<script defer src="render/brief.js?v=20260409b"></script>
+<script defer src="actions/pcs.js?v=20260409b"></script>
+<script defer src="actions/pcs-longpress.js?v=20260409b"></script>
+<script src="07-post-load.js?v=20260409b" defer></script>
+<script src="08-post-actions.js?v=20260409b" defer></script>
+<script src="09-library.js?v=20260409b" defer></script>
+<script src="09-approval.js?v=20260409b" defer></script>
+<script src="04-router.js?v=20260409b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6378,6 +6378,45 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   fill: none;
   stroke-width: 1.8;
 }
+.pcs-react-emoji {
+  font-size: 14px;
+}
+.pcs-reacted .pcs-react-icon svg {
+  stroke: #FF4B4B;
+  fill: #FF4B4B33;
+}
+.pcs-react-count {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  color: #8E8E93;
+  line-height: 1;
+}
+.pcs-emoji-picker {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  right: 0;
+  background: #16161f;
+  border: 1px solid #323244;
+  display: flex;
+  gap: 2px;
+  padding: 4px;
+  z-index: 300;
+  white-space: nowrap;
+}
+.pcs-emoji-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.pcs-emoji-btn:active {
+  background: #323244;
+}
 
 /* Resolved label for tasks */
 .pcs-resolved-label {


### PR DESCRIPTION
## Summary

- **Reactions wired to DB**: `loadPcsComments` now fetches `/post_comment_reactions` for the current post. Reactions stored in `window._pcsReactions` keyed by `comment_id`. Both render functions show the user's emoji (or heart SVG if unreacted) with a count badge.
- **Emoji picker**: Tap the heart → 5-emoji inline picker (❤️ 👍 🎯 👀 ✅). Tap again when already reacted → unreacts. `guardAction` wrapped to prevent double-taps.
- **Optimistic UI**: `_pcsAddReaction` and `_pcsRemoveReaction` update DOM directly after API call — no full `loadPcsComments` re-fetch needed.
- **toggleTaskResolve bug fix**: Now accepts `isInternalNote` boolean parameter. Routes PATCH to `/internal_notes` when true, `/post_comments` when false. Previously always patched `/post_comments`, causing silent failure for internal note tasks. All 3 callers updated (client render, note render, long-press handler).

**Zero visual layout changes from Part 2A. Zero new HTML structure. No CSS changes to existing classes.**

### Files changed

| File | What changed |
|------|-------------|
| `actions/pcs.js` | Reaction fetch in `loadPcsComments`, reaction rendering in both `_renderSingleClient`/`_renderSingleNote`, `_pcsShowEmojiPicker`/`_pcsAddReaction`/`_pcsRemoveReaction` functions added, `toggleTaskResolve` fixed with `isInternalNote` param |
| `actions/pcs-longpress.js` | `toggleTaskResolve` call updated to pass `isInternalNote` |
| `index.html` | All 21 `?v=` bumped to `20260409b` |
| `styles.css` | New classes: `.pcs-react-emoji`, `.pcs-reacted`, `.pcs-react-count`, `.pcs-emoji-picker`, `.pcs-emoji-btn` |
| `CLAUDE.md` | Version string, global functions, new Section 12 entry |

## Test plan

- [x] `npx vitest run` — 508/508 passing
- [x] `npx playwright test` (3 critical specs) — 40/40 passing
- [ ] Manual: Tap heart on a comment → emoji picker appears with 5 options
- [ ] Manual: Select an emoji → heart replaced with emoji, count shows "1"
- [ ] Manual: Tap the emoji again → unreacts, reverts to heart SVG, count removed
- [ ] Manual: Multiple users react → count increments correctly
- [ ] Manual: Refresh PCS → reactions persist (fetched from DB)
- [ ] Manual: Create a task in internal notes tab → resolve via checkbox → PATCH hits /internal_notes (check network tab)
- [ ] Manual: Create a task in client tab → resolve → PATCH hits /post_comments

https://claude.ai/code/session_01G8J4Nvj1Nkcu4o11U4uQA6