### PR TITLE
PCS visual fixes Part 1: stage bare text, date year removed, metadata…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260409b
+Version format: ?v=YYYYMMDDx. Current: ?v=20260409c
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1754,6 +1754,44 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Zero visual layout changes from Part 2A. Zero new HTML structure.
    508/508 unit passing, 40/40 e2e passing.
    Status: FIXED (PR#TBD). Bumped to ?v=20260409b.
+1. PCS visual fixes Part 1 — 10 targeted fixes
+   Location: actions/pcs.js, styles.css, index.html
+   Scope:
+   (a) Stage pill removed — .pcs-stage-pill restyled to bare text
+       (no border, no background, no padding). Font changed from
+       Courier New to IBM Plex Mono. Color #C8A84B (gold). Arrow
+       span font-size 6px, opacity .4.
+   (b) ADD/EDIT/SAVE buttons bumped from #505060 to #808090 with
+       font-weight:500. Active state changed to #B8B8C0.
+   (c) Date format year removed — toLocaleDateString options
+       changed from {weekday:'short',day:'numeric',month:'short',
+       year:'numeric'} to {weekday:'short',day:'numeric',
+       month:'short'}. Output: "Wed, 1 Apr" not "Wed, 1 Apr 2026".
+   (d) Trailing dot safety — items.filter(Boolean) added before
+       join(_dot) in _buildChipsRow to prevent empty-item dots.
+   (e) Metadata dot separators already correct: #505060,
+       font-weight:600, padding 0 7px, user-select:none.
+   (f) Client owner color changed from pcs-mv--amber (#F6A623)
+       to pcs-mv--red (#FF4B4B). Other owner colors unchanged.
+   (g) Topbar tightened: padding changed from 8px 16px 0 to
+       10px 16px, border-bottom 1px solid #323244 added. Photo
+       header margin-top removed (6px→0), padding-bottom added
+       (0→4px).
+   (h) WhatsApp button + hint text removed from caption pane.
+       pcs-wa-container now always set to ''. Topbar WA icon and
+       _buildWAHtml function preserved.
+   (i) Admin filtered from owner dropdown — .filter(o =>
+       o.toLowerCase() !== 'admin') applied to ALLOWED_OWNERS
+       when building dropdown items. ALLOWED_OWNERS array itself
+       unchanged.
+   (j) Metadata row nowrap — flex-wrap changed from wrap to
+       nowrap, overflow-x:auto added, scrollbar-width:none,
+       -webkit-overflow-scrolling:touch. Webkit scrollbar hidden.
+   (k) All separators verified #323244 (meta-row border-bottom,
+       tab-bar border-bottom, topbar border-bottom).
+   Zero business logic changes. Zero data flow changes.
+   508/508 unit passing, 40/40 e2e passing.
+   Status: FIXED (PR#TBD). Bumped to ?v=20260409c.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -294,10 +294,9 @@ window._renderPCS = function(postId) {
       '<input type="hidden" id="pcs-post-id" value="' + esc(id) + '">';
   }
 
-  // f) WA button
-  var waHtml = _buildWAHtml(post, id, postId, stageLC);
+  // f) WA button removed from caption pane (topbar icon stays)
   var waContainer = document.getElementById('pcs-wa-container');
-  if (waContainer) waContainer.innerHTML = waHtml;
+  if (waContainer) waContainer.innerHTML = '';
 
   // f2) Caption action buttons (canManage only)
   var capActionsContainer = document.getElementById('pcs-cap-actions-container');
@@ -490,7 +489,7 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
     var ownerLC = (post.owner || '').toLowerCase();
     if (ownerLC === 'servicing') ownerColor = ' pcs-mv--cyan';
     else if (ownerLC === 'creative') ownerColor = ' pcs-mv--purple';
-    else if (ownerLC === 'client') ownerColor = ' pcs-mv--amber';
+    else if (ownerLC === 'client') ownerColor = ' pcs-mv--red';
     items.push('<span class="pcs-mv' + ownerColor + '"' +
       (canEdit ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'owner\',\'' + esc(id) + '\')"' : '') +
       '>' + esc(typeof formatOwner === 'function' ? formatOwner(post.owner) : post.owner) +
@@ -504,7 +503,7 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
     try {
       var _dp = new Date(rawDate + 'T00:00:00');
       if (!isNaN(_dp.getTime())) {
-        dateDisplay = _dp.toLocaleDateString('en-IN', { weekday:'short', day:'numeric', month:'short', year:'numeric' });
+        dateDisplay = _dp.toLocaleDateString('en-IN', { weekday:'short', day:'numeric', month:'short' });
       }
     } catch(e) {}
   }
@@ -547,7 +546,7 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
     items.push('<span class="pcs-mv" onclick="event.stopPropagation();window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')">+ Location &#9662;</span>');
   }
 
-  return items.join(_dot);
+  return items.filter(function(s){return s;}).join(_dot);
 }
 
 // -- Chip dropdown handler (body-appended, getBoundingClientRect positioned) --
@@ -592,7 +591,7 @@ window._pcsChipDrop = function(chipEl, field, postId) {
     items = ['Mumbai','Sakarwadi','Sameerwadi','Other'];
     currentVal = post ? (post.location || '') : '';
   } else if (field === 'owner') {
-    items = typeof ALLOWED_OWNERS !== 'undefined' ? ALLOWED_OWNERS : ['Creative','Servicing','Client','Admin'];
+    items = (typeof ALLOWED_OWNERS !== 'undefined' ? ALLOWED_OWNERS : ['Creative','Servicing','Client','Admin']).filter(function(o){return o.toLowerCase() !== 'admin';});
     currentVal = post ? (post.owner || '') : '';
   } else if (field === 'stage') {
     items = typeof STAGES_DB !== 'undefined' ? STAGES_DB : [];

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260409b">
+ <link rel="stylesheet" href="styles.css?v=20260409c">
 
 </head>
 <body>
@@ -1077,27 +1077,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260409b"></script>
-<script src="00-appstate-compat.js?v=20260409b"></script>
-<script src="01-config.js?v=20260409b" defer></script>
-<script src="02-session.js?v=20260409b" defer></script>
-<script src="utils.js?v=20260409b" defer></script>
-<script src="03-auth.js?v=20260409b" defer></script>
-<script src="05-api.js?v=20260409b" defer></script>
-<script src="10-ui.js?v=20260409b" defer></script>
+<script src="00-appstate.js?v=20260409c"></script>
+<script src="00-appstate-compat.js?v=20260409c"></script>
+<script src="01-config.js?v=20260409c" defer></script>
+<script src="02-session.js?v=20260409c" defer></script>
+<script src="utils.js?v=20260409c" defer></script>
+<script src="03-auth.js?v=20260409c" defer></script>
+<script src="05-api.js?v=20260409c" defer></script>
+<script src="10-ui.js?v=20260409c" defer></script>
 
-<script src="06-post-create.js?v=20260409b" defer></script>
-<script defer src="render/dashboard.js?v=20260409b"></script>
-<script defer src="render/client.js?v=20260409b"></script>
-<script defer src="render/pipeline.js?v=20260409b"></script>
-<script defer src="render/brief.js?v=20260409b"></script>
-<script defer src="actions/pcs.js?v=20260409b"></script>
-<script defer src="actions/pcs-longpress.js?v=20260409b"></script>
-<script src="07-post-load.js?v=20260409b" defer></script>
-<script src="08-post-actions.js?v=20260409b" defer></script>
-<script src="09-library.js?v=20260409b" defer></script>
-<script src="09-approval.js?v=20260409b" defer></script>
-<script src="04-router.js?v=20260409b" defer></script>
+<script src="06-post-create.js?v=20260409c" defer></script>
+<script defer src="render/dashboard.js?v=20260409c"></script>
+<script defer src="render/client.js?v=20260409c"></script>
+<script defer src="render/pipeline.js?v=20260409c"></script>
+<script defer src="render/brief.js?v=20260409c"></script>
+<script defer src="actions/pcs.js?v=20260409c"></script>
+<script defer src="actions/pcs-longpress.js?v=20260409c"></script>
+<script src="07-post-load.js?v=20260409c" defer></script>
+<script src="08-post-actions.js?v=20260409c" defer></script>
+<script src="09-library.js?v=20260409c" defer></script>
+<script src="09-approval.js?v=20260409c" defer></script>
+<script src="04-router.js?v=20260409c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -3359,8 +3359,9 @@ label.pcs-date-tap:active { transform: scale(0.98); }
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 16px 0;
+  padding: 10px 16px;
   flex-shrink: 0;
+  border-bottom: 1px solid #323244;
 }
 .pc-icon-btn {
   width: 34px;
@@ -6688,15 +6689,20 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* Topbar pills */
 .pcs-stage-pill {
-  padding: 4px 10px;
-  font-family: 'Courier New', monospace; font-size: 8px;
-  letter-spacing: .07em; text-transform: uppercase;
-  background: #F6A6231A;
-  border: 1px solid #F6A62366;
-  color: #F6A623; cursor: pointer;
-  display: flex; align-items: center; gap: 4px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: #C8A84B;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
-.pcs-stage-pill .pcs-pill-arr { font-size: 8px; opacity: .5; }
+.pcs-stage-pill .pcs-pill-arr { font-size: 6px; opacity: .4; }
 .pcs-od-pill {
   padding: 4px 9px;
   font-family: 'Courier New', monospace; font-size: 8px;
@@ -6732,10 +6738,10 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-photo-act {
   font-family: 'IBM Plex Mono', monospace; font-size: 7px;
   letter-spacing: .06em; text-transform: uppercase;
-  color: #505060; background: none; border: none;
-  padding: 10px 8px; cursor: pointer;
+  color: #808090; background: none; border: none;
+  padding: 10px 8px; cursor: pointer; font-weight: 500;
 }
-.pcs-photo-act:active { color: #F0F0F2; }
+.pcs-photo-act:active { color: #B8B8C0; }
 
 /* PCS PHOTO GRID — hero-driven layout */
 
@@ -6893,11 +6899,15 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 /* Metadata row (dot-separated text values) */
 .pcs-meta-row {
   padding: 4px 16px 10px;
-  display: flex; flex-wrap: wrap; align-items: center;
+  display: flex; flex-wrap: nowrap; overflow-x: auto;
+  align-items: center;
   font-family: 'IBM Plex Mono', monospace;
   font-size: 8px; letter-spacing: .04em;
   border-bottom: 1px solid #323244;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
 }
+.pcs-meta-row::-webkit-scrollbar { display: none; }
 .pcs-mv {
   color: #B8B8C0; cursor: pointer; padding: 3px 0;
   position: relative; transition: color .12s;
@@ -7074,7 +7084,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* FIX 7: Tight spacing between topbar and photos */
 #pcs-scroll { padding-top: 0; }
-.pcs-photo-header { padding: 6px 16px 0; margin-top: 6px; margin-bottom: 0; }
+.pcs-photo-header { padding: 6px 16px 4px; margin-top: 0; margin-bottom: 0; }
 #pcs-photo-grid-wrap { margin-top: 0; padding-top: 0; }
 
 /* FIX 8: Tighter caption */


### PR DESCRIPTION
… nowrap

10 targeted fixes: (1) stage pill → bare gold text, no border/bg/padding, IBM Plex Mono; (2) ADD/EDIT/SAVE buttons #808090 + font-weight 500; (3) date format removes year; (4) trailing dot safety filter; (5) dots verified #505060/600; (6) client owner → #FF4B4B red; (7) topbar padding 10px 16px + border-bottom, photo header margin-top 0; (8) WhatsApp removed from caption pane; (9) Admin filtered from owner dropdown; (10) metadata row nowrap + overflow-x auto. Version bump ?v=20260409c.

https://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM