### PR TITLE
PCS micro fixes: overdue bare text, calendar, metadata nowrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260409d
+Version format: ?v=YYYYMMDDx. Current: ?v=20260409e
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1817,6 +1817,30 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    setSelectionRange. _pcsClearReply now sets inp.value = '' when
    cancelling reply. Works on both client and notes inputs.
    508/508 unit passing. Bumped to ?v=20260409d.
+1. PCS micro fixes — 5 targeted visual fixes
+   Location: actions/pcs.js, styles.css, index.html
+   Scope:
+   (a) Overdue badge bare text — .pcs-od-pill restyled: removed
+       border, background, padding. IBM Plex Mono 7px, #FF4B4B.
+       Pulsing dot retained with new @keyframes pcs-od-pulse.
+   (b) Metadata values nowrap — .pcs-mv gains white-space:nowrap,
+       display:inline-flex, align-items:center so value + arrow
+       never split across lines. Row scrolls via overflow-x:auto.
+   (c) Format/pillar/location capitalized — _ucFirst() helper
+       applied to format, pillar, location values in _buildChipsRow.
+       "photo" → "Photo", "growth" → "Growth".
+   (d) Date picker replaced — native showPicker() removed, custom
+       calendar dropdown built inline. Month nav, day grid, today
+       highlight (gold), selected highlight (gold bg). Fires
+       _pcsDateChange on day click. CSS: .pcs-cal, .pcs-cal-hdr,
+       .pcs-cal-days with all solid hex. Document click listener
+       date input guard removed (calendar uses contains() check).
+   (e) Courier New eliminated from PCS — .pcs-od-pill, .pcs-tab,
+       .pcs-wa-btn all changed from Courier New to IBM Plex Mono.
+       Zero Courier New remaining in styles.css.
+   Zero business logic changes. Zero data flow changes.
+   508/508 unit passing, 40/40 e2e passing.
+   Status: FIXED (PR#TBD). Bumped to ?v=20260409e.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -26,7 +26,6 @@ document.addEventListener('click', function(e) {
   var menu = window.AppState && window.AppState.pcs && window.AppState.pcs.activeMenu;
   if (!menu) return;
   if (e.target.closest('.pcs-confirm-overlay')) return;
-  if (menu.querySelector('input[type="date"]')) return;
   if (!menu.contains(e.target)) {
     menu.remove();
     window.AppState.pcs.activeMenu = null;
@@ -478,6 +477,7 @@ window._buildDriveLinkCard = _buildDriveLinkCard;
 
 // -- Metadata row builder (dot-separated text values) --
 // Order: Owner → Date → Format → Pillar → Location
+function _ucFirst(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : ''; }
 function _buildChipsRow(post, canEdit, canEditCreative, id) {
   var stageLC = post.stage || '';
   var canManage = canEdit || canEditCreative;
@@ -520,7 +520,7 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
   if (post.format) {
     items.push('<span class="pcs-mv"' +
       (canManage ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(post.format) +
+      '>' + esc(_ucFirst(post.format)) +
       (canManage ? ' &#9662;' : '') + '</span>');
   } else if (canManage) {
     items.push('<span class="pcs-mv" onclick="event.stopPropagation();window._pcsChipDrop(this,\'format\',\'' + esc(id) + '\')">+ Format &#9662;</span>');
@@ -531,7 +531,7 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
     var pillarVal = typeof formatPillarDisplay === 'function' ? formatPillarDisplay(post.contentPillar) : post.contentPillar;
     items.push('<span class="pcs-mv"' +
       (canManage ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(pillarVal) +
+      '>' + esc(_ucFirst(pillarVal)) +
       (canManage ? ' &#9662;' : '') + '</span>');
   } else if (canManage) {
     items.push('<span class="pcs-mv" onclick="event.stopPropagation();window._pcsChipDrop(this,\'pillar\',\'' + esc(id) + '\')">+ Pillar &#9662;</span>');
@@ -541,7 +541,7 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
   if (post.location) {
     items.push('<span class="pcs-mv"' +
       (canManage ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(post.location) +
+      '>' + esc(_ucFirst(post.location)) +
       (canManage ? ' &#9662;' : '') + '</span>');
   } else if (canManage) {
     items.push('<span class="pcs-mv" onclick="event.stopPropagation();window._pcsChipDrop(this,\'location\',\'' + esc(id) + '\')">+ Location &#9662;</span>');
@@ -563,24 +563,81 @@ window._pcsChipDrop = function(chipEl, field, postId) {
 
   var post = typeof getPostById === 'function' ? getPostById(postId) : null;
 
-  // DATE: inline date input in dropdown
+  // DATE: custom calendar dropdown
   if (field === 'date') {
     var rect = chipEl.getBoundingClientRect();
     var drop = document.createElement('div');
     drop.className = 'pcs-chip-drop';
     drop.setAttribute('data-pcs-field', 'date');
     drop.style.cssText = 'position:fixed;top:' + (rect.bottom + 4) + 'px;left:' + rect.left + 'px;z-index:9700;';
-    drop.innerHTML = '<div style="padding:12px 16px;background:#141420">' +
-      '<input type="date" value="' + esc(post ? (post.targetDate || '') : '') + '" ' +
-      'style="width:100%;padding:10px 12px;background:#0f0f1a;border:1px solid #1c1c26;color:#fff;font-size:14px;outline:none;color-scheme:dark;font-family:inherit" ' +
-      'onchange="window._pcsDateChange(\'' + esc(postId) + '\',this.value)"/></div>';
+
+    var _curDate = post ? (post.targetDate || post.target_date || '') : '';
+    var _viewDate = _curDate ? new Date(_curDate + 'T00:00:00') : new Date();
+    if (isNaN(_viewDate.getTime())) _viewDate = new Date();
+
+    function _renderCal() {
+      var yr = _viewDate.getFullYear();
+      var mo = _viewDate.getMonth();
+      var today = new Date(); today.setHours(0,0,0,0);
+      var sel = _curDate ? new Date(_curDate + 'T00:00:00') : null;
+      var first = new Date(yr, mo, 1);
+      var startDay = first.getDay();
+      var daysInMonth = new Date(yr, mo + 1, 0).getDate();
+      var prevDays = new Date(yr, mo, 0).getDate();
+      var months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+
+      var html = '<div class="pcs-cal">';
+      html += '<div class="pcs-cal-hdr">';
+      html += '<button data-cal-nav="prev">&#8249;</button>';
+      html += '<span>' + months[mo] + ' ' + yr + '</span>';
+      html += '<button data-cal-nav="next">&#8250;</button>';
+      html += '</div>';
+      html += '<div class="pcs-cal-days">';
+      var dayLabels = ['Su','Mo','Tu','We','Th','Fr','Sa'];
+      for (var d = 0; d < 7; d++) html += '<span>' + dayLabels[d] + '</span>';
+
+      for (var p = startDay - 1; p >= 0; p--) {
+        html += '<button class="other-month" data-cal-day="">' + (prevDays - p) + '</button>';
+      }
+      for (var i = 1; i <= daysInMonth; i++) {
+        var dd = new Date(yr, mo, i);
+        var cls = '';
+        if (dd.getTime() === today.getTime()) cls += ' today';
+        if (sel && dd.getTime() === sel.getTime()) cls += ' selected';
+        var iso = yr + '-' + String(mo + 1).padStart(2, '0') + '-' + String(i).padStart(2, '0');
+        html += '<button class="' + cls.trim() + '" data-cal-day="' + iso + '">' + i + '</button>';
+      }
+      var totalCells = startDay + daysInMonth;
+      var remaining = (7 - (totalCells % 7)) % 7;
+      for (var r = 1; r <= remaining; r++) {
+        html += '<button class="other-month" data-cal-day="">' + r + '</button>';
+      }
+      html += '</div></div>';
+      drop.innerHTML = html;
+
+      drop.querySelector('[data-cal-nav="prev"]').onclick = function(e) {
+        e.stopPropagation();
+        _viewDate.setMonth(_viewDate.getMonth() - 1);
+        _renderCal();
+      };
+      drop.querySelector('[data-cal-nav="next"]').onclick = function(e) {
+        e.stopPropagation();
+        _viewDate.setMonth(_viewDate.getMonth() + 1);
+        _renderCal();
+      };
+      drop.querySelectorAll('[data-cal-day]').forEach(function(btn) {
+        var val = btn.getAttribute('data-cal-day');
+        if (!val) return;
+        btn.onclick = function(e) {
+          e.stopPropagation();
+          window._pcsDateChange(postId, val);
+        };
+      });
+    }
+
+    _renderCal();
     document.body.appendChild(drop);
     setTimeout(function() { window.AppState.pcs.activeMenu = drop; }, 0);
-    var dateInp = drop.querySelector('input');
-    if (dateInp) {
-      dateInp.focus();
-      try { dateInp.showPicker(); } catch(e) {}
-    }
     return;
   }
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260409d">
+ <link rel="stylesheet" href="styles.css?v=20260409e">
 
 </head>
 <body>
@@ -1078,27 +1078,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260409d"></script>
-<script src="00-appstate-compat.js?v=20260409d"></script>
-<script src="01-config.js?v=20260409d" defer></script>
-<script src="02-session.js?v=20260409d" defer></script>
-<script src="utils.js?v=20260409d" defer></script>
-<script src="03-auth.js?v=20260409d" defer></script>
-<script src="05-api.js?v=20260409d" defer></script>
-<script src="10-ui.js?v=20260409d" defer></script>
+<script src="00-appstate.js?v=20260409e"></script>
+<script src="00-appstate-compat.js?v=20260409e"></script>
+<script src="01-config.js?v=20260409e" defer></script>
+<script src="02-session.js?v=20260409e" defer></script>
+<script src="utils.js?v=20260409e" defer></script>
+<script src="03-auth.js?v=20260409e" defer></script>
+<script src="05-api.js?v=20260409e" defer></script>
+<script src="10-ui.js?v=20260409e" defer></script>
 
-<script src="06-post-create.js?v=20260409d" defer></script>
-<script defer src="render/dashboard.js?v=20260409d"></script>
-<script defer src="render/client.js?v=20260409d"></script>
-<script defer src="render/pipeline.js?v=20260409d"></script>
-<script defer src="render/brief.js?v=20260409d"></script>
-<script defer src="actions/pcs.js?v=20260409d"></script>
-<script defer src="actions/pcs-longpress.js?v=20260409d"></script>
-<script src="07-post-load.js?v=20260409d" defer></script>
-<script src="08-post-actions.js?v=20260409d" defer></script>
-<script src="09-library.js?v=20260409d" defer></script>
-<script src="09-approval.js?v=20260409d" defer></script>
-<script src="04-router.js?v=20260409d" defer></script>
+<script src="06-post-create.js?v=20260409e" defer></script>
+<script defer src="render/dashboard.js?v=20260409e"></script>
+<script defer src="render/client.js?v=20260409e"></script>
+<script defer src="render/pipeline.js?v=20260409e"></script>
+<script defer src="render/brief.js?v=20260409e"></script>
+<script defer src="actions/pcs.js?v=20260409e"></script>
+<script defer src="actions/pcs-longpress.js?v=20260409e"></script>
+<script src="07-post-load.js?v=20260409e" defer></script>
+<script src="08-post-actions.js?v=20260409e" defer></script>
+<script src="09-library.js?v=20260409e" defer></script>
+<script src="09-approval.js?v=20260409e" defer></script>
+<script src="04-router.js?v=20260409e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6704,20 +6704,25 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .pcs-stage-pill .pcs-pill-arr { font-size: 6px; opacity: .4; }
 .pcs-od-pill {
-  padding: 4px 9px;
-  font-family: 'Courier New', monospace; font-size: 8px;
-  letter-spacing: .06em; text-transform: uppercase;
-  background: #FF4B4B14;
-  border: 1px solid #FF4B4B59;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
   color: #FF4B4B;
-  display: flex; align-items: center; gap: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: none;
+  border: none;
+  padding: 0;
 }
 .pcs-od-dot {
   width: 4px; height: 4px; border-radius: 50%;
   background: #FF4B4B;
-  animation: pcs-blink 1.5s infinite;
+  display: inline-block;
+  animation: pcs-od-pulse 2s infinite;
 }
-@keyframes pcs-blink { 0%,100%{opacity:1} 50%{opacity:.2} }
+@keyframes pcs-od-pulse { 0%,100%{opacity:1} 50%{opacity:.2} }
 
 /* Photo header */
 .pcs-photo-header {
@@ -6911,6 +6916,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-mv {
   color: #B8B8C0; cursor: pointer; padding: 3px 0;
   position: relative; transition: color .12s;
+  white-space: nowrap; display: inline-flex; align-items: center;
 }
 .pcs-mv:active { color: #F0F0F2; }
 .pcs-mv--red { color: #FF4B4B; }
@@ -6923,6 +6929,45 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-weight: 600; user-select: none;
 }
 
+/* Custom date calendar dropdown */
+.pcs-cal {
+  background: #101016;
+  border: 1px solid #18181f;
+  padding: 14px;
+  min-width: 270px;
+  box-shadow: 0 8px 32px #00000080;
+  font-family: 'IBM Plex Mono', monospace;
+}
+.pcs-cal-hdr {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 10px;
+}
+.pcs-cal-hdr span {
+  font-size: 11px; color: #E8E8E8; letter-spacing: .02em;
+}
+.pcs-cal-hdr button {
+  background: none; border: none; color: #AEAEB2; font-size: 14px;
+  cursor: pointer; padding: 4px 8px;
+}
+.pcs-cal-hdr button:active { color: #E8E8E8; }
+.pcs-cal-days {
+  display: grid; grid-template-columns: repeat(7, 1fr);
+  gap: 2px; text-align: center;
+}
+.pcs-cal-days span {
+  font-size: 8px; color: #8E8E93; padding: 4px 0;
+  text-transform: uppercase; letter-spacing: .06em;
+}
+.pcs-cal-days button {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px; color: #AEAEB2; background: none; border: none;
+  padding: 6px 0; cursor: pointer; text-align: center;
+}
+.pcs-cal-days button:hover { color: #E8E8E8; }
+.pcs-cal-days button.today { color: #C8A84B; font-weight: 700; }
+.pcs-cal-days button.selected { color: #080808; background: #C8A84B; }
+.pcs-cal-days button.other-month { color: #505060; }
+
 /* Tab bar */
 .pcs-tab-bar {
   display: flex;
@@ -6931,7 +6976,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .pcs-tab {
   flex: 1; padding: 11px 8px;
-  font-family: 'Courier New', monospace;
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 8px; letter-spacing: .07em; text-transform: uppercase;
   background: none; border: none; cursor: pointer;
   color: #6e6e80; text-align: center;
@@ -6950,7 +6995,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   border-bottom: 1px solid #3ECF8E1F;
   border-left: 1px solid #3ECF8E33;
   box-shadow: 0 2px 6px #00000080, inset 0 1px 0 #3ECF8E14;
-  color: #3ECF8E; font-family: 'Courier New', monospace;
+  color: #3ECF8E; font-family: 'IBM Plex Mono', monospace;
   font-size: 9px; letter-spacing: .08em; text-transform: uppercase;
   cursor: pointer; display: flex; align-items: center;
   justify-content: center; gap: 8px;


### PR DESCRIPTION
## Summary\n- **Overdue badge** — removed pill styling (border/bg/padding), now bare red text with pulsing dot, IBM Plex Mono\n- **Metadata values nowrap** — value + dropdown arrow never split across lines (white-space:nowrap + inline-flex)\n- **Format/pillar/location capitalized** — _ucFirst() helper: \"photo\" → \"Photo\", \"growth\" → \"Growth\"\n- **Custom calendar** — replaced native showPicker() with custom dropdown (month nav, day grid, today highlight gold, selected highlight gold bg)\n- **Courier New eliminated** — .pcs-od-pill, .pcs-tab, .pcs-wa-btn all changed to IBM Plex Mono. Zero Courier New remaining in styles.css\n\n## Files changed\n- **styles.css** — .pcs-od-pill bare text, .pcs-mv nowrap, .pcs-tab/.pcs-wa-btn IBM Plex Mono, new .pcs-cal calendar classes\n- **actions/pcs.js** — _ucFirst() helper, format/pillar/location capitalized, native date picker replaced with custom calendar, date input guard removed\n- **index.html** — version bump ?v=20260409e (all 21)\n- **CLAUDE.md** — version + bug entry\n\n## Test plan\n- [x] 508/508 unit tests passing\n- [x] 40/40 e2e tests passing\n- [ ] Manual: OVERDUE = bare red text + pulsing dot, no box\n- [ ] Manual: metadata values + arrows never split across lines\n- [ ] Manual: \"Photo\" not \"photo\", \"Growth\" not \"growth\"\n- [ ] Manual: date tap opens custom calendar with month nav\n- [ ] Manual: no Courier New in PCS (all IBM Plex Mono)\n\nhttps://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM