### PR TITLE
fix: smoke test 5 selector — match live data-card-id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2097,6 +2097,17 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    mergePosts() + scheduleRender() so pipeline re-renders with
    fresh server data automatically.
    508/508 unit passing. Bumped to ?v=20260410n.
+1. Post-deploy smoke test 5 timing out — wrong selector
+   Location: tests/e2e/live-smoke-schedule.spec.js line 107 — test
+   waited for #client-view [data-post-id], but live render/client.js
+   post card wrappers use data-card-id (the inner comment <input>
+   carries data-post-id, but it only renders for awaiting_approval
+   and awaiting_brand_input stages). Test never found a card,
+   timed out at 15000ms.
+   Status: FIXED (PR#TBD) — changed smoke test selector to
+   [data-card-id] to match live production code. Increased
+   timeout from 15000ms to 30000ms for CI headroom. Zero
+   production code changes — test-only fix. 508/508 unit passing.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/tests/e2e/live-smoke-schedule.spec.js
+++ b/tests/e2e/live-smoke-schedule.spec.js
@@ -104,8 +104,8 @@ test('5. client can open a post and comments/empty-state renders', async ({ page
   await page.goto(SITE_URL, { waitUntil: 'domcontentloaded', timeout: 20000 });
 
   // Wait for at least one post card in the client feed, then click.
-  const firstCard = page.locator('#client-view [data-post-id]').first();
-  await expect(firstCard).toBeVisible({ timeout: 15000 });
+  const firstCard = page.locator('#client-view [data-card-id]').first();
+  await expect(firstCard).toBeVisible({ timeout: 30000 });
   await firstCard.click();
 
   // Overlay may be PCS or the client post overlay; the comments


### PR DESCRIPTION
## Summary
- **tests/e2e/live-smoke-schedule.spec.js**: changed selector `[data-post-id]` → `[data-card-id]` to match live production code in `render/client.js`
- Timeout increased from 15000ms to 30000ms for CI headroom
- **CLAUDE.md**: bug entry added to Section 12

Live post card wrappers in render/client.js use `data-card-id`. The inner comment `<input>` uses `data-post-id` but only renders for `awaiting_approval`/`awaiting_brand_input` stages, so the test never matched any card and timed out at 15s.

Zero production code changes — test-only fix. No version bump needed.

## Test plan
- [x] 508/508 unit tests passing
- [ ] Verify post-deploy smoke CI workflow now passes on main

https://claude.ai/code/session_01MofNeTKC3hweFvRdsxLbCH