### PR TITLE
fix: stage change from Library — fallback to #pcs-post-id input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410q
+Version format: ?v=YYYYMMDDx. Current: ?v=20260410s
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -2204,6 +2204,19 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    bare R2 key is passed to the Worker, and download works for
    both legacy r2.dev URLs and new images.srtd.io URLs. No other
    functions touched. 508/508 unit passing. Bumped to ?v=20260410q.
+1. Stage change does nothing when PCS is opened from Library
+   Location: actions/pcs.js changeStage() line 836 — read postId
+   from window._pcs.postId only. libOpenCard() in 09-library.js
+   opens PCS without populating window._pcs.postId, so changeStage
+   early-returned at the `if (!postId) return;` guard and the
+   confirm sheet never appeared. The hidden #pcs-post-id input is
+   set by _renderPCS on every open regardless of entry path, so a
+   DOM fallback recovers the id.
+   Status: FIXED (PR#TBD) — added a fallback to read
+   document.getElementById('pcs-post-id').value when
+   window._pcs.postId is falsy. `const postId` switched to `var`
+   so the fallback can reassign. No other function touched.
+   508/508 unit passing. Bumped to ?v=20260410s.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -833,7 +833,11 @@ window._pcsTitleEdit = function(el, postId) {
 
 // -- Unified stage change with confirmation --
 window.changeStage = function(newStage) {
-  const postId = window._pcs.postId;
+  var postId = window._pcs.postId;
+  if (!postId) {
+    var el = document.getElementById('pcs-post-id');
+    if (el) postId = el.value;
+  }
   if (!postId) return;
   if (newStage === 'published') {
     _showPublishSheet(postId);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260410r">
+ <link rel="stylesheet" href="styles.css?v=20260410s">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260410r"></script>
-<script src="00-appstate-compat.js?v=20260410r"></script>
-<script src="01-config.js?v=20260410r" defer></script>
-<script src="02-session.js?v=20260410r" defer></script>
-<script src="utils.js?v=20260410r" defer></script>
-<script src="03-auth.js?v=20260410r" defer></script>
-<script src="05-api.js?v=20260410r" defer></script>
-<script src="10-ui.js?v=20260410r" defer></script>
+<script src="00-appstate.js?v=20260410s"></script>
+<script src="00-appstate-compat.js?v=20260410s"></script>
+<script src="01-config.js?v=20260410s" defer></script>
+<script src="02-session.js?v=20260410s" defer></script>
+<script src="utils.js?v=20260410s" defer></script>
+<script src="03-auth.js?v=20260410s" defer></script>
+<script src="05-api.js?v=20260410s" defer></script>
+<script src="10-ui.js?v=20260410s" defer></script>
 
-<script src="06-post-create.js?v=20260410r" defer></script>
-<script defer src="render/dashboard.js?v=20260410r"></script>
-<script defer src="render/client.js?v=20260410r"></script>
-<script defer src="render/pipeline.js?v=20260410r"></script>
-<script defer src="render/brief.js?v=20260410r"></script>
-<script defer src="actions/pcs.js?v=20260410r"></script>
-<script defer src="actions/pcs-longpress.js?v=20260410r"></script>
-<script src="07-post-load.js?v=20260410r" defer></script>
-<script src="08-post-actions.js?v=20260410r" defer></script>
-<script src="09-library.js?v=20260410r" defer></script>
-<script src="09-approval.js?v=20260410r" defer></script>
-<script src="04-router.js?v=20260410r" defer></script>
+<script src="06-post-create.js?v=20260410s" defer></script>
+<script defer src="render/dashboard.js?v=20260410s"></script>
+<script defer src="render/client.js?v=20260410s"></script>
+<script defer src="render/pipeline.js?v=20260410s"></script>
+<script defer src="render/brief.js?v=20260410s"></script>
+<script defer src="actions/pcs.js?v=20260410s"></script>
+<script defer src="actions/pcs-longpress.js?v=20260410s"></script>
+<script src="07-post-load.js?v=20260410s" defer></script>
+<script src="08-post-actions.js?v=20260410s" defer></script>
+<script src="09-library.js?v=20260410s" defer></script>
+<script src="09-approval.js?v=20260410s" defer></script>
+<script src="04-router.js?v=20260410s" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
changeStage() only read window._pcs.postId, which is not set when PCS is opened via libOpenCard() from the Library view. The hidden #pcs-post-id input is always populated by _renderPCS regardless of entry path, so fall back to it when window._pcs.postId is missing.