### PR TITLE
Caption max-height 62px → 200px to reduce dead space

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260409f
+Version format: ?v=YYYYMMDDx. Current: ?v=20260409g
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -732,16 +732,16 @@ function _buildCaptionHtml(post, canEdit, canEditCreative, id) {
       '<div id="pcs-caption-text" data-raw="' + esc(post.caption) + '" style="font-family:\'DM Sans\',sans-serif;' +
       'font-size:13px;color:#888;line-height:1.6;white-space:pre-wrap;word-wrap:break-word;' +
       'overflow-wrap:break-word;word-break:break-word;max-width:100%;' +
-      'max-height:62px;overflow:hidden;' +
-      '-webkit-mask-image:linear-gradient(to bottom,black 30px,transparent 60px);' +
-      'mask-image:linear-gradient(to bottom,black 30px,transparent 60px);">' +
+      'max-height:200px;overflow:hidden;' +
+      '-webkit-mask-image:linear-gradient(to bottom,black 160px,transparent 198px);' +
+      'mask-image:linear-gradient(to bottom,black 160px,transparent 198px);">' +
       esc(post.caption) + '</div>' +
       '<button id="pcs-caption-see-more" onclick="(function(){' +
       'var t=document.getElementById(\'pcs-caption-text\');' +
       'var b=document.getElementById(\'pcs-caption-see-more\');' +
       'if(!t||!b)return;' +
-      'if(t.style.maxHeight===\'62px\'){t.style.maxHeight=\'none\';t.style.webkitMaskImage=\'none\';t.style.maskImage=\'none\';t.style.overflow=\'visible\';b.textContent=\'See Less\';}' +
-      'else{t.style.maxHeight=\'62px\';t.style.overflow=\'hidden\';t.style.webkitMaskImage=\'linear-gradient(to bottom,black 30px,transparent 60px)\';t.style.maskImage=\'linear-gradient(to bottom,black 30px,transparent 60px)\';b.textContent=\'See More\';}' +
+      'if(t.style.maxHeight===\'200px\'){t.style.maxHeight=\'none\';t.style.webkitMaskImage=\'none\';t.style.maskImage=\'none\';t.style.overflow=\'visible\';b.textContent=\'See Less\';}' +
+      'else{t.style.maxHeight=\'200px\';t.style.overflow=\'hidden\';t.style.webkitMaskImage=\'linear-gradient(to bottom,black 160px,transparent 198px)\';t.style.maskImage=\'linear-gradient(to bottom,black 160px,transparent 198px)\';b.textContent=\'See More\';}' +
       '})()" style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;letter-spacing:0.1em;' +
       'text-transform:uppercase;color:#F6A623;background:transparent;border:none;cursor:pointer;' +
       'padding:6px 0 0 0;">See More</button>'

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260409f">
+ <link rel="stylesheet" href="styles.css?v=20260409g">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260409f"></script>
-<script src="00-appstate-compat.js?v=20260409f"></script>
-<script src="01-config.js?v=20260409f" defer></script>
-<script src="02-session.js?v=20260409f" defer></script>
-<script src="utils.js?v=20260409f" defer></script>
-<script src="03-auth.js?v=20260409f" defer></script>
-<script src="05-api.js?v=20260409f" defer></script>
-<script src="10-ui.js?v=20260409f" defer></script>
+<script src="00-appstate.js?v=20260409g"></script>
+<script src="00-appstate-compat.js?v=20260409g"></script>
+<script src="01-config.js?v=20260409g" defer></script>
+<script src="02-session.js?v=20260409g" defer></script>
+<script src="utils.js?v=20260409g" defer></script>
+<script src="03-auth.js?v=20260409g" defer></script>
+<script src="05-api.js?v=20260409g" defer></script>
+<script src="10-ui.js?v=20260409g" defer></script>
 
-<script src="06-post-create.js?v=20260409f" defer></script>
-<script defer src="render/dashboard.js?v=20260409f"></script>
-<script defer src="render/client.js?v=20260409f"></script>
-<script defer src="render/pipeline.js?v=20260409f"></script>
-<script defer src="render/brief.js?v=20260409f"></script>
-<script defer src="actions/pcs.js?v=20260409f"></script>
-<script defer src="actions/pcs-longpress.js?v=20260409f"></script>
-<script src="07-post-load.js?v=20260409f" defer></script>
-<script src="08-post-actions.js?v=20260409f" defer></script>
-<script src="09-library.js?v=20260409f" defer></script>
-<script src="09-approval.js?v=20260409f" defer></script>
-<script src="04-router.js?v=20260409f" defer></script>
+<script src="06-post-create.js?v=20260409g" defer></script>
+<script defer src="render/dashboard.js?v=20260409g"></script>
+<script defer src="render/client.js?v=20260409g"></script>
+<script defer src="render/pipeline.js?v=20260409g"></script>
+<script defer src="render/brief.js?v=20260409g"></script>
+<script defer src="actions/pcs.js?v=20260409g"></script>
+<script defer src="actions/pcs-longpress.js?v=20260409g"></script>
+<script src="07-post-load.js?v=20260409g" defer></script>
+<script src="08-post-actions.js?v=20260409g" defer></script>
+<script src="09-library.js?v=20260409g" defer></script>
+<script src="09-approval.js?v=20260409g" defer></script>
+<script src="04-router.js?v=20260409g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary\n- Caption default max-height increased from 62px to 200px so most captions display fully without needing See More\n- Gradient fade adjusted to black 160px → transparent 198px\n- See More / See Less toggle unchanged — still works for captions longer than ~8 lines\n\n## Files changed\n- **actions/pcs.js** — 3 occurrences of 62px → 200px, gradient 30px/60px → 160px/198px\n- **index.html** — version bump ?v=20260409g (all 21)\n- **CLAUDE.md** — version updated\n\n## Test plan\n- [x] 508/508 unit tests passing\n- [x] 40/40 e2e tests passing\n- [ ] Manual: short caption displays fully, no See More needed\n- [ ] Manual: long caption fades at ~200px, See More expands it\n- [ ] Manual: See Less collapses back to 200px with fade\n\nhttps://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM