### PR TITLE
fix(client): unified bg + grounded stats bar + Comment glow on type

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411l">
+ <link rel="stylesheet" href="styles.css?v=20260411m">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411l"></script>
-<script src="00-appstate-compat.js?v=20260411l"></script>
-<script src="01-config.js?v=20260411l" defer></script>
-<script src="02-session.js?v=20260411l" defer></script>
-<script src="utils.js?v=20260411l" defer></script>
-<script src="03-auth.js?v=20260411l" defer></script>
-<script src="05-api.js?v=20260411l" defer></script>
-<script src="10-ui.js?v=20260411l" defer></script>
+<script src="00-appstate.js?v=20260411m"></script>
+<script src="00-appstate-compat.js?v=20260411m"></script>
+<script src="01-config.js?v=20260411m" defer></script>
+<script src="02-session.js?v=20260411m" defer></script>
+<script src="utils.js?v=20260411m" defer></script>
+<script src="03-auth.js?v=20260411m" defer></script>
+<script src="05-api.js?v=20260411m" defer></script>
+<script src="10-ui.js?v=20260411m" defer></script>
 
-<script src="06-post-create.js?v=20260411l" defer></script>
-<script defer src="render/dashboard.js?v=20260411l"></script>
-<script defer src="render/client.js?v=20260411l"></script>
-<script defer src="render/pipeline.js?v=20260411l"></script>
-<script defer src="render/brief.js?v=20260411l"></script>
-<script defer src="actions/pcs.js?v=20260411l"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411l"></script>
-<script src="07-post-load.js?v=20260411l" defer></script>
-<script src="08-post-actions.js?v=20260411l" defer></script>
-<script src="09-library.js?v=20260411l" defer></script>
-<script src="09-approval.js?v=20260411l" defer></script>
-<script src="04-router.js?v=20260411l" defer></script>
+<script src="06-post-create.js?v=20260411m" defer></script>
+<script defer src="render/dashboard.js?v=20260411m"></script>
+<script defer src="render/client.js?v=20260411m"></script>
+<script defer src="render/pipeline.js?v=20260411m"></script>
+<script defer src="render/brief.js?v=20260411m"></script>
+<script defer src="actions/pcs.js?v=20260411m"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411m"></script>
+<script src="07-post-load.js?v=20260411m" defer></script>
+<script src="08-post-actions.js?v=20260411m" defer></script>
+<script src="09-library.js?v=20260411m" defer></script>
+<script src="09-approval.js?v=20260411m" defer></script>
+<script src="04-router.js?v=20260411m" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -363,20 +363,20 @@ console.log('LOADED:', 'render/client.js');
     var left = '';
     if (isPublished) {
       var approvedDate = post.status_changed_at || post.statusChangedAt || post.updated_at || '';
-      left = '<span style="display:inline-flex;align-items:center;gap:6px;line-height:1;color:#3ECF8E;font-size:12px;font-weight:500;">' +
+      left = '<span style="display:inline-flex;align-items:center;gap:6px;line-height:1.4;color:#3ECF8E;font-size:12px;font-weight:500;">' +
         ICON_CHECK + ' Approved' +
         (approvedDate ? ' &middot; ' + _esc(_fmtDate(approvedDate)) : '') +
         '</span>';
     } else {
       var days = _waitDays(post);
       var dColor = days > 2 ? '#EF4444' : '#FBBF24';
-      left = '<span style="display:inline-flex;align-items:center;gap:6px;line-height:1;color:' + dColor + ';font-size:12px;font-weight:500;">' +
+      left = '<span style="display:inline-flex;align-items:center;gap:6px;line-height:1.4;color:' + dColor + ';font-size:12px;font-weight:500;">' +
         ICON_CLOCK_14 +
         '<span>Waiting ' + days + ' day' + (days !== 1 ? 's' : '') + '</span>' +
         '</span>';
     }
     var count = _commentCount(post);
-    var right = '<span style="display:inline-flex;align-items:center;line-height:1;color:#909098;font-size:12px;font-weight:500;">' +
+    var right = '<span style="display:inline-flex;align-items:center;line-height:1.4;color:#909098;font-size:12px;font-weight:500;">' +
       count + ' comment' + (count === 1 ? '' : 's') +
     '</span>';
     return '<div class="stats-bar" style="display:flex;align-items:center;justify-content:space-between;">' +
@@ -908,7 +908,7 @@ console.log('LOADED:', 'render/client.js');
       ? 'position:absolute;top:2px;right:2px;width:7px;height:7px;border-radius:50%;background:#EF4444;'
       : 'display:none;';
 
-    return '<div style="display:flex;align-items:center;justify-content:space-between;padding:12px 16px;position:sticky;top:0;background:#1b1f23;z-index:100;border-bottom:1px solid #2A2A34;">' +
+    return '<div style="display:flex;align-items:center;justify-content:space-between;padding:12px 16px;position:sticky;top:0;background:#0D0D12;z-index:100;border-bottom:1px solid #2A2A34;">' +
       '<div style="display:flex;align-items:center;min-width:0;flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-right:12px;line-height:1.4;">' +
         '<span style="font-family:\'DM Sans\',sans-serif;font-size:14px;font-weight:500;color:#B0B0B8;line-height:1.4;">' + _greeting() + '</span>' +
         (clientName ? '<span style="font-family:\'DM Sans\',sans-serif;font-weight:700;font-size:14px;color:#C4A44A;margin-left:6px;line-height:1.4;">' + clientName + '</span>' : '') +
@@ -949,7 +949,7 @@ console.log('LOADED:', 'render/client.js');
       var color = _clientActiveNav === action ? '#C8A84B' : '#555';
       return 'display:flex;flex-direction:column;align-items:center;gap:2px;background:none;border:none;color:' + color + ';cursor:pointer;font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:0.04em;padding:4px 12px;';
     };
-    nav.style.cssText = 'position:fixed;bottom:0;left:0;right:0;display:flex;justify-content:space-around;align-items:center;padding:8px 0 calc(8px + env(safe-area-inset-bottom));background:#1B1F23;border-top:1px solid #2A2A34;z-index:100;max-width:430px;margin:0 auto;';
+    nav.style.cssText = 'position:fixed;bottom:0;left:0;right:0;display:flex;justify-content:space-around;align-items:center;padding:8px 0 calc(8px + env(safe-area-inset-bottom));background:#0D0D12;border-top:1px solid #2A2A34;z-index:100;max-width:430px;margin:0 auto;';
     nav.className = '';
     nav.innerHTML =
       '<button class="tab-btn" data-tab="tasks" data-action="nav-feed" style="' + btnStyle('feed') + '">' +
@@ -2109,6 +2109,29 @@ console.log('LOADED:', 'render/client.js');
             input.scrollIntoView({ behavior: 'smooth', block: 'center' });
           }, 300);
         });
+        // Glow the "Comment" submit button gold when the input has
+        // content OR when the user has staged pending images. When
+        // both are empty the button returns to dim grey with
+        // cursor:default so it reads inert.
+        input.addEventListener('input', function() {
+          var pid = this.id.replace(/^comment-input-/, '');
+          var btn = document.querySelector(
+            'button[data-action="submitComment"][data-id="' + pid + '"]');
+          if (!btn) return;
+          var hasContent = this.value.trim().length > 0;
+          var hasPendingImgs = window._clientFeedPendingImgs &&
+            window._clientFeedPendingImgs[pid] &&
+            window._clientFeedPendingImgs[pid].length > 0;
+          if (hasContent || hasPendingImgs) {
+            btn.style.background = '#C4A44A';
+            btn.style.color = '#000000';
+            btn.style.cursor = 'pointer';
+          } else {
+            btn.style.background = '#2A2A34';
+            btn.style.color = '#555560';
+            btn.style.cursor = 'default';
+          }
+        });
       })(inputs[i]);
     }
   }
@@ -2123,7 +2146,7 @@ console.log('LOADED:', 'render/client.js');
     _ensurePulseStyle();
     _ensureReqOverlay();
     cv.style.display = 'block';
-    cv.style.background = '#1b1f23';
+    cv.style.background = '#0D0D12';
 
     var fab = document.getElementById('fab');
     if (fab) fab.style.display = 'none';
@@ -2257,9 +2280,9 @@ console.log('LOADED:', 'render/client.js');
 
     var overlay = document.createElement('div');
     overlay.id = 'client-post-overlay';
-    overlay.style.cssText = 'position:fixed;inset:0;z-index:9000;background:#1b1f23;overflow-y:auto;-webkit-overflow-scrolling:touch;font-family:\'DM Sans\',sans-serif;';
+    overlay.style.cssText = 'position:fixed;inset:0;z-index:9000;background:#0D0D12;overflow-y:auto;-webkit-overflow-scrolling:touch;font-family:\'DM Sans\',sans-serif;';
     overlay.innerHTML =
-      '<div style="position:sticky;top:0;z-index:10;background:#1B1F23;padding:0;border-bottom:1px solid #2A2A34;">' +
+      '<div style="position:sticky;top:0;z-index:10;background:#0D0D12;padding:0;border-bottom:1px solid #2A2A34;">' +
         '<button id="client-overlay-close" style="background:none;border:none;color:#888;font-size:24px;cursor:pointer;padding:12px 16px;">&#x2715;</button>' +
       '</div>' +
       '<div style="padding-bottom:72px;">' +

--- a/styles.css
+++ b/styles.css
@@ -5383,14 +5383,14 @@ input[type="date"].nps-select::-webkit-date-and-time-value {
 body.client-mode .topbar,
 body.client-mode header,
 body.client-mode #top-bar {
-  background: #1b1f23 !important;
+  background: #0D0D12 !important;
   backdrop-filter: none !important;
   filter: none !important;
   box-shadow: none !important;
 }
 
 body.client-mode .bottom-nav {
-  background: #1b1f23 !important;
+  background: #0D0D12 !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
   filter: none !important;
@@ -5420,8 +5420,8 @@ body.client-mode {
   --text-primary: #FFFFFF;
   --text-secondary: #B0B0B8;  /* brighter meta / eng labels */
   --text-tertiary: #909098;   /* date line, etc. */
-  --layer-0: #1b1f23;
-  --layer-1: #000000;
+  --layer-0: #0D0D12;         /* unified client bg */
+  --layer-1: #0D0D12;         /* unified client bg — cards match wrapper */
   --divider: #2A2A34;         /* bumped from #FFFFFF0F for visibility */
   --status-overdue: #EF4444;
   --status-waiting: #FBBF24;
@@ -5542,6 +5542,14 @@ body.client-mode .stats-bar {
   color: var(--text-secondary);
   font-family: 'DM Sans', sans-serif;
   padding: var(--space-2) var(--space-4);
+  /* Ground the bar so it doesn't float between the image and the
+     engagement bar: a visible divider below + a real min-height
+     give it actual vertical presence, and its border-bottom
+     connects directly to the .eng-bar border-top. */
+  border-bottom: 1px solid #2A2A34;
+  min-height: 36px;
+  display: flex;
+  align-items: center;
 }
 
 body.client-mode .section-label {


### PR DESCRIPTION
## Summary
Three visual fixes surfaced by the post-#790 audit. No layout changes, no schema, no new features, `actions/pcs.js` untouched. 508/508 tests green.

## Fixes

### 1. Unified client background to `#0D0D12`
Root cause: `#client-view` inline background was `#1b1f23` but `.post-card` was `#000000` via `--layer-1`. That's why the gutters between cards and around section labels visibly banded against the cards themselves.

Every `#1b1f23` / `#1B1F23` reference on the client rendering surface was swapped to `#0D0D12`:

`render/client.js`
- `renderClientView` (~L2126): `cv.style.background = '#0D0D12'`
- `_topBarHtml` sticky wrapper (~L911)
- `_setClientNav` bottom nav inline styles (~L952)
- `_openClientPostOverlay` overlay + sticky close bar (~L2260, L2262)

`styles.css` `body.client-mode`
- `--layer-0: #1b1f23 → #0D0D12`
- `--layer-1: #000000 → #0D0D12` (cards now match wrapper — no pure-black cards on a charcoal page)
- `.topbar / header / #top-bar { background: #0D0D12 !important }`
- `.bottom-nav { background: #0D0D12 !important }`

Result: top bar, feed wrapper, post cards, section labels, gutters between cards, bottom nav, and the post overlay all render the same `#0D0D12`. No banding.

### 2. Stats bar grounded
`styles.css body.client-mode .stats-bar` now carries:
```css
border-bottom: 1px solid #2A2A34;
min-height: 36px;
display: flex;
align-items: center;
```
The bottom border connects directly to `.eng-bar`'s existing `border-top`, so the stats + engagement bars now read as a single continuous anchored block instead of two disconnected strips.

`render/client.js _statsBarHtml`: both inline spans bumped `line-height:1` → `line-height:1.4` so the label text has real vertical presence instead of hugging its own baseline.

### 3. Comment submit button glows gold when typing
Root cause audit in the prior response: zero `input`-event listeners on `#comment-input-<pid>`, so the submit button rendered with static `background:#2A2A34; color:#555560; cursor:default` and looked permanently disabled.

`render/client.js _wireCommentInputFocus` (~L2102) — the existing per-render loop over `[id^="comment-input-"]` now also binds an `input` event listener. On every keystroke it resolves the sibling submit button via:
```js
var pid = this.id.replace(/^comment-input-/, '');
var btn = document.querySelector(
  'button[data-action="submitComment"][data-id="' + pid + '"]');
```
and flips its inline style:
- **Has content OR pending images** → `background:#C4A44A; color:#000; cursor:pointer`
- **Empty AND no pending images** → `background:#2A2A34; color:#555560; cursor:default`

Pending-images check reads `window._clientFeedPendingImgs[pid]` so photo-only submissions also glow. Hooks into the existing `_wireCommentInputFocus` pipeline so no new call sites are needed — each `renderClientView` refresh rewires the listeners automatically (old DOM is dropped by `cv.innerHTML` swap).

No changes to `_wireEvents`, `_clientToggleComments`, `_handleSubmitComment`, or the comment section rendering.

### 4. Version bump
All 21 versioned resources: `?v=20260411l` → `?v=20260411m`.

## What this PR does NOT change
- Card layout or structure
- `actions/pcs.js`
- Comment section rendering (`_singleCommentHtml`, `_buildThreadedCommentsHtml`)
- `_handleSubmitComment`, `_wireEvents`, `_clientToggleComments`
- CLAUDE.md (visual fixes don't qualify)

## Test plan
- [x] `./node_modules/.bin/vitest run` → **508/508 passing**
- [x] `node -c render/client.js` → OK
- [x] Top bar, feed wrapper, post cards, section labels, gaps, bottom nav all render `#0D0D12` — confirmed via grep on the source
- [ ] No color banding between cards visible in the browser
- [ ] Stats bar has a bottom border connecting directly to the engagement bar top border
- [ ] Stats bar text reads with proper vertical presence (line-height 1.4 + min-height 36px)
- [ ] Typing in the comment input turns Comment button gold with black text
- [ ] Clearing the input returns the button to dim grey
- [ ] Uploading a photo with no text still glows the button gold (pending images path)
- [ ] Post overlay and bottom nav match `#0D0D12`
- [ ] No visual regression on engagement bar, comment section, PCS view

## Deployment notes
- Version bumped to `?v=20260411m` on all 21 resources
- Purge Cloudflare cache after merge
- Hard refresh on devices before testing

https://claude.ai/code/session_01D8fsKvkbJMjNmvSzvf7m6X