### PR TITLE
Dropdown toggle, @mention on client tab, reply auto-fills @author

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260409c
+Version format: ?v=YYYYMMDDx. Current: ?v=20260409d
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1792,6 +1792,31 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Zero business logic changes. Zero data flow changes.
    508/508 unit passing, 40/40 e2e passing.
    Status: FIXED (PR#TBD). Bumped to ?v=20260409c.
+1. Metadata dropdown not toggling — clicking same chip doesn't close
+   Location: actions/pcs.js _pcsChipDrop() — always opened a new
+   dropdown without checking if the same field was already open.
+   Status: FIXED (PR#TBD) — added data-pcs-field attribute to
+   dropdowns, _pcsChipDrop checks if same field is open and closes
+   it instead of reopening. Works for owner, date, format, pillar,
+   location, stage. 508/508 unit passing.
+1. @mention autocomplete missing on client comment input
+   Location: actions/pcs.js _initMentionDropup() was hardcoded to
+   #pcs-note-input and #pcs-mention-dropup. Client comment input
+   (#pcs-comment-input) had no @mention support.
+   Status: FIXED (PR#TBD) — refactored _initMentionDropup to
+   accept inputId and dropupId parameters. Called twice from
+   _renderPCS: once for notes, once for client. Added
+   #pcs-client-mention-dropup container to index.html inside
+   .pcs-ibar-wrap.client. Same _AGENCY_MEMBERS list for both.
+   508/508 unit passing.
+1. Reply does not auto-fill @author in input (Instagram-style)
+   Location: actions/pcs.js _pcsSetReply() focused input but did
+   not pre-fill with @author. _pcsClearReply() did not clear input.
+   Status: FIXED (PR#TBD) — _pcsSetReply now sets input.value to
+   '@' + author + ' ' before focus, with cursor at end via
+   setSelectionRange. _pcsClearReply now sets inp.value = '' when
+   cancelling reply. Works on both client and notes inputs.
+   508/508 unit passing. Bumped to ?v=20260409d.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -336,9 +336,10 @@ window._renderPCS = function(postId) {
   window._pcsActiveTab = 'caption';
   _pcsTabSwitch('caption');
 
-  // l) Mention dropup
+  // l) Mention dropup (notes + client)
   if (typeof window._initMentionDropup === 'function') {
-    window._initMentionDropup();
+    window._initMentionDropup('pcs-note-input', 'pcs-mention-dropup');
+    window._initMentionDropup('pcs-comment-input', 'pcs-client-mention-dropup');
   }
 }
 
@@ -551,10 +552,13 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
 
 // -- Chip dropdown handler (body-appended, getBoundingClientRect positioned) --
 window._pcsChipDrop = function(chipEl, field, postId) {
-  // Close any existing dropdown
-  if (window.AppState.pcs.activeMenu) {
-    window.AppState.pcs.activeMenu.remove();
+  // Toggle: if same field's dropdown is already open, close it and return
+  var existingMenu = window.AppState.pcs.activeMenu;
+  if (existingMenu) {
+    var wasField = existingMenu.getAttribute('data-pcs-field');
+    existingMenu.remove();
     window.AppState.pcs.activeMenu = null;
+    if (wasField === field) return;
   }
 
   var post = typeof getPostById === 'function' ? getPostById(postId) : null;
@@ -564,6 +568,7 @@ window._pcsChipDrop = function(chipEl, field, postId) {
     var rect = chipEl.getBoundingClientRect();
     var drop = document.createElement('div');
     drop.className = 'pcs-chip-drop';
+    drop.setAttribute('data-pcs-field', 'date');
     drop.style.cssText = 'position:fixed;top:' + (rect.bottom + 4) + 'px;left:' + rect.left + 'px;z-index:9700;';
     drop.innerHTML = '<div style="padding:12px 16px;background:#141420">' +
       '<input type="date" value="' + esc(post ? (post.targetDate || '') : '') + '" ' +
@@ -602,6 +607,7 @@ window._pcsChipDrop = function(chipEl, field, postId) {
   var rect = chipEl.getBoundingClientRect();
   var drop = document.createElement('div');
   drop.className = 'pcs-chip-drop';
+  drop.setAttribute('data-pcs-field', field);
   drop.style.position = 'fixed';
   drop.style.top = rect.bottom + 4 + 'px';
   drop.style.left = rect.left + 'px';
@@ -2351,15 +2357,18 @@ var _AGENCY_MEMBERS = [
   { name: 'Shivangini', role: 'Client' }
 ];
 
-function _hideMentionDropup() {
-  var dropup = document.getElementById('pcs-mention-dropup');
+function _hideMentionDropup(dropupId) {
+  var id = dropupId || 'pcs-mention-dropup';
+  var dropup = document.getElementById(id);
   if (dropup) dropup.style.display = 'none';
 }
 
-window._initMentionDropup = function() {
-  var textarea = document.getElementById('pcs-note-input');
+window._initMentionDropup = function(inputId, dropupId) {
+  var textareaId = inputId || 'pcs-note-input';
+  var dropId = dropupId || 'pcs-mention-dropup';
+  var textarea = document.getElementById(textareaId);
   if (!textarea) return;
-  var dropup = document.getElementById('pcs-mention-dropup');
+  var dropup = document.getElementById(dropId);
   if (!dropup) return;
 
   var _currentMentionStart = -1;
@@ -2370,17 +2379,17 @@ window._initMentionDropup = function() {
     var textBeforeCursor = val.slice(0, cursor);
     var atIndex = textBeforeCursor.lastIndexOf('@');
 
-    if (atIndex === -1) { _hideMentionDropup(); return; }
+    if (atIndex === -1) { _hideMentionDropup(dropId); return; }
 
     var query = textBeforeCursor.slice(atIndex + 1);
-    if (/\s/.test(query)) { _hideMentionDropup(); return; }
+    if (/\s/.test(query)) { _hideMentionDropup(dropId); return; }
 
     _currentMentionStart = atIndex;
     var filtered = _AGENCY_MEMBERS.filter(function(m) {
       return m.name.toLowerCase().startsWith(query.toLowerCase());
     });
 
-    if (!filtered.length) { _hideMentionDropup(); return; }
+    if (!filtered.length) { _hideMentionDropup(dropId); return; }
 
     dropup.innerHTML = filtered.map(function(m) {
       return '<div class="pcs-mention-item" data-name="' + m.name + '">' +
@@ -2399,14 +2408,14 @@ window._initMentionDropup = function() {
         var after = val.slice(cursor);
         textarea.value = before + '@' + name + ' ' + after;
         textarea.dispatchEvent(new Event('input'));
-        _hideMentionDropup();
+        _hideMentionDropup(dropId);
         textarea.focus();
       });
     });
   });
 
   textarea.addEventListener('blur', function() {
-    setTimeout(_hideMentionDropup, 150);
+    setTimeout(function() { _hideMentionDropup(dropId); }, 150);
   });
 };
 
@@ -2751,7 +2760,9 @@ window._pcsSetReply = function(zone, commentId, author, message) {
     });
   }
   if (input) {
+    input.value = '@' + author + ' ';
     input.focus();
+    input.setSelectionRange(input.value.length, input.value.length);
   }
 };
 
@@ -2771,7 +2782,10 @@ window._pcsClearReply = function(zone) {
       el.classList.remove('pcs-comment-replying-to');
     });
   var inp = document.getElementById(zone === 'client' ? 'pcs-comment-input' : 'pcs-note-input');
-  if (inp) inp.focus();
+  if (inp) {
+    inp.value = '';
+    inp.focus();
+  }
 };
 
 window._pcsCopyComment = function(message) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260409c">
+ <link rel="stylesheet" href="styles.css?v=20260409d">
 
 </head>
 <body>
@@ -910,6 +910,7 @@
         <div id="pcs-comments-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:12px 16px;scrollbar-width:none;min-height:0"></div>
         <div class="pcs-ibar-wrap client">
           <div id="pcs-client-img-previews"></div>
+          <div id="pcs-client-mention-dropup" style="display:none"></div>
           <div class="pcs-ibar-pill">
             <div style="position:relative">
               <button class="pcs-ibar-plus" onclick="window._pcsTogglePlusMenu(this,'client')">+</button>
@@ -1077,27 +1078,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260409c"></script>
-<script src="00-appstate-compat.js?v=20260409c"></script>
-<script src="01-config.js?v=20260409c" defer></script>
-<script src="02-session.js?v=20260409c" defer></script>
-<script src="utils.js?v=20260409c" defer></script>
-<script src="03-auth.js?v=20260409c" defer></script>
-<script src="05-api.js?v=20260409c" defer></script>
-<script src="10-ui.js?v=20260409c" defer></script>
+<script src="00-appstate.js?v=20260409d"></script>
+<script src="00-appstate-compat.js?v=20260409d"></script>
+<script src="01-config.js?v=20260409d" defer></script>
+<script src="02-session.js?v=20260409d" defer></script>
+<script src="utils.js?v=20260409d" defer></script>
+<script src="03-auth.js?v=20260409d" defer></script>
+<script src="05-api.js?v=20260409d" defer></script>
+<script src="10-ui.js?v=20260409d" defer></script>
 
-<script src="06-post-create.js?v=20260409c" defer></script>
-<script defer src="render/dashboard.js?v=20260409c"></script>
-<script defer src="render/client.js?v=20260409c"></script>
-<script defer src="render/pipeline.js?v=20260409c"></script>
-<script defer src="render/brief.js?v=20260409c"></script>
-<script defer src="actions/pcs.js?v=20260409c"></script>
-<script defer src="actions/pcs-longpress.js?v=20260409c"></script>
-<script src="07-post-load.js?v=20260409c" defer></script>
-<script src="08-post-actions.js?v=20260409c" defer></script>
-<script src="09-library.js?v=20260409c" defer></script>
-<script src="09-approval.js?v=20260409c" defer></script>
-<script src="04-router.js?v=20260409c" defer></script>
+<script src="06-post-create.js?v=20260409d" defer></script>
+<script defer src="render/dashboard.js?v=20260409d"></script>
+<script defer src="render/client.js?v=20260409d"></script>
+<script defer src="render/pipeline.js?v=20260409d"></script>
+<script defer src="render/brief.js?v=20260409d"></script>
+<script defer src="actions/pcs.js?v=20260409d"></script>
+<script defer src="actions/pcs-longpress.js?v=20260409d"></script>
+<script src="07-post-load.js?v=20260409d" defer></script>
+<script src="08-post-actions.js?v=20260409d" defer></script>
+<script src="09-library.js?v=20260409d" defer></script>
+<script src="09-approval.js?v=20260409d" defer></script>
+<script src="04-router.js?v=20260409d" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary\n- **Dropdown toggle** — clicking a metadata chip (owner/date/format/pillar/location) now closes its dropdown if already open, instead of requiring a tap outside\n- **@mention on client tab** — typing @ in the client comment input now shows the autocomplete dropup with all team members (was only working on internal notes)\n- **Reply auto-fills @author** — tapping Reply on a comment pre-fills the input with \"@AuthorName \" so replies are addressed Instagram-style; cancelling reply clears the input\n\n## Files changed\n- **actions/pcs.js** — _pcsChipDrop toggle logic + data-pcs-field attr; _initMentionDropup refactored to accept inputId/dropupId params, called twice; _pcsSetReply pre-fills @author; _pcsClearReply clears input\n- **index.html** — added #pcs-client-mention-dropup container in client input wrapper; version bump ?v=20260409d (all 21)\n- **CLAUDE.md** — version + 3 new bug entries\n\n## Test plan\n- [x] 508/508 unit tests passing (npx vitest run)\n- [x] 40/40 e2e tests passing (client-flows + pcs + admin-flows)\n- [ ] Manual: tap Client chip → opens → tap again → closes\n- [ ] Manual: tap Client → opens → tap Format → Client closes, Format opens\n- [ ] Manual: type @ in client comment input → dropup appears with all members\n- [ ] Manual: select name → @Name inserted → send → renders purple\n- [ ] Manual: tap Reply on Manisha's comment → input shows \"@Manisha \"\n- [ ] Manual: cancel reply (tap X) → input clears completely\n- [ ] Manual: internal notes @mention + reply still works as before\n\nhttps://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM