### PR TITLE
fix: PCS comment image lightbox accepts external URL array

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410q
+Version format: ?v=YYYYMMDDx. Current: ?v=20260410s
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -2204,6 +2204,35 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    bare R2 key is passed to the Worker, and download works for
    both legacy r2.dev URLs and new images.srtd.io URLs. No other
    functions touched. 508/508 unit passing. Bumped to ?v=20260410q.
+1. PCS comment image lightbox — onclick passed wrong arg shape,
+   lightbox opened blank / showed wrong photos
+   Location: actions/pcs.js _pcsOpenLightbox() line 1903. Original
+   signature was (postId, idx) — two parameters. Comment image
+   onclicks in _renderSingleClient (line 1124) and _renderSingleNote
+   (line 1258) pass three arguments: (postId, urlArray, indexOfUrl).
+   The URL array landed in the `idx` parameter, got assigned to
+   window._pcsLbIdx (an array, truthy), and _pcsLbImages was still
+   overwritten with post.images. Net effect: clicking a comment
+   image opened the lightbox, showed the post's main photos (if
+   any) indexed by garbage, and made download impossible. On posts
+   with no images the lightbox was blank.
+   Status: FIXED (PR#TBD) — widened _pcsOpenLightbox to
+   (postId, arg2, arg3). Detects Array.isArray(arg2) to tell
+   comment mode (external URL list) from post-grid mode (integer
+   index). Sets window._pcsLbImages to the external list in comment
+   mode, post.images in normal mode. Adds window._pcsLbReadonly
+   flag set true in comment mode so the admin action bar
+   (ADD/EDIT/SAVE/REMOVE) is hidden — those buttons operate on
+   post.images and would corrupt comment galleries. Download still
+   works because _pcsLbDownload reads _pcsLbImages which now holds
+   the correct comment URLs. Zero changes to comment rendering,
+   _pcsLbRender, or _pcsLbDownload. Existing post-grid onclicks
+   that pass (postId, integer) keep working via the non-array
+   branch. Client feed rendering untouched — clients still see no
+   comment images in the feed itself, but once a post opens in PCS
+   (agency side) the comment image thumbs are now viewable in the
+   lightbox as intended. 508/508 unit passing. Bumped to
+   ?v=20260410s.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1900,20 +1900,25 @@ window._pcsDoReplace = function(postId) {
   ta.focus();
 };
 
-window._pcsOpenLightbox = function(postId, idx) {
+window._pcsOpenLightbox = function(postId, arg2, arg3) {
+  var externalImgs = Array.isArray(arg2) ? arg2 : null;
+  var idx = externalImgs ? (arg3 || 0) : (arg2 || 0);
   var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
-  window._pcsLbImages = (post && Array.isArray(post.images)) ? post.images : [];
-  window._pcsLbIdx = idx || 0;
+  window._pcsLbImages = externalImgs
+    ? externalImgs
+    : ((post && Array.isArray(post.images)) ? post.images : []);
+  window._pcsLbIdx = idx;
+  window._pcsLbReadonly = !!externalImgs;
   _pcsLbRender();
   var lb = document.getElementById('pcs-lightbox');
   if (lb) { lb.style.display = 'flex'; document.body.style.overflow = 'hidden'; }
   var actionBar = document.getElementById('pcs-lb-action-bar');
   if (actionBar) {
     var _r = (window.AppState.user.effectiveRole || '').toLowerCase();
-    var _canManageLb = _r !== 'client';
+    var _canManageLb = _r !== 'client' && !window._pcsLbReadonly;
     actionBar.style.display = _canManageLb ? 'flex' : 'none';
   }
-}
+};
 
 window._pcsLbRender = function() {
   if (window._pcsLbEditMode) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410r">
+ <link rel="stylesheet" href="styles.css?v=20260410s">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410r"></script>
-<script src="00-appstate-compat.js?v=20260410r"></script>
-<script src="01-config.js?v=20260410r" defer></script>
-<script src="02-session.js?v=20260410r" defer></script>
-<script src="utils.js?v=20260410r" defer></script>
-<script src="03-auth.js?v=20260410r" defer></script>
-<script src="05-api.js?v=20260410r" defer></script>
-<script src="10-ui.js?v=20260410r" defer></script>
+<script src="00-appstate.js?v=20260410s"></script>
+<script src="00-appstate-compat.js?v=20260410s"></script>
+<script src="01-config.js?v=20260410s" defer></script>
+<script src="02-session.js?v=20260410s" defer></script>
+<script src="utils.js?v=20260410s" defer></script>
+<script src="03-auth.js?v=20260410s" defer></script>
+<script src="05-api.js?v=20260410s" defer></script>
+<script src="10-ui.js?v=20260410s" defer></script>
 
-<script src="06-post-create.js?v=20260410r" defer></script>
-<script defer src="render/dashboard.js?v=20260410r"></script>
-<script defer src="render/client.js?v=20260410r"></script>
-<script defer src="render/pipeline.js?v=20260410r"></script>
-<script defer src="render/brief.js?v=20260410r"></script>
-<script defer src="actions/pcs.js?v=20260410r"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410r"></script>
-<script src="07-post-load.js?v=20260410r" defer></script>
-<script src="08-post-actions.js?v=20260410r" defer></script>
-<script src="09-library.js?v=20260410r" defer></script>
-<script src="09-approval.js?v=20260410r" defer></script>
-<script src="04-router.js?v=20260410r" defer></script>
+<script src="06-post-create.js?v=20260410s" defer></script>
+<script defer src="render/dashboard.js?v=20260410s"></script>
+<script defer src="render/client.js?v=20260410s"></script>
+<script defer src="render/pipeline.js?v=20260410s"></script>
+<script defer src="render/brief.js?v=20260410s"></script>
+<script defer src="actions/pcs.js?v=20260410s"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410s"></script>
+<script src="07-post-load.js?v=20260410s" defer></script>
+<script src="08-post-actions.js?v=20260410s" defer></script>
+<script src="09-library.js?v=20260410s" defer></script>
+<script src="09-approval.js?v=20260410s" defer></script>
+<script src="04-router.js?v=20260410s" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
_pcsOpenLightbox signature widened from (postId, idx) to (postId, arg2, arg3). When arg2 is an array (comment images), uses the external URL list and hides EDIT/SAVE/REMOVE buttons via new _pcsLbReadonly flag. When arg2 is an integer (post grid), keeps existing post.images behavior. Fixes blank lightbox when tapping image attachments in PCS comments and internal notes.

https://claude.ai/code/session_01BqtGFsYELnDmYpiu2PxeLy