### PR TITLE
feat: fetch-and-stash while modal open + drain fixes (rebased)

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -393,8 +393,22 @@ function startRealtime() {
   window.AppState.timers.realtimeTimer = setInterval(async () => {
     if (document.hidden) return;
     if (!localStorage.getItem('sb_access_token')) return;
-    // Skip poll while user is in a modal  -  they'll get fresh data on close
-    if (window.AppState.ui.modalOpen) return;
+    // Modal open: FETCH but STASH — keep the network flowing so a drain on
+    // modal close is instant, without mutating posts.all / re-rendering
+    // under the user's active overlay. Latest-wins (no queue).
+    if (window.AppState.ui.modalOpen) {
+      try {
+        const data = await apiFetch('/posts?select=*&order=created_at.desc');
+        const fresh = normalise(data);
+        if (_postsFingerprint(fresh) !== _postsFingerprint(window.AppState.posts.all)) {
+          window._postsPollStash = fresh;
+          window._postsPollStashFp = _postsFingerprint(fresh);
+        }
+      } catch (e) {
+        console.warn('[poll] stash fetch error', e);
+      }
+      return;
+    }
     try {
       const data  = await apiFetch('/posts?select=*&order=created_at.desc');
       const fresh = normalise(data);
@@ -438,6 +452,21 @@ function stopRealtime() {
   // sessions are fully cleaned up through a single entry point.
   if (typeof stopClientRealtime === 'function') stopClientRealtime();
 }
+
+// Drain the agency-poll stash. Called from 10-ui.js:_drainDeferredRender
+// on every modal-close path. If the 15s poll stashed a fresh normalised
+// array while a modal was open, merge it now and re-render. Latest-wins,
+// no queue — stash is cleared before mergePosts runs.
+function _drainPollStash() {
+  var stash = window._postsPollStash;
+  if (!stash) return;
+  window._postsPollStash = null;
+  window._postsPollStashFp = null;
+  mergePosts(stash);
+  scheduleRender();
+  if (typeof updateNotifBadge === 'function') updateNotifBadge();
+}
+window._drainPollStash = _drainPollStash;
 
 // 30-second background data poll for the Client role. Mirrors the
 // startRealtime() pattern but hits the client-scoped fetch (via

--- a/10-ui.js
+++ b/10-ui.js
@@ -130,6 +130,10 @@ function _drainDeferredRender() {
     clearTimeout(window.AppState.timers.renderTimer);
     window.AppState.timers.renderTimer = setTimeout(safeRender, 60);
   }
+  // Also drain any poll data that was stashed while a modal was open.
+  // _drainPollStash is a no-op when there is nothing stashed, so this is
+  // safe to call from every modal-close site.
+  if (typeof window._drainPollStash === 'function') window._drainPollStash();
 }
 
 // -- Undo toast --------------------------------
@@ -1637,6 +1641,7 @@ function closeNotifications() {
   if (overlay) overlay.style.display = 'none';
   document.body.style.overflow = '';
   window.AppState.ui.modalOpen = false;
+  _drainDeferredRender();
 }
 
 window.openNotifications = openNotifications;
@@ -1795,6 +1800,7 @@ function closePipelineFilter() {
   if (overlay) overlay.style.display = 'none';
   document.body.style.overflow = '';
   window.AppState.ui.modalOpen = false;
+  _drainDeferredRender();
 }
 
 window.openPipelineFilter = openPipelineFilter;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Sorted (srtd.io)
 
-Last updated: 2026-04-11 (client-poll). Full history: `CLAUDE-archive-20260411.md`.
+Last updated: 2026-04-11 (poll-stash). Full history: `CLAUDE-archive-20260411.md`.
 
 ## 1 — WHAT IS SORTED
 
@@ -68,7 +68,7 @@ Root:
 - `04-router.js` — routing, deep-link handling (must be LAST script)
 - `05-api.js` — apiFetch (no-cache headers, 401 retry), uploadPostAsset, logActivity, normalise
 - `06-post-create.js` — new post form, asset input, WhatsApp KV preview seed
-- `07-post-load.js` — loadPosts, loadPostsForClient(skipRenderIfUnchanged), mergePosts, startRealtime (agency 15s poll), startClientRealtime/stopClientRealtime (client 30s poll), _postsFingerprint, _clientPostsFingerprint, _renderBackgroundViews, bottom sheets, _cardClickDelegate
+- `07-post-load.js` — loadPosts, loadPostsForClient(skipRenderIfUnchanged), mergePosts, startRealtime (agency 15s poll with modal-open fetch-and-stash), startClientRealtime/stopClientRealtime (client 30s poll), _postsFingerprint, _clientPostsFingerprint, _drainPollStash, _renderBackgroundViews, bottom sheets, _cardClickDelegate
 - `08-post-actions.js` — quickStage, updatePost, clientApprove, _confirmPublish, _sendStageNotif, _startSaveTimeout/_clearSaveTimeout
 - `09-approval.js` — client approval flow, submitApproval
 - `09-library.js` — library view (calls `_renderPCS` directly — keep on window.*)
@@ -123,10 +123,17 @@ window.AppState = {
 
 ### Render pipeline
 - `setStage(post, stage)` is a PURE logger — mutates `post.stage` and appends to activity log. It does NOT touch `_isSaving`, does NOT fire notifications, does NOT render. Safe for rollback paths.
-- `scheduleRender()` DEFERS when `AppState.ui.modalOpen === true`, queuing intent in `AppState.ui.deferredRender`. `_drainDeferredRender()` fires the queued render on PCS close.
+- `scheduleRender()` DEFERS when `AppState.ui.modalOpen === true`, flipping `window._deferredRender = true`. `_drainDeferredRender()` fires the queued render on modal close AND drains the agency poll stash via `_drainPollStash()`.
 - `_postsFingerprint()` is a cheap hash of `posts.all`. Renderers skip rebuild when the fingerprint is unchanged — always mutate via `setAll` so the fingerprint changes.
 - `_renderBackgroundViews()` re-renders dashboard + pipeline + client feed without tearing down PCS — call after a successful PATCH.
 - PCS render goes through `_renderPCS()`. Do not mutate PCS DOM from other modules. `09-library.js` is the one exception (opens PCS without the router).
+
+### Agency poll fetch-and-stash (`startRealtime` in 07-post-load.js)
+- The 15s agency poll NO LONGER skips while a modal is open. It fetches, normalises, and if the fingerprint differs, stashes the fresh array in `window._postsPollStash` (+ `window._postsPollStashFp`). Latest-wins, no queue — subsequent polls overwrite the stash.
+- `_drainPollStash()` in 07-post-load.js reads the stash, clears it, runs `mergePosts(stash)`, `scheduleRender()`, and `updateNotifBadge()`. It is a no-op when the stash is null.
+- `_drainDeferredRender()` in 10-ui.js now calls `_drainPollStash()` unconditionally after its existing safeRender debounce — so every modal-close site that drains also picks up stashed poll data.
+- Drain sites (all call `_drainDeferredRender` after setting `modalOpen = false`): `forcePCSReset` (actions/pcs.js:156), `closeAdminEdit` (08-post-actions.js:195), `closeNewPostModal` (06-post-create.js:231), `closeNotifications` (10-ui.js), `closePipelineFilter` (10-ui.js), `_lbClose` (render/client.js), client post overlay close + back-to-notifs paths (render/client.js).
+- The client 30s poll (`startClientRealtime`) still has NO stash. It uses the active-typing guard + `_clientPostsFingerprint` to avoid clobbering open inputs, and does not need a modal gate.
 
 ### Runtime-enriched fields (NOT in DB — added by loadPosts)
 - `_commentCount` (int), `_clientCommentAt` (ISO | null) — set after batch comment fetch.
@@ -184,7 +191,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 21 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 20 scripts). Current: `?v=20260411c`.
+1. Bump ALL 21 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 20 scripts). Current: `?v=20260411g`.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411f">
+ <link rel="stylesheet" href="styles.css?v=20260411g">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411f"></script>
-<script src="00-appstate-compat.js?v=20260411f"></script>
-<script src="01-config.js?v=20260411f" defer></script>
-<script src="02-session.js?v=20260411f" defer></script>
-<script src="utils.js?v=20260411f" defer></script>
-<script src="03-auth.js?v=20260411f" defer></script>
-<script src="05-api.js?v=20260411f" defer></script>
-<script src="10-ui.js?v=20260411f" defer></script>
+<script src="00-appstate.js?v=20260411g"></script>
+<script src="00-appstate-compat.js?v=20260411g"></script>
+<script src="01-config.js?v=20260411g" defer></script>
+<script src="02-session.js?v=20260411g" defer></script>
+<script src="utils.js?v=20260411g" defer></script>
+<script src="03-auth.js?v=20260411g" defer></script>
+<script src="05-api.js?v=20260411g" defer></script>
+<script src="10-ui.js?v=20260411g" defer></script>
 
-<script src="06-post-create.js?v=20260411f" defer></script>
-<script defer src="render/dashboard.js?v=20260411f"></script>
-<script defer src="render/client.js?v=20260411f"></script>
-<script defer src="render/pipeline.js?v=20260411f"></script>
-<script defer src="render/brief.js?v=20260411f"></script>
-<script defer src="actions/pcs.js?v=20260411f"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411f"></script>
-<script src="07-post-load.js?v=20260411f" defer></script>
-<script src="08-post-actions.js?v=20260411f" defer></script>
-<script src="09-library.js?v=20260411f" defer></script>
-<script src="09-approval.js?v=20260411f" defer></script>
-<script src="04-router.js?v=20260411f" defer></script>
+<script src="06-post-create.js?v=20260411g" defer></script>
+<script defer src="render/dashboard.js?v=20260411g"></script>
+<script defer src="render/client.js?v=20260411g"></script>
+<script defer src="render/pipeline.js?v=20260411g"></script>
+<script defer src="render/brief.js?v=20260411g"></script>
+<script defer src="actions/pcs.js?v=20260411g"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411g"></script>
+<script src="07-post-load.js?v=20260411g" defer></script>
+<script src="08-post-actions.js?v=20260411g" defer></script>
+<script src="09-library.js?v=20260411g" defer></script>
+<script src="09-approval.js?v=20260411g" defer></script>
+<script src="04-router.js?v=20260411g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1761,6 +1761,7 @@ console.log('LOADED:', 'render/client.js');
     _lbIndex = 0;
     window.AppState.ui.modalOpen = false;
     document.body.style.overflow = '';
+    if (typeof _drainDeferredRender === 'function') _drainDeferredRender();
   }
 
   function _lbPrev() {
@@ -2128,6 +2129,7 @@ console.log('LOADED:', 'render/client.js');
           _self_overlay.remove();
           window.AppState.ui.modalOpen = false;
           document.body.style.overflow = '';
+          if (typeof _drainDeferredRender === 'function') _drainDeferredRender();
           setTimeout(function() {
             if (typeof window.openNotifications === 'function') window.openNotifications();
           }, 150);
@@ -2143,6 +2145,7 @@ console.log('LOADED:', 'render/client.js');
           _self_overlay.remove();
           window.AppState.ui.modalOpen = false;
           document.body.style.overflow = '';
+          if (typeof _drainDeferredRender === 'function') _drainDeferredRender();
         });
       }
     });


### PR DESCRIPTION
## Summary
Fresh replay of the fetch-and-stash refactor (originally PR #783) onto latest `main-/-root` after intervening merges (#781 #782 #784). The stale PR #783 is based on an older commit and should be closed in favor of this one.

## How this was rebased
```
git fetch origin
git checkout main-/-root
git pull origin main-/-root
git checkout -b claude/fetch-stash-modal
git cherry-pick --no-commit origin/claude/audit-client-polling-xN0Wn
git checkout main-/-root -- index.html   # resolve version-string conflict
# bump all 21 version strings (see note below)
git add -A
git commit -m "feat: fetch-and-stash while modal open + drain fixes"
git push -u origin claude/fetch-stash-modal
```

Auto-merge cleanly handled `render/client.js` + `10-ui.js` + `07-post-load.js` + `CLAUDE.md`. Only `index.html` conflicted (version string drift).

## ⚠️ Version-bump correction
The brief asked for `?v=20260411d`. That's now a **regression** — `main-/-root` already shipped `?v=20260411f` via the three intervening merges. Bumping to `d` would downgrade the cache-busting tag. I bumped **monotonically to `?v=20260411g`** instead. Same applies to the CLAUDE.md §7 reference.

## Changes (identical to original PR #783)
- **07-post-load.js**
  - `startRealtime` modalOpen branch: `apiFetch` → `normalise` → fingerprint-compare → `window._postsPollStash = fresh; window._postsPollStashFp = fp;` → `return`. Latest-wins, no queue.
  - Non-modal branch unchanged.
  - New `_drainPollStash()` near `stopRealtime`: reads stash, clears it, runs `mergePosts` + `scheduleRender` + `updateNotifBadge`. Exported on `window`.
- **10-ui.js**
  - `_drainDeferredRender()` calls `window._drainPollStash()` at its tail (no-op when stash is null).
  - `closeNotifications()` and `closePipelineFilter()` now call `_drainDeferredRender()` after `modalOpen = false` — fixes pre-existing drain bugs.
- **render/client.js**
  - `_lbClose()`, `_openClientPostOverlay` close button, and the back-to-notifs button all call `_drainDeferredRender()` after flipping `modalOpen = false`.
- **index.html**: bump all 21 version strings `20260411f` → `20260411g`.
- **CLAUDE.md**: new §4 "Agency poll fetch-and-stash" subsection, updated file-map entry, updated `scheduleRender` description, version reference in §7 bumped to `g`.

## Left alone
- `mergePosts` internals — still only checks `_isSaving`.
- `_postsFingerprint` — unchanged.
- `loadPostsForClient` / `startClientRealtime` — client poll already has active-typing guard + `_clientPostsFingerprint`, no stash needed.
- Non-modal poll path in `startRealtime` — byte-for-byte identical.

## Test plan
- [x] `npx vitest run` — 508 / 508 passing against the rebased state.
- [ ] Manual: Agency, open PCS, have another tab move a stage. Close PCS. New stage should appear immediately (not wait for next 15 s tick).
- [ ] Manual: Admin Edit kept open > 15 s → close → stashed change appears.
- [ ] Manual: Notifications panel kept open > 15 s → close → any stash applies.
- [ ] Manual: Pipeline Filter kept open > 15 s → close → same.
- [ ] Manual: Client lightbox and client post overlay kept open > 30 s → close → drain fires (client poll has no stash but the deferred-render path still runs).
- [ ] Manual: Rapid close/reopen PCS within 300 ms — stash drain is idempotent + null-safe.

## Action requested
Close superseded PR: Guneygaar/guneygaar.github.io#783

https://claude.ai/code/session_01Qtb9PqYhBSJ4mnFMf2SKgr