### PR TITLE
feat(client): comment images + reply threading + emoji picker bounds

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -2767,11 +2767,21 @@ window._pcsShowEmojiPicker = function(reactEl) {
     picker.appendChild(btn);
   });
   var _rect = reactEl.getBoundingClientRect();
+  var _PICKER_W = 220; // approx: 6 btns * 32 + 5 gaps * 2 + padding + border
   picker.style.position = 'fixed';
   picker.style.top = (_rect.top - 40) + 'px';
-  picker.style.right = (window.innerWidth - _rect.right) + 'px';
   picker.style.bottom = 'auto';
-  picker.style.left = 'auto';
+  // Right-anchor by default (correct for PCS .pcs-cmt-rt column).
+  // If right-anchoring would push the picker off the left edge,
+  // switch to left-anchoring so it stays on-screen (client view
+  // Like span is left-aligned and triggers this branch).
+  if (_rect.right - _PICKER_W < 8) {
+    picker.style.left = Math.max(8, _rect.left) + 'px';
+    picker.style.right = 'auto';
+  } else {
+    picker.style.right = (window.innerWidth - _rect.right) + 'px';
+    picker.style.left = 'auto';
+  }
   document.body.appendChild(picker);
 
   // Close on outside click

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411c">
+ <link rel="stylesheet" href="styles.css?v=20260411d">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411c"></script>
-<script src="00-appstate-compat.js?v=20260411c"></script>
-<script src="01-config.js?v=20260411c" defer></script>
-<script src="02-session.js?v=20260411c" defer></script>
-<script src="utils.js?v=20260411c" defer></script>
-<script src="03-auth.js?v=20260411c" defer></script>
-<script src="05-api.js?v=20260411c" defer></script>
-<script src="10-ui.js?v=20260411c" defer></script>
+<script src="00-appstate.js?v=20260411d"></script>
+<script src="00-appstate-compat.js?v=20260411d"></script>
+<script src="01-config.js?v=20260411d" defer></script>
+<script src="02-session.js?v=20260411d" defer></script>
+<script src="utils.js?v=20260411d" defer></script>
+<script src="03-auth.js?v=20260411d" defer></script>
+<script src="05-api.js?v=20260411d" defer></script>
+<script src="10-ui.js?v=20260411d" defer></script>
 
-<script src="06-post-create.js?v=20260411c" defer></script>
-<script defer src="render/dashboard.js?v=20260411c"></script>
-<script defer src="render/client.js?v=20260411c"></script>
-<script defer src="render/pipeline.js?v=20260411c"></script>
-<script defer src="render/brief.js?v=20260411c"></script>
-<script defer src="actions/pcs.js?v=20260411c"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411c"></script>
-<script src="07-post-load.js?v=20260411c" defer></script>
-<script src="08-post-actions.js?v=20260411c" defer></script>
-<script src="09-library.js?v=20260411c" defer></script>
-<script src="09-approval.js?v=20260411c" defer></script>
-<script src="04-router.js?v=20260411c" defer></script>
+<script src="06-post-create.js?v=20260411d" defer></script>
+<script defer src="render/dashboard.js?v=20260411d"></script>
+<script defer src="render/client.js?v=20260411d"></script>
+<script defer src="render/pipeline.js?v=20260411d"></script>
+<script defer src="render/brief.js?v=20260411d"></script>
+<script defer src="actions/pcs.js?v=20260411d"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411d"></script>
+<script src="07-post-load.js?v=20260411d" defer></script>
+<script src="08-post-actions.js?v=20260411d" defer></script>
+<script src="09-library.js?v=20260411d" defer></script>
+<script src="09-approval.js?v=20260411d" defer></script>
+<script src="04-router.js?v=20260411d" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -569,11 +569,44 @@ console.log('LOADED:', 'render/client.js');
     return escapedText.replace(/@(\w+)/g, '<span style="color:#4A9FD8;font-weight:600;">@$1</span>');
   }
 
-  function _singleCommentHtml(c) {
+  function _parseCommentAttachments(c) {
+    try {
+      return typeof c.attachments === 'string'
+        ? JSON.parse(c.attachments)
+        : c.attachments;
+    } catch (e) { return null; }
+  }
+
+  function _commentImgHtml(c) {
+    var _att = _parseCommentAttachments(c);
+    if (!_att || _att.type !== 'images' || !_att.urls || !_att.urls.length) return '';
+    var urls = _att.urls;
+    var postIdArg = _esc(c.post_id || '');
+    var jsArr = '[' + urls.map(function(u){ return '&#39;' + _esc(u) + '&#39;'; }).join(',') + ']';
+    return '<div class="pcs-comment-imgs">' +
+      urls.map(function(u, i) {
+        return '<img src="' + _esc(u) + '" class="pcs-comment-img-thumb" ' +
+          'onclick="window._pcsOpenLightbox(&#39;' + postIdArg + '&#39;,' + jsArr + ',' + i + ')">';
+      }).join('') +
+    '</div>';
+  }
+
+  function _singleCommentHtml(c, opts) {
+    opts = opts || {};
+    var isReply = !!opts.isReply;
+    var parentAuthor = opts.parentAuthor || '';
     var cid = _esc(c.id || '');
+    var postId = _esc(c.post_id || '');
+    var avSize = isReply ? 22 : 28;
+    var avFontPx = isReply ? 9 : 10;
+    var wrapperPad = isReply ? '8px 14px 8px 46px' : '10px 14px';
+    var connectorHtml = isReply
+      ? '<div style="position:absolute;left:17px;top:-8px;bottom:18px;width:2px;background:#404050;border-radius:1px;"></div>'
+      : '';
     if (c.deleted) {
-      return '<div style="display:flex;gap:10px;padding:8px 14px;align-items:center;">' +
-        '<div style="width:28px;height:28px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;background:#40405030;font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:700;color:#404050;">?</div>' +
+      return '<div style="display:flex;gap:10px;padding:' + wrapperPad + ';align-items:center;position:relative;">' +
+        connectorHtml +
+        '<div style="width:' + avSize + 'px;height:' + avSize + 'px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;background:#40405030;font-family:\'IBM Plex Mono\',monospace;font-size:' + avFontPx + 'px;font-weight:700;color:#404050;">?</div>' +
         '<div class="client-comment-tombstone">This message was deleted.</div>' +
       '</div>';
     }
@@ -581,17 +614,26 @@ console.log('LOADED:', 'render/client.js');
     var initial = (c.author || '?').charAt(0).toUpperCase();
     var roleLabel = _esc((c.author_role || '').toUpperCase());
     var ts = _relativeTime(c.created_at);
-    var avatarStyle = 'width:28px;height:28px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:700;color:' + palette.fg + ';background:' + palette.bg + ';';
+    var avatarStyle = 'width:' + avSize + 'px;height:' + avSize + 'px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:' + avFontPx + 'px;font-weight:700;color:' + palette.fg + ';background:' + palette.bg + ';';
     var messageHtml = _highlightClientMentions(_esc(c.message || ''));
-    return '<div style="display:flex;gap:10px;padding:10px 14px;">' +
+    var imgHtml = _commentImgHtml(c);
+    var replyTagHtml = (isReply && parentAuthor)
+      ? '<div style="font-family:\'DM Sans\',sans-serif;font-size:11px;color:#A0A0B0;margin-bottom:3px;">' +
+          '\u21a9 <span style="color:#A0A0B0;font-weight:600;">' + _esc(parentAuthor) + '</span>' +
+        '</div>'
+      : '';
+    return '<div style="display:flex;gap:10px;padding:' + wrapperPad + ';position:relative;">' +
+      connectorHtml +
       '<div style="' + avatarStyle + '">' + _esc(initial) + '</div>' +
       '<div style="flex:1;min-width:0;">' +
+        replyTagHtml +
         '<div style="display:flex;align-items:baseline;flex-wrap:wrap;gap:6px;">' +
           '<span style="font-family:\'DM Sans\',sans-serif;font-weight:700;font-size:14px;color:#FFFFFF;">' + _esc(c.author) + '</span>' +
           '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;font-weight:600;text-transform:uppercase;color:#A0A0B0;">' + roleLabel + '</span>' +
           '<span style="margin-left:auto;font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#909098;">' + ts + '</span>' +
         '</div>' +
         '<div style="font-family:\'DM Sans\',sans-serif;font-size:14px;color:#E0E0E8;line-height:1.55;margin-top:3px;white-space:pre-wrap;">' + messageHtml + '</div>' +
+        imgHtml +
         '<div class="client-comment-actions">' +
           '<span class="pcs-comment-react" data-comment-id="' + cid + '" ' +
             'onclick="window._pcsShowEmojiPicker(this)">' +
@@ -601,24 +643,72 @@ console.log('LOADED:', 'render/client.js');
           '<span style="color:#505058;font-size:12px;">|</span>' +
           '<span onclick="window._clientSetReply(\'' +
             cid + '\',\'' + _esc(c.author || '') + '\',\'' +
-            _esc(c.post_id || '') + '\')">Reply</span>' +
+            postId + '\')">Reply</span>' +
         '</div>' +
       '</div>' +
     '</div>';
+  }
+
+  /* Build threaded HTML for a flat list of comments.
+     topCap: max top-level entries to render (null = all).
+     Returns an object { html, remainingTop }. */
+  function _buildThreadedCommentsHtml(comments, topCap, pid) {
+    var topLevel = [];
+    var replyMap = {};
+    var byId = {};
+    comments.forEach(function(c) { if (c.id) byId[c.id] = c; });
+    comments.forEach(function(c) {
+      if (c.reply_to && byId[c.reply_to]) {
+        if (!replyMap[c.reply_to]) replyMap[c.reply_to] = [];
+        replyMap[c.reply_to].push(c);
+      } else {
+        topLevel.push(c);
+      }
+    });
+    var cap = (typeof topCap === 'number' && topCap > 0) ? topCap : topLevel.length;
+    var showTop = topLevel.slice(0, cap);
+    var remainingTop = topLevel.length - showTop.length;
+    var html = '';
+    for (var i = 0; i < showTop.length; i++) {
+      var parent = showTop[i];
+      html += _singleCommentHtml(parent);
+      var replies = replyMap[parent.id] || [];
+      if (!replies.length) continue;
+      var parentAuthor = parent.author || '';
+      if (replies.length === 1) {
+        html += _singleCommentHtml(replies[0], { isReply: true, parentAuthor: parentAuthor });
+      } else if (replies.length === 2) {
+        html += _singleCommentHtml(replies[0], { isReply: true, parentAuthor: parentAuthor });
+        html += _singleCommentHtml(replies[1], { isReply: true, parentAuthor: parentAuthor });
+      } else {
+        var first = replies[0];
+        var last = replies[replies.length - 1];
+        var middle = replies.slice(1, replies.length - 1);
+        var hiddenId = 'client-hidden-replies-' + _esc(parent.id || '') + '-' + i;
+        html += _singleCommentHtml(first, { isReply: true, parentAuthor: parentAuthor });
+        html += '<div class="pcs-expand-link" onclick="(function(el){var t=document.getElementById(\'' + hiddenId + '\');if(t){t.style.display=\'block\';}el.style.display=\'none\';})(this)" style="padding:6px 14px 6px 46px;cursor:pointer;color:#4A9FD8;font-size:13px;font-weight:600;font-family:\'DM Sans\',sans-serif;">' +
+          'See ' + middle.length + ' more repl' + (middle.length === 1 ? 'y' : 'ies') +
+        '</div>';
+        html += '<div id="' + hiddenId + '" style="display:none;">';
+        middle.forEach(function(r) {
+          html += _singleCommentHtml(r, { isReply: true, parentAuthor: parentAuthor });
+        });
+        html += '</div>';
+        html += _singleCommentHtml(last, { isReply: true, parentAuthor: parentAuthor });
+      }
+    }
+    return { html: html, remainingTop: remainingTop };
   }
 
   function _commentsListHtml(post) {
     var visibleComments = (post.post_comments || []);
     if (!visibleComments.length) return '';
     var pid = _esc(post.post_id || post.id || '');
-    var show = visibleComments.length <= 3 ? visibleComments : visibleComments.slice(0, 3);
-    var remaining = visibleComments.length - show.length;
+    var built = _buildThreadedCommentsHtml(visibleComments, 5, pid);
     var html = '<div data-comments-list="' + pid + '" data-full-comments="' + _esc(JSON.stringify(visibleComments)) + '" style="margin-top:6px;">';
-    for (var i = 0; i < show.length; i++) {
-      html += _singleCommentHtml(show[i]);
-    }
-    if (remaining > 0) {
-      html += '<div data-action="expandComments" data-id="' + pid + '" style="font-size:12px;color:#555;padding:4px 14px 8px;cursor:pointer;font-family:\'DM Sans\',sans-serif;">View ' + remaining + ' more comment' + (remaining > 1 ? 's' : '') + '</div>';
+    html += built.html;
+    if (built.remainingTop > 0) {
+      html += '<div data-action="expandComments" data-id="' + pid + '" style="font-size:12px;color:#555;padding:4px 14px 8px;cursor:pointer;font-family:\'DM Sans\',sans-serif;">View ' + built.remainingTop + ' more comment' + (built.remainingTop > 1 ? 's' : '') + '</div>';
     }
     html += '</div>';
     return html;
@@ -1267,11 +1357,8 @@ console.log('LOADED:', 'render/client.js');
           if (clDiv) {
             try {
               var allComments = JSON.parse(clDiv.getAttribute('data-full-comments') || '[]');
-              var ecHtml = '';
-              for (var ecI = 0; ecI < allComments.length; ecI++) {
-                ecHtml += _singleCommentHtml(allComments[ecI]);
-              }
-              clDiv.innerHTML = ecHtml;
+              var built = _buildThreadedCommentsHtml(allComments, null, id);
+              clDiv.innerHTML = built.html;
             } catch (_ec) {}
           }
           break;


### PR DESCRIPTION
## Summary
Three targeted fixes to the client comment section. No schema, no new API calls, no changes to comment submission (`_handleSubmitComment`), loading (`loadPostsForClient`), or the comment input bar (`_commentInputHtml`).

## Changes

### 1. Emoji picker positioning fix — `actions/pcs.js`
`window._pcsShowEmojiPicker` (lines ~2769–2785) now bounds-checks the right-anchor math before applying it. If right-anchoring would push the picker past the left edge of the viewport (`_rect.right - 220 < 8`, where 220px ≈ picker width), it falls back to **left-anchoring** at `Math.max(8, _rect.left)`. Otherwise it keeps the original right-anchor behavior.

- **PCS** (`.pcs-cmt-rt` right-column react element): bounds check passes → right-anchor preserved → no visual change.
- **Client view** (left-aligned Like span inside `.client-comment-actions`): bounds check fails → left-anchors at the span's left edge → picker stays fully on-screen instead of being clipped.

Single function touched. No other PCS or longpress code affected.

### 2. Comment image rendering — `render/client.js`
`_singleCommentHtml` now parses `c.attachments` (handles both stringified and pre-parsed JSON, try/catch guarded like PCS) and emits a `.pcs-comment-imgs` block with `.pcs-comment-img-thumb` thumbnails between the message body and the actions row. Tapping a thumbnail calls `window._pcsOpenLightbox(postId, urlsArray, index)` — the shared helper that already handles the `Array.isArray(arg2)` comment-mode branch.

- Extracted helper: `_parseCommentAttachments(c)` and `_commentImgHtml(c)` — pure, side-effect free.
- No new CSS: `.pcs-comment-imgs` (styles.css:6087) and `.pcs-comment-img-thumb` (styles.css:6094) already exist.
- Lightbox arguments are HTML-escaped and the urls array is built with `&#39;` entities so the inline `onclick` string is safe.

### 3. Reply threading — `render/client.js`
`_singleCommentHtml` now accepts an optional second parameter `opts = { isReply, parentAuthor }`. When `isReply === true`:
- Wrapper padding-left bumps to 46px
- Avatar shrinks from 28px to 22px (font from 10 → 9px)
- A vertical connector line (`position:absolute; left:17px; top:-8px; bottom:18px; width:2px; background:#404050; border-radius:1px`) is added inside the (now-relative) wrapper
- A reply tag `↩ <parentAuthor>` is rendered above the author row (`#A0A0B0`, DM Sans, inline styled)
- Deleted-comment tombstone gets the same indent + connector treatment

New helper `_buildThreadedCommentsHtml(comments, topCap, pid)`:
1. Indexes comments by id, splits into `topLevel` (no `reply_to` or parent missing from batch) and `replyMap` keyed by parent id.
2. Orphaned replies are promoted to top-level so nothing is hidden.
3. For each parent (capped by `topCap`, null = unlimited):
   - **0 replies** → just the parent
   - **1 reply** → parent + inline reply
   - **2 replies** → parent + both replies inline
   - **3+ replies** → parent + first reply + `See N more replies` link (`.pcs-expand-link`, `#4A9FD8`, DM Sans 13px 600) + hidden middle block + last reply. Link's `onclick` toggles `display` of the hidden div by id (unique per parent instance to avoid collisions).
4. Returns `{ html, remainingTop }` so the caller can emit the top-level "View N more comments" affordance.

`_commentsListHtml(post)` now calls `_buildThreadedCommentsHtml(comments, 5, pid)` and appends the existing `data-action="expandComments"` footer when `remainingTop > 0`.

The `expandComments` router case (~L1265) is rewired to call `_buildThreadedCommentsHtml(allComments, null, id)` so the expanded view also renders threaded (otherwise it would re-flatten).

### 4. Version bump — `index.html`
All 21 versioned resources: `?v=20260411c` → `?v=20260411d`

## What this PR does NOT change
- `_handleSubmitComment` — untouched
- `_commentInputHtml` — untouched (separate PR)
- `loadPostsForClient` / `07-post-load.js` — untouched
- `actions/pcs-longpress.js` — untouched
- Resolve labels, 3-dot menu, edit functionality — separate PRs
- All existing DOM ids (`data-comments-list`, `data-full-comments`, `data-comment-id`, `data-post-id`) preserved

## Test plan
- [x] `./node_modules/.bin/vitest run` → **508/508 passing**
- [x] Syntax check on `render/client.js` and `actions/pcs.js` (`node -c`) → OK
- [ ] Emoji picker opens on-screen when tapping Like in the client view (no left-edge clipping)
- [ ] Emoji picker still opens correctly on PCS react column (right-anchored, unchanged)
- [ ] Comments with image attachments show thumbnails in the client feed
- [ ] Tapping a comment thumbnail opens the existing lightbox
- [ ] Reply comments render indented with a vertical connector line
- [ ] Reply rows show the `↩ <parentAuthor>` tag
- [ ] Parents with 3+ replies show `See N more replies` that expands the hidden middle block
- [ ] Top-level cap of 5 still shows `View N more comments` when exceeded
- [ ] Expanding via `View N more comments` renders the full list threaded (not flat)
- [ ] No visual regression on PCS comment section

## Deployment notes
- Version bumped to `?v=20260411d` on all 21 resources
- Purge Cloudflare cache after merge
- Hard refresh on devices before testing

https://claude.ai/code/session_01D8fsKvkbJMjNmvSzvf7m6X