### PR TITLE
PCS topbar merge + lightbox actions + empty state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260409e
+Version format: ?v=YYYYMMDDx. Current: ?v=20260409f
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1841,6 +1841,39 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Zero business logic changes. Zero data flow changes.
    508/508 unit passing, 40/40 e2e passing.
    Status: FIXED (PR#TBD). Bumped to ?v=20260409e.
+1. PCS visual redesign Part 1 — top section, caption pane, desktop
+   Location: actions/pcs.js, index.html, styles.css
+   Scope:
+   (a) Topbar simplified: stage pill + overdue badge removed from
+       topbar-right. Replaced with WhatsApp icon button (same
+       SVG and handler as _sharePostOnWhatsApp, same visibility
+       condition as _buildWAHtml). Close X, back, back-to-notifs
+       buttons unchanged.
+   (b) Photo header row: stage pill + overdue badge moved here
+       (left side). Same HTML, same onclick handler, same isAdmin
+       check for dropdown arrow. Right side: ADD/EDIT/SAVE text
+       buttons replace the ··· unified menu trigger. ADD calls
+       _pcsAddPhotos, EDIT calls _pcsEnterEditMode (only when
+       imgs.length > 0), SAVE calls _pcsSaveAllPhotos (only when
+       imgs.length > 0). All canManage-gated, same conditions.
+   STATUS UPDATE: Topbar merged into single row (X + stage +
+   overdue as plain red text + WhatsApp). Photo header row removed
+   entirely. ADD/EDIT/SAVE moved into lightbox action bar. Zero-
+   photos empty state with "ADD PHOTOS" added. DONE button margin
+   tightened to 8px.
+   (c) Topbar is now sticky with backdrop-filter blur. Stage and
+       overdue sit in .pcs-topbar-left alongside X button. Overdue
+       is plain text (#FF4B4B, 7px, IBM Plex Mono) — no pulsing
+       dot, no border, no background, no separator from stage.
+   (d) Lightbox action bar: ADD · EDIT · SAVE · DOWNLOAD · REMOVE
+       at bottom of lightbox overlay. canManage-gated. Old standalone
+       download button removed from lightbox header.
+   (e) Zero-photos empty state: .pcs-photos-empty with "ADD PHOTOS"
+       centered, dashed border, taps trigger _pcsAddPhotos().
+   (f) DONE button margin-bottom changed from 10px to 8px.
+   Zero business logic changes. Zero data flow changes.
+   508/508 unit passing, 40/40 e2e passing.
+   Status: FIXED (PR#TBD). Bumped to ?v=20260409f.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -218,42 +218,44 @@ window._renderPCS = function(postId) {
       : '';
   }
 
-  // b) Photo section
-  var imgs = Array.isArray(post.images) ? post.images : [];
-  var photoHeader = document.getElementById('pcs-photo-header-row');
-  var photoGridWrap = document.getElementById('pcs-photo-grid-wrap');
-  if (photoHeader) {
-    photoHeader.style.display = (canManage || imgs.length > 0) ? 'flex' : 'none';
-    // Left side: stage pill + overdue
-    var _stageLabel = (typeof STAGE_DISPLAY !== 'undefined' && STAGE_DISPLAY[stageLC]) || stageLC || 'Unknown';
-    var _leftHtml = '<div class="pcs-photo-left">' +
-      '<span class="pcs-stage-pill" id="pcs-stage-pill"' +
-      (isAdmin ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'stage\',\'' + esc(id) + '\')"' : '') +
-      '>' + esc(_stageLabel) +
-      (isAdmin ? ' <span class="pcs-pill-arr">&#x25BE;</span>' : '') +
-      '</span>';
+  // a2) Stage + overdue in topbar left
+  var _stageLabel = (typeof STAGE_DISPLAY !== 'undefined' && STAGE_DISPLAY[stageLC]) || stageLC || 'Unknown';
+  var topbarStage = document.getElementById('pcs-topbar-stage');
+  if (topbarStage) {
+    topbarStage.className = 'pcs-stage-pill';
+    topbarStage.id = 'pcs-stage-pill';
+    if (isAdmin) {
+      topbarStage.onclick = function(e) { e.stopPropagation(); window._pcsChipDrop(topbarStage, 'stage', id); };
+    } else {
+      topbarStage.onclick = null;
+    }
+    topbarStage.innerHTML = esc(_stageLabel) +
+      (isAdmin ? ' <span class="pcs-pill-arr">&#x25BE;</span>' : '');
+  }
+  var topbarOverdue = document.getElementById('pcs-topbar-overdue');
+  if (topbarOverdue) {
     var _noOverdue = ['published','parked','rejected','scheduled'];
+    var _isOd = false;
     if (_noOverdue.indexOf(stageLC) === -1 && dateValue) {
       var _td = typeof parseDate === 'function' ? parseDate(dateValue) : null;
       var _now = new Date(); _now.setHours(0,0,0,0);
-      if (_td && _td < _now) {
-        _leftHtml += '<span class="pcs-hdr-dot">\u00B7</span>' +
-          '<span class="pcs-od-pill" id="pcs-od-pill"><span class="pcs-od-dot"></span>Overdue</span>';
-      }
+      if (_td && _td < _now) _isOd = true;
     }
-    _leftHtml += '</div>';
-    // Right side: ADD / EDIT / SAVE (canManage only)
-    var _rightHtml = '';
-    if (canManage) {
-      _rightHtml = '<div class="pcs-photo-actions">' +
-        '<button class="pcs-photo-act" onclick="window._pcsAddPhotos(\'' + esc(id) + '\')">ADD</button>' +
-        (imgs.length > 0 ? '<button class="pcs-photo-act" onclick="window._pcsEnterEditMode(\'' + esc(id) + '\')">EDIT</button>' : '') +
-        (imgs.length > 0 ? '<button class="pcs-photo-act" onclick="window._pcsSaveAllPhotos(\'' + esc(id) + '\')">SAVE</button>' : '') +
-        '</div>';
-    }
-    photoHeader.innerHTML = _leftHtml + _rightHtml;
+    topbarOverdue.className = 'pcs-topbar-od';
+    topbarOverdue.textContent = _isOd ? 'OVERDUE' : '';
+    topbarOverdue.style.display = _isOd ? '' : 'none';
   }
-  if (photoGridWrap) photoGridWrap.innerHTML = _buildPhotoGrid(imgs, canEdit, canEditCreative, isAdmin, id);
+
+  // b) Photo section
+  var imgs = Array.isArray(post.images) ? post.images : [];
+  var photoGridWrap = document.getElementById('pcs-photo-grid-wrap');
+  if (photoGridWrap) {
+    if (imgs.length > 0) {
+      photoGridWrap.innerHTML = _buildPhotoGrid(imgs, canEdit, canEditCreative, isAdmin, id);
+    } else {
+      photoGridWrap.innerHTML = '<div class="pcs-photos-empty" onclick="window._pcsAddPhotos(\'' + esc(id) + '\')">ADD PHOTOS</div>';
+    }
+  }
 
   // b2) Drive link card
   var driveLinkWrap = document.getElementById('pcs-drive-link-wrap');
@@ -1914,6 +1916,12 @@ window._pcsOpenLightbox = function(postId, idx) {
   _pcsLbRender();
   var lb = document.getElementById('pcs-lightbox');
   if (lb) { lb.style.display = 'flex'; document.body.style.overflow = 'hidden'; }
+  var actionBar = document.getElementById('pcs-lb-action-bar');
+  if (actionBar) {
+    var _r = (window.AppState.user.effectiveRole || '').toLowerCase();
+    var _canManageLb = _r !== 'client';
+    actionBar.style.display = _canManageLb ? 'flex' : 'none';
+  }
 }
 
 window._pcsLbRender = function() {
@@ -1950,6 +1958,8 @@ window._pcsLbPrev = function() {
 window._pcsLbClose = function() {
   var lb = document.getElementById('pcs-lightbox');
   if (lb) { lb.style.display = 'none'; document.body.style.overflow = ''; }
+  var actionBar = document.getElementById('pcs-lb-action-bar');
+  if (actionBar) actionBar.style.display = 'none';
 }
 
 window._pcsLbDownload = function() {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260409e">
+ <link rel="stylesheet" href="styles.css?v=20260409f">
 
 </head>
 <body>
@@ -864,13 +864,15 @@
 <div id="pcs-overlay" data-action="overlay-close" data-close="closePCS">
   <div id="pcs-screen" class="pc-sheet">
 
-    <!-- Topbar: back+X left, stage+overdue pills right -->
+    <!-- Topbar: single row — X + stage + overdue | spacer | WhatsApp -->
     <div class="pc-topbar">
-      <div style="display:flex;align-items:center;gap:0;">
-        <button id="pcs-back-btn" style="display:none;background:none;border:none;color:#AEAEB2;font-family:'IBM Plex Mono',monospace;font-size:18px;padding:8px;cursor:pointer;" onclick="closePCS()" aria-label="Back to sheet">&#x2190;</button>
+      <div class="pcs-topbar-left">
+        <button id="pcs-back-btn" style="display:none;background:none;border:none;color:#AEAEB2;font-family:'IBM Plex Mono',monospace;font-size:18px;padding:4px 8px;cursor:pointer;" onclick="closePCS()" aria-label="Back to sheet">&#x2190;</button>
         <button class="pc-icon-btn" onclick="closePCS()" aria-label="Close">
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </button>
+        <span id="pcs-topbar-stage"></span>
+        <span id="pcs-topbar-overdue"></span>
       </div>
       <div id="pcs-topbar-right" style="display:flex;align-items:center;gap:6px"></div>
     </div>
@@ -879,7 +881,6 @@
     <div class="pc-scroll-body" id="pcs-scroll">
 
       <!-- Photo section -->
-      <div class="pcs-photo-header" id="pcs-photo-header-row" style="display:none"></div>
       <div id="pcs-photo-grid-wrap"></div>
       <div id="pcs-drive-link-wrap" style="display:none;"></div>
 
@@ -1078,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260409e"></script>
-<script src="00-appstate-compat.js?v=20260409e"></script>
-<script src="01-config.js?v=20260409e" defer></script>
-<script src="02-session.js?v=20260409e" defer></script>
-<script src="utils.js?v=20260409e" defer></script>
-<script src="03-auth.js?v=20260409e" defer></script>
-<script src="05-api.js?v=20260409e" defer></script>
-<script src="10-ui.js?v=20260409e" defer></script>
+<script src="00-appstate.js?v=20260409f"></script>
+<script src="00-appstate-compat.js?v=20260409f"></script>
+<script src="01-config.js?v=20260409f" defer></script>
+<script src="02-session.js?v=20260409f" defer></script>
+<script src="utils.js?v=20260409f" defer></script>
+<script src="03-auth.js?v=20260409f" defer></script>
+<script src="05-api.js?v=20260409f" defer></script>
+<script src="10-ui.js?v=20260409f" defer></script>
 
-<script src="06-post-create.js?v=20260409e" defer></script>
-<script defer src="render/dashboard.js?v=20260409e"></script>
-<script defer src="render/client.js?v=20260409e"></script>
-<script defer src="render/pipeline.js?v=20260409e"></script>
-<script defer src="render/brief.js?v=20260409e"></script>
-<script defer src="actions/pcs.js?v=20260409e"></script>
-<script defer src="actions/pcs-longpress.js?v=20260409e"></script>
-<script src="07-post-load.js?v=20260409e" defer></script>
-<script src="08-post-actions.js?v=20260409e" defer></script>
-<script src="09-library.js?v=20260409e" defer></script>
-<script src="09-approval.js?v=20260409e" defer></script>
-<script src="04-router.js?v=20260409e" defer></script>
+<script src="06-post-create.js?v=20260409f" defer></script>
+<script defer src="render/dashboard.js?v=20260409f"></script>
+<script defer src="render/client.js?v=20260409f"></script>
+<script defer src="render/pipeline.js?v=20260409f"></script>
+<script defer src="render/brief.js?v=20260409f"></script>
+<script defer src="actions/pcs.js?v=20260409f"></script>
+<script defer src="actions/pcs-longpress.js?v=20260409f"></script>
+<script src="07-post-load.js?v=20260409f" defer></script>
+<script src="08-post-actions.js?v=20260409f" defer></script>
+<script src="09-library.js?v=20260409f" defer></script>
+<script src="09-approval.js?v=20260409f" defer></script>
+<script src="04-router.js?v=20260409f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 
@@ -1648,11 +1649,7 @@ window.setPcsVisibility = function(el, vis) {
     <span id="pcs-lb-counter"
       style="font-family:'IBM Plex Mono',monospace;font-size:8px;
       letter-spacing:0.14em;color:#444;">1 / 1</span>
-    <button onclick="_pcsLbDownload()"
-      style="font-family:'IBM Plex Mono',monospace;font-size:7px;
-      letter-spacing:0.12em;text-transform:uppercase;color:#3ECF8E;
-      background:transparent;border:1px solid #3ECF8E4D;
-      padding:6px 12px;cursor:pointer;">&#x2193; Download</button>
+    <div style="width:40px"></div>
   </div>
   <div style="flex:1;display:flex;align-items:center;justify-content:center;
     padding:60px 0 80px;">
@@ -1661,11 +1658,11 @@ window.setPcsVisibility = function(el, vis) {
       style="max-width:100%;max-height:100%;object-fit:contain;display:block;">
   </div>
   <div id="pcs-lb-dots"
-    style="position:absolute;bottom:68px;left:0;right:0;
+    style="position:absolute;bottom:120px;left:0;right:0;
     display:flex;justify-content:center;gap:5px;"></div>
-  <div style="position:absolute;bottom:0;left:0;right:0;
-    background:#000000CC;padding:10px 18px 24px;
-    display:flex;align-items:center;gap:8px;">
+  <div style="position:absolute;bottom:60px;left:0;right:0;
+    display:flex;align-items:center;justify-content:center;gap:8px;
+    padding:0 18px;">
     <button onclick="_pcsLbPrev()"
       style="width:40px;height:40px;display:flex;align-items:center;
       justify-content:center;background:#FFFFFF0D;
@@ -1680,6 +1677,13 @@ window.setPcsVisibility = function(el, vis) {
       justify-content:center;background:#FFFFFF0D;
       border:1px solid #FFFFFF12;color:#555;
       font-size:16px;cursor:pointer;">&#x2192;</button>
+  </div>
+  <div id="pcs-lb-action-bar" class="pcs-lb-actions" style="display:none">
+    <button class="pcs-lb-act" onclick="window._pcsAddPhotos&&window._pcsAddPhotos(window._pcs&&window._pcs.postId||'')">ADD</button>
+    <button class="pcs-lb-act" onclick="window._pcsEnterEditMode&&window._pcsEnterEditMode(window._pcs&&window._pcs.postId||'')">EDIT</button>
+    <button class="pcs-lb-act" onclick="window._pcsSaveAllPhotos&&window._pcsSaveAllPhotos(window._pcs&&window._pcs.postId||'')">SAVE</button>
+    <button class="pcs-lb-act" onclick="window._pcsLbDownload&&window._pcsLbDownload()">DOWNLOAD</button>
+    <button class="pcs-lb-act pcs-lb-act--remove" onclick="window._pcsConfirmRemovePhoto&&window._pcsConfirmRemovePhoto()">REMOVE</button>
   </div>
 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -3357,15 +3357,28 @@ label.pcs-date-tap:active { transform: scale(0.98); }
 /*  FIX 2: Topbar  X left, trash right  */
 .pc-topbar {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 10px 16px;
-  flex-shrink: 0;
+  padding: 8px 12px;
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  background: #080808E0;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   border-bottom: 1px solid #323244;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.pcs-topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
 }
 .pc-icon-btn {
-  width: 34px;
-  height: 34px;
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
   border: 1px solid var(--muted2);
   background: #FFFFFF08;
@@ -6724,29 +6737,64 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 @keyframes pcs-od-pulse { 0%,100%{opacity:1} 50%{opacity:.2} }
 
-/* Photo header */
-.pcs-photo-header {
-  display: flex; align-items: center;
-  justify-content: space-between;
-  padding: 5px 16px 0;
+/* Topbar overdue text */
+.pcs-topbar-od {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: #FF4B4B;
+  margin-left: 2px;
 }
-.pcs-photo-left {
-  display: flex; align-items: center; gap: 4px;
+
+/* Zero-photos empty state */
+.pcs-photos-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 5/3;
+  background: #0c0c11;
+  border: 1px dashed #2e2e3a;
+  cursor: pointer;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: #505060;
+  transition: all .15s;
 }
-.pcs-hdr-dot {
-  color: #505060; padding: 0 4px; font-weight: 600;
-  font-family: 'IBM Plex Mono', monospace; font-size: 8px;
+.pcs-photos-empty:active {
+  color: #808090;
+  border-color: #505060;
 }
-.pcs-photo-actions {
-  display: flex; gap: 0;
+
+/* Lightbox action bar */
+.pcs-lb-actions {
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  max-width: 480px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0px));
+  background: linear-gradient(transparent, #000000CC);
+  z-index: 9601;
 }
-.pcs-photo-act {
-  font-family: 'IBM Plex Mono', monospace; font-size: 7px;
-  letter-spacing: .06em; text-transform: uppercase;
-  color: #808090; background: none; border: none;
-  padding: 10px 8px; cursor: pointer; font-weight: 500;
+.pcs-lb-act {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: #B8B8C0;
+  background: none;
+  border: none;
+  padding: 10px 14px;
+  cursor: pointer;
 }
-.pcs-photo-act:active { color: #B8B8C0; }
+.pcs-lb-act:active { color: #F0F0F2; }
+.pcs-lb-act--remove { color: #FF4B4B; }
+.pcs-lb-act--remove:active { color: #FF6B6B; }
 
 /* PCS PHOTO GRID — hero-driven layout */
 
@@ -7108,7 +7156,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* Done button */
 .pcs-close-btn {
-  display: block; width: calc(100% - 32px); margin: 0 16px 10px;
+  display: block; width: calc(100% - 32px); margin: 0 16px 8px;
   padding: 11px; font-family: 'IBM Plex Mono', monospace;
   font-size: 8px; letter-spacing: .08em; text-transform: uppercase;
   color: #505060; background: none; border: 1px solid #323244;
@@ -7129,7 +7177,6 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 
 /* FIX 7: Tight spacing between topbar and photos */
 #pcs-scroll { padding-top: 0; }
-.pcs-photo-header { padding: 6px 16px 4px; margin-top: 0; margin-bottom: 0; }
 #pcs-photo-grid-wrap { margin-top: 0; padding-top: 0; }
 
 /* FIX 8: Tighter caption */


### PR DESCRIPTION
## Summary\n- **Topbar merged** — single sticky row: X + stage (gold) + overdue (plain red text, no dot/border/bg) + spacer + WhatsApp icon. Photo header row removed entirely.\n- **Lightbox action bar** — ADD · EDIT · SAVE · DOWNLOAD · REMOVE at bottom of lightbox overlay. canManage-gated. Old download button removed from lightbox header.\n- **Zero-photos empty state** — \"ADD PHOTOS\" centered in dashed border box (5:3 aspect ratio). Taps trigger file picker.\n- **Bottom spacing** — DONE button margin-bottom tightened from 10px to 8px.\n\n## Files changed\n- **styles.css** — .pc-topbar sticky + backdrop blur, .pcs-topbar-left/.pcs-topbar-od new classes, .pcs-photo-header/.pcs-photo-left/.pcs-hdr-dot/.pcs-photo-actions/.pcs-photo-act removed, .pcs-photos-empty empty state, .pcs-lb-actions/.pcs-lb-act lightbox bar, .pcs-close-btn margin 8px\n- **actions/pcs.js** — stage+overdue moved into topbar spans, photo header rendering removed, empty state added, lightbox open/close toggles action bar\n- **index.html** — topbar restructured with .pcs-topbar-left + stage/overdue spans, photo header row removed, lightbox rewritten with action bar, version bump ?v=20260409f (all 21)\n- **CLAUDE.md** — version + bug entry\n\n## Test plan\n- [x] 508/508 unit tests passing\n- [x] 40/40 e2e tests passing\n- [ ] Manual: ONE topbar row — X · AWAITING APPROVAL ▾ OVERDUE ........ WhatsApp\n- [ ] Manual: stage gold, overdue red, tight, no dot between them\n- [ ] Manual: stage dropdown opens on tap\n- [ ] Manual: no ADD/EDIT/SAVE on photo section\n- [ ] Manual: lightbox bottom bar — ADD · EDIT · SAVE · DOWNLOAD · REMOVE\n- [ ] Manual: zero photos → \"ADD PHOTOS\" empty state\n- [ ] Manual: DONE button has ~8px below it\n\nhttps://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM