### PR TITLE
Fix reaction emoji position drop after picker interaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410e
+Version format: ?v=YYYYMMDDx. Current: ?v=20260410f
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -2741,7 +2741,6 @@ window._pcsShowEmojiPicker = function(reactEl) {
     });
     picker.appendChild(btn);
   });
-  reactEl.style.position = 'relative';
   reactEl.appendChild(picker);
 
   // Close on outside click

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410e">
+ <link rel="stylesheet" href="styles.css?v=20260410f">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410e"></script>
-<script src="00-appstate-compat.js?v=20260410e"></script>
-<script src="01-config.js?v=20260410e" defer></script>
-<script src="02-session.js?v=20260410e" defer></script>
-<script src="utils.js?v=20260410e" defer></script>
-<script src="03-auth.js?v=20260410e" defer></script>
-<script src="05-api.js?v=20260410e" defer></script>
-<script src="10-ui.js?v=20260410e" defer></script>
+<script src="00-appstate.js?v=20260410f"></script>
+<script src="00-appstate-compat.js?v=20260410f"></script>
+<script src="01-config.js?v=20260410f" defer></script>
+<script src="02-session.js?v=20260410f" defer></script>
+<script src="utils.js?v=20260410f" defer></script>
+<script src="03-auth.js?v=20260410f" defer></script>
+<script src="05-api.js?v=20260410f" defer></script>
+<script src="10-ui.js?v=20260410f" defer></script>
 
-<script src="06-post-create.js?v=20260410e" defer></script>
-<script defer src="render/dashboard.js?v=20260410e"></script>
-<script defer src="render/client.js?v=20260410e"></script>
-<script defer src="render/pipeline.js?v=20260410e"></script>
-<script defer src="render/brief.js?v=20260410e"></script>
-<script defer src="actions/pcs.js?v=20260410e"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410e"></script>
-<script src="07-post-load.js?v=20260410e" defer></script>
-<script src="08-post-actions.js?v=20260410e" defer></script>
-<script src="09-library.js?v=20260410e" defer></script>
-<script src="09-approval.js?v=20260410e" defer></script>
-<script src="04-router.js?v=20260410e" defer></script>
+<script src="06-post-create.js?v=20260410f" defer></script>
+<script defer src="render/dashboard.js?v=20260410f"></script>
+<script defer src="render/client.js?v=20260410f"></script>
+<script defer src="render/pipeline.js?v=20260410f"></script>
+<script defer src="render/brief.js?v=20260410f"></script>
+<script defer src="actions/pcs.js?v=20260410f"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410f"></script>
+<script src="07-post-load.js?v=20260410f" defer></script>
+<script src="08-post-actions.js?v=20260410f" defer></script>
+<script src="09-library.js?v=20260410f" defer></script>
+<script src="09-approval.js?v=20260410f" defer></script>
+<script src="04-router.js?v=20260410f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary\n\n**One line deleted.** `reactEl.style.position = 'relative'` in `_pcsShowEmojiPicker` (line 2744).\n\n**Root cause:** Emoji picker set `position:relative` as inline style on `.pcs-comment-react` to create a containing block. This overrode the CSS `position:absolute` and was never cleaned up after picker closed. Reaction element permanently fell into document flow.\n\n**Fix:** Deleted the line. `position:absolute` (from CSS) already creates a containing block for absolutely-positioned children. Picker still positions correctly via its own `position:absolute; bottom:calc(100% + 6px)`.\n\n## Files changed\n- **actions/pcs.js** — deleted `reactEl.style.position = 'relative'`\n- **index.html** — version bump ?v=20260410f (all 21)\n- **CLAUDE.md** — version updated\n\n## Test plan\n- [x] 508/508 unit tests passing\n- [x] 40/40 e2e tests passing\n- [ ] Manual: reaction at top-right aligned with author name\n- [ ] Manual: open emoji picker → select → reaction stays at top-right\n- [ ] Manual: open picker → close without selecting → stays at top-right\n- [ ] Manual: scroll through comments → all reactions consistently positioned\n\nhttps://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM