### PR TITLE
fix: resolve toggle for all comments (client + internal tabs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Root config files:
 ## SECTION 3 — FILE LOAD ORDER (sacred — matches index.html exactly)
 
 20 script tags + 1 stylesheet = 21 versioned resources total.
-Version format: ?v=YYYYMMDDx. Current: ?v=20260410s
+Version format: ?v=YYYYMMDDx. Current: ?v=20260411b
 
 styles.css               — all styles
 00-appstate.js           — AppState brain, NO defer, loads FIRST
@@ -2332,6 +2332,73 @@ window._pcsConfirmDeleteComment, window._pcsDoDeleteComment
    reads the same flag the timeout just cleared, so the next
    attempt goes through. 508/508 unit passing. Bumped to
    ?v=20260411a.
+1. Resolve toggle was one-way; only tasks could be resolved
+   Location: actions/pcs.js toggleTaskResolve() L2487 always
+   PATCHed { resolved: true } regardless of current state, so
+   "unresolve" was impossible. Resolve was also restricted to
+   task comments — long-press menu showed "Resolve task" only
+   when .pcs-task-check existed (pcs-longpress.js L69), and
+   the inline render code only emitted the "Resolved by"
+   label when (_isTask && c.resolved && c.resolved_by). Plain
+   comments and notes had no way to be marked resolved at all.
+   Status: FIXED (PR#TBD) —
+   (a) toggleTaskResolve now does a GET /post_comments or
+       /internal_notes ?id=eq.X&select=resolved first, branches
+       on the current value, and PATCHes either
+       { resolved:false, resolved_by:null } (unresolve) or
+       { resolved:true, resolved_by:user.name||'Admin' } (resolve).
+       All existing guards (commentId validation, post refresh
+       via loadPcsComments, error logging) preserved.
+   (b) _renderSingleClient and _renderSingleNote now wrap Reply
+       in a new .pcs-comment-actions flex row containing a new
+       .pcs-comment-resolve-btn span next to the existing
+       .pcs-comment-reply-btn (now also a span). Button label
+       is "Unresolve" when c.resolved, else "Resolve". onclick
+       calls toggleTaskResolve(c.id, postId, false) for client
+       comments and (..., true) for internal notes. Buttons are
+       NOT rendered on deleted comments (early-return branch
+       unchanged). Visibility tag rendering on notes preserved
+       intact.
+   (c) Resolved-by label guard widened from
+       (_isTask && c.resolved && c.resolved_by) to
+       (c.resolved && c.resolved_by) in both _renderSingleClient
+       and _renderSingleNote. Label HTML now prepends a
+       12x12 SVG checkmark circle (#3ECF8E stroke) before the
+       "Resolved by ..." text.
+   (d) loadPcsComments now splits clientRows into
+       activeClientRows and resolvedClientRows the same way
+       internalRows already split. Active rows render normally
+       via _renderClientThread; if resolvedClientRows.length,
+       a <details class="pcs-resolved-wrap"> accordion is
+       appended with a "↳ N Resolved Comment(s) (click to
+       expand)" summary, mirroring the existing internal-notes
+       accordion at L1389-1399. #pcs-comments-count is updated
+       to activeClientRows.length so the inline counter only
+       reflects unresolved comments; the tab badge
+       (#pcs-tab-client-count) still uses total clientRows.length.
+   (e) actions/pcs-longpress.js: removed the hasTask block that
+       rendered the "Resolve task" button (L69), removed the
+       resolveBtn click handler wiring (L123-129), removed the
+       now-unused _isTask helper. Long-press menu now only
+       shows Copy text / Reply / Delete / Cancel — Resolve has
+       moved into the visible action row on every comment.
+   (f) styles.css: .pcs-comment-actions repurposed from
+       display:none to display:flex with align-items:center,
+       gap:16px, margin-top:5px. .pcs-comment-actions
+       .pcs-comment-reply-btn margin-top reset to 0 so the
+       button no longer doubles up its existing 5px margin.
+       New .pcs-comment-resolve-btn rule mirrors
+       .pcs-comment-reply-btn exactly (IBM Plex Mono 9px
+       #8E8E93 .04em letter-spacing, no border, no padding,
+       cursor pointer). :active hover state #AEAEB2.
+   No opacity changes to resolved comments. No new
+   resolved-specific muting classes. Resolved comments simply
+   move into the accordion section and display the "Resolved
+   by" label. Tasks still render with their dotted-circle
+   .pcs-task-check checkbox; the inline Resolve button works
+   on tasks too (no conflict — both routes call
+   toggleTaskResolve via the same path).
+   508/508 unit passing. Bumped to ?v=20260411b.
 
 ## SECTION 13 — STABILITY ROADMAP
 

--- a/actions/pcs-longpress.js
+++ b/actions/pcs-longpress.js
@@ -30,10 +30,6 @@ console.log("LOADED:", "actions/pcs-longpress.js");
     return el ? el.value : '';
   }
 
-  function _isTask(item) {
-    return item && !!item.querySelector('.pcs-task-check');
-  }
-
   function _showMenu(item) {
     // Remove existing menu
     _removeMenu();
@@ -43,7 +39,6 @@ console.log("LOADED:", "actions/pcs-longpress.js");
     var author = item.getAttribute('data-author') || '';
     var postId = _getPostId();
     var isInternalNote = zone === 'note';
-    var hasTask = _isTask(item);
     var textEl = item.querySelector('.pcs-comment-text');
     var message = textEl ? textEl.textContent : '';
 
@@ -64,11 +59,6 @@ console.log("LOADED:", "actions/pcs-longpress.js");
     menu.className = 'pcs-lp-menu';
 
     var html = '';
-
-    // Resolve task button (only for task comments)
-    if (hasTask) {
-      html += '<button class="pcs-lp-item pcs-lp-resolve" id="pcs-lp-resolve">Resolve task</button>';
-    }
 
     html += '<button class="pcs-lp-item" id="pcs-lp-copy">Copy text</button>';
     html += '<button class="pcs-lp-item" id="pcs-lp-reply">Reply</button>';
@@ -117,14 +107,6 @@ console.log("LOADED:", "actions/pcs-longpress.js");
       _removeMenu();
       if (typeof window._pcsConfirmDeleteComment === 'function') {
         window._pcsConfirmDeleteComment(commentId, postId, isInternalNote);
-      }
-    });
-
-    var resolveBtn = document.getElementById('pcs-lp-resolve');
-    if (resolveBtn) resolveBtn.addEventListener('click', function() {
-      _removeMenu();
-      if (typeof window.toggleTaskResolve === 'function') {
-        window.toggleTaskResolve(commentId, postId, isInternalNote);
       }
     });
   }

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1131,8 +1131,9 @@ window.loadPcsComments = async function(postId) {
           }).join('') +
         '</div>';
       }
-      var _resolvedLabel = (_isTask && c.resolved && c.resolved_by)
-        ? '<div class="pcs-resolved-label">Resolved by ' + esc(c.resolved_by) + '</div>'
+      var _resolvedSvg = '<svg width="12" height="12" viewBox="0 0 18 18" style="vertical-align:middle;margin-right:3px"><circle cx="9" cy="9" r="7" fill="none" stroke="#3ECF8E" stroke-width="1.5"/><polyline points="6,9 8.5,11.5 12.5,6.5" fill="none" stroke="#3ECF8E" stroke-width="1.5"/></svg>';
+      var _resolvedLabel = (c.resolved && c.resolved_by)
+        ? '<div class="pcs-resolved-label">' + _resolvedSvg + 'Resolved by ' + esc(c.resolved_by) + '</div>'
         : '';
       var _escapedMsg = esc(c.message).replace(/'/g, '&#39;');
       var _cReactions = (window._pcsReactions && window._pcsReactions[c.id]) || [];
@@ -1144,6 +1145,7 @@ window.loadPcsComments = async function(postId) {
       _reactInner += _reactCount > 0
         ? '<span class="pcs-react-count">' + _reactCount + '</span>'
         : '';
+      var _resolveBtnLabel = c.resolved ? 'Unresolve' : 'Resolve';
       return '<div class="pcs-comment-item" data-comment-id="' + esc(c.id) + '" data-author="' + esc(c.author) + '">' +
         '<div class="pcs-cmt-av"><div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div></div>' +
         '<div class="pcs-cmt-mid">' +
@@ -1159,10 +1161,15 @@ window.loadPcsComments = async function(postId) {
           _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
           _imgHtml +
           _resolvedLabel +
-          '<div class="pcs-comment-reply-btn" ' +
-            'onclick="window._pcsSetReply(\'client\',\'' +
-            esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
-            _escapedMsg + '\')">Reply</div>' +
+          '<div class="pcs-comment-actions">' +
+            '<span class="pcs-comment-reply-btn" ' +
+              'onclick="window._pcsSetReply(\'client\',\'' +
+              esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
+              _escapedMsg + '\')">Reply</span>' +
+            '<span class="pcs-comment-resolve-btn" ' +
+              'onclick="toggleTaskResolve(\'' + esc(c.id) + '\',\'' + esc(postId) + '\',false)">' +
+              _resolveBtnLabel + '</span>' +
+          '</div>' +
         '</div>' +
         '<div class="pcs-cmt-rt pcs-comment-react' + (_myReact ? ' pcs-reacted' : '') + '" data-comment-id="' + esc(c.id) + '" onclick="window._pcsShowEmojiPicker(this)">' +
           _reactInner +
@@ -1265,8 +1272,9 @@ window.loadPcsComments = async function(postId) {
           }).join('') +
         '</div>';
       }
-      var _resolvedLabel = (_isTask && c.resolved && c.resolved_by)
-        ? '<div class="pcs-resolved-label">Resolved by ' + esc(c.resolved_by) + '</div>'
+      var _resolvedSvg = '<svg width="12" height="12" viewBox="0 0 18 18" style="vertical-align:middle;margin-right:3px"><circle cx="9" cy="9" r="7" fill="none" stroke="#3ECF8E" stroke-width="1.5"/><polyline points="6,9 8.5,11.5 12.5,6.5" fill="none" stroke="#3ECF8E" stroke-width="1.5"/></svg>';
+      var _resolvedLabel = (c.resolved && c.resolved_by)
+        ? '<div class="pcs-resolved-label">' + _resolvedSvg + 'Resolved by ' + esc(c.resolved_by) + '</div>'
         : '';
       var _escapedMsg = esc(c.message).replace(/'/g, '&#39;');
       var _cReactions = (window._pcsReactions && window._pcsReactions[c.id]) || [];
@@ -1278,6 +1286,7 @@ window.loadPcsComments = async function(postId) {
       _reactInner += _reactCount > 0
         ? '<span class="pcs-react-count">' + _reactCount + '</span>'
         : '';
+      var _resolveBtnLabel = c.resolved ? 'Unresolve' : 'Resolve';
       return '<div class="pcs-note-item' +
         (c.resolved ? ' pcs-resolved' : '') + '" data-comment-id="' + esc(c.id) + '" data-author="' + esc(c.author) + '">' +
         '<div class="pcs-cmt-av"><div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div></div>' +
@@ -1295,10 +1304,15 @@ window.loadPcsComments = async function(postId) {
           _taskPrefix + _highlightMentions(esc(c.message)) + '</div>' +
           _imgHtml +
           _resolvedLabel +
-          '<div class="pcs-comment-reply-btn" ' +
-            'onclick="window._pcsSetReply(\'note\',\'' +
-            esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
-            _escapedMsg + '\')">Reply</div>' +
+          '<div class="pcs-comment-actions">' +
+            '<span class="pcs-comment-reply-btn" ' +
+              'onclick="window._pcsSetReply(\'note\',\'' +
+              esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
+              _escapedMsg + '\')">Reply</span>' +
+            '<span class="pcs-comment-resolve-btn" ' +
+              'onclick="toggleTaskResolve(\'' + esc(c.id) + '\',\'' + esc(postId) + '\',true)">' +
+              _resolveBtnLabel + '</span>' +
+          '</div>' +
         '</div>' +
         '<div class="pcs-cmt-rt pcs-comment-react' + (_myReact ? ' pcs-reacted' : '') + '" data-comment-id="' + esc(c.id) + '" onclick="window._pcsShowEmojiPicker(this)">' +
           _reactInner +
@@ -1356,11 +1370,28 @@ window.loadPcsComments = async function(postId) {
       '<div class="pcs-empty-text">No client comments yet.<br>Client and team see this thread.</div>' +
       '</div>';
 
-    list.innerHTML = _renderClientThread(clientRows, emptyClient);
+    var resolvedClientRows = clientRows.filter(function(c) { return c.resolved; });
+    var activeClientRows = clientRows.filter(function(c) { return !c.resolved; });
+
+    var clientHtml = _renderClientThread(activeClientRows, emptyClient);
+
+    if (resolvedClientRows.length) {
+      clientHtml +=
+        '<details class="pcs-resolved-wrap">' +
+        '<summary class="pcs-resolved-summary">' +
+        '\u21B3 ' + resolvedClientRows.length +
+        ' Resolved Comment' +
+        (resolvedClientRows.length > 1 ? 's' : '') +
+        ' (click to expand)</summary>' +
+        _renderClientThread(resolvedClientRows, '') +
+        '</details>';
+    }
+
+    list.innerHTML = clientHtml;
 
     var countEl = document.getElementById('pcs-comments-count');
     if (countEl) {
-      countEl.textContent = clientRows.length;
+      countEl.textContent = activeClientRows.length;
     }
 
     // Update tab count badge
@@ -2489,14 +2520,18 @@ window.toggleTaskResolve = function(commentId, postId, isInternalNote) {
     console.warn('toggleTaskResolve: missing or invalid commentId, aborting');
     return;
   }
-  var _endpoint = (isInternalNote ? '/internal_notes' : '/post_comments') + '?id=eq.' + commentId;
-  apiFetch(_endpoint, {
-    method: 'PATCH',
-    headers: {'Prefer': 'return=minimal'},
-    body: JSON.stringify({
-      resolved: true,
-      resolved_by: window.AppState.user.name || 'Admin'
-    })
+  var _table = isInternalNote ? '/internal_notes' : '/post_comments';
+  var _endpoint = _table + '?id=eq.' + commentId;
+  apiFetch(_table + '?id=eq.' + commentId + '&select=resolved').then(function(rows) {
+    var _isResolved = !!(rows && rows[0] && rows[0].resolved);
+    var _payload = _isResolved
+      ? { resolved: false, resolved_by: null }
+      : { resolved: true, resolved_by: window.AppState.user.name || 'Admin' };
+    return apiFetch(_endpoint, {
+      method: 'PATCH',
+      headers: {'Prefer': 'return=minimal'},
+      body: JSON.stringify(_payload)
+    });
   }).then(function() {
     loadPcsComments(postId);
   }).catch(function(e) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411a">
+ <link rel="stylesheet" href="styles.css?v=20260411b">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411a"></script>
-<script src="00-appstate-compat.js?v=20260411a"></script>
-<script src="01-config.js?v=20260411a" defer></script>
-<script src="02-session.js?v=20260411a" defer></script>
-<script src="utils.js?v=20260411a" defer></script>
-<script src="03-auth.js?v=20260411a" defer></script>
-<script src="05-api.js?v=20260411a" defer></script>
-<script src="10-ui.js?v=20260411a" defer></script>
+<script src="00-appstate.js?v=20260411b"></script>
+<script src="00-appstate-compat.js?v=20260411b"></script>
+<script src="01-config.js?v=20260411b" defer></script>
+<script src="02-session.js?v=20260411b" defer></script>
+<script src="utils.js?v=20260411b" defer></script>
+<script src="03-auth.js?v=20260411b" defer></script>
+<script src="05-api.js?v=20260411b" defer></script>
+<script src="10-ui.js?v=20260411b" defer></script>
 
-<script src="06-post-create.js?v=20260411a" defer></script>
-<script defer src="render/dashboard.js?v=20260411a"></script>
-<script defer src="render/client.js?v=20260411a"></script>
-<script defer src="render/pipeline.js?v=20260411a"></script>
-<script defer src="render/brief.js?v=20260411a"></script>
-<script defer src="actions/pcs.js?v=20260411a"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411a"></script>
-<script src="07-post-load.js?v=20260411a" defer></script>
-<script src="08-post-actions.js?v=20260411a" defer></script>
-<script src="09-library.js?v=20260411a" defer></script>
-<script src="09-approval.js?v=20260411a" defer></script>
-<script src="04-router.js?v=20260411a" defer></script>
+<script src="06-post-create.js?v=20260411b" defer></script>
+<script defer src="render/dashboard.js?v=20260411b"></script>
+<script defer src="render/client.js?v=20260411b"></script>
+<script defer src="render/pipeline.js?v=20260411b"></script>
+<script defer src="render/brief.js?v=20260411b"></script>
+<script defer src="actions/pcs.js?v=20260411b"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411b"></script>
+<script src="07-post-load.js?v=20260411b" defer></script>
+<script src="08-post-actions.js?v=20260411b" defer></script>
+<script src="09-library.js?v=20260411b" defer></script>
+<script src="09-approval.js?v=20260411b" defer></script>
+<script src="04-router.js?v=20260411b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6320,7 +6320,28 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 .pcs-comment-actions {
-  display: none;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 5px;
+}
+
+.pcs-comment-actions .pcs-comment-reply-btn {
+  margin-top: 0;
+}
+
+.pcs-comment-resolve-btn {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #8E8E93;
+  letter-spacing: .04em;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+.pcs-comment-resolve-btn:active {
+  color: #AEAEB2;
 }
 
 .pcs-comment-action {


### PR DESCRIPTION
## Summary
Extends resolve/unresolve to every comment (not just tasks) on both the PCS client tab and the internal notes tab.

## Changes
- **actions/pcs.js** — `toggleTaskResolve` now does a `GET ?select=resolved` first and toggles between `{resolved:true, resolved_by:name}` and `{resolved:false, resolved_by:null}` instead of always setting true. `_renderSingleClient` and `_renderSingleNote` wrap Reply + new Resolve/Unresolve button in a `.pcs-comment-actions` flex row. "Resolved by" label guard widened from `_isTask && c.resolved && c.resolved_by` to `c.resolved && c.resolved_by`, and the label now includes a 12x12 green checkmark SVG. `loadPcsComments` splits `clientRows` into active + resolved and appends a resolved-comments accordion mirroring the existing notes accordion.
- **actions/pcs-longpress.js** — removed the "Resolve task" button, its click handler, and the now-unused `_isTask` helper. Menu now shows Copy/Reply/Delete/Cancel only.
- **styles.css** — `.pcs-comment-actions` repurposed from `display:none` to `display:flex` with gap 16px, margin-top 5px. New `.pcs-comment-resolve-btn` rule mirrors `.pcs-comment-reply-btn` exactly.
- **index.html** — all 21 `?v=` strings bumped to `?v=20260411b`.
- **CLAUDE.md** — bug status logged in Section 12; current version updated in Section 3.

## Test plan
- [x] Unit tests: 508/508 passing (`npx vitest run`)
- [ ] Resolve button visible next to Reply on every client comment
- [ ] Resolve button visible next to Reply on every internal note
- [ ] Tap Resolve → comment moves to accordion, "Resolved by [name]" label appears with green checkmark, button flips to "Unresolve"
- [ ] Tap Unresolve → comment returns to active list, label disappears, button flips back to "Resolve"
- [ ] Client tab resolved accordion appears at bottom when resolved comments exist
- [ ] Internal tab resolved accordion still works (existing feature)
- [ ] Long-press menu shows Copy/Reply/Delete/Cancel only — no "Resolve task"
- [ ] Tasks still render with dotted circle + TASK chip, resolve works on them
- [ ] Deleted comments do not show Resolve button

https://claude.ai/code/session_01BAbHcYKZWmzWqQbMW8TgJW