### PR TITLE
Internal notes visual polish: vis tag, spacing, chips

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260409g
+Version format: ?v=YYYYMMDDx. Current: ?v=20260409h
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1874,6 +1874,119 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Zero business logic changes. Zero data flow changes.
    508/508 unit passing, 40/40 e2e passing.
    Status: FIXED (PR#TBD). Bumped to ?v=20260409f.
+1. PCS comment visual redesign Part 2A — Instagram-style rendering
+   Location: actions/pcs.js, actions/pcs-longpress.js (new),
+   index.html, styles.css
+   Scope:
+   (a) _renderClientThread and _renderNoteThread rewritten:
+       DELETE/COPY action row removed from comment HTML. Only
+       visible "Reply" text remains below each comment (calls
+       exact same _pcsSetReply function). Heart SVG placeholder
+       added on right side (visual only, not wired to DB).
+       data-comment-id and data-author attributes added to
+       comment div for long-press handler to read.
+   (b) Thread grouping: comments grouped by parent_id. Top-level
+       comment + last reply always visible. Middle replies hidden
+       behind "View N more replies" expand link. Orphaned replies
+       render as top-level. Uses .pcs-thread-group wrapper.
+   (c) Same changes applied to internal notes (_renderNoteThread).
+       All note-specific features preserved: .pcs-vis-tag,
+       .pcs-mention-badge, .pcs-task-assignee, resolved accordion.
+   (d) Task checkbox: ☐/☑ emoji replaced with SVG dotted circles.
+       Unchecked = hollow dotted circle. Checked = green dotted
+       circle with checkmark polyline. onclick calls exact same
+       toggleTaskResolve(). "Resolved by" label added below done
+       tasks when resolved_by is truthy.
+   (e) Long-press bottom sheet: new file actions/pcs-longpress.js.
+       500ms touch-hold on .pcs-comment-item/.pcs-note-item shows
+       bottom sheet with Copy/Reply/Delete + Resolve task (for
+       tasks only). All buttons call exact same existing functions.
+       Delete permission: author === name || admin. Desktop
+       fallback via contextmenu event. Haptic vibrate(12).
+   (f) Plus button menu: + button in both input bars now shows
+       Task/Image popover instead of directly opening file picker.
+       Image calls exact same file input click. Task calls exact
+       same submitPcsComment(isTask=true) or _showTaskAssign().
+   (g) Reply tag moved inside input pill: old .pcs-reply-bar
+       removed from HTML. New .pcs-reply-tag inline element added
+       inside .pcs-ibar-pill showing "Author ·" with X dismiss.
+       _pcsSetReply and _pcsClearReply updated for new element IDs.
+   (h) CSS overhaul: comment items no border-bottom (whitespace
+       only). Avatar 30px (up from 28). Author 13px/700 #F0F0F2.
+       Text 13.5px #C0C0C8. Avatar colors solid hex backgrounds
+       (no alpha). .pcs-comment-reply no border-left. New classes:
+       .pcs-thread-group, .pcs-expand-link, .pcs-expand-line,
+       .pcs-expand-text, .pcs-comment-reply-btn, .pcs-comment-react,
+       .pcs-react-icon, .pcs-resolved-label, .pcs-lp-backdrop,
+       .pcs-lp-menu, .pcs-lp-item, .pcs-lp-cancel, .pcs-lp-delete,
+       .pcs-lp-resolve, .pcs-plus-menu, .pcs-plus-item,
+       .pcs-reply-tag, .pcs-reply-tag-x. Zero rgba(). All hex.
+   New file: actions/pcs-longpress.js. Script count: 21 (20+1).
+   Zero business logic changes. Zero new DB calls. Zero new API
+   endpoints. All onclick handlers call exact same functions.
+   508/508 unit passing, 40/40 e2e passing.
+   Status: FIXED (PR#TBD). Bumped to ?v=20260409a.
+1. PCS comment wiring Part 2B — reactions DB + toggleTaskResolve fix
+   Location: actions/pcs.js, actions/pcs-longpress.js, styles.css
+   Scope:
+   (a) loadPcsComments now fetches /post_comment_reactions for the
+       post in a third API call. Results stored in window._pcsReactions
+       keyed by comment_id. Fetch is try/catch wrapped — failure does
+       not break comment loading.
+   (b) _renderSingleClient and _renderSingleNote now check
+       window._pcsReactions[commentId]. If user has reacted: show
+       their emoji instead of heart SVG, add .pcs-reacted class.
+       If reactions exist: show count via .pcs-react-count span.
+   (c) New function window._pcsShowEmojiPicker(reactEl): if user
+       already reacted, unreacts (removes). Otherwise shows inline
+       5-emoji picker (❤️ 👍 🎯 👀 ✅) positioned above the react
+       div. Click outside closes picker.
+   (d) New function window._pcsAddReaction(commentId, emoji, reactEl):
+       POST to /post_comment_reactions, optimistic DOM update, no
+       full re-fetch. Wrapped in guardAction.
+   (e) New function window._pcsRemoveReaction(commentId, reactEl):
+       DELETE from /post_comment_reactions by reaction id, optimistic
+       DOM update. Wrapped in guardAction.
+   (f) BUG FIX: toggleTaskResolve now accepts third parameter
+       isInternalNote (boolean). Routes PATCH to /internal_notes
+       when true, /post_comments when false. Previously always
+       patched /post_comments causing silent failure for internal
+       note tasks. All callers updated: _renderSingleClient passes
+       false, _renderSingleNote passes true, pcs-longpress.js
+       passes isInternalNote based on zone detection.
+   (g) CSS: .pcs-react-emoji, .pcs-reacted, .pcs-react-count,
+       .pcs-emoji-picker, .pcs-emoji-btn added. All solid hex.
+   Zero visual layout changes from Part 2A. Zero new HTML structure.
+   508/508 unit passing, 40/40 e2e passing.
+   Status: FIXED (PR#TBD). Bumped to ?v=20260409b.
+1. Internal notes visual polish — 6 targeted rendering fixes
+   Location: actions/pcs.js, styles.css, index.html
+   Scope:
+   (a) Visibility tag moved inline with author — sits after
+       timestamp in .pcs-comment-meta row. Color-coded by
+       visibility: admin=#C8A84B, servicing=#22D3EE,
+       creative=#9b87f5, all=#505060 (default dim). Old
+       margin-left:auto removed (no longer right-floating).
+   (b) Duplicate @mention badge removed from note header —
+       _mentionBadge variable replaced with comment. Mentions
+       render only inside message body via _highlightMentions.
+       .pcs-mention-badge CSS class removed from styles.css.
+   (c) Note spacing tightened — .pcs-note-item padding changed
+       from 14px 16px 0 to 10px 16px, margin-bottom:0. Matches
+       client tab density.
+   (d) Visibility chips restyled — inline styles removed from
+       index.html, replaced with .pcs-vis-row/.pcs-vis-chip CSS
+       classes. Inactive: #505060 text, #2e2e3a border. Active:
+       #F6A623 amber text + border + subtle bg. IBM Plex Mono.
+   (e) Thread grouping CSS — .pcs-thread-group now has padding
+       6px 0 + border-bottom 1px solid #323244, last-child no
+       border. Matches client tab thread separators.
+   (f) Heart icon verified identical to client tab — same SVG
+       path, same .pcs-comment-react positioning. No change needed.
+   Zero business logic changes. Zero data flow changes.
+   Zero changes to post_comments/internal_notes routing.
+   508/508 unit passing, 40/40 e2e passing.
+   Status: FIXED (PR#TBD). Bumped to ?v=20260409h.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1236,13 +1236,16 @@ window.loadPcsComments = async function(postId) {
           '</div></div>';
       }
       var _initial = (c.author||'?').charAt(0).toUpperCase();
-      var _mu = Array.isArray(c.mentioned_users) ? c.mentioned_users : [];
-      var _mentionBadge = _mu.length
-        ? '<span class="pcs-mention-badge">@' + esc(_mu.join(', @')) + '</span>'
-        : '';
+      // Mentions render inside message body via _highlightMentions only
       var _vis = (c.visibility||'all').toUpperCase();
       if (_vis === 'SERVICING') _vis = 'SERV';
-      var _visTag = '<span class="pcs-vis-tag">' + _vis + '</span>';
+      if (_vis === 'CREATIVE') _vis = 'CREAT';
+      var _visCls = 'pcs-vis-tag';
+      var _visLC = (c.visibility||'all').toLowerCase();
+      if (_visLC === 'admin') _visCls += ' pcs-vis--admin';
+      else if (_visLC === 'servicing') _visCls += ' pcs-vis--serv';
+      else if (_visLC === 'creative') _visCls += ' pcs-vis--creat';
+      var _visTag = '<span class="' + _visCls + '">' + _vis + '</span>';
       var _taskObj = _parseTask(c);
       var _isTask = !!_taskObj;
       var _assignedTo = (_taskObj && _taskObj.assigned_to) ? _taskObj.assigned_to : null;
@@ -1300,7 +1303,6 @@ window.loadPcsComments = async function(postId) {
           '<div class="pcs-comment-meta">' +
             '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
             '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
-            _mentionBadge +
             _visTag +
           '</div>' +
           (c.reply_to && c.reply_to_author ?

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260409g">
+ <link rel="stylesheet" href="styles.css?v=20260409h">
 
 </head>
 <body>
@@ -929,11 +929,11 @@
       <!-- Tab pane: Internal -->
       <div id="pcs-pane-internal" class="pcs-tab-pane" style="display:none;flex:1;flex-direction:column;overflow:hidden">
         <span id="pcs-notes-count" style="display:none">0</span>
-        <div id="pcs-vis-selector" style="flex-shrink:0;display:flex;gap:4px;padding:8px 16px;border-bottom:1px solid #0f0f16;background:#09080a">
-          <button class="pcs-vis-chip" data-vis="all" data-action="pcs-vis" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #F6A62359;color:#F6A623;background:#F6A6230A;cursor:pointer">ALL</button>
-          <button class="pcs-vis-chip" data-vis="admin" data-action="pcs-vis" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">ADMIN</button>
-          <button class="pcs-vis-chip" data-vis="servicing" data-action="pcs-vis" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">SERV</button>
-          <button class="pcs-vis-chip" data-vis="creative" data-action="pcs-vis" style="padding:4px 10px;font-family:'Courier New',monospace;font-size:7px;letter-spacing:.07em;text-transform:uppercase;border:1px solid #1a1808;color:#302418;background:none;cursor:pointer">CREATIVE</button>
+        <div id="pcs-vis-selector" class="pcs-vis-row">
+          <button class="pcs-vis-chip active" data-vis="all" data-action="pcs-vis">ALL</button>
+          <button class="pcs-vis-chip" data-vis="admin" data-action="pcs-vis">ADMIN</button>
+          <button class="pcs-vis-chip" data-vis="servicing" data-action="pcs-vis">SERV</button>
+          <button class="pcs-vis-chip" data-vis="creative" data-action="pcs-vis">CREATIVE</button>
         </div>
         <div id="pcs-notes-section" style="flex:1;display:flex;flex-direction:column;min-height:0">
           <div id="pcs-notes-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:12px 16px;background:#080806;scrollbar-width:none;min-height:0"></div>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260409g"></script>
-<script src="00-appstate-compat.js?v=20260409g"></script>
-<script src="01-config.js?v=20260409g" defer></script>
-<script src="02-session.js?v=20260409g" defer></script>
-<script src="utils.js?v=20260409g" defer></script>
-<script src="03-auth.js?v=20260409g" defer></script>
-<script src="05-api.js?v=20260409g" defer></script>
-<script src="10-ui.js?v=20260409g" defer></script>
+<script src="00-appstate.js?v=20260409h"></script>
+<script src="00-appstate-compat.js?v=20260409h"></script>
+<script src="01-config.js?v=20260409h" defer></script>
+<script src="02-session.js?v=20260409h" defer></script>
+<script src="utils.js?v=20260409h" defer></script>
+<script src="03-auth.js?v=20260409h" defer></script>
+<script src="05-api.js?v=20260409h" defer></script>
+<script src="10-ui.js?v=20260409h" defer></script>
 
-<script src="06-post-create.js?v=20260409g" defer></script>
-<script defer src="render/dashboard.js?v=20260409g"></script>
-<script defer src="render/client.js?v=20260409g"></script>
-<script defer src="render/pipeline.js?v=20260409g"></script>
-<script defer src="render/brief.js?v=20260409g"></script>
-<script defer src="actions/pcs.js?v=20260409g"></script>
-<script defer src="actions/pcs-longpress.js?v=20260409g"></script>
-<script src="07-post-load.js?v=20260409g" defer></script>
-<script src="08-post-actions.js?v=20260409g" defer></script>
-<script src="09-library.js?v=20260409g" defer></script>
-<script src="09-approval.js?v=20260409g" defer></script>
-<script src="04-router.js?v=20260409g" defer></script>
+<script src="06-post-create.js?v=20260409h" defer></script>
+<script defer src="render/dashboard.js?v=20260409h"></script>
+<script defer src="render/client.js?v=20260409h"></script>
+<script defer src="render/pipeline.js?v=20260409h"></script>
+<script defer src="render/brief.js?v=20260409h"></script>
+<script defer src="actions/pcs.js?v=20260409h"></script>
+<script defer src="actions/pcs-longpress.js?v=20260409h"></script>
+<script src="07-post-load.js?v=20260409h" defer></script>
+<script src="08-post-actions.js?v=20260409h" defer></script>
+<script src="09-library.js?v=20260409h" defer></script>
+<script src="09-approval.js?v=20260409h" defer></script>
+<script src="04-router.js?v=20260409h" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5911,8 +5911,9 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-note-item {
   display: flex;
   gap: 10px;
-  padding: 14px 16px 0;
+  padding: 10px 16px;
   position: relative;
+  margin-bottom: 0;
 }
 .pcs-unread-dot {
   position: absolute;
@@ -5974,23 +5975,19 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   color: #8E8E93;
 }
 .pcs-vis-tag {
-  font-family: var(--mono);
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 7px;
-  color: #A872FF73;
-  border: 1px dotted #A872FF33;
-  padding: 1px 4px;
-  margin-left: auto;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: #505060;
+  padding: 1px 6px;
+  border: 1px solid #2e2e3a;
+  margin-left: 6px;
   flex-shrink: 0;
-  align-self: flex-start;
 }
-.pcs-mention-badge {
-  font-family: var(--mono);
-  font-size: 7px;
-  color: #c7a3ff;
-  background: #A872FF1A;
-  border: 1px solid #A872FF40;
-  padding: 1px 4px;
-}
+.pcs-vis--admin { color: #C8A84B; border-color: #C8A84B33; }
+.pcs-vis--serv { color: #22D3EE; border-color: #22D3EE33; }
+.pcs-vis--creat { color: #9b87f5; border-color: #9b87f533; }
 .pcs-comment-text {
   font-size: 13.5px;
   color: #C0C0C8;
@@ -6083,22 +6080,32 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   display: flex;
   gap: 4px;
 }
+.pcs-vis-row {
+  flex-shrink: 0;
+  display: flex;
+  gap: 4px;
+  padding: 8px 16px;
+  border-bottom: 1px solid #191924;
+  background: #0d0d12;
+}
 .pcs-vis-chip {
-  font-family: var(--mono);
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 7px;
-  letter-spacing: 0.06em;
-  padding: 3px 7px;
-  border: 1px dotted #4a3a6b;
-  color: #8E8E93;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: #505060;
+  background: none;
+  border: 1px solid #2e2e3a;
+  padding: 4px 9px;
   cursor: pointer;
   user-select: none;
   -webkit-user-select: none;
   transition: all 0.15s;
 }
 .pcs-vis-chip.active {
-  background: #A872FF1F;
-  color: #c7a3ff;
-  border-color: #9b87f5;
+  color: #F6A623;
+  border-color: #F6A62340;
+  background: #F6A6230F;
 }
 
 /* COUNT BADGES */
@@ -6443,8 +6450,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 /* Thread grouping */
-.pcs-thread-group { padding: 0; }
-.pcs-thread-group + .pcs-thread-group { padding-top: 20px; }
+.pcs-thread-group { padding: 6px 0; border-bottom: 1px solid #323244; }
+.pcs-thread-group:last-child { border-bottom: none; }
 .pcs-expand-link {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary\n- **Visibility tag inline** — moved from right-floating (overlapping heart) to inline after timestamp. Color-coded: admin gold, servicing cyan, creative purple, all dim gray.\n- **Duplicate mention badge removed** — @mentions now render only inside message body via _highlightMentions, not duplicated in header.\n- **Spacing tightened** — note padding matches client tab (10px 16px). Thread groups separated by #323244 borders.\n- **Chips restyled** — inline styles removed, CSS classes added. Active = amber (#F6A623), inactive = dim (#505060). IBM Plex Mono.\n- **Heart icon** — verified identical to client tab, no change needed.\n\n## Files changed\n- **actions/pcs.js** — vis tag color classes, mention badge removed, CREATIVE abbreviated to CREAT\n- **styles.css** — .pcs-vis-tag inline + color variants, .pcs-note-item tightened, .pcs-vis-row/.pcs-vis-chip restyled, .pcs-thread-group borders, .pcs-mention-badge removed\n- **index.html** — vis chip inline styles replaced with classes, version bump ?v=20260409h (all 21)\n- **CLAUDE.md** — version + bug entries for Part 2A, 2B, and this PR\n\n## Test plan\n- [x] 508/508 unit tests passing\n- [x] 40/40 e2e tests passing\n- [ ] Manual: vis tag inline after timestamp, not overlapping heart\n- [ ] Manual: no duplicate @mention in header\n- [ ] Manual: note spacing matches client tab\n- [ ] Manual: ALL chip amber, others dim gray\n- [ ] Manual: thread groups separated by borders\n- [ ] CRITICAL: Client tab shows zero internal notes\n- [ ] CRITICAL: Client role preview has no Internal tab access\n\nhttps://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM