### PR TITLE
Fix activity logging: old_stage/new_stage, auth guard, await

### DIFF
--- a/05-api.js
+++ b/05-api.js
@@ -136,7 +136,9 @@ async function uploadPostAsset(file, postId) {
   return data.url;
 }
 
-async function logActivity({ post_id, actor, actor_role, action }) {
+async function logActivity({ post_id, actor, actor_role, action, old_stage, new_stage }) {
+  var token = localStorage.getItem('sb_access_token');
+  if (!token) return;
   try {
     await apiFetch('/activity_log', {
       method: 'POST',
@@ -145,6 +147,8 @@ async function logActivity({ post_id, actor, actor_role, action }) {
         actor:      actor   || 'Unknown',
         action:     action  || '',
         created_at: new Date().toISOString(),
+        old_stage:  old_stage || null,
+        new_stage:  new_stage || null,
       }),
     });
   } catch (err) {

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -104,7 +104,7 @@ async function quickStage(postId, newStage) {
     }
     post._isSaving = false;
     scheduleRender();
-    await logActivity({ post_id: postId, actor: actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}` });
+    await logActivity({ post_id: postId, actor: actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}`, old_stage: oldStage, new_stage: newStage });
     var _qsRecipients = _stageRecipients(newStage);
     if (_qsRecipients.length) window._sendStageNotif(postId, getTitle(post), newStage, _qsRecipients, actor);
     showUndoToast('Moved to ' + _stageLabel(newStage), function() { quickStage(postId, oldStage); });
@@ -225,7 +225,7 @@ async function clientApprove(postId, btn) {
         method: 'PATCH',
         body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: 'Client' }),
       });
-      await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
+      await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled', old_stage: post.stage, new_stage: 'scheduled' });
       window._sendStageNotif(postId, getTitle(post), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || 'Client');
       var confirmEl = document.getElementById('approved-confirm-' + postId);
       if (confirmEl) confirmEl.classList.add('show');
@@ -476,7 +476,8 @@ function _confirmPublish(postId) {
   apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
     method: 'PATCH',
     body: JSON.stringify(payload)
-  }).then(function() {
+  }).then(async function() {
+    var _pubOldStage = (getPostById(postId) || {}).stage || '';
     var _found_408 = false;
     var _next_408 = window.AppState.posts.all.map(function(p) {
       if (getPostId(p) === postId) {
@@ -493,11 +494,13 @@ function _confirmPublish(postId) {
       console.warn('[AppState] Post not found', postId);
     }
     window.AppState.posts.setAll(_next_408);
-    logActivity({
+    await logActivity({
       post_id: postId,
       actor: window.AppState.user.name || 'Shubham',
       actor_role: window.AppState.user.effectiveRole || 'Admin',
-      action: 'published'
+      action: 'published',
+      old_stage: _pubOldStage,
+      new_stage: 'published'
     });
     var _pubPost = getPostById(postId);
     window._sendStageNotif(postId, (_pubPost ? getTitle(_pubPost) : postId), 'published', ['Admin', 'Servicing', 'Creative', 'Client'], window.AppState.user.name || 'Shubham');
@@ -592,7 +595,7 @@ async function _executeStageChangeAsync(post, postId, newStage, previousStage) {
   }
 
   // -- NON-CRITICAL  -  completely outside DB try/catch --
-  try { logActivity({ post_id: postId, actor: actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}` }); } catch(e) { console.warn('[PCS] logActivity failed:', e); }
+  try { await logActivity({ post_id: postId, actor: actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}`, old_stage: previousStage, new_stage: newStage }); } catch(e) { console.warn('[PCS] logActivity failed:', e); }
   try { var _esRecipients = _stageRecipients(newStage); if (_esRecipients.length) window._sendStageNotif(postId, getTitle(post), newStage, _esRecipients, actor); } catch(e) { console.warn('[PCS] stage notif failed:', e); }
   try { showUndoToast(`Moved to ${newStage}`, () => _executeStageChange(postId, previousStage)); } catch(e) { console.warn('[PCS] showUndoToast failed:', e); }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410a
+Version format: ?v=YYYYMMDDx. Current: ?v=20260410b
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -1987,6 +1987,38 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    Zero changes to post_comments/internal_notes routing.
    508/508 unit passing, 40/40 e2e passing.
    Status: FIXED (PR#TBD). Bumped to ?v=20260409h.
+1. logActivity() missing old_stage/new_stage + auth guard + fire-and-forget
+   Location: 05-api.js logActivity(), 08-post-actions.js quickStage(),
+   _executeStageChangeAsync(), clientApprove(), _confirmPublish()
+   Root cause (4 issues):
+   (a) logActivity() POST payload only sent post_id, actor, action,
+       created_at. The activity_log table has old_stage and new_stage
+       columns (previously populated by DB triggers, now dropped), but
+       the app-side logActivity() never sent them. Dashboard streak
+       queries and timeline views read old_stage/new_stage and got NULL.
+   (b) logActivity() had no session token guard. When called after
+       logout or token expiry, it fired a guaranteed-to-fail 401
+       request that was silently swallowed by its internal catch.
+   (c) _executeStageChangeAsync line 595 called logActivity() without
+       await. If PCS closed before the Promise resolved, the browser
+       could abort the request, silently dropping the activity_log row.
+   (d) _confirmPublish line 496 same fire-and-forget pattern — called
+       logActivity() without await inside a .then() callback.
+   Status: FIXED (PR#TBD) —
+   (a) Added old_stage and new_stage to logActivity() signature and
+       POST body (05-api.js:139). Both default to null when omitted.
+   (b) Added localStorage sb_access_token guard at top of logActivity()
+       — returns early with no API call when no token (05-api.js:140-141).
+   (c) Added await before logActivity() in _executeStageChangeAsync
+       (08-post-actions.js:598).
+   (d) Made _confirmPublish .then() callback async, added await before
+       logActivity() (08-post-actions.js:479,497).
+   (e) All 4 stage-change callers now pass old_stage and new_stage:
+       quickStage (old_stage: oldStage), _executeStageChangeAsync
+       (old_stage: previousStage), clientApprove (old_stage: post.stage,
+       new_stage: 'scheduled'), _confirmPublish (old_stage captured
+       before setAll, new_stage: 'published').
+   508/508 unit passing. Bumped to ?v=20260410b.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410a">
+ <link rel="stylesheet" href="styles.css?v=20260410b">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410a"></script>
-<script src="00-appstate-compat.js?v=20260410a"></script>
-<script src="01-config.js?v=20260410a" defer></script>
-<script src="02-session.js?v=20260410a" defer></script>
-<script src="utils.js?v=20260410a" defer></script>
-<script src="03-auth.js?v=20260410a" defer></script>
-<script src="05-api.js?v=20260410a" defer></script>
-<script src="10-ui.js?v=20260410a" defer></script>
+<script src="00-appstate.js?v=20260410b"></script>
+<script src="00-appstate-compat.js?v=20260410b"></script>
+<script src="01-config.js?v=20260410b" defer></script>
+<script src="02-session.js?v=20260410b" defer></script>
+<script src="utils.js?v=20260410b" defer></script>
+<script src="03-auth.js?v=20260410b" defer></script>
+<script src="05-api.js?v=20260410b" defer></script>
+<script src="10-ui.js?v=20260410b" defer></script>
 
-<script src="06-post-create.js?v=20260410a" defer></script>
-<script defer src="render/dashboard.js?v=20260410a"></script>
-<script defer src="render/client.js?v=20260410a"></script>
-<script defer src="render/pipeline.js?v=20260410a"></script>
-<script defer src="render/brief.js?v=20260410a"></script>
-<script defer src="actions/pcs.js?v=20260410a"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410a"></script>
-<script src="07-post-load.js?v=20260410a" defer></script>
-<script src="08-post-actions.js?v=20260410a" defer></script>
-<script src="09-library.js?v=20260410a" defer></script>
-<script src="09-approval.js?v=20260410a" defer></script>
-<script src="04-router.js?v=20260410a" defer></script>
+<script src="06-post-create.js?v=20260410b" defer></script>
+<script defer src="render/dashboard.js?v=20260410b"></script>
+<script defer src="render/client.js?v=20260410b"></script>
+<script defer src="render/pipeline.js?v=20260410b"></script>
+<script defer src="render/brief.js?v=20260410b"></script>
+<script defer src="actions/pcs.js?v=20260410b"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410b"></script>
+<script src="07-post-load.js?v=20260410b" defer></script>
+<script src="08-post-actions.js?v=20260410b" defer></script>
+<script src="09-library.js?v=20260410b" defer></script>
+<script src="09-approval.js?v=20260410b" defer></script>
+<script src="04-router.js?v=20260410b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- **logActivity()** now sends `old_stage` and `new_stage` to the `activity_log` table — previously only populated by dropped DB triggers, these columns were always NULL for app-written rows
- Added session token guard to logActivity() — prevents silent 401 failures when called after logout or token expiry
- Awaited logActivity() in `_executeStageChangeAsync()` and `_confirmPublish()` — prevents browser aborting the request when PCS closes before the Promise resolves
- All 4 stage-change callers (`quickStage`, `_executeStageChangeAsync`, `clientApprove`, `_confirmPublish`) now pass correct old_stage and new_stage values

## Files changed
| File | What changed |
|------|-------------|
| `05-api.js` | Added `old_stage`/`new_stage` params + POST body fields, added `sb_access_token` guard |
| `08-post-actions.js` | All 4 stage-change logActivity calls pass old_stage/new_stage, await added to 2 fire-and-forget calls |
| `index.html` | Version bump ?v=20260410a → ?v=20260410b (all 21 resources) |
| `CLAUDE.md` | Bug entry added, version string updated |

## Test plan
- [x] 508/508 unit tests passing (npx vitest run)
- [ ] Verify activity_log rows now contain old_stage and new_stage after a stage change
- [ ] Verify logActivity silently skips when no session token present
- [ ] Purge Cloudflare cache after merge

https://claude.ai/code/session_01LyA1MkEfqU5QWzEX6rsb2o