### PR TITLE
fix: fetch fresh data when switching to Pipeline tab

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -235,6 +235,8 @@ const _TAB_TITLES = {
   updates: 'Updates',
 };
 
+var _isFetchingPosts = false;
+
 function switchTab(btn) {
   if (typeof btn === 'string') {
     btn = document.querySelector('.tab-btn[data-tab="' + btn + '"]');
@@ -277,6 +279,11 @@ function switchTab(btn) {
     if (greetHdr) greetHdr.style.display = 'none';
     var appHdr = document.querySelector('.app-header');
     if (appHdr) appHdr.style.display = 'none';
+    // Fetch fresh data so pipeline never shows stale stages
+    if (!_isFetchingPosts && typeof loadPosts === 'function') {
+      _isFetchingPosts = true;
+      loadPosts().then(function() { _isFetchingPosts = false; }).catch(function() { _isFetchingPosts = false; });
+    }
   } else if (tab === 'tasks') {
     if (titleEl) titleEl.style.display = 'none';
     if (greetHdr) greetHdr.style.display = '';

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410j
+Version format: ?v=YYYYMMDDx. Current: ?v=20260410n
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -2084,6 +2084,19 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    #505060→#606078. Stage pill arrow opacity .4→.6. Button borders
    #323244→#3a3a4a. Primary text (#F0F0F2), body text (#B8B8C0),
    role colors unchanged. 508/508 unit passing. Bumped to ?v=20260410j.
+1. Pipeline tab shows stale stages after switching from Dashboard
+   Location: 10-ui.js switchTab() — tab === 'pipeline' branch had
+   no loadPosts() call. Tasks tab called loadPosts() on every switch
+   (line 287), but pipeline rendered from whatever stale data was
+   already in AppState.posts.all. If a stage changed in the DB while
+   the user was on Dashboard, pipeline showed the old stage until
+   the next 15s poll fired.
+   Status: FIXED (PR#TBD) — added loadPosts() call in pipeline
+   branch with _isFetchingPosts boolean guard to prevent double-
+   fetching on rapid tab spam. loadPosts() internally calls
+   mergePosts() + scheduleRender() so pipeline re-renders with
+   fresh server data automatically.
+   508/508 unit passing. Bumped to ?v=20260410n.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410j">
+ <link rel="stylesheet" href="styles.css?v=20260410n">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410j"></script>
-<script src="00-appstate-compat.js?v=20260410j"></script>
-<script src="01-config.js?v=20260410j" defer></script>
-<script src="02-session.js?v=20260410j" defer></script>
-<script src="utils.js?v=20260410j" defer></script>
-<script src="03-auth.js?v=20260410j" defer></script>
-<script src="05-api.js?v=20260410j" defer></script>
-<script src="10-ui.js?v=20260410j" defer></script>
+<script src="00-appstate.js?v=20260410n"></script>
+<script src="00-appstate-compat.js?v=20260410n"></script>
+<script src="01-config.js?v=20260410n" defer></script>
+<script src="02-session.js?v=20260410n" defer></script>
+<script src="utils.js?v=20260410n" defer></script>
+<script src="03-auth.js?v=20260410n" defer></script>
+<script src="05-api.js?v=20260410n" defer></script>
+<script src="10-ui.js?v=20260410n" defer></script>
 
-<script src="06-post-create.js?v=20260410j" defer></script>
-<script defer src="render/dashboard.js?v=20260410j"></script>
-<script defer src="render/client.js?v=20260410j"></script>
-<script defer src="render/pipeline.js?v=20260410j"></script>
-<script defer src="render/brief.js?v=20260410j"></script>
-<script defer src="actions/pcs.js?v=20260410j"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410j"></script>
-<script src="07-post-load.js?v=20260410j" defer></script>
-<script src="08-post-actions.js?v=20260410j" defer></script>
-<script src="09-library.js?v=20260410j" defer></script>
-<script src="09-approval.js?v=20260410j" defer></script>
-<script src="04-router.js?v=20260410j" defer></script>
+<script src="06-post-create.js?v=20260410n" defer></script>
+<script defer src="render/dashboard.js?v=20260410n"></script>
+<script defer src="render/client.js?v=20260410n"></script>
+<script defer src="render/pipeline.js?v=20260410n"></script>
+<script defer src="render/brief.js?v=20260410n"></script>
+<script defer src="actions/pcs.js?v=20260410n"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410n"></script>
+<script src="07-post-load.js?v=20260410n" defer></script>
+<script src="08-post-actions.js?v=20260410n" defer></script>
+<script src="09-library.js?v=20260410n" defer></script>
+<script src="09-approval.js?v=20260410n" defer></script>
+<script src="04-router.js?v=20260410n" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- **10-ui.js**: added `loadPosts()` call in `switchTab()` pipeline branch — pipeline was rendering from stale AppState data because only the Tasks tab fetched fresh server data on switch
- **10-ui.js**: added `_isFetchingPosts` boolean guard to prevent double-fetch on rapid tab spam
- **index.html**: version bump `?v=20260410j` → `?v=20260410n` (all 21 resources)
- **CLAUDE.md**: version updated, bug entry added

## Test plan
- [x] 508/508 unit tests passing
- [ ] Switch Dashboard → Pipeline rapidly — verify no double-fetch (check Network tab)
- [ ] Change a post stage in Supabase, switch to Pipeline — verify fresh stage shows
- [ ] Purge Cloudflare cache after merge

https://claude.ai/code/session_01MofNeTKC3hweFvRdsxLbCH