### PR TITLE
Fix @mention dropup on client tab, reaction position, task prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410d
+Version format: ?v=YYYYMMDDx. Current: ?v=20260410e
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -2251,6 +2251,13 @@ window._sharePostOnWhatsApp = function(postId) {
 window.submitPcsComment = async function(postId, message, visibility, isTask, isInternal) {
   return window.guardAction('submit-pcs-comment-' + postId, async function() {
   try {
+  // Check task flag from + menu pre-fill
+  var _clientInp = document.getElementById('pcs-comment-input');
+  if (!isTask && _clientInp && _clientInp.dataset.isTask === 'true') {
+    isTask = true;
+    delete _clientInp.dataset.isTask;
+    _clientInp.placeholder = 'Reply to client...';
+  }
   isTask = isTask || false;
   visibility = visibility || 'all';
 
@@ -2848,12 +2855,16 @@ window._pcsTogglePlusMenu = function(btn, zone) {
   taskBtn.addEventListener('click', function() {
     menu.remove();
     if (zone === 'client') {
-      // Same flow as #pcs-task-btn-client onclick
-      var pid = document.getElementById('pcs-post-id');
       var inp = document.getElementById('pcs-comment-input');
-      if (pid && inp && inp.value.trim()) {
-        window.submitPcsComment(pid.value, inp.value, 'all', true, false);
+      if (inp) {
+        inp.value = 'Task: ';
+        inp.placeholder = 'Describe the task...';
+        inp.dataset.isTask = 'true';
+        inp.focus();
+        inp.setSelectionRange(inp.value.length, inp.value.length);
+        inp.dispatchEvent(new Event('input'));
       }
+      return;
     } else {
       // Same flow as #pcs-task-btn-note onclick
       if (typeof window._showTaskAssign === 'function') {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410d">
+ <link rel="stylesheet" href="styles.css?v=20260410e">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410d"></script>
-<script src="00-appstate-compat.js?v=20260410d"></script>
-<script src="01-config.js?v=20260410d" defer></script>
-<script src="02-session.js?v=20260410d" defer></script>
-<script src="utils.js?v=20260410d" defer></script>
-<script src="03-auth.js?v=20260410d" defer></script>
-<script src="05-api.js?v=20260410d" defer></script>
-<script src="10-ui.js?v=20260410d" defer></script>
+<script src="00-appstate.js?v=20260410e"></script>
+<script src="00-appstate-compat.js?v=20260410e"></script>
+<script src="01-config.js?v=20260410e" defer></script>
+<script src="02-session.js?v=20260410e" defer></script>
+<script src="utils.js?v=20260410e" defer></script>
+<script src="03-auth.js?v=20260410e" defer></script>
+<script src="05-api.js?v=20260410e" defer></script>
+<script src="10-ui.js?v=20260410e" defer></script>
 
-<script src="06-post-create.js?v=20260410d" defer></script>
-<script defer src="render/dashboard.js?v=20260410d"></script>
-<script defer src="render/client.js?v=20260410d"></script>
-<script defer src="render/pipeline.js?v=20260410d"></script>
-<script defer src="render/brief.js?v=20260410d"></script>
-<script defer src="actions/pcs.js?v=20260410d"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410d"></script>
-<script src="07-post-load.js?v=20260410d" defer></script>
-<script src="08-post-actions.js?v=20260410d" defer></script>
-<script src="09-library.js?v=20260410d" defer></script>
-<script src="09-approval.js?v=20260410d" defer></script>
-<script src="04-router.js?v=20260410d" defer></script>
+<script src="06-post-create.js?v=20260410e" defer></script>
+<script defer src="render/dashboard.js?v=20260410e"></script>
+<script defer src="render/client.js?v=20260410e"></script>
+<script defer src="render/pipeline.js?v=20260410e"></script>
+<script defer src="render/brief.js?v=20260410e"></script>
+<script defer src="actions/pcs.js?v=20260410e"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410e"></script>
+<script src="07-post-load.js?v=20260410e" defer></script>
+<script src="08-post-actions.js?v=20260410e" defer></script>
+<script src="09-library.js?v=20260410e" defer></script>
+<script src="09-approval.js?v=20260410e" defer></script>
+<script src="04-router.js?v=20260410e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5951,7 +5951,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 /* MENTION / TASK ASSIGN DROPUPS */
-#pcs-mention-dropup {
+#pcs-mention-dropup,
+#pcs-client-mention-dropup {
   background: #191924;
   border: 1px solid #9B87F540;
   position: relative;
@@ -6082,7 +6083,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-comment-react {
   position: absolute;
   right: 16px;
-  top: 16px;
+  top: 14px;
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -6090,7 +6091,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   cursor: pointer;
 }
 .pcs-react-icon {
-  font-size: 12px;
+  font-size: 16px;
   line-height: 1;
 }
 .pcs-react-icon svg {


### PR DESCRIPTION
## Summary\n\n### @mention dropup fix (audit finding)\n**BUG:** `#pcs-client-mention-dropup` had no CSS — only `#pcs-mention-dropup` was styled. Client tab dropup rendered as unstyled invisible block when typing @.\n**FIX:** Added `#pcs-client-mention-dropup` to the CSS selector. Both dropups now share background, border, z-index styles.\n\n### Reaction position\n- top: 16px → 14px (aligns with author name, matches comment padding-top)\n- Emoji font-size: 12px → 16px for visibility\n\n### Task prefix\n- Tapping Task in + menu pre-fills \"Task: \" with cursor at end\n- Placeholder changes to \"Describe the task...\"\n- `data-is-task` flag on input, detected by `submitPcsComment` to route as isTask=true\n- Placeholder resets after submit\n\n## Files changed\n- **styles.css** — `#pcs-client-mention-dropup` added to selector, reaction top/font-size\n- **actions/pcs.js** — task prefix pre-fill in + menu, isTask detection in submitPcsComment\n- **index.html** — version bump ?v=20260410e (all 21)\n- **CLAUDE.md** — version updated\n\n## Test plan\n- [x] 508/508 unit tests passing\n- [x] 40/40 e2e tests passing\n- [ ] Manual: type @ in client tab input → dropup with names appears\n- [ ] Manual: reaction emoji aligns with author name\n- [ ] Manual: tap + → Task → input shows \"Task: \" pre-filled\n\nhttps://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM