### PR TITLE
fix: eliminate stale stage display across Dashboard/Pipeline/Client v…

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -52,6 +52,8 @@ function _clearSessionAndLogin() {
   localStorage.removeItem('hinglish_email');
   localStorage.removeItem('hinglish_name');
   if (typeof stopRealtime === 'function') stopRealtime();
+  clearInterval(window._clientDataTimer); window._clientDataTimer = null;
+  clearInterval(window._clientTokenTimer); window._clientTokenTimer = null;
   showLoginOverlay();
 }
 window._clearSessionAndLogin = _clearSessionAndLogin;
@@ -350,6 +352,20 @@ function activateRole(role) {
     if (loginOv) loginOv.classList.add('hidden');
     document.getElementById('client-view')?.classList.add('active');
     if (typeof loadPostsForClient === 'function') loadPostsForClient();
+    // Client data poll — 15s interval, same guards as agency startRealtime
+    if (!window._clientDataTimer) {
+      window._clientDataTimer = setInterval(async function() {
+        if (document.hidden) return;
+        if (!localStorage.getItem('sb_access_token')) return;
+        if (window.AppState.ui.modalOpen) return;
+        try {
+          if (typeof loadPostsForClient === 'function') loadPostsForClient();
+        } catch(err) {
+          console.warn('[auth] client data poll failed', err);
+          window.logError && window.logError(err && err.message, err && err.stack, 'client-data-poll');
+        }
+      }, 15000);
+    }
     if (!window._clientTokenTimer) {
       window._clientTokenTimer = setInterval(async function() {
         try {

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -356,11 +356,11 @@ function startRealtime() {
   if (window.AppState.timers.realtimeTimer) return;
 
   // Data polling  -  every 15 seconds (was 8s; reduces API calls & DOM churn)
+  // Always fetches and merges even while modal is open so AppState stays fresh.
+  // scheduleRender() already defers rendering when modalOpen — no data is lost.
   window.AppState.timers.realtimeTimer = setInterval(async () => {
     if (document.hidden) return;
     if (!localStorage.getItem('sb_access_token')) return;
-    // Skip poll while user is in a modal  -  they'll get fresh data on close
-    if (window.AppState.ui.modalOpen) return;
     try {
       const data  = await apiFetch('/posts?select=*&order=created_at.desc');
       const fresh = normalise(data);
@@ -595,10 +595,10 @@ function renderAll() {
   run('updateStats',        updateStats);
   run('roleVisibility',     applyRoleVisibility);
 
-  // Active tab detection  -  only render the visible tab
+  // Active tab detection
   const activeTab = document.querySelector('.tab-btn.active')?.dataset?.tab || 'tasks';
 
-  // Tasks tab widgets (always needed when tasks visible)
+  // Always render dashboard widgets (lightweight stats used by both views)
   if (activeTab === 'tasks') {
     run('dashboard',          renderDashboard);
     run('dashHdr',            updateDashboardHeader);
@@ -609,8 +609,11 @@ function renderAll() {
     run('nextPost',           renderNextPost);
     run('tasks',              renderTasks);
     run('taskStageChips',     renderTaskStageChips);
-  } else if (activeTab === 'pipeline') {
-    run('pipeline',           renderPipeline);
+  }
+
+  // Always render pipeline so its DOM is never stale when user switches to it
+  if (typeof renderPipeline === 'function') run('pipeline', renderPipeline);
+  if (activeTab === 'pipeline' && typeof updatePipelineHeader === 'function') {
     run('pipelineHdr',        updatePipelineHeader);
   }
 

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -86,6 +86,8 @@ async function quickStage(postId, newStage) {
   const oldStage = post.stage;
   setStage(post, newStage, 'quickStage');
   post._isSaving = true;
+  // Safety net: clear _isSaving after 30s in case PATCH hangs
+  var _qsSafetyTimer = setTimeout(function() { post._isSaving = false; }, 30000);
   console.log('[PCS] LOCAL UPDATE:', postId, newStage, Date.now());
   scheduleRender();
   try {
@@ -102,6 +104,7 @@ async function quickStage(postId, newStage) {
       if (server.stage) server.stage = toUiStage(server.stage);
       Object.assign(post, server);
     }
+    clearTimeout(_qsSafetyTimer);
     post._isSaving = false;
     scheduleRender();
     await logActivity({ post_id: postId, actor: actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}`, old_stage: oldStage, new_stage: newStage });
@@ -109,6 +112,7 @@ async function quickStage(postId, newStage) {
     if (_qsRecipients.length) window._sendStageNotif(postId, getTitle(post), newStage, _qsRecipients, actor);
     showUndoToast('Moved to ' + _stageLabel(newStage), function() { quickStage(postId, oldStage); });
   } catch (err) {
+    clearTimeout(_qsSafetyTimer);
     post._isSaving = false;
     setStage(post, oldStage, 'quickStage_rollback');
     scheduleRender();
@@ -222,6 +226,7 @@ async function clientApprove(postId, btn) {
     var oldStage = post.stage;
     setStage(post, 'scheduled', 'clientApprove');
     post._isSaving = true;
+    var _caSafetyTimer = setTimeout(function() { post._isSaving = false; }, 30000);
     try {
       // scheduled -> owner remains unchanged (per ownership rules)
       var rows = await apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
@@ -234,6 +239,7 @@ async function clientApprove(postId, btn) {
         if (server.stage) server.stage = toUiStage(server.stage);
         Object.assign(post, server);
       }
+      clearTimeout(_caSafetyTimer);
       post._isSaving = false;
       // Show confirmation UI
       var confirmEl = document.getElementById('approved-confirm-' + postId);
@@ -261,6 +267,7 @@ async function clientApprove(postId, btn) {
       await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled', old_stage: oldStage, new_stage: 'scheduled' });
       window._sendStageNotif(postId, getTitle(post), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || 'Client');
     } catch (err) {
+      clearTimeout(_caSafetyTimer);
       post._isSaving = false;
       setStage(post, oldStage, 'clientApprove_rollback');
       scheduleRender();
@@ -565,6 +572,8 @@ function _executeStageChange(postId, newStage) {
   const previousStage = post.stage;
   setStage(post, newStage, '_executeStageChange');
   post._isSaving = true;
+  // Safety net: clear _isSaving after 30s in case PATCH hangs
+  post._isSavingTimer = setTimeout(function() { post._isSaving = false; }, 30000);
   console.log('[PCS] LOCAL UPDATE:', postId, newStage, Date.now());
 
   // -- 2. Instant UI re-render (before DB) --
@@ -595,6 +604,7 @@ async function _executeStageChangeAsync(post, postId, newStage, previousStage) {
       if (server.stage) server.stage = toUiStage(server.stage);
       Object.assign(post, server);
     }
+    clearTimeout(post._isSavingTimer);
     post._isSaving = false;
 
     // FINAL TRUTH RENDER
@@ -605,6 +615,7 @@ async function _executeStageChangeAsync(post, postId, newStage, previousStage) {
   } catch (err) {
     console.error('[PCS] DB WRITE FAILED:', postId, err);
 
+    clearTimeout(post._isSavingTimer);
     post._isSaving = false;
     setStage(post, previousStage, '_executeStageChange_rollback');
 

--- a/10-ui.js
+++ b/10-ui.js
@@ -130,6 +130,13 @@ function _drainDeferredRender() {
     clearTimeout(window.AppState.timers.renderTimer);
     window.AppState.timers.renderTimer = setTimeout(safeRender, 60);
   }
+  // Fetch fresh server data after modal close so views are never stale
+  var _drRole = (window.AppState.user.effectiveRole || '').toLowerCase();
+  if (_drRole === 'client') {
+    if (typeof loadPostsForClient === 'function') loadPostsForClient();
+  } else {
+    if (typeof loadPosts === 'function') loadPosts();
+  }
 }
 
 // -- Undo toast --------------------------------
@@ -269,6 +276,8 @@ function switchTab(btn) {
   btn.classList.add('active');
   const tab = btn.dataset.tab;
   const panel = document.getElementById('panel-' + tab);
+  // Re-render BEFORE making the panel visible so the user never sees stale DOM
+  safeRender();
   if (panel) panel.classList.add('active');
   const titleEl = document.getElementById('app-header-title');
   var greetHdr = document.getElementById('dash-greeting-hdr');
@@ -277,6 +286,13 @@ function switchTab(btn) {
     if (greetHdr) greetHdr.style.display = 'none';
     var appHdr = document.querySelector('.app-header');
     if (appHdr) appHdr.style.display = 'none';
+    // Fetch fresh data so pipeline never shows stale stages
+    var _plRole = (window.AppState.user.effectiveRole || '').toLowerCase();
+    if (_plRole === 'client') {
+      if (typeof loadPostsForClient === 'function') loadPostsForClient();
+    } else {
+      if (typeof loadPosts === 'function') loadPosts();
+    }
   } else if (tab === 'tasks') {
     if (titleEl) titleEl.style.display = 'none';
     if (greetHdr) greetHdr.style.display = '';
@@ -294,7 +310,6 @@ function switchTab(btn) {
     window._taskFilter = null;
   }
   if (tab === 'updates') { loadNotifications(); }
-  safeRender();
   _fabAttachScroll();
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410j
+Version format: ?v=YYYYMMDDx. Current: ?v=20260410k
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -443,7 +443,7 @@ Pages branch:   main-/-root
 1. 04-router.js must always be LAST script tag
 1. apiFetch() never calls logout() on 401 — by design
 1. AppState.ui.modalOpen guards render — do not bypass
-1. 15-second poll interval, 50-minute token refresh
+1. 15-second poll interval, 50-minute token refresh (both agency AND client)
 1. Client DB role takes absolute priority over pcs_role_preview
 1. Silent .catch(function(){}) is a bug — always use window.logError
 1. Vitest must pass 508/508 before every push
@@ -2081,6 +2081,50 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    #505060→#606078. Stage pill arrow opacity .4→.6. Button borders
    #323244→#3a3a4a. Primary text (#F0F0F2), body text (#B8B8C0),
    role colors unchanged. 508/508 unit passing. Bumped to ?v=20260410j.
+1. Stale stages in Pipeline — Dashboard shows correct stage but
+   Pipeline shows old stage for the same post in the same session
+   Root cause: 7 cascading issues (audit confirmed all 7):
+   (a) switchTab('pipeline') never called loadPosts() — only
+       switchTab('tasks') did. Pipeline rendered from stale AppState.
+   (b) renderAll() only rendered the ACTIVE tab — inactive tab DOM
+       went stale whenever poll data arrived.
+   (c) Tab panel DOM was made visible BEFORE safeRender() ran, so
+       user saw stale HTML flash before re-render.
+   (d) Client role had zero data polling — only one-time fetch on
+       login, never refreshed post data.
+   (e) 15s poll skipped fetch entirely while modalOpen — AppState
+       went stale during PCS/modal use. scheduleRender already
+       defers rendering, so the modalOpen guard on fetch was wrong.
+   (f) _isSaving had no timeout — if a PATCH hung, the post was
+       permanently frozen in AppState (poll merge skipped it).
+   (g) index.html had no cache-control meta tags — browser could
+       serve stale HTML with old ?v= strings after deploy.
+   Location: 10-ui.js switchTab(), 07-post-load.js renderAll() +
+   startRealtime(), 03-auth.js activateRole() Client branch,
+   08-post-actions.js quickStage/_executeStageChange/clientApprove,
+   index.html <head>
+   Status: FIXED (PR#TBD) —
+   (a) switchTab: pipeline tab now calls loadPosts() (or
+       loadPostsForClient for client role) same as tasks tab.
+   (b) renderAll: pipeline always rendered regardless of active tab.
+       Dashboard widgets still only render when tasks tab active.
+   (c) switchTab: safeRender() moved BEFORE panel.classList.add
+       ('active') so DOM is rebuilt while panel is still hidden.
+       Duplicate safeRender() at end of switchTab removed.
+   (d) activateRole Client branch: added _clientDataTimer 15s
+       setInterval calling loadPostsForClient() with same guards
+       as agency polling (document.hidden, token check, modalOpen).
+       _clearSessionAndLogin clears both _clientDataTimer and
+       _clientTokenTimer.
+   (e) startRealtime: removed modalOpen guard from poll fetch.
+       Poll now always fetches and merges. scheduleRender() handles
+       render deferral. _drainDeferredRender: added loadPosts() /
+       loadPostsForClient() call so modal close gets fresh data.
+   (f) quickStage, clientApprove, _executeStageChange: added 30s
+       setTimeout safety net that clears _isSaving. Timer cleared
+       in both success and catch paths.
+   (g) index.html: added Cache-Control, Pragma, Expires meta tags.
+   508/508 unit passing. Bumped to ?v=20260410k.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -53,10 +53,13 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410j">
+ <link rel="stylesheet" href="styles.css?v=20260410k">
 
 </head>
 <body>
@@ -1079,27 +1082,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410j"></script>
-<script src="00-appstate-compat.js?v=20260410j"></script>
-<script src="01-config.js?v=20260410j" defer></script>
-<script src="02-session.js?v=20260410j" defer></script>
-<script src="utils.js?v=20260410j" defer></script>
-<script src="03-auth.js?v=20260410j" defer></script>
-<script src="05-api.js?v=20260410j" defer></script>
-<script src="10-ui.js?v=20260410j" defer></script>
+<script src="00-appstate.js?v=20260410k"></script>
+<script src="00-appstate-compat.js?v=20260410k"></script>
+<script src="01-config.js?v=20260410k" defer></script>
+<script src="02-session.js?v=20260410k" defer></script>
+<script src="utils.js?v=20260410k" defer></script>
+<script src="03-auth.js?v=20260410k" defer></script>
+<script src="05-api.js?v=20260410k" defer></script>
+<script src="10-ui.js?v=20260410k" defer></script>
 
-<script src="06-post-create.js?v=20260410j" defer></script>
-<script defer src="render/dashboard.js?v=20260410j"></script>
-<script defer src="render/client.js?v=20260410j"></script>
-<script defer src="render/pipeline.js?v=20260410j"></script>
-<script defer src="render/brief.js?v=20260410j"></script>
-<script defer src="actions/pcs.js?v=20260410j"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410j"></script>
-<script src="07-post-load.js?v=20260410j" defer></script>
-<script src="08-post-actions.js?v=20260410j" defer></script>
-<script src="09-library.js?v=20260410j" defer></script>
-<script src="09-approval.js?v=20260410j" defer></script>
-<script src="04-router.js?v=20260410j" defer></script>
+<script src="06-post-create.js?v=20260410k" defer></script>
+<script defer src="render/dashboard.js?v=20260410k"></script>
+<script defer src="render/client.js?v=20260410k"></script>
+<script defer src="render/pipeline.js?v=20260410k"></script>
+<script defer src="render/brief.js?v=20260410k"></script>
+<script defer src="actions/pcs.js?v=20260410k"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410k"></script>
+<script src="07-post-load.js?v=20260410k" defer></script>
+<script src="08-post-actions.js?v=20260410k" defer></script>
+<script src="09-library.js?v=20260410k" defer></script>
+<script src="09-approval.js?v=20260410k" defer></script>
+<script src="04-router.js?v=20260410k" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/tests/session-resilience.test.js
+++ b/tests/session-resilience.test.js
@@ -68,10 +68,13 @@ describe('LAYER 1 — refreshSession typed error returns', function() {
   });
 
   it('10. client 50-min timer handles auth_expired', function() {
-    var clientTimer = authSrc.match(/_clientTokenTimer[\s\S]{0,400}/);
+    var clientTimer = authSrc.match(/50 \* 60 \* 1000[\s\S]{0,50}/);
     expect(clientTimer).toBeTruthy();
-    expect(clientTimer[0]).toContain("result.error === 'auth_expired'");
-    expect(clientTimer[0]).toContain('_clearSessionAndLogin');
+    // Verify the 50-min timer block contains auth_expired handling
+    var timerBlock = authSrc.match(/_clientTokenTimer = setInterval[\s\S]{0,600}/);
+    expect(timerBlock).toBeTruthy();
+    expect(timerBlock[0]).toContain("result.error === 'auth_expired'");
+    expect(timerBlock[0]).toContain('_clearSessionAndLogin');
   });
 
   it('11. non-client 50-min timer handles auth_expired', function() {


### PR DESCRIPTION
…iews

7-layer fix for the critical trust bug where Pipeline showed old stages while Dashboard showed correct stages from the same AppState:

1. switchTab: pipeline tab now calls loadPosts() on switch (was tasks-only)
2. renderAll: pipeline always rendered regardless of active tab
3. switchTab: safeRender() before panel.active (no stale DOM flash)
4. Client role: added 15s data polling via _clientDataTimer
5. startRealtime: removed modalOpen guard from poll fetch; _drainDeferredRender now calls loadPosts on modal close
6. _isSaving: 30s timeout safety net on quickStage/clientApprove/_executeStageChange
7. index.html: added Cache-Control/Pragma/Expires meta tags

508/508 unit tests passing. Bumped to ?v=20260410k.

https://claude.ai/code/session_015tdrnrEBGE4cbLNFBdBptM