### PR TITLE
feat: open WhatsApp share button for in_production and scheduled stages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2171,6 +2171,25 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    fetch(), no blob, no async. Retained the "Downloading..." toast
    for user feedback. No other functions touched.
    508/508 unit passing. Bumped to ?v=20260410p.
+1. WhatsApp share button only available for awaiting_approval posts
+   Location: actions/pcs.js:198-200 (topbar WA icon) and
+   actions/pcs.js:771-774 (_buildWAHtml caption-pane section).
+   Both render gates accepted only _pcsRole === 'client' or
+   stageLC === 'awaiting_approval', so internal team members
+   (Admin/Servicing/Creative) could not preview in_production or
+   scheduled posts via WhatsApp without opening the full app. KV
+   previews are already seeded for every post at creation time
+   (06-post-create.js:322, render/brief.js:500), so the share URL
+   works for any stage — only the PCS render gates needed to widen.
+   Status: FIXED (PR#TBD) — added || stageLC === 'in_production'
+   || stageLC === 'scheduled' to both gates. Client view
+   engagement bar and card menu (render/client.js) intentionally
+   untouched — clients do not see in_production/scheduled posts.
+   Worker /generate-preview flow and hardcoded "Awaiting your
+   approval" OG description intentionally untouched — tracked as
+   a separate follow-up (KV previews would need regeneration on
+   stage change for stage-aware descriptions to propagate).
+   508/508 unit passing. Bumped to ?v=20260410r.
 1. Image download broken for new images.srtd.io CDN host
    Location: actions/pcs.js _pcsLbDownload() + _pcsSaveAllPhotos() —
    both functions only stripped the old r2.dev host prefix when

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -196,7 +196,7 @@ window._renderPCS = function(postId) {
   var topbarRight = document.getElementById('pcs-topbar-right');
   if (topbarRight) {
     var _showTopWA = post.caption && (
-      _pcsRole === 'client' || stageLC === 'awaiting_approval'
+      _pcsRole === 'client' || stageLC === 'awaiting_approval' || stageLC === 'in_production' || stageLC === 'scheduled'
     );
     topbarRight.innerHTML = _showTopWA
       ? '<button class="pcs-topbar-wa" onclick="window._sharePostOnWhatsApp(\'' + esc(id) + '\')">' +
@@ -770,7 +770,7 @@ function _buildLinkedInHtml(post, id, stageLC) {
 function _buildWAHtml(post, id, postId, stageLC) {
   var showWA = post.caption && (
     (window.AppState.user.effectiveRole || '').toLowerCase() === 'client' ||
-    stageLC === 'awaiting_approval'
+    stageLC === 'awaiting_approval' || stageLC === 'in_production' || stageLC === 'scheduled'
   );
   if (!showWA) return '';
   var _isDesktop = window.innerWidth > 768 && !('ontouchstart' in window);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410q">
+ <link rel="stylesheet" href="styles.css?v=20260410r">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410q"></script>
-<script src="00-appstate-compat.js?v=20260410q"></script>
-<script src="01-config.js?v=20260410q" defer></script>
-<script src="02-session.js?v=20260410q" defer></script>
-<script src="utils.js?v=20260410q" defer></script>
-<script src="03-auth.js?v=20260410q" defer></script>
-<script src="05-api.js?v=20260410q" defer></script>
-<script src="10-ui.js?v=20260410q" defer></script>
+<script src="00-appstate.js?v=20260410r"></script>
+<script src="00-appstate-compat.js?v=20260410r"></script>
+<script src="01-config.js?v=20260410r" defer></script>
+<script src="02-session.js?v=20260410r" defer></script>
+<script src="utils.js?v=20260410r" defer></script>
+<script src="03-auth.js?v=20260410r" defer></script>
+<script src="05-api.js?v=20260410r" defer></script>
+<script src="10-ui.js?v=20260410r" defer></script>
 
-<script src="06-post-create.js?v=20260410q" defer></script>
-<script defer src="render/dashboard.js?v=20260410q"></script>
-<script defer src="render/client.js?v=20260410q"></script>
-<script defer src="render/pipeline.js?v=20260410q"></script>
-<script defer src="render/brief.js?v=20260410q"></script>
-<script defer src="actions/pcs.js?v=20260410q"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410q"></script>
-<script src="07-post-load.js?v=20260410q" defer></script>
-<script src="08-post-actions.js?v=20260410q" defer></script>
-<script src="09-library.js?v=20260410q" defer></script>
-<script src="09-approval.js?v=20260410q" defer></script>
-<script src="04-router.js?v=20260410q" defer></script>
+<script src="06-post-create.js?v=20260410r" defer></script>
+<script defer src="render/dashboard.js?v=20260410r"></script>
+<script defer src="render/client.js?v=20260410r"></script>
+<script defer src="render/pipeline.js?v=20260410r"></script>
+<script defer src="render/brief.js?v=20260410r"></script>
+<script defer src="actions/pcs.js?v=20260410r"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410r"></script>
+<script src="07-post-load.js?v=20260410r" defer></script>
+<script src="08-post-actions.js?v=20260410r" defer></script>
+<script src="09-library.js?v=20260410r" defer></script>
+<script src="09-approval.js?v=20260410r" defer></script>
+<script src="04-router.js?v=20260410r" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Widened PCS WhatsApp share gate so internal team members (Admin/Servicing/Creative) can preview `in_production` and `scheduled` posts via WhatsApp without opening the full app.
- Both PCS entry points widened: topbar WA icon (`actions/pcs.js:199`) and `_buildWAHtml` caption-pane section (`actions/pcs.js:773`). Old gates accepted only `client` role or `awaiting_approval` stage.
- `render/client.js` intentionally untouched — clients do not see `in_production`/`scheduled` posts.
- Worker `/generate-preview` flow intentionally untouched — KV previews are already seeded at post creation time (`06-post-create.js:322`, `render/brief.js:500`), so the `srtd.io/p/XXXX` URL already resolves for every stage. Hardcoded `"Awaiting your approval"` OG description is a separate follow-up (would need KV regeneration on stage change to propagate).

## Files changed
- `actions/pcs.js` — two one-liner gate edits (lines 199, 773)
- `index.html` — 21 version strings bumped `?v=20260410q` → `?v=20260410r`
- `CLAUDE.md` — new SECTION 12 entry documenting the fix

## Test plan
- [x] 508/508 unit tests passing (`npx vitest run`)
- [ ] Open a post in `in_production` stage as Admin → WhatsApp icon visible in PCS topbar + Share on WhatsApp button visible in caption pane
- [ ] Open a post in `scheduled` stage as Admin → same
- [ ] Open a post in `awaiting_approval` stage → no regression, button still visible
- [ ] Open a post in `brief` stage → button still hidden
- [ ] Tap WhatsApp button → opens `wa.me` with `srtd.io/p/XXXX` URL, preview resolves

## Version bump
`?v=20260410r` across all 21 resources.

https://claude.ai/code/session_01NyKcyxxKmZpcriJoB93sxb