### PR TITLE
feat(client): card visual uplift + smart top-bar badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411i">
+ <link rel="stylesheet" href="styles.css?v=20260411k">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411i"></script>
-<script src="00-appstate-compat.js?v=20260411i"></script>
-<script src="01-config.js?v=20260411i" defer></script>
-<script src="02-session.js?v=20260411i" defer></script>
-<script src="utils.js?v=20260411i" defer></script>
-<script src="03-auth.js?v=20260411i" defer></script>
-<script src="05-api.js?v=20260411i" defer></script>
-<script src="10-ui.js?v=20260411i" defer></script>
+<script src="00-appstate.js?v=20260411k"></script>
+<script src="00-appstate-compat.js?v=20260411k"></script>
+<script src="01-config.js?v=20260411k" defer></script>
+<script src="02-session.js?v=20260411k" defer></script>
+<script src="utils.js?v=20260411k" defer></script>
+<script src="03-auth.js?v=20260411k" defer></script>
+<script src="05-api.js?v=20260411k" defer></script>
+<script src="10-ui.js?v=20260411k" defer></script>
 
-<script src="06-post-create.js?v=20260411i" defer></script>
-<script defer src="render/dashboard.js?v=20260411i"></script>
-<script defer src="render/client.js?v=20260411i"></script>
-<script defer src="render/pipeline.js?v=20260411i"></script>
-<script defer src="render/brief.js?v=20260411i"></script>
-<script defer src="actions/pcs.js?v=20260411i"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411i"></script>
-<script src="07-post-load.js?v=20260411i" defer></script>
-<script src="08-post-actions.js?v=20260411i" defer></script>
-<script src="09-library.js?v=20260411i" defer></script>
-<script src="09-approval.js?v=20260411i" defer></script>
-<script src="04-router.js?v=20260411i" defer></script>
+<script src="06-post-create.js?v=20260411k" defer></script>
+<script defer src="render/dashboard.js?v=20260411k"></script>
+<script defer src="render/client.js?v=20260411k"></script>
+<script defer src="render/pipeline.js?v=20260411k"></script>
+<script defer src="render/brief.js?v=20260411k"></script>
+<script defer src="actions/pcs.js?v=20260411k"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411k"></script>
+<script src="07-post-load.js?v=20260411k" defer></script>
+<script src="08-post-actions.js?v=20260411k" defer></script>
+<script src="09-library.js?v=20260411k" defer></script>
+<script src="09-approval.js?v=20260411k" defer></script>
+<script src="04-router.js?v=20260411k" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -214,13 +214,13 @@ console.log('LOADED:', 'render/client.js');
     var id = 'cap-' + (post.post_id || post.id || '');
 
     if (short) {
-      return '<div id="' + _esc(id) + '" style="font-family:\'DM Sans\',sans-serif;font-size:13px;line-height:1.55;color:#ccc;padding:0 14px;margin-top:8px;">' +
+      return '<div id="' + _esc(id) + '" class="cf-caption" style="font-family:\'DM Sans\',sans-serif;font-size:14px;line-height:1.6;color:#E0E0E8;padding:0 14px;margin-top:8px;">' +
         _hashtagHtml(short) +
-        '<span data-action="expand-caption" data-id="' + _esc(id) + '" style="color:#0a66c2;cursor:pointer;font-size:12px;">...more</span>' +
+        '<span class="see-more" data-action="expand-caption" data-id="' + _esc(id) + '" style="color:#4A9FD8;font-weight:500;cursor:pointer;font-size:13px;">...more</span>' +
         '<span style="display:none;" data-full>' + _hashtagHtml(text) + '</span>' +
         '</div>';
     }
-    return '<div style="font-family:\'DM Sans\',sans-serif;font-size:13px;line-height:1.55;color:#ccc;padding:0 14px;margin-top:8px;">' + _hashtagHtml(text) + '</div>';
+    return '<div class="cf-caption" style="font-family:\'DM Sans\',sans-serif;font-size:14px;line-height:1.6;color:#E0E0E8;padding:0 14px;margin-top:8px;">' + _hashtagHtml(text) + '</div>';
   }
 
   /* ---- image grid ---- */
@@ -361,19 +361,19 @@ console.log('LOADED:', 'render/client.js');
     var left = '';
     if (isPublished) {
       var approvedDate = post.status_changed_at || post.statusChangedAt || post.updated_at || '';
-      left = '<span style="display:inline-flex;align-items:center;gap:4px;color:#22c55e;">' +
+      left = '<span style="display:inline-flex;align-items:center;gap:4px;color:#3ECF8E;font-size:11px;font-weight:600;">' +
         ICON_CHECK + ' Approved' +
         (approvedDate ? ' &middot; ' + _esc(_fmtDate(approvedDate)) : '') +
         '</span>';
     } else {
       var days = _waitDays(post);
-      var dColor = days > 2 ? '#FF4B4B' : '#444';
-      left = '<span style="display:inline-flex;align-items:center;gap:4px;color:' + dColor + ';">' +
+      var dColor = days > 2 ? '#EF4444' : '#FBBF24';
+      left = '<span style="display:inline-flex;align-items:center;gap:4px;color:' + dColor + ';font-size:11px;font-weight:600;">' +
         ICON_CLOCK + ' Waiting ' + days + ' day' + (days !== 1 ? 's' : '') +
         '</span>';
     }
     var count = _commentCount(post);
-    var right = '<span style="display:inline-flex;align-items:center;gap:4px;color:#444;">' +
+    var right = '<span style="display:inline-flex;align-items:center;gap:4px;color:#B0B0B8;font-size:11px;">' +
       ICON_COMMENT_SM + ' ' + count + '</span>';
     return '<div class="stats-bar" style="display:flex;align-items:center;justify-content:space-between;">' +
       left + right + '</div>';
@@ -386,9 +386,10 @@ console.log('LOADED:', 'render/client.js');
     var pid = _esc(post.post_id || post.id || '');
     var title = _esc(post.title || '');
     var btnStyle = 'flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;' +
-      'background:none;border:none;border-right:1px solid #FFFFFF08;' +
+      'background:none;border:none;border-right:1px solid #2A2A34;' +
+      'color:#B0B0B8;font-size:11px;font-weight:500;' +
       'cursor:pointer;';
-    var lastBtnStyle = btnStyle.replace('border-right:1px solid #FFFFFF08;', '');
+    var lastBtnStyle = btnStyle.replace('border-right:1px solid #2A2A34;', '');
 
     var btn1 = '';
     if (post.stage === 'awaiting_approval') {
@@ -417,7 +418,7 @@ console.log('LOADED:', 'render/client.js');
 
   function _approvePopupHtml() {
     return '<div id="client-approve-popup" style="display:none;position:fixed;inset:0;z-index:1500;background:#000000BF;align-items:center;justify-content:center;">' +
-      '<div style="background:#1a1a1a;border:1px solid #FFFFFF14;border-radius:12px;padding:24px;max-width:340px;width:90%;text-align:center;">' +
+      '<div style="background:#1a1a1a;border:1px solid #2A2A34;border-radius:12px;padding:24px;max-width:340px;width:90%;text-align:center;">' +
         '<div style="font-family:\'DM Sans\',sans-serif;font-weight:600;font-size:16px;color:#e8e2d9;">Approve this post?</div>' +
         '<div id="client-approve-title" style="font-family:\'IBM Plex Mono\',monospace;font-size:12px;color:#C8A84B;margin-top:10px;"></div>' +
         '<div style="font-family:\'DM Sans\',sans-serif;font-size:12px;color:#666;margin-top:10px;line-height:1.5;">This will send it for scheduling. Your team will be notified immediately.</div>' +
@@ -432,7 +433,7 @@ console.log('LOADED:', 'render/client.js');
   /* ---- card 3-dot menu (singleton, repositioned on open) ---- */
 
   var _menuBtnStyle = 'display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#ccc;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;';
-  var _menuBtnBorder = 'border-top:1px solid #FFFFFF0F;';
+  var _menuBtnBorder = 'border-top:1px solid #2A2A34;';
 
   function _handleCardMenuAction(action, postId) {
     var post = (window.AppState.posts.all || []).find(function (p) { return p.post_id === postId || p.id === postId; });
@@ -845,7 +846,7 @@ console.log('LOADED:', 'render/client.js');
   /* ---- section label ---- */
 
   function _sectionLabel(text) {
-    return '<div class="section-label" style="font-family:\'IBM Plex Mono\',monospace;font-size:10px;letter-spacing:0.14em;text-transform:uppercase;">' + text + '</div>';
+    return '<div class="section-label" style="font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:600;letter-spacing:0.2em;text-transform:uppercase;color:#A0A0B0;">' + text + '</div>';
   }
 
   /* ---- top bar ---- */
@@ -856,32 +857,70 @@ console.log('LOADED:', 'render/client.js');
     return { c: '#C8A84B', bg: '#C8A84B0A', bc: '#C8A84B4D' };
   }
 
-  var ICON_BELL_SM = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>';
+  var ICON_BELL_SM = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#B0B0B8" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>';
 
-  function _topBarHtml(awaitCount) {
-    var clientName = _esc(window.AppState.user.name || '');
-    var pill = '';
-    if (awaitCount > 0) {
-      var pc = _pillColor(awaitCount);
-      pill = '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:10px;letter-spacing:0.06em;padding:3px 9px;border-radius:10px;background:' + pc.bg + ';color:' + pc.c + ';border:1px dotted ' + pc.bc + ';">' + awaitCount + ' AWAITING</span>';
+  /* Smart awaiting-pill palette.
+     State 1 (overdue):     red    #EF4444 / #EF444420
+     State 2 (awaiting):    gold   #C4A44A / #C4A44A18
+     State 3 (all clear):   green  #3ECF8E / #3ECF8E18 */
+  function _clientTopBarPill(awaitingPosts) {
+    var count = awaitingPosts.length;
+    if (count === 0) {
+      return {
+        text: 'All clear \u2713',
+        color: '#3ECF8E',
+        bg: '#3ECF8E18'
+      };
     }
-    return '<div style="display:flex;align-items:center;justify-content:space-between;padding:14px 16px;position:sticky;top:0;background:#1b1f23;z-index:100;border-bottom:1px dotted #FFFFFF14;">' +
-      '<div style="display:flex;align-items:baseline;">' +
-        '<span style="font-family:\'DM Sans\',sans-serif;font-size:13px;color:#555;">' + _greeting() + '</span>' +
-        (clientName ? '<span style="font-family:\'DM Sans\',sans-serif;font-weight:500;font-size:13px;color:#C8A84B;margin-left:5px;">' + clientName + '</span>' : '') +
+    var todayStr = new Date().toISOString().slice(0, 10);
+    var overdue = awaitingPosts.some(function(p) {
+      var td = p.targetDate || p.target_date || '';
+      return td && td < todayStr;
+    });
+    if (overdue) {
+      return {
+        text: count + ' awaiting',
+        color: '#EF4444',
+        bg: '#EF444420'
+      };
+    }
+    return {
+      text: count + ' awaiting',
+      color: '#C4A44A',
+      bg: '#C4A44A18'
+    };
+  }
+
+  function _topBarHtml(buckets) {
+    var clientName = _esc(window.AppState.user.name || '');
+    var awaiting = (buckets.approval || []).concat(buckets.input || []);
+    var pillData = _clientTopBarPill(awaiting);
+    var pillStyle = 'font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:700;letter-spacing:0.04em;padding:3px 10px;border-radius:12px;background:' + pillData.bg + ';color:' + pillData.color + ';border:none;white-space:nowrap;';
+    var pill = '<span style="' + pillStyle + '">' + _esc(pillData.text) + '</span>';
+
+    // Bell red dot only when unread notifications exist.
+    var unread = (window.AppState && window.AppState.ui && window.AppState.ui.unreadCount) || 0;
+    var bellDotStyle = unread > 0
+      ? 'position:absolute;top:2px;right:2px;width:7px;height:7px;border-radius:50%;background:#EF4444;'
+      : 'display:none;';
+
+    return '<div style="display:flex;align-items:center;justify-content:space-between;padding:14px 16px;position:sticky;top:0;background:#1b1f23;z-index:100;border-bottom:1px solid #2A2A34;">' +
+      '<div style="display:flex;align-items:baseline;min-width:0;flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-right:12px;">' +
+        '<span style="font-family:\'DM Sans\',sans-serif;font-size:15px;font-weight:600;color:#D0D0D8;">' + _greeting() + '</span>' +
+        (clientName ? '<span style="font-family:\'DM Sans\',sans-serif;font-weight:700;font-size:15px;color:#C4A44A;margin-left:6px;">' + clientName + '</span>' : '') +
       '</div>' +
-      '<div style="display:flex;align-items:center;gap:12px;">' +
+      '<div style="display:flex;align-items:center;gap:12px;flex-shrink:0;">' +
         pill +
-        '<button data-action="open-notifications" style="position:relative;background:none;border:none;color:#444;cursor:pointer;padding:4px;">' +
+        '<button data-action="open-notifications" style="position:relative;background:none;border:none;cursor:pointer;padding:4px;">' +
           ICON_BELL_SM +
-          '<span data-bell-dot style="position:absolute;top:2px;right:2px;width:6px;height:6px;border-radius:50%;background:#ef4444;"></span>' +
+          '<span data-bell-dot style="' + bellDotStyle + '"></span>' +
         '</button>' +
         '<div style="position:relative;">' +
-          '<button data-action="top-menu-toggle" style="background:none;border:none;color:#444;cursor:pointer;padding:4px;">' + ICON_DOTS + '</button>' +
-          '<div data-top-menu style="display:none;position:fixed;background:#0d0d0d;border:1px dotted #FFFFFF1F;border-radius:0;min-width:160px;z-index:999999;box-shadow:0 8px 24px #00000099;">' +
+          '<button data-action="top-menu-toggle" style="background:none;border:none;color:#909098;cursor:pointer;padding:4px;font-size:16px;">' + ICON_DOTS + '</button>' +
+          '<div data-top-menu style="display:none;position:fixed;background:#0d0d0d;border:1px solid #2A2A34;border-radius:0;min-width:160px;z-index:999999;box-shadow:0 8px 24px #00000099;">' +
             '<button data-action="new-request" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#ccc;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;">New Request</button>' +
-            '<button data-action="light-mode" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#555;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;border-top:1px solid #FFFFFF0F;">Light Mode</button>' +
-            '<button data-action="sign-out" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#888;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;border-top:1px solid #FFFFFF0F;">Sign Out</button>' +
+            '<button data-action="light-mode" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#555;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;border-top:1px solid #2A2A34;">Light Mode</button>' +
+            '<button data-action="sign-out" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#888;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;border-top:1px solid #2A2A34;">Sign Out</button>' +
           '</div>' +
         '</div>' +
       '</div>' +
@@ -906,7 +945,7 @@ console.log('LOADED:', 'render/client.js');
       var color = _clientActiveNav === action ? '#C8A84B' : '#555';
       return 'display:flex;flex-direction:column;align-items:center;gap:2px;background:none;border:none;color:' + color + ';cursor:pointer;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.04em;padding:4px 12px;';
     };
-    nav.style.cssText = 'position:fixed;bottom:0;left:0;right:0;display:flex;justify-content:space-around;align-items:center;padding:8px 0 calc(8px + env(safe-area-inset-bottom));background:#1B1F23;border-top:1px solid #FFFFFF0F;z-index:100;max-width:430px;margin:0 auto;';
+    nav.style.cssText = 'position:fixed;bottom:0;left:0;right:0;display:flex;justify-content:space-around;align-items:center;padding:8px 0 calc(8px + env(safe-area-inset-bottom));background:#1B1F23;border-top:1px solid #2A2A34;z-index:100;max-width:430px;margin:0 auto;';
     nav.className = '';
     nav.innerHTML =
       '<button class="tab-btn" data-tab="tasks" data-action="nav-feed" style="' + btnStyle('feed') + '">' +
@@ -2092,7 +2131,7 @@ console.log('LOADED:', 'render/client.js');
     var buckets = _bucket(posts);
     var awaitCount = buckets.approval.length + buckets.input.length;
 
-    var html = _topBarHtml(awaitCount);
+    var html = _topBarHtml(buckets);
 
     var hasContent = buckets.approval.length || buckets.input.length || buckets.published.length;
 
@@ -2216,7 +2255,7 @@ console.log('LOADED:', 'render/client.js');
     overlay.id = 'client-post-overlay';
     overlay.style.cssText = 'position:fixed;inset:0;z-index:9000;background:#1b1f23;overflow-y:auto;-webkit-overflow-scrolling:touch;font-family:\'DM Sans\',sans-serif;';
     overlay.innerHTML =
-      '<div style="position:sticky;top:0;z-index:10;background:#1B1F23;padding:0;border-bottom:1px solid #FFFFFF0F;">' +
+      '<div style="position:sticky;top:0;z-index:10;background:#1B1F23;padding:0;border-bottom:1px solid #2A2A34;">' +
         '<button id="client-overlay-close" style="background:none;border:none;color:#888;font-size:24px;cursor:pointer;padding:12px 16px;">&#x2715;</button>' +
       '</div>' +
       '<div style="padding-bottom:72px;">' +

--- a/styles.css
+++ b/styles.css
@@ -5413,20 +5413,20 @@ body.client-mode {
   --space-3: 0.75rem;
   --space-4: 1rem;
   --space-5: 1.25rem;
-  --text-name: 0.9375rem;
-  --text-meta: 0.75rem;
-  --text-caption: 0.9375rem;
-  --text-action: 0.75rem;
+  --text-name: 1rem;          /* 16px — post title */
+  --text-meta: 0.6875rem;     /* 11px — meta line */
+  --text-caption: 0.875rem;   /* 14px — caption body */
+  --text-action: 0.6875rem;   /* 11px — eng-bar labels */
   --text-primary: #FFFFFF;
-  --text-secondary: #FFFFFF99;
-  --text-tertiary: #FFFFFF59;
+  --text-secondary: #B0B0B8;  /* brighter meta / eng labels */
+  --text-tertiary: #909098;   /* date line, etc. */
   --layer-0: #1b1f23;
   --layer-1: #000000;
-  --divider: #FFFFFF0F;
-  --status-overdue: #FF5A5AD9;
-  --status-waiting: #F6A623D9;
-  --status-input: #22D3EED9;
-  --status-live: #3ECF8ED9;
+  --divider: #2A2A34;         /* bumped from #FFFFFF0F for visibility */
+  --status-overdue: #EF4444;
+  --status-waiting: #FBBF24;
+  --status-input: #22D3EE;
+  --status-live: #3ECF8E;
 }
 
 body.client-mode .post-card {
@@ -5458,7 +5458,7 @@ body.client-mode .cf-headtext {
 
 body.client-mode .cf-title {
   font-size: var(--text-name);
-  font-weight: 600;
+  font-weight: 700;
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -5477,23 +5477,23 @@ body.client-mode .cf-meta-line {
   line-height: 1.4;
 }
 
-body.client-mode .cf-dot { opacity: 0.35; }
+body.client-mode .cf-dot { color: #505058; opacity: 1; }
 
-body.client-mode .cf-status { font-weight: 500; }
+body.client-mode .cf-status { font-weight: 600; }
 body.client-mode .cf-overdue { color: var(--status-overdue); }
 body.client-mode .cf-waiting { color: var(--status-waiting); }
 body.client-mode .cf-input-needed { color: var(--status-input); }
 body.client-mode .cf-live { color: var(--status-live); }
 
 body.client-mode .cf-date-line {
-  font-size: 0.6875rem;
+  font-size: 0.625rem; /* 10px */
   color: var(--text-tertiary);
   margin-top: 1px;
   line-height: 1.4;
 }
 
 body.client-mode .cf-dots {
-  color: var(--text-tertiary);
+  color: #909098;
   cursor: pointer;
   padding: 0.125rem 0 0.125rem 0.5rem;
   flex-shrink: 0;
@@ -5504,11 +5504,11 @@ body.client-mode .cf-caption {
   margin-top: var(--space-3);
   padding: 0 var(--space-4);
   font-size: var(--text-caption);
-  line-height: 1.55;
-  color: var(--text-primary);
+  line-height: 1.6;
+  color: #E0E0E8;
 }
 
-body.client-mode .see-more { color: #0a66c2; }
+body.client-mode .see-more { color: #4A9FD8; font-weight: 500; }
 
 body.client-mode .eng-bar {
   background: transparent;
@@ -5518,6 +5518,7 @@ body.client-mode .eng-bar {
 
 body.client-mode .eng-btn {
   font-size: var(--text-action);
+  font-weight: 500;
   color: var(--text-secondary);
   padding: 0.75rem var(--space-2);
   min-height: 44px;
@@ -5527,21 +5528,30 @@ body.client-mode .eng-btn {
   gap: 4px;
 }
 
+body.client-mode .eng-btn svg {
+  stroke: #B0B0B8;
+}
+
 body.client-mode .eng-btn:active {
   opacity: 0.5;
-  background: #FFFFFF08;
+  background: #2A2A34;
 }
 
 body.client-mode .stats-bar {
-  font-size: 0.75rem;
-  color: var(--text-tertiary);
+  font-size: 0.6875rem; /* 11px */
+  color: var(--text-secondary);
   font-family: 'DM Sans', sans-serif;
   padding: var(--space-2) var(--space-4);
 }
 
 body.client-mode .section-label {
-  color: var(--text-tertiary);
+  color: #A0A0B0;
   padding: var(--space-3) var(--space-4) var(--space-2);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.625rem; /* 10px */
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
 }
 
 body.client-mode .img-single {


### PR DESCRIPTION
## Summary
Visual-only pass over the client feed. No layout changes, no new features, no schema. `actions/pcs.js` untouched, comment section untouched (already revamped in prior PRs). 508/508 tests green.

## Changes

### 1. `_topBarHtml` — smart awaiting pill + bright greeting
`render/client.js`. Signature changed from `(awaitCount)` → `(buckets)` and the single `renderClientView` caller was updated. New `_clientTopBarPill(awaitingPosts)` helper returns one of three states:

| State | Text | Color | Background |
|---|---|---|---|
| Any awaiting post has `target_date < today` | `{N} awaiting` | `#EF4444` | `#EF444420` |
| Awaiting posts exist but none overdue | `{N} awaiting` | `#C4A44A` | `#C4A44A18` |
| Zero awaiting posts | `All clear ✓` | `#3ECF8E` | `#3ECF8E18` |

Pill has `border:none`, `border-radius:12px`, `padding:3px 10px`, IBM Plex Mono `10px / 700`, `white-space:nowrap`. Greeting is 15px 600 `#D0D0D8`, name is 15px 700 `#C4A44A`, greeting row is `flex:1 min-width:0 white-space:nowrap overflow:hidden text-overflow:ellipsis` so it can never wrap. Bell icon stroke bumped to `#B0B0B8`, red dot renders only when `AppState.ui.unreadCount > 0`. Menu dots color `#909098` 16px. Top-bar `border-bottom` bumped to `1px solid #2A2A34`.

### 2. Card header (`_cardHeaderHtml`)
Handled via `body.client-mode` CSS tokens (the function already uses `.cf-title`, `.cf-meta-line`, `.cf-date-line`, `.cf-dot`, `.cf-dots` classes):
- `.cf-title` → 16px 700 `#FFFFFF` (was 15px 600)
- `.cf-meta-line` → 11px `#B0B0B8` (was 12px `#FFFFFF99`)
- `.cf-dot` → color `#505058` opacity 1 (was opacity 0.35)
- `.cf-status` → font-weight 600
- `.cf-overdue` → uses `--status-overdue: #EF4444`
- `.cf-date-line` → 10px `#909098`
- `.cf-dots` → color `#909098`

### 3. `_captionHtml`
14px / line-height 1.6 / `#E0E0E8` body. `"...more"` link uses the `.see-more` class which is now `#4A9FD8` 500. Inline styles kept in the function body for parity with the CSS block.

### 4. `_statsBarHtml`
Waiting >2 days now `#EF4444`, otherwise `#FBBF24`. Both 11px 600. Comment count `#B0B0B8` 11px. Published-state `Approved` line is `#3ECF8E` 11px 600.

### 5. `_engagementBarHtml`
Between-button divider `1px solid #2A2A34` (was `#FFFFFF08`). Button labels `color:#B0B0B8; font-size:11px; font-weight:500` inline. CSS `.eng-btn svg { stroke: #B0B0B8 }` added so Approve/Comment/WhatsApp icons match the labels. `:active` bg bumped `#FFFFFF08` → `#2A2A34`.

### 6. `_sectionLabel`
`#A0A0B0`, IBM Plex Mono 10px 600, letter-spacing `0.2em`, uppercase. Applied both inline and in the `body.client-mode .section-label` CSS block.

### 7. Borders & dividers bumped to `#2A2A34`
`render/client.js`:
- approve-popup border (`_approvePopupHtml`)
- card 3-dot menu button border-top (`_menuBtnBorder`)
- bottom nav border-top (`_setClientNav`)
- post-overlay header border (`_openClientPostOverlay`)
- top menu dropdown border + separators (`_topBarHtml`)

`styles.css body.client-mode`:
- `--divider: #2A2A34` (was `#FFFFFF0F`)
- Token palette: `--text-secondary: #B0B0B8`, `--text-tertiary: #909098`, `--text-name: 1rem`, `--text-meta: 0.6875rem`, `--text-caption: 0.875rem`, `--text-action: 0.6875rem`
- Status palette hardened: overdue `#EF4444`, waiting `#FBBF24`, input `#22D3EE`, live `#3ECF8E` (drop the `D9` alpha)

PCS-side rules untouched — all changes scoped to `body.client-mode` or the client-only client.js helpers.

### 8. Version bump
All 21 versioned resources: `?v=20260411i` → `?v=20260411k`.

## What this PR does NOT change
- Card layout, ordering, or any functional wiring
- `actions/pcs.js`
- Comment section visuals (already revamped in #779 / #781 / #782 / #784 / #786 / #787 / #788)
- `_handleSubmitComment`, `_clientToggleComments`, `_wireEvents`, `loadPostsForClient`
- CLAUDE.md (visual-only pass doesn't qualify)

## Test plan
- [x] `./node_modules/.bin/vitest run` → **508/508 passing**
- [x] `node -c render/client.js` → OK
- [ ] Top bar shows greeting + name on a single line, name in gold
- [ ] Feed with an overdue awaiting_approval post → pill renders red
- [ ] Feed with awaiting posts but none overdue → pill renders gold
- [ ] Feed with zero awaiting posts → pill renders green "All clear ✓"
- [ ] Unread notifications → red dot on the bell; zero → no dot
- [ ] Post titles are pure white and bold
- [ ] Meta line and date line are clearly readable
- [ ] Caption body is bright `#E0E0E8`, `...more` link is `#4A9FD8`
- [ ] Stats bar uses correct urgency colors per day count
- [ ] Engagement bar labels and SVG strokes are `#B0B0B8`
- [ ] Section labels (`AWAITING YOUR APPROVAL`, etc.) are bright mono caps
- [ ] All dividers visible at `#2A2A34`
- [ ] No regression on PCS comment section

## Deployment notes
- Version bumped to `?v=20260411k` on all 21 resources
- Purge Cloudflare cache after merge
- Hard refresh on devices before testing

https://claude.ai/code/session_01D8fsKvkbJMjNmvSzvf7m6X