### PR TITLE
fix: PCS stage chip stale text after stage change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410n
+Version format: ?v=YYYYMMDDx. Current: ?v=20260410o
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -2097,6 +2097,31 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    mergePosts() + scheduleRender() so pipeline re-renders with
    fresh server data automatically.
    508/508 unit passing. Bumped to ?v=20260410n.
+1. PCS stage chip shows stale stage after stage change (CRITICAL)
+   Location: actions/pcs.js _renderPCS() line 213 — the topbar
+   stage element was initialized in index.html with id
+   "pcs-topbar-stage", but on every _renderPCS the code executed
+   topbarStage.id = 'pcs-stage-pill', permanently renaming the
+   element's id on the FIRST PCS open. On every subsequent open,
+   getElementById('pcs-topbar-stage') at line 210 returned null,
+   the entire update block (lines 211-221) was skipped, and the
+   stale innerHTML from the previous PCS open remained in the
+   DOM. This manifested as Pipeline correctly showing "Scheduled"
+   (reading post.stage from AppState.posts.all) while PCS showed
+   the old "Awaiting Approval" label from a previous open.
+   forcePCSReset() only resets styles/state — it does not rebuild
+   the DOM, so the renamed id persisted across opens until a full
+   page reload.
+   Status: FIXED (PR#TBD) — deleted the single line
+   `topbarStage.id = 'pcs-stage-pill';` at actions/pcs.js:213.
+   The element keeps its original id "pcs-topbar-stage" forever,
+   so getElementById always finds it and the stage label + overdue
+   badge always re-render with fresh post.stage. CSS class
+   .pcs-stage-pill is still assigned via className (line 212), so
+   styling is unchanged. Two e2e selectors in tests/e2e/pcs.spec.js
+   (TEST 4 line 152, TEST 7 line 179) updated from '#pcs-stage-pill'
+   to '#pcs-topbar-stage' to match the id that now persists.
+   508/508 unit passing. Bumped to ?v=20260410o.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -210,7 +210,6 @@ window._renderPCS = function(postId) {
   var topbarStage = document.getElementById('pcs-topbar-stage');
   if (topbarStage) {
     topbarStage.className = 'pcs-stage-pill';
-    topbarStage.id = 'pcs-stage-pill';
     if (isAdmin) {
       topbarStage.onclick = function(e) { e.stopPropagation(); window._pcsChipDrop(topbarStage, 'stage', id); };
     } else {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410n">
+ <link rel="stylesheet" href="styles.css?v=20260410o">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410n"></script>
-<script src="00-appstate-compat.js?v=20260410n"></script>
-<script src="01-config.js?v=20260410n" defer></script>
-<script src="02-session.js?v=20260410n" defer></script>
-<script src="utils.js?v=20260410n" defer></script>
-<script src="03-auth.js?v=20260410n" defer></script>
-<script src="05-api.js?v=20260410n" defer></script>
-<script src="10-ui.js?v=20260410n" defer></script>
+<script src="00-appstate.js?v=20260410o"></script>
+<script src="00-appstate-compat.js?v=20260410o"></script>
+<script src="01-config.js?v=20260410o" defer></script>
+<script src="02-session.js?v=20260410o" defer></script>
+<script src="utils.js?v=20260410o" defer></script>
+<script src="03-auth.js?v=20260410o" defer></script>
+<script src="05-api.js?v=20260410o" defer></script>
+<script src="10-ui.js?v=20260410o" defer></script>
 
-<script src="06-post-create.js?v=20260410n" defer></script>
-<script defer src="render/dashboard.js?v=20260410n"></script>
-<script defer src="render/client.js?v=20260410n"></script>
-<script defer src="render/pipeline.js?v=20260410n"></script>
-<script defer src="render/brief.js?v=20260410n"></script>
-<script defer src="actions/pcs.js?v=20260410n"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410n"></script>
-<script src="07-post-load.js?v=20260410n" defer></script>
-<script src="08-post-actions.js?v=20260410n" defer></script>
-<script src="09-library.js?v=20260410n" defer></script>
-<script src="09-approval.js?v=20260410n" defer></script>
-<script src="04-router.js?v=20260410n" defer></script>
+<script src="06-post-create.js?v=20260410o" defer></script>
+<script defer src="render/dashboard.js?v=20260410o"></script>
+<script defer src="render/client.js?v=20260410o"></script>
+<script defer src="render/pipeline.js?v=20260410o"></script>
+<script defer src="render/brief.js?v=20260410o"></script>
+<script defer src="actions/pcs.js?v=20260410o"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410o"></script>
+<script src="07-post-load.js?v=20260410o" defer></script>
+<script src="08-post-actions.js?v=20260410o" defer></script>
+<script src="09-library.js?v=20260410o" defer></script>
+<script src="09-approval.js?v=20260410o" defer></script>
+<script src="04-router.js?v=20260410o" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/tests/e2e/pcs.spec.js
+++ b/tests/e2e/pcs.spec.js
@@ -149,7 +149,7 @@ test('TEST 4 — Stage pill shows current stage label', async ({ page }) => {
 
   // Advance button was removed from the redesign; the stage pill
   // in the PCS topbar now shows the current stage label.
-  const stagePill = page.locator('#pcs-stage-pill');
+  const stagePill = page.locator('#pcs-topbar-stage');
   await expect(stagePill).toBeVisible({ timeout: 5000 });
   await expect(stagePill).not.toBeEmpty();
 
@@ -176,7 +176,7 @@ test('TEST 6 — PCS caption is visible', async ({ page }) => {
 test('TEST 7 — PCS stage pill opens dropdown', async ({ page }) => {
   await openPCSCard(page);
 
-  const stagePill = page.locator('#pcs-stage-pill');
+  const stagePill = page.locator('#pcs-topbar-stage');
   await expect(stagePill).toBeVisible({ timeout: 5000 });
 
   // Click the stage pill to open the chip dropdown


### PR DESCRIPTION
Deleted the single line in actions/pcs.js _renderPCS that permanently renamed the topbar stage element's id from pcs-topbar-stage to pcs-stage-pill on the first open. After the rename the second getElementById lookup returned null and the entire update block was skipped, leaving the previous stage label in the DOM while Pipeline correctly showed the new stage.

Updated two e2e selectors in tests/e2e/pcs.spec.js to the persistent id. Bumped all 21 version strings in index.html to ?v=20260410o.

https://claude.ai/code/session_01WSybrAPCf8L4cPNK8H9fTF