### PR TITLE
fix(client): Edit/Delete silently no-op — stop overlay bubble + scope querySelector

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411f">
+ <link rel="stylesheet" href="styles.css?v=20260411g">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411f"></script>
-<script src="00-appstate-compat.js?v=20260411f"></script>
-<script src="01-config.js?v=20260411f" defer></script>
-<script src="02-session.js?v=20260411f" defer></script>
-<script src="utils.js?v=20260411f" defer></script>
-<script src="03-auth.js?v=20260411f" defer></script>
-<script src="05-api.js?v=20260411f" defer></script>
-<script src="10-ui.js?v=20260411f" defer></script>
+<script src="00-appstate.js?v=20260411g"></script>
+<script src="00-appstate-compat.js?v=20260411g"></script>
+<script src="01-config.js?v=20260411g" defer></script>
+<script src="02-session.js?v=20260411g" defer></script>
+<script src="utils.js?v=20260411g" defer></script>
+<script src="03-auth.js?v=20260411g" defer></script>
+<script src="05-api.js?v=20260411g" defer></script>
+<script src="10-ui.js?v=20260411g" defer></script>
 
-<script src="06-post-create.js?v=20260411f" defer></script>
-<script defer src="render/dashboard.js?v=20260411f"></script>
-<script defer src="render/client.js?v=20260411f"></script>
-<script defer src="render/pipeline.js?v=20260411f"></script>
-<script defer src="render/brief.js?v=20260411f"></script>
-<script defer src="actions/pcs.js?v=20260411f"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411f"></script>
-<script src="07-post-load.js?v=20260411f" defer></script>
-<script src="08-post-actions.js?v=20260411f" defer></script>
-<script src="09-library.js?v=20260411f" defer></script>
-<script src="09-approval.js?v=20260411f" defer></script>
-<script src="04-router.js?v=20260411f" defer></script>
+<script src="06-post-create.js?v=20260411g" defer></script>
+<script defer src="render/dashboard.js?v=20260411g"></script>
+<script defer src="render/client.js?v=20260411g"></script>
+<script defer src="render/pipeline.js?v=20260411g"></script>
+<script defer src="render/brief.js?v=20260411g"></script>
+<script defer src="actions/pcs.js?v=20260411g"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411g"></script>
+<script src="07-post-load.js?v=20260411g" defer></script>
+<script src="08-post-actions.js?v=20260411g" defer></script>
+<script src="09-library.js?v=20260411g" defer></script>
+<script src="09-approval.js?v=20260411g" defer></script>
+<script src="04-router.js?v=20260411g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -640,7 +640,7 @@ console.log('LOADED:', 'render/client.js');
         'data-author="' + _esc(c.author || '') + '" ' +
         'data-post-id="' + postId + '" ' +
         'data-message="' + _esc(c.message || '') + '" ' +
-        'onclick="window._clientShowCommentMenu(this)" ' +
+        'onclick="event.stopPropagation();window._clientShowCommentMenu(this)" ' +
         'style="margin-left:auto;cursor:pointer;display:inline-flex;align-items:center;padding:2px 4px;">' +
         '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#78788C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
           '<circle cx="12" cy="5" r="1"/>' +
@@ -1067,7 +1067,8 @@ console.log('LOADED:', 'render/client.js');
   /* ---- Inline edit comment ---- */
 
   window._clientEditComment = function(commentId, currentMessage, postId) {
-    var wrap = document.querySelector('.client-comment-wrap[data-comment-id="' + commentId + '"]');
+    var _host = document.getElementById('client-post-overlay') || document.getElementById('client-view');
+    var wrap = _host && _host.querySelector('.client-comment-wrap[data-comment-id="' + commentId + '"]');
     if (!wrap) return;
     var msgEl = wrap.querySelector('.client-comment-body');
     if (!msgEl) return;
@@ -1232,7 +1233,8 @@ console.log('LOADED:', 'render/client.js');
             });
           });
         } catch (_) {}
-        var wrap = document.querySelector('.client-comment-wrap[data-comment-id="' + commentId + '"]');
+        var _host = document.getElementById('client-post-overlay') || document.getElementById('client-view');
+        var wrap = _host && _host.querySelector('.client-comment-wrap[data-comment-id="' + commentId + '"]');
         if (wrap && wrap.parentNode) {
           var tombHost = document.createElement('div');
           tombHost.innerHTML = _singleCommentHtml({ deleted: true, id: commentId });


### PR DESCRIPTION
## Summary
Two compounding bugs found in the audit were making client Edit + Delete silently no-op. Three-line fix in one file.

## Root cause recap
1. The 3-dot span in `_singleCommentHtml` carried a `data-post-id` attribute. The document-level `_cardClickDelegate` at `07-post-load.js:2651` ran on every dots tap, found `data-post-id` on the dots span itself, and called `window._openClientPostOverlay(pid)` as a side effect. That appended a second full copy of the comment tree to `document.body`, so the DOM ended up with two `.client-comment-wrap` nodes for every comment.
2. `window._clientEditComment` (`render/client.js:1070`) and `window._clientDeleteComment` (`render/client.js:1236`) used unscoped `document.querySelector('.client-comment-wrap[data-comment-id=…]')` which returns the FIRST match in document order — always the feed copy, never the visible overlay. So Edit inserted the textarea into the hidden feed DOM and Delete swapped the tombstone into the hidden feed DOM while the user stared at an unchanged overlay.

Net user impact: Edit "does nothing"; Delete "does nothing until I refresh".

## Fixes (render/client.js only)
### 1. Stop dots click bubbling to `_cardClickDelegate`
Dots `onclick` now runs `event.stopPropagation()` first:
```diff
- 'onclick="window._clientShowCommentMenu(this)" ' +
+ 'onclick="event.stopPropagation();window._clientShowCommentMenu(this)" ' +
```
`data-post-id` is intentionally kept on the span because `_clientShowCommentMenu` reads it for the Reply/Edit/Delete args. Post cards (the intended routing target of `_cardClickDelegate`) still open normally because they don't go through this onclick.

### 2. Scope `_clientEditComment` to the visible host
```diff
  window._clientEditComment = function(commentId, currentMessage, postId) {
-   var wrap = document.querySelector('.client-comment-wrap[data-comment-id="' + commentId + '"]');
+   var _host = document.getElementById('client-post-overlay') || document.getElementById('client-view');
+   var wrap = _host && _host.querySelector('.client-comment-wrap[data-comment-id="' + commentId + '"]');
    if (!wrap) return;
```
Overlay wins if open, feed wins otherwise. Same pattern used by agency helpers elsewhere for deferred-render hosts.

### 3. Scope `_clientDeleteComment` tombstone swap the same way
```diff
-       var wrap = document.querySelector('.client-comment-wrap[data-comment-id="' + commentId + '"]');
+       var _host = document.getElementById('client-post-overlay') || document.getElementById('client-view');
+       var wrap = _host && _host.querySelector('.client-comment-wrap[data-comment-id="' + commentId + '"]');
        if (wrap && wrap.parentNode) {
```

### 4. Version bump
All 21 versioned resources: `?v=20260411f` → `?v=20260411g`.

## What this PR does NOT change
- `07-post-load.js` / `_cardClickDelegate` — untouched
- `actions/pcs.js` — untouched
- `_handleSubmitComment`, `_commentInputHtml`, `loadPostsForClient` — untouched
- CLAUDE.md — no architectural change, not touched

## Test plan
- [x] `./node_modules/.bin/vitest run` → **508/508 passing**
- [x] `node -c render/client.js` → OK
- [ ] Tap `···` on own comment in the client feed → menu opens, post overlay does NOT open behind it
- [ ] Tap Edit → textarea appears on the visible feed comment
- [ ] Type + Save → comment updates with new text + `(edited)` label
- [ ] Cancel → original text restored
- [ ] Delete → confirm dialog → tombstone appears on the visible comment immediately
- [ ] Tap `···` on a comment inside the post overlay (opened from a notification) → Edit + Delete target the overlay copy
- [ ] Tapping a post card body still opens the post overlay normally (not gated by this fix)
- [ ] No visual regression on PCS view (file untouched)

## Deployment notes
- Version bumped to `?v=20260411g` on all 21 resources
- Purge Cloudflare cache after merge
- Hard refresh on devices before testing

https://claude.ai/code/session_01D8fsKvkbJMjNmvSzvf7m6X