### PR TITLE
Fix stale data, clientApprove pipeline refresh, activity log debug

### DIFF
--- a/05-api.js
+++ b/05-api.js
@@ -11,6 +11,8 @@ function getAuthHeaders(extra = {}) {
     'Content-Type':  'application/json',
     'Prefer':        'return=representation',
     'Accept':        'application/json',
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+    'Pragma':        'no-cache',
     ...extra,
   };
 }
@@ -137,8 +139,9 @@ async function uploadPostAsset(file, postId) {
 }
 
 async function logActivity({ post_id, actor, actor_role, action, old_stage, new_stage }) {
+  console.log('[logActivity] called:', { post_id, actor, action, old_stage, new_stage });
   var token = localStorage.getItem('sb_access_token');
-  if (!token) return;
+  if (!token) { console.log('[logActivity] SKIPPED - no auth token'); return; }
   try {
     await apiFetch('/activity_log', {
       method: 'POST',
@@ -151,8 +154,9 @@ async function logActivity({ post_id, actor, actor_role, action, old_stage, new_
         new_stage:  new_stage || null,
       }),
     });
+    console.log('[logActivity] SUCCESS:', post_id, action);
   } catch (err) {
-    console.warn('logActivity failed:', err);
+    console.warn('[logActivity] FAILED:', post_id, action, err.message || err);
     window.logError && window.logError(err && err.message, err && err.stack, 'log-activity');
   }
 }

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -219,14 +219,23 @@ async function clientApprove(postId, btn) {
   if (alreadyApproved) { showToast('Already approved ok', 'success'); return; }
   return window.guardAction('client-approve-' + postId, async function() {
     if (btn) btn.disabled = true;
+    var oldStage = post.stage;
+    setStage(post, 'scheduled', 'clientApprove');
+    post._isSaving = true;
     try {
       // scheduled -> owner remains unchanged (per ownership rules)
-      await apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
+      var rows = await apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
         method: 'PATCH',
         body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: 'Client' }),
       });
-      await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled', old_stage: post.stage, new_stage: 'scheduled' });
-      window._sendStageNotif(postId, getTitle(post), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || 'Client');
+      // Apply server response - same pattern as quickStage
+      if (Array.isArray(rows) && rows[0]) {
+        var server = normalise(rows)[0];
+        if (server.stage) server.stage = toUiStage(server.stage);
+        Object.assign(post, server);
+      }
+      post._isSaving = false;
+      // Show confirmation UI
       var confirmEl = document.getElementById('approved-confirm-' + postId);
       if (confirmEl) confirmEl.classList.add('show');
       var cardEl = document.getElementById('approved-confirm-' + postId);
@@ -245,9 +254,20 @@ async function clientApprove(postId, btn) {
           }
         }
       }
-      setStage(post, 'scheduled', 'clientApprove');
-      setTimeout(function() { if (typeof loadPostsForClient === 'function') loadPostsForClient(); }, 1200);
-    } catch (err) { if (btn) btn.disabled = false; showToast('Failed  -  try again', 'error'); window.logError && window.logError(err && err.message, err && err.stack, 'client-approve'); }
+      // Trigger renders - same as _executeStageChange pattern
+      scheduleRender();
+      _renderBackgroundViews();
+      // Non-critical side effects
+      await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled', old_stage: oldStage, new_stage: 'scheduled' });
+      window._sendStageNotif(postId, getTitle(post), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || 'Client');
+    } catch (err) {
+      post._isSaving = false;
+      setStage(post, oldStage, 'clientApprove_rollback');
+      scheduleRender();
+      if (btn) btn.disabled = false;
+      showToast('Failed  -  try again', 'error');
+      window.logError && window.logError(err && err.message, err && err.stack, 'client-approve');
+    }
   });
 }
 
@@ -591,6 +611,7 @@ async function _executeStageChangeAsync(post, postId, newStage, previousStage) {
     _renderPCS(postId);
     _renderBackgroundViews();
     showToast('Update failed  -  rolled back', 'error');
+    console.error('[STAGE CHANGE] PATCH FAILED - logActivity will not run:', postId, err.message || err);
     return; // STOP  -  do not run side effects
   }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410g
+Version format: ?v=YYYYMMDDx. Current: ?v=20260410h
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -2019,6 +2019,28 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
        new_stage: 'scheduled'), _confirmPublish (old_stage captured
        before setAll, new_stage: 'published').
    508/508 unit passing. Bumped to ?v=20260410b.
+1. Stale data after refresh — browser HTTP cache serving old GET responses
+   Location: 05-api.js getAuthHeaders() — no Cache-Control or Pragma
+   headers, so identical GET URLs (e.g. /posts?select=*) could be
+   served from browser HTTP cache instead of hitting Supabase.
+   Status: FIXED (PR#TBD) — added Cache-Control: no-cache, no-store,
+   must-revalidate and Pragma: no-cache to getAuthHeaders() before
+   the ...extra spread. Every apiFetch call now bypasses browser cache.
+   508/508 unit passing. Bumped to ?v=20260410h.
+1. clientApprove() missing _isSaving guard, server response, and render
+   Location: 08-post-actions.js clientApprove() — did not set
+   _isSaving (poll could overwrite in-memory state), did not apply
+   server PATCH response (discarded rows), did not call
+   scheduleRender() or _renderBackgroundViews() (pipeline never
+   updated), used setTimeout(loadPostsForClient, 1200) instead of
+   direct render, had no rollback on failure.
+   Status: FIXED (PR#TBD) — rewritten to match quickStage pattern:
+   oldStage captured before setStage, _isSaving set before PATCH,
+   server response applied via Object.assign, _isSaving cleared after
+   apply, scheduleRender() + _renderBackgroundViews() called,
+   setTimeout(loadPostsForClient) removed, catch block rolls back
+   stage + clears _isSaving + calls scheduleRender().
+   508/508 unit passing. Bumped to ?v=20260410h.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410g">
+ <link rel="stylesheet" href="styles.css?v=20260410h">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410g"></script>
-<script src="00-appstate-compat.js?v=20260410g"></script>
-<script src="01-config.js?v=20260410g" defer></script>
-<script src="02-session.js?v=20260410g" defer></script>
-<script src="utils.js?v=20260410g" defer></script>
-<script src="03-auth.js?v=20260410g" defer></script>
-<script src="05-api.js?v=20260410g" defer></script>
-<script src="10-ui.js?v=20260410g" defer></script>
+<script src="00-appstate.js?v=20260410h"></script>
+<script src="00-appstate-compat.js?v=20260410h"></script>
+<script src="01-config.js?v=20260410h" defer></script>
+<script src="02-session.js?v=20260410h" defer></script>
+<script src="utils.js?v=20260410h" defer></script>
+<script src="03-auth.js?v=20260410h" defer></script>
+<script src="05-api.js?v=20260410h" defer></script>
+<script src="10-ui.js?v=20260410h" defer></script>
 
-<script src="06-post-create.js?v=20260410g" defer></script>
-<script defer src="render/dashboard.js?v=20260410g"></script>
-<script defer src="render/client.js?v=20260410g"></script>
-<script defer src="render/pipeline.js?v=20260410g"></script>
-<script defer src="render/brief.js?v=20260410g"></script>
-<script defer src="actions/pcs.js?v=20260410g"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410g"></script>
-<script src="07-post-load.js?v=20260410g" defer></script>
-<script src="08-post-actions.js?v=20260410g" defer></script>
-<script src="09-library.js?v=20260410g" defer></script>
-<script src="09-approval.js?v=20260410g" defer></script>
-<script src="04-router.js?v=20260410g" defer></script>
+<script src="06-post-create.js?v=20260410h" defer></script>
+<script defer src="render/dashboard.js?v=20260410h"></script>
+<script defer src="render/client.js?v=20260410h"></script>
+<script defer src="render/pipeline.js?v=20260410h"></script>
+<script defer src="render/brief.js?v=20260410h"></script>
+<script defer src="actions/pcs.js?v=20260410h"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410h"></script>
+<script src="07-post-load.js?v=20260410h" defer></script>
+<script src="08-post-actions.js?v=20260410h" defer></script>
+<script src="09-library.js?v=20260410h" defer></script>
+<script src="09-approval.js?v=20260410h" defer></script>
+<script src="04-router.js?v=20260410h" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- **Cache-busting headers** — `getAuthHeaders()` now sends `Cache-Control: no-cache, no-store, must-revalidate` + `Pragma: no-cache` on every Supabase REST call, preventing browser HTTP cache from serving stale GET responses (root cause of posts showing wrong stages after refresh)
- **clientApprove() rewrite** — rewritten to match the proven `quickStage()` pattern: `_isSaving` guard, optimistic `setStage` before PATCH, server response applied via `Object.assign`, `scheduleRender()` + `_renderBackgroundViews()` for instant pipeline update, rollback on failure. Removed stale `setTimeout(loadPostsForClient, 1200)`
- **Activity log debug logging** — `logActivity()` now logs call params, success, skip (no token), and failure with post_id + action. `_executeStageChangeAsync` PATCH failure now logs that logActivity will not run

## Files changed
| File | What changed |
|------|-------------|
| `05-api.js` | Cache-Control + Pragma headers in `getAuthHeaders()`; debug logging in `logActivity()` |
| `08-post-actions.js` | `clientApprove()` rewritten with _isSaving/optimistic/render/rollback pattern; debug log in `_executeStageChangeAsync` catch |
| `index.html` | Version bump ?v=20260410g → ?v=20260410h (all 21 resources) |
| `CLAUDE.md` | Two bug entries added, version string updated |

## Test plan
- [x] 508/508 unit tests passing (npx vitest run)
- [ ] Hard refresh srtd.io — posts should never show stale stages
- [ ] Client approves a post — pipeline should update instantly for Admin
- [ ] Check browser console for `[logActivity]` debug lines after any stage change
- [ ] Purge Cloudflare cache after merge

https://claude.ai/code/session_01LyA1MkEfqU5QWzEX6rsb2o