### PR TITLE
feat(client): visual revamp of client comment rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411b">
+ <link rel="stylesheet" href="styles.css?v=20260411c">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411b"></script>
-<script src="00-appstate-compat.js?v=20260411b"></script>
-<script src="01-config.js?v=20260411b" defer></script>
-<script src="02-session.js?v=20260411b" defer></script>
-<script src="utils.js?v=20260411b" defer></script>
-<script src="03-auth.js?v=20260411b" defer></script>
-<script src="05-api.js?v=20260411b" defer></script>
-<script src="10-ui.js?v=20260411b" defer></script>
+<script src="00-appstate.js?v=20260411c"></script>
+<script src="00-appstate-compat.js?v=20260411c"></script>
+<script src="01-config.js?v=20260411c" defer></script>
+<script src="02-session.js?v=20260411c" defer></script>
+<script src="utils.js?v=20260411c" defer></script>
+<script src="03-auth.js?v=20260411c" defer></script>
+<script src="05-api.js?v=20260411c" defer></script>
+<script src="10-ui.js?v=20260411c" defer></script>
 
-<script src="06-post-create.js?v=20260411b" defer></script>
-<script defer src="render/dashboard.js?v=20260411b"></script>
-<script defer src="render/client.js?v=20260411b"></script>
-<script defer src="render/pipeline.js?v=20260411b"></script>
-<script defer src="render/brief.js?v=20260411b"></script>
-<script defer src="actions/pcs.js?v=20260411b"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411b"></script>
-<script src="07-post-load.js?v=20260411b" defer></script>
-<script src="08-post-actions.js?v=20260411b" defer></script>
-<script src="09-library.js?v=20260411b" defer></script>
-<script src="09-approval.js?v=20260411b" defer></script>
-<script src="04-router.js?v=20260411b" defer></script>
+<script src="06-post-create.js?v=20260411c" defer></script>
+<script defer src="render/dashboard.js?v=20260411c"></script>
+<script defer src="render/client.js?v=20260411c"></script>
+<script defer src="render/pipeline.js?v=20260411c"></script>
+<script defer src="render/brief.js?v=20260411c"></script>
+<script defer src="actions/pcs.js?v=20260411c"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411c"></script>
+<script src="07-post-load.js?v=20260411c" defer></script>
+<script src="08-post-actions.js?v=20260411c" defer></script>
+<script src="09-library.js?v=20260411c" defer></script>
+<script src="09-approval.js?v=20260411c" defer></script>
+<script src="04-router.js?v=20260411c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -553,49 +553,62 @@ console.log('LOADED:', 'render/client.js');
 
   var ICON_PERSON = '<svg viewBox="0 0 24 24" fill="none" stroke="#3a3a3a" stroke-width="1.5" width="16" height="16"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>';
 
+  var _CLIENT_AVATAR_PALETTE = {
+    client:    { bg: '#FF6B8A30', fg: '#FF6B8A' },
+    servicing: { bg: '#22D3EE30', fg: '#22D3EE' },
+    admin:     { bg: '#C4A44A30', fg: '#C4A44A' },
+    creative:  { bg: '#9b87f530', fg: '#9b87f5' }
+  };
+
+  function _clientAvatarColors(role) {
+    var k = (role || '').toLowerCase();
+    return _CLIENT_AVATAR_PALETTE[k] || { bg: '#40405030', fg: '#A0A0B0' };
+  }
+
+  function _highlightClientMentions(escapedText) {
+    return escapedText.replace(/@(\w+)/g, '<span style="color:#4A9FD8;font-weight:600;">@$1</span>');
+  }
+
   function _singleCommentHtml(c) {
-    var isClient = (c.author_role || '').toLowerCase() === 'client';
-    var color = _roleColor(c.author_role);
+    var cid = _esc(c.id || '');
+    if (c.deleted) {
+      return '<div style="display:flex;gap:10px;padding:8px 14px;align-items:center;">' +
+        '<div style="width:28px;height:28px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;background:#40405030;font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:700;color:#404050;">?</div>' +
+        '<div class="client-comment-tombstone">This message was deleted.</div>' +
+      '</div>';
+    }
+    var palette = _clientAvatarColors(c.author_role);
     var initial = (c.author || '?').charAt(0).toUpperCase();
     var roleLabel = _esc((c.author_role || '').toUpperCase());
     var ts = _relativeTime(c.created_at);
-    var avatarInner = isClient
-      ? ICON_PERSON
-      : _esc(initial);
-    var avatarStyle = isClient
-      ? 'width:28px;height:28px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;background:#111111;'
-      : 'width:28px;height:28px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:700;color:' + color + ';background:' + color + '1F;';
-    return '<div style="display:flex;gap:8px;padding:6px 14px;">' +
-      '<div style="' + avatarStyle + '">' + avatarInner + '</div>' +
+    var avatarStyle = 'width:28px;height:28px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:700;color:' + palette.fg + ';background:' + palette.bg + ';';
+    var messageHtml = _highlightClientMentions(_esc(c.message || ''));
+    return '<div style="display:flex;gap:10px;padding:10px 14px;">' +
+      '<div style="' + avatarStyle + '">' + _esc(initial) + '</div>' +
       '<div style="flex:1;min-width:0;">' +
         '<div style="display:flex;align-items:baseline;flex-wrap:wrap;gap:6px;">' +
-          '<span style="font-family:\'DM Sans\',sans-serif;font-weight:600;font-size:12px;color:#ccc;">' + _esc(c.author) + '</span>' +
-          '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;text-transform:uppercase;color:#8E8E93;">' + roleLabel + '</span>' +
-          '<span style="margin-left:auto;font-family:\'IBM Plex Mono\',monospace;font-size:10px;color:#8E8E93;">' + ts + '</span>' +
+          '<span style="font-family:\'DM Sans\',sans-serif;font-weight:700;font-size:14px;color:#FFFFFF;">' + _esc(c.author) + '</span>' +
+          '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;font-weight:600;text-transform:uppercase;color:#A0A0B0;">' + roleLabel + '</span>' +
+          '<span style="margin-left:auto;font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#909098;">' + ts + '</span>' +
         '</div>' +
-        '<div style="font-family:\'DM Sans\',sans-serif;font-size:13px;color:#999;line-height:1.5;margin-top:2px;white-space:pre-wrap;">' + _esc(c.message) + '</div>' +
-        '<div class="pcs-comment-actions">' +
-        '<span class="pcs-comment-action" ' +
-          'onclick="window._clientSetReply(\'' +
-          _esc(c.id || '') + '\',\'' + _esc(c.author || '') + '\',\'' +
-          _esc(c.post_id || '') + '\')">REPLY</span>' +
-        '<span class="pcs-comment-action" ' +
-          'onclick="window._pcsCopyComment(\'' +
-          _esc(c.message || '') + '\')">COPY</span>' +
-        ((c.author === window.AppState.user.name || (window.AppState.user.effectiveRole || '').toLowerCase() === 'admin')
-          ? '<span class="pcs-comment-action" ' +
-            'onclick="window._pcsConfirmDeleteComment(\'' +
-            _esc(c.id || '') + '\',\'' + _esc(c.post_id || '') + '\')">DELETE</span>'
-          : '') +
+        '<div style="font-family:\'DM Sans\',sans-serif;font-size:14px;color:#E0E0E8;line-height:1.55;margin-top:3px;white-space:pre-wrap;">' + messageHtml + '</div>' +
+        '<div class="client-comment-actions">' +
+          '<span class="pcs-comment-react" data-comment-id="' + cid + '" ' +
+            'onclick="window._pcsShowEmojiPicker(this)">' +
+            '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="#B0B0B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:5px;"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>' +
+            'Like' +
+          '</span>' +
+          '<span style="color:#505058;font-size:12px;">|</span>' +
+          '<span onclick="window._clientSetReply(\'' +
+            cid + '\',\'' + _esc(c.author || '') + '\',\'' +
+            _esc(c.post_id || '') + '\')">Reply</span>' +
         '</div>' +
       '</div>' +
     '</div>';
   }
 
   function _commentsListHtml(post) {
-    var visibleComments = (post.post_comments || []).filter(function(c) {
-      return !c.deleted;
-    });
+    var visibleComments = (post.post_comments || []);
     if (!visibleComments.length) return '';
     var pid = _esc(post.post_id || post.id || '');
     var show = visibleComments.length <= 3 ? visibleComments : visibleComments.slice(0, 3);

--- a/styles.css
+++ b/styles.css
@@ -5576,13 +5576,13 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 /* CLIENT COMMENTS SECTION */
 .client-comments-section {
   background: #191924;
-  border: 1px solid #FFFFFF1F;
+  border: 1px solid #2A2A34;
   box-shadow: inset 0 1px 0 #FFFFFF0A;
   margin-bottom: 3px;
 }
 .client-section-header {
   padding: 12px 16px 10px;
-  border-bottom: 1px solid #FFFFFF0D;
+  border-bottom: 1px solid #2A2A34;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -5604,7 +5604,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   letter-spacing: 0.08em;
 }
 .client-input-zone {
-  border-top: 1px solid #FFFFFF0D;
+  border-top: 1px solid #2A2A34;
   padding: 10px 16px 12px;
   background: #191924;
   display: flex;
@@ -5614,6 +5614,25 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .client-input-zone .pcs-textarea {
   background: #00000040;
   border: 1px solid #FFFFFF14;
+}
+.client-comment-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 8px;
+}
+.client-comment-actions span {
+  cursor: pointer;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  color: #B0B0B8;
+}
+.client-comment-tombstone {
+  font-size: 13px;
+  color: #606068;
+  font-style: italic;
+  padding: 8px 0;
 }
 
 /* INTERNAL NOTES SECTION */


### PR DESCRIPTION
## Summary
Foundation PR for all future client-view upgrades. Touches **only** `_singleCommentHtml` output + related CSS — no new features, no schema/API/data changes. Zero changes to `actions/pcs.js`, zero changes to `_commentInputHtml`, zero changes to `_handleSubmitComment`.

## Changes

### render/client.js — `_singleCommentHtml` rewrite
- **Colored avatars** (28px circle, IBM Plex Mono 10px bold first letter) replacing the grey `ICON_PERSON` SVG for client authors and the generic initial for team:
  - Client: `#FF6B8A30` / `#FF6B8A`
  - Servicing: `#22D3EE30` / `#22D3EE`
  - Admin: `#C4A44A30` / `#C4A44A`
  - Creative: `#9b87f530` / `#9b87f5`
  - Fallback: `#40405030` / `#A0A0B0`
- **Brighter typography**
  - Author name: `#FFFFFF`, DM Sans 700, 14px
  - Role badge: `#A0A0B0`, IBM Plex Mono 600, 9px uppercase
  - Timestamp: `#909098`, IBM Plex Mono, 9px
  - Message body: `#E0E0E8`, DM Sans 14px, line-height 1.55
- **@mention highlighting** — new helper `_highlightClientMentions()` wraps `@word` in `<span style="color:#4A9FD8;font-weight:600">` after HTML escape (regex-based, same spirit as PCS `_highlightMentions`)
- **Action row restructure** — replaces scattered `REPLY` / `COPY` / `DELETE` text buttons:
  - `Like` text + 18×18 heart SVG stroke `#B0B0B8`, wired to existing `window._pcsShowEmojiPicker(this)` via class `pcs-comment-react` + `data-comment-id`, so reactions work day-one on the client view
  - `|` separator (`#505058` 12px)
  - `Reply` text, onclick still calls `window._clientSetReply(...)`
  - Old `COPY` and `DELETE` buttons removed from the visible row (moving to a 3-dot menu in a later PR)
- **Deleted-comment tombstone** — early-return when `c.deleted` is true: grey `?` avatar (`#40405030`/`#404050`) + `This message was deleted.` in italic `#606068`, no actions. `_commentsListHtml` no longer filters deleted rows so the tombstone can actually render.

### styles.css — client comment section
- Dividers bumped to `#2A2A34`:
  - `.client-comments-section` border
  - `.client-section-header` border-bottom
  - `.client-input-zone` border-top
- New rules:
  - `.client-comment-actions` — flex row, gap 14px, margin-top 8px
  - `.client-comment-actions span` — DM Sans 500, 13px, `#B0B0B8`, cursor pointer
  - `.client-comment-tombstone` — 13px italic `#606068`, padding 8px 0

### index.html — version bump
All 21 versioned resources: `?v=20260411b` → `?v=20260411c`

## What this PR does NOT change
- `actions/pcs.js` — untouched
- `_commentInputHtml` — untouched (separate PR)
- `_handleSubmitComment` — untouched
- Any API calls, data loading, or schema
- PCS comment section — no visual regression possible (file untouched)
- No threading, no reactions display, no comment image rendering, no resolve labels, no 3-dot menu — all tracked for separate PRs

## Test plan
- [x] `./node_modules/.bin/vitest run` → **508/508 passing**
- [ ] Client comment avatars render with correct role colors
- [ ] Author name is white/bold, role badge visible uppercase, timestamp readable
- [ ] Message body is bright `#E0E0E8`
- [ ] `@mention` highlighted in `#4A9FD8`
- [ ] `Like | Reply` row appears on every comment
- [ ] Tapping `Like` opens the existing PCS emoji picker
- [ ] Deleted comments show the tombstone row
- [ ] No visual regression in PCS comment section (actions/pcs.js untouched)

## Deployment notes
- Version bumped to `?v=20260411c` on all 21 resources
- Purge Cloudflare cache after merge
- No CLAUDE.md update: visual-only change, no architectural/schema/gotcha shifts

https://claude.ai/code/session_01D8fsKvkbJMjNmvSzvf7m6X