### PR TITLE
PCS topbar: always show X close, remove NOTIFS text variant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260409i
+Version format: ?v=YYYYMMDDx. Current: ?v=20260409j
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -165,25 +165,12 @@ window._renderPCS = function(postId) {
     backBtn.style.display = (window.AppState.pcs.openedFrom === 'sheet') ? 'block' : 'none';
   }
 
-  // Back-to-notifications button (shows when PCS opened from notif panel)
+  // Clean up any stale back-to-notifications button from previous open
   var existingNb = document.querySelector('.pcs-back-notif-btn');
   if (existingNb && existingNb.parentNode) existingNb.parentNode.removeChild(existingNb);
-  // Restore close button visibility (may have been hidden on previous notif open)
+  // Always show X close button
   var pcsCloseX = document.querySelector('#pcs-overlay .pc-topbar [aria-label="Close"]');
   if (pcsCloseX) pcsCloseX.style.display = '';
-  if (window._notifOpenedPCS) {
-    // Hide the ✕ close button — ← NOTIFS replaces it
-    if (pcsCloseX) pcsCloseX.style.display = 'none';
-    var nbBtn = document.createElement('button');
-    nbBtn.className = 'pcs-back-notif-btn';
-    nbBtn.textContent = '\u2190 NOTIFS';
-    nbBtn.onclick = function() {
-      if (typeof closePCS === 'function') closePCS();
-    };
-    var pcsTopbar = document.querySelector('#pcs-overlay .pc-topbar') ||
-                    document.getElementById('pcs-topbar');
-    if (pcsTopbar) pcsTopbar.prepend(nbBtn);
-  }
 
   // 1. Fetch post
   var post = getPostById(postId);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260409i">
+ <link rel="stylesheet" href="styles.css?v=20260409j">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260409i"></script>
-<script src="00-appstate-compat.js?v=20260409i"></script>
-<script src="01-config.js?v=20260409i" defer></script>
-<script src="02-session.js?v=20260409i" defer></script>
-<script src="utils.js?v=20260409i" defer></script>
-<script src="03-auth.js?v=20260409i" defer></script>
-<script src="05-api.js?v=20260409i" defer></script>
-<script src="10-ui.js?v=20260409i" defer></script>
+<script src="00-appstate.js?v=20260409j"></script>
+<script src="00-appstate-compat.js?v=20260409j"></script>
+<script src="01-config.js?v=20260409j" defer></script>
+<script src="02-session.js?v=20260409j" defer></script>
+<script src="utils.js?v=20260409j" defer></script>
+<script src="03-auth.js?v=20260409j" defer></script>
+<script src="05-api.js?v=20260409j" defer></script>
+<script src="10-ui.js?v=20260409j" defer></script>
 
-<script src="06-post-create.js?v=20260409i" defer></script>
-<script defer src="render/dashboard.js?v=20260409i"></script>
-<script defer src="render/client.js?v=20260409i"></script>
-<script defer src="render/pipeline.js?v=20260409i"></script>
-<script defer src="render/brief.js?v=20260409i"></script>
-<script defer src="actions/pcs.js?v=20260409i"></script>
-<script defer src="actions/pcs-longpress.js?v=20260409i"></script>
-<script src="07-post-load.js?v=20260409i" defer></script>
-<script src="08-post-actions.js?v=20260409i" defer></script>
-<script src="09-library.js?v=20260409i" defer></script>
-<script src="09-approval.js?v=20260409i" defer></script>
-<script src="04-router.js?v=20260409i" defer></script>
+<script src="06-post-create.js?v=20260409j" defer></script>
+<script defer src="render/dashboard.js?v=20260409j"></script>
+<script defer src="render/client.js?v=20260409j"></script>
+<script defer src="render/pipeline.js?v=20260409j"></script>
+<script defer src="render/brief.js?v=20260409j"></script>
+<script defer src="actions/pcs.js?v=20260409j"></script>
+<script defer src="actions/pcs-longpress.js?v=20260409j"></script>
+<script src="07-post-load.js?v=20260409j" defer></script>
+<script src="08-post-actions.js?v=20260409j" defer></script>
+<script src="09-library.js?v=20260409j" defer></script>
+<script src="09-approval.js?v=20260409j" defer></script>
+<script src="04-router.js?v=20260409j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary\n- PCS topbar always shows X close button regardless of where PCS was opened from\n- Removed conditional that hid X and showed \"← NOTIFS\" text when opened from notifications\n- closePCS() already handles routing back to correct view via AppState.pcs.openedFrom — zero behavior change\n\n## Files changed\n- **actions/pcs.js** — removed 12-line conditional block that created .pcs-back-notif-btn and hid X\n- **index.html** — version bump ?v=20260409j (all 21)\n- **CLAUDE.md** — version updated\n\n## Test plan\n- [x] 508/508 unit tests passing\n- [x] 40/40 e2e tests passing\n- [ ] Manual: open PCS from notification → X button shows (not \"← NOTIFS\")\n- [ ] Manual: tap X → returns to notifications panel\n- [ ] Manual: open PCS from pipeline → X shows, tap X → returns to pipeline\n\nhttps://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM