### PR TITLE
Fix photo upload progress bar: broken element ID + styling upgrade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260409h
+Version format: ?v=YYYYMMDDx. Current: ?v=20260409i
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1529,19 +1529,15 @@ window._pcsHandlePhotoInput = async function(postId, input) {
   var uploaded = [];
   var progressWrap = document.createElement('div');
   progressWrap.id = 'pcs-upload-progress';
-  progressWrap.style.cssText = 'padding:8px 18px;border-bottom:' +
-    '1px solid #FFFFFF12;';
   progressWrap.innerHTML =
-    '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;' +
-    'letter-spacing:0.14em;text-transform:uppercase;color:#555;' +
-    'margin-bottom:6px;" id="pcs-upload-label">Uploading 0 of ' +
-    files.length + '...</div>' +
-    '<div style="height:2px;background:#FFFFFF0F;width:100%;">' +
-    '<div id="pcs-upload-bar" style="height:2px;background:#F6A623;' +
-    'width:0%;transition:width 0.2s ease;"></div></div>';
-  var photoSection = document.getElementById('pcs-photo-section');
-  if (photoSection) photoSection.parentNode.insertBefore(
-    progressWrap, photoSection);
+    '<div style="width:100%;height:3px;background:#1a1a22;overflow:hidden;position:relative;">' +
+    '<div id="pcs-upload-bar" style="height:100%;background:#C8A84B;width:0%;transition:width 0.3s ease;"></div></div>' +
+    '<div id="pcs-upload-label" style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
+    'letter-spacing:.06em;color:#808090;padding:4px 16px;text-transform:uppercase;">' +
+    'UPLOADING 0 OF ' + files.length + '...</div>';
+  var photoGrid = document.getElementById('pcs-photo-grid-wrap');
+  if (photoGrid && photoGrid.parentNode) photoGrid.parentNode.insertBefore(
+    progressWrap, photoGrid);
   for (var fi = 0; fi < files.length; fi++) {
     if (currentImages.length + uploaded.length >= 20) break;
     try {
@@ -1553,10 +1549,13 @@ window._pcsHandlePhotoInput = async function(postId, input) {
     var pct = Math.round(((fi + 1) / files.length) * 100);
     var bar = document.getElementById('pcs-upload-bar');
     var lbl = document.getElementById('pcs-upload-label');
-    if (bar) bar.style.width = pct + '%';
-    if (lbl) lbl.textContent = 'Uploading ' + (fi + 1) +
-      ' of ' + files.length + '...' +
-      (pct === 100 ? ' Done.' : '');
+    if (bar) {
+      bar.style.width = pct + '%';
+      if (pct === 100) bar.style.background = '#3ECF8E';
+    }
+    if (lbl) lbl.textContent = pct === 100
+      ? 'DONE'
+      : 'UPLOADING ' + (fi + 1) + ' OF ' + files.length + '...';
   }
   if (!uploaded.length) return;
   var newImages = currentImages.concat(uploaded);
@@ -1577,11 +1576,9 @@ window._pcsHandlePhotoInput = async function(postId, input) {
       console.warn('[AppState] Post not found', postId);
     }
     window.AppState.posts.setAll(_next_1379);
-    var section = document.getElementById('pcs-photo-section');
-    if (section && post) {
-      post.images = newImages;
-      if (typeof openPCS === 'function') openPCS(postId, '');
-    }
+    post.images = newImages;
+    showToast && showToast(uploaded.length + ' photo' + (uploaded.length > 1 ? 's' : '') + ' uploaded', 'success');
+    if (typeof openPCS === 'function') openPCS(postId, '');
     var pw = document.getElementById('pcs-upload-progress');
     if (pw) pw.remove();
   } catch(e) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260409h">
+ <link rel="stylesheet" href="styles.css?v=20260409i">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260409h"></script>
-<script src="00-appstate-compat.js?v=20260409h"></script>
-<script src="01-config.js?v=20260409h" defer></script>
-<script src="02-session.js?v=20260409h" defer></script>
-<script src="utils.js?v=20260409h" defer></script>
-<script src="03-auth.js?v=20260409h" defer></script>
-<script src="05-api.js?v=20260409h" defer></script>
-<script src="10-ui.js?v=20260409h" defer></script>
+<script src="00-appstate.js?v=20260409i"></script>
+<script src="00-appstate-compat.js?v=20260409i"></script>
+<script src="01-config.js?v=20260409i" defer></script>
+<script src="02-session.js?v=20260409i" defer></script>
+<script src="utils.js?v=20260409i" defer></script>
+<script src="03-auth.js?v=20260409i" defer></script>
+<script src="05-api.js?v=20260409i" defer></script>
+<script src="10-ui.js?v=20260409i" defer></script>
 
-<script src="06-post-create.js?v=20260409h" defer></script>
-<script defer src="render/dashboard.js?v=20260409h"></script>
-<script defer src="render/client.js?v=20260409h"></script>
-<script defer src="render/pipeline.js?v=20260409h"></script>
-<script defer src="render/brief.js?v=20260409h"></script>
-<script defer src="actions/pcs.js?v=20260409h"></script>
-<script defer src="actions/pcs-longpress.js?v=20260409h"></script>
-<script src="07-post-load.js?v=20260409h" defer></script>
-<script src="08-post-actions.js?v=20260409h" defer></script>
-<script src="09-library.js?v=20260409h" defer></script>
-<script src="09-approval.js?v=20260409h" defer></script>
-<script src="04-router.js?v=20260409h" defer></script>
+<script src="06-post-create.js?v=20260409i" defer></script>
+<script defer src="render/dashboard.js?v=20260409i"></script>
+<script defer src="render/client.js?v=20260409i"></script>
+<script defer src="render/pipeline.js?v=20260409i"></script>
+<script defer src="render/brief.js?v=20260409i"></script>
+<script defer src="actions/pcs.js?v=20260409i"></script>
+<script defer src="actions/pcs-longpress.js?v=20260409i"></script>
+<script src="07-post-load.js?v=20260409i" defer></script>
+<script src="08-post-actions.js?v=20260409i" defer></script>
+<script src="09-library.js?v=20260409i" defer></script>
+<script src="09-approval.js?v=20260409i" defer></script>
+<script src="04-router.js?v=20260409i" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary\n- **BUG FIX:** Photo upload progress bar targeted `#pcs-photo-section` which doesn't exist. Actual ID is `#pcs-photo-grid-wrap`. `insertBefore` silently failed — zero visual feedback during upload.\n- **Second broken ref:** `openPCS` refresh was gated behind the same nonexistent element, so the photo grid never refreshed after upload.\n- **Styling upgrade:** 3px bar, gold (#C8A84B) → green (#3ECF8E) on complete. Label: \"UPLOADING 1 OF 3...\" → \"DONE\"\n- **Success toast:** \"2 photos uploaded\" on completion\n\n## Files changed\n- **actions/pcs.js** — 3 broken `#pcs-photo-section` refs → `#pcs-photo-grid-wrap`, progress bar HTML upgraded, success toast added\n- **index.html** — version bump ?v=20260409i (all 21)\n- **CLAUDE.md** — version updated\n\n## Test plan\n- [x] 508/508 unit tests passing\n- [x] 40/40 e2e tests passing\n- [ ] Manual: ADD photos → gold progress bar appears above grid, animates per file\n- [ ] Manual: on completion → bar turns green, label shows DONE, toast appears\n- [ ] Manual: photos appear in grid after refresh\n- [ ] Manual: zero-photos post → ADD PHOTOS → same progress behavior\n\nhttps://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM