### PR TITLE
PCS comment fixes: reaction spacing, thread padding, OK emoji

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410c
+Version format: ?v=YYYYMMDDx. Current: ?v=20260410d
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -2701,7 +2701,7 @@ window._pcsRemoveCommentImg = function(zone, idx) {
 };
 
 // -- Emoji reactions --
-var _PCS_EMOJIS = ['\u2764\uFE0F', '\uD83D\uDC4D', '\uD83C\uDFAF', '\uD83D\uDC40', '\u2705'];
+var _PCS_EMOJIS = ['\u2764\uFE0F', '\uD83D\uDC4D', '\uD83C\uDFAF', '\uD83D\uDC40', '\u2705', '\uD83C\uDD97'];
 
 window._pcsShowEmojiPicker = function(reactEl) {
   if (!reactEl) return;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410c">
+ <link rel="stylesheet" href="styles.css?v=20260410d">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410c"></script>
-<script src="00-appstate-compat.js?v=20260410c"></script>
-<script src="01-config.js?v=20260410c" defer></script>
-<script src="02-session.js?v=20260410c" defer></script>
-<script src="utils.js?v=20260410c" defer></script>
-<script src="03-auth.js?v=20260410c" defer></script>
-<script src="05-api.js?v=20260410c" defer></script>
-<script src="10-ui.js?v=20260410c" defer></script>
+<script src="00-appstate.js?v=20260410d"></script>
+<script src="00-appstate-compat.js?v=20260410d"></script>
+<script src="01-config.js?v=20260410d" defer></script>
+<script src="02-session.js?v=20260410d" defer></script>
+<script src="utils.js?v=20260410d" defer></script>
+<script src="03-auth.js?v=20260410d" defer></script>
+<script src="05-api.js?v=20260410d" defer></script>
+<script src="10-ui.js?v=20260410d" defer></script>
 
-<script src="06-post-create.js?v=20260410c" defer></script>
-<script defer src="render/dashboard.js?v=20260410c"></script>
-<script defer src="render/client.js?v=20260410c"></script>
-<script defer src="render/pipeline.js?v=20260410c"></script>
-<script defer src="render/brief.js?v=20260410c"></script>
-<script defer src="actions/pcs.js?v=20260410c"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410c"></script>
-<script src="07-post-load.js?v=20260410c" defer></script>
-<script src="08-post-actions.js?v=20260410c" defer></script>
-<script src="09-library.js?v=20260410c" defer></script>
-<script src="09-approval.js?v=20260410c" defer></script>
-<script src="04-router.js?v=20260410c" defer></script>
+<script src="06-post-create.js?v=20260410d" defer></script>
+<script defer src="render/dashboard.js?v=20260410d"></script>
+<script defer src="render/client.js?v=20260410d"></script>
+<script defer src="render/pipeline.js?v=20260410d"></script>
+<script defer src="render/brief.js?v=20260410d"></script>
+<script defer src="actions/pcs.js?v=20260410d"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410d"></script>
+<script src="07-post-load.js?v=20260410d" defer></script>
+<script src="08-post-actions.js?v=20260410d" defer></script>
+<script src="09-library.js?v=20260410d" defer></script>
+<script src="09-approval.js?v=20260410d" defer></script>
+<script src="04-router.js?v=20260410d" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5621,7 +5621,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-comment-item {
   display: flex;
   gap: 10px;
-  padding: 14px 16px 0;
+  padding: 14px 16px;
   position: relative;
 }
 .pcs-note-item {
@@ -6083,10 +6083,10 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   position: absolute;
   right: 16px;
   top: 16px;
-  display: flex;
-  flex-direction: column;
+  display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: 4px;
+  padding: 2px 6px;
   cursor: pointer;
 }
 .pcs-react-icon {
@@ -6109,8 +6109,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .pcs-react-count {
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  color: #8E8E93;
+  font-size: 11px;
+  color: #B8B8C0;
   line-height: 1;
 }
 .pcs-emoji-picker {
@@ -6151,8 +6151,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 /* Thread grouping */
-.pcs-thread-group { padding: 6px 0; border-bottom: 1px solid #323244; }
-.pcs-thread-group:last-child { border-bottom: none; }
+.pcs-thread-group { padding: 6px 0 8px; margin-bottom: 4px; border-bottom: 1px solid #323244; }
+.pcs-thread-group:last-child { border-bottom: none; margin-bottom: 0; }
 .pcs-expand-link {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary\n- **Reaction spacing** — emoji + count now side-by-side with 4px gap (was column stacked). Count font 11px #B8B8C0 (was 8px #8E8E93).\n- **Comment padding** — .pcs-comment-item bottom padding added (was 0). Thread groups get 8px padding-bottom + 4px margin-bottom for breathing room.\n- **🆗 emoji** — added to reaction picker. Now 6 options: ❤️ 👍 🎯 👀 ✅ 🆗\n\n## Files changed\n- **styles.css** — .pcs-comment-react inline-flex, .pcs-react-count 11px, .pcs-comment-item padding, .pcs-thread-group spacing\n- **actions/pcs.js** — _PCS_EMOJIS array +🆗\n- **index.html** — version bump ?v=20260410d (all 21)\n- **CLAUDE.md** — version updated\n\n## Test plan\n- [x] 508/508 unit tests passing\n- [x] 40/40 e2e tests passing\n- [ ] Manual: heart + count have clear spacing\n- [ ] Manual: comments have breathing room between them\n- [ ] Manual: emoji picker shows 6 emojis including 🆗\n\nhttps://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM