### PR TITLE
feat(client): resolved label + Like brightness + timestamp repositioned

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411d">
+ <link rel="stylesheet" href="styles.css?v=20260411e">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411d"></script>
-<script src="00-appstate-compat.js?v=20260411d"></script>
-<script src="01-config.js?v=20260411d" defer></script>
-<script src="02-session.js?v=20260411d" defer></script>
-<script src="utils.js?v=20260411d" defer></script>
-<script src="03-auth.js?v=20260411d" defer></script>
-<script src="05-api.js?v=20260411d" defer></script>
-<script src="10-ui.js?v=20260411d" defer></script>
+<script src="00-appstate.js?v=20260411e"></script>
+<script src="00-appstate-compat.js?v=20260411e"></script>
+<script src="01-config.js?v=20260411e" defer></script>
+<script src="02-session.js?v=20260411e" defer></script>
+<script src="utils.js?v=20260411e" defer></script>
+<script src="03-auth.js?v=20260411e" defer></script>
+<script src="05-api.js?v=20260411e" defer></script>
+<script src="10-ui.js?v=20260411e" defer></script>
 
-<script src="06-post-create.js?v=20260411d" defer></script>
-<script defer src="render/dashboard.js?v=20260411d"></script>
-<script defer src="render/client.js?v=20260411d"></script>
-<script defer src="render/pipeline.js?v=20260411d"></script>
-<script defer src="render/brief.js?v=20260411d"></script>
-<script defer src="actions/pcs.js?v=20260411d"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411d"></script>
-<script src="07-post-load.js?v=20260411d" defer></script>
-<script src="08-post-actions.js?v=20260411d" defer></script>
-<script src="09-library.js?v=20260411d" defer></script>
-<script src="09-approval.js?v=20260411d" defer></script>
-<script src="04-router.js?v=20260411d" defer></script>
+<script src="06-post-create.js?v=20260411e" defer></script>
+<script defer src="render/dashboard.js?v=20260411e"></script>
+<script defer src="render/client.js?v=20260411e"></script>
+<script defer src="render/pipeline.js?v=20260411e"></script>
+<script defer src="render/brief.js?v=20260411e"></script>
+<script defer src="actions/pcs.js?v=20260411e"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411e"></script>
+<script src="07-post-load.js?v=20260411e" defer></script>
+<script src="08-post-actions.js?v=20260411e" defer></script>
+<script src="09-library.js?v=20260411e" defer></script>
+<script src="09-approval.js?v=20260411e" defer></script>
+<script src="04-router.js?v=20260411e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -617,23 +617,44 @@ console.log('LOADED:', 'render/client.js');
     var avatarStyle = 'width:' + avSize + 'px;height:' + avSize + 'px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:' + avFontPx + 'px;font-weight:700;color:' + palette.fg + ';background:' + palette.bg + ';';
     var messageHtml = _highlightClientMentions(_esc(c.message || ''));
     var imgHtml = _commentImgHtml(c);
+    var resolvedHtml = '';
+    if (c.resolved && c.resolved_by) {
+      resolvedHtml = '<div style="display:flex;align-items:center;gap:4px;margin-top:6px;">' +
+        '<svg width="12" height="12" viewBox="0 0 18 18" fill="none" stroke="#3ECF8E" stroke-width="1.5">' +
+          '<circle cx="9" cy="9" r="7"/>' +
+          '<polyline points="6,9 8.5,11.5 12.5,6.5"/>' +
+        '</svg>' +
+        '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#3ECF8E;font-weight:500;">Resolved by ' + _esc(c.resolved_by) + '</span>' +
+      '</div>';
+    }
     var replyTagHtml = (isReply && parentAuthor)
       ? '<div style="font-family:\'DM Sans\',sans-serif;font-size:11px;color:#A0A0B0;margin-bottom:3px;">' +
           '\u21a9 <span style="color:#A0A0B0;font-weight:600;">' + _esc(parentAuthor) + '</span>' +
         '</div>'
       : '';
+    var dotsBtnHtml = '<span class="client-comment-dots" data-comment-id="' + cid + '" ' +
+        'onclick="if(window._clientCommentMenu){window._clientCommentMenu(this,\'' + cid + '\');}" ' +
+        'style="margin-left:auto;cursor:pointer;display:inline-flex;align-items:center;padding:2px 4px;">' +
+        '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#78788C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+          '<circle cx="12" cy="5" r="1"/>' +
+          '<circle cx="12" cy="12" r="1"/>' +
+          '<circle cx="12" cy="19" r="1"/>' +
+        '</svg>' +
+      '</span>';
     return '<div style="display:flex;gap:10px;padding:' + wrapperPad + ';position:relative;">' +
       connectorHtml +
       '<div style="' + avatarStyle + '">' + _esc(initial) + '</div>' +
       '<div style="flex:1;min-width:0;">' +
         replyTagHtml +
-        '<div style="display:flex;align-items:baseline;flex-wrap:wrap;gap:6px;">' +
+        '<div style="display:flex;align-items:center;flex-wrap:nowrap;gap:6px;">' +
           '<span style="font-family:\'DM Sans\',sans-serif;font-weight:700;font-size:14px;color:#FFFFFF;">' + _esc(c.author) + '</span>' +
           '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;font-weight:600;text-transform:uppercase;color:#A0A0B0;">' + roleLabel + '</span>' +
-          '<span style="margin-left:auto;font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#909098;">' + ts + '</span>' +
+          dotsBtnHtml +
         '</div>' +
+        '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#909098;margin-top:1px;">' + ts + '</div>' +
         '<div style="font-family:\'DM Sans\',sans-serif;font-size:14px;color:#E0E0E8;line-height:1.55;margin-top:3px;white-space:pre-wrap;">' + messageHtml + '</div>' +
         imgHtml +
+        resolvedHtml +
         '<div class="client-comment-actions">' +
           '<span class="pcs-comment-react" data-comment-id="' + cid + '" ' +
             'onclick="window._pcsShowEmojiPicker(this)">' +

--- a/styles.css
+++ b/styles.css
@@ -5634,6 +5634,19 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-style: italic;
   padding: 8px 0;
 }
+/* Client Like button must match Reply brightness — override the
+   shared .pcs-comment-react dim (.55 opacity, #78788C stroke) so
+   the heart + "Like" text read at the same weight as Reply. */
+.client-comment-actions .pcs-comment-react {
+  opacity: 1;
+  color: #B0B0B8;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+}
+.client-comment-actions .pcs-comment-react svg {
+  stroke: #B0B0B8;
+}
 
 /* INTERNAL NOTES SECTION */
 /* SHARED COMMENT ITEMS — Instagram-style (Part 2A) */


### PR DESCRIPTION
## Summary
Three targeted visual fixes to the client comment section. No schema, no new API calls, no changes to comment submission, loading, or input bar. `actions/pcs.js` untouched.

## Changes

### 1. Resolved label on client view — `render/client.js` `_singleCommentHtml`
Display-only row inserted between the comment images and the actions row when `c.resolved === true && c.resolved_by` is truthy:
- 12×12 green check SVG (`circle cx9 cy9 r7` + `polyline 6,9 8.5,11.5 12.5,6.5`, `#3ECF8E` 1.5 stroke)
- `Resolved by <name>` in IBM Plex Mono 9px `#3ECF8E` 500
- Flex row, gap 4px, margin-top 6px
- **No** resolve/unresolve button on client view — display only

Data is already fetched: `loadPostsForClient` (`07-post-load.js:300-303`) runs `/post_comments?post_id=in.(…)` with no `?select=` filter, so `resolved` and `resolved_by` come through on every row.

### 2. Like button brightness — `styles.css`
Root cause: `.pcs-comment-react { opacity: .55 }` at `styles.css:6121` and `.pcs-comment-react svg { stroke: #78788C }` at `:6129` dim the shared react element so it reads as a passive heart in PCS (by design). In client view the Like span uses the same class (so it works with `window._pcsShowEmojiPicker`), but the CSS makes it read dimmer than the neighboring Reply.

Fix: new client-scoped override rules right after `.client-comment-tombstone`:
```css
.client-comment-actions .pcs-comment-react {
  opacity: 1;
  color: #B0B0B8;
  font-family: 'DM Sans', sans-serif;
  font-size: 13px;
  font-weight: 500;
}
.client-comment-actions .pcs-comment-react svg {
  stroke: #B0B0B8;
}
```
Scoped to `.client-comment-actions` so PCS comment react buttons keep their existing dimmed style. Like and Reply now read with identical weight and color on the client.

### 3. Timestamp repositioned — `render/client.js` `_singleCommentHtml`
Name row split into two lines:
- **Line 1** (flex row, `nowrap`, gap 6px): `<author (white 14px 700)> <ROLE badge (#A0A0B0 mono 9px 600 uppercase)> <3-dot menu (right, margin-left:auto)>`
- **Line 2**: `<timestamp>` alone (IBM Plex Mono 9px `#909098`, margin-top 1px)

3-dot menu placeholder uses a vertical 3-circle SVG (`#78788C` stroke), carries `data-comment-id`, and its onclick is guarded — `if (window._clientCommentMenu) { window._clientCommentMenu(this, cid); }` — so a later PR can wire it without touching the markup. Present but silent today.

### 4. Version bump — `index.html`
All 21 versioned resources: `?v=20260411d` → `?v=20260411e`.

## What this PR does NOT change
- `actions/pcs.js` — untouched
- `_handleSubmitComment` — untouched
- `_commentInputHtml` — untouched
- `loadPostsForClient` / `07-post-load.js` — untouched
- No resolve/unresolve button for clients
- All existing DOM ids and data attributes preserved

## Test plan
- [x] `./node_modules/.bin/vitest run` → **508/508 passing**
- [x] `node -c render/client.js` → OK
- [ ] Comments with `resolved === true` show green check + `Resolved by <name>`
- [ ] Comments with `resolved === false`/`null` show no label
- [ ] Like and Reply render at identical weight, color, and font size
- [ ] Heart stroke is `#B0B0B8`, not the PCS grey
- [ ] Timestamp sits on its own line below the author row
- [ ] 3-dot menu visible on the right of the name row (placeholder, no-op click)
- [ ] No visual regression on PCS comment section (shared class overrides are scoped)

## Deployment notes
- Version bumped to `?v=20260411e` on all 21 resources
- Purge Cloudflare cache after merge
- Hard refresh on devices before testing

https://claude.ai/code/session_01D8fsKvkbJMjNmvSzvf7m6X