### PR TITLE
Improve PCS comment contrast for bright ambient light

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410i
+Version format: ?v=YYYYMMDDx. Current: ?v=20260410j
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410i">
+ <link rel="stylesheet" href="styles.css?v=20260410j">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410i"></script>
-<script src="00-appstate-compat.js?v=20260410i"></script>
-<script src="01-config.js?v=20260410i" defer></script>
-<script src="02-session.js?v=20260410i" defer></script>
-<script src="utils.js?v=20260410i" defer></script>
-<script src="03-auth.js?v=20260410i" defer></script>
-<script src="05-api.js?v=20260410i" defer></script>
-<script src="10-ui.js?v=20260410i" defer></script>
+<script src="00-appstate.js?v=20260410j"></script>
+<script src="00-appstate-compat.js?v=20260410j"></script>
+<script src="01-config.js?v=20260410j" defer></script>
+<script src="02-session.js?v=20260410j" defer></script>
+<script src="utils.js?v=20260410j" defer></script>
+<script src="03-auth.js?v=20260410j" defer></script>
+<script src="05-api.js?v=20260410j" defer></script>
+<script src="10-ui.js?v=20260410j" defer></script>
 
-<script src="06-post-create.js?v=20260410i" defer></script>
-<script defer src="render/dashboard.js?v=20260410i"></script>
-<script defer src="render/client.js?v=20260410i"></script>
-<script defer src="render/pipeline.js?v=20260410i"></script>
-<script defer src="render/brief.js?v=20260410i"></script>
-<script defer src="actions/pcs.js?v=20260410i"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410i"></script>
-<script src="07-post-load.js?v=20260410i" defer></script>
-<script src="08-post-actions.js?v=20260410i" defer></script>
-<script src="09-library.js?v=20260410i" defer></script>
-<script src="09-approval.js?v=20260410i" defer></script>
-<script src="04-router.js?v=20260410i" defer></script>
+<script src="06-post-create.js?v=20260410j" defer></script>
+<script defer src="render/dashboard.js?v=20260410j"></script>
+<script defer src="render/client.js?v=20260410j"></script>
+<script defer src="render/pipeline.js?v=20260410j"></script>
+<script defer src="render/brief.js?v=20260410j"></script>
+<script defer src="actions/pcs.js?v=20260410j"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410j"></script>
+<script src="07-post-load.js?v=20260410j" defer></script>
+<script src="08-post-actions.js?v=20260410j" defer></script>
+<script src="09-library.js?v=20260410j" defer></script>
+<script src="09-approval.js?v=20260410j" defer></script>
+<script src="04-router.js?v=20260410j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5701,7 +5701,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-comment-time {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 8px;
-  color: #505060;
+  color: #8888A0;
   margin-left: 8px;
 }
 .pcs-vis-tag {
@@ -5709,7 +5709,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-size: 7px;
   letter-spacing: .06em;
   text-transform: uppercase;
-  color: #505060;
+  color: #7878A0;
   padding: 1px 6px;
   border: 1px solid #2e2e3a;
   margin-left: 6px;
@@ -6084,7 +6084,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-comment-reply-btn {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 9px;
-  color: #505060;
+  color: #8888A0;
   margin-top: 5px;
   letter-spacing: .04em;
   background: none;
@@ -6099,7 +6099,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 /* Heart placeholder (visual only) */
 .pcs-comment-react {
   cursor: pointer;
-  opacity: .35;
+  opacity: .55;
   transition: opacity .15s;
   padding: 2px;
 }
@@ -6107,7 +6107,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-comment-react svg {
   width: 18px;
   height: 18px;
-  stroke: #505060;
+  stroke: #8888A0;
   fill: none;
   stroke-width: 1.5;
 }
@@ -6130,7 +6130,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-react-count {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 9px;
-  color: #808090;
+  color: #9898A8;
   line-height: 1;
   letter-spacing: .02em;
 }


### PR DESCRIPTION
## Summary\nSix color/opacity bumps for readability in bright ambient light. All CSS-only, zero JS changes.\n\n| Element | Before | After |\n|---------|--------|-------|\n| .pcs-comment-time | #505060 | #8888A0 |\n| .pcs-comment-reply-btn | #505060 | #8888A0 |\n| .pcs-comment-react opacity | .35 | .55 |\n| .pcs-comment-react svg stroke | #505060 | #8888A0 |\n| .pcs-react-count | #808090 | #9898A8 |\n| .pcs-vis-tag | #505060 | #7878A0 |\n\nAuthor (#F0F0F2) and comment text (#B8B8C0) unchanged — already readable.\n\n## Files changed\n- **styles.css** — 6 color/opacity values\n- **index.html** — version bump ?v=20260410j (all 21)\n- **CLAUDE.md** — version updated\n\n## Test plan\n- [x] 508/508 unit tests passing\n- [x] 40/40 e2e tests passing\n- [ ] Manual: timestamp, Reply, and heart visible in bright light\n\nhttps://claude.ai/code/session_01H1JZ5ZGGkwt4M77TSXjQqM