### PR TITLE
fix(client): remove double border between stats bar and eng bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411m">
+ <link rel="stylesheet" href="styles.css?v=20260411n">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411m"></script>
-<script src="00-appstate-compat.js?v=20260411m"></script>
-<script src="01-config.js?v=20260411m" defer></script>
-<script src="02-session.js?v=20260411m" defer></script>
-<script src="utils.js?v=20260411m" defer></script>
-<script src="03-auth.js?v=20260411m" defer></script>
-<script src="05-api.js?v=20260411m" defer></script>
-<script src="10-ui.js?v=20260411m" defer></script>
+<script src="00-appstate.js?v=20260411n"></script>
+<script src="00-appstate-compat.js?v=20260411n"></script>
+<script src="01-config.js?v=20260411n" defer></script>
+<script src="02-session.js?v=20260411n" defer></script>
+<script src="utils.js?v=20260411n" defer></script>
+<script src="03-auth.js?v=20260411n" defer></script>
+<script src="05-api.js?v=20260411n" defer></script>
+<script src="10-ui.js?v=20260411n" defer></script>
 
-<script src="06-post-create.js?v=20260411m" defer></script>
-<script defer src="render/dashboard.js?v=20260411m"></script>
-<script defer src="render/client.js?v=20260411m"></script>
-<script defer src="render/pipeline.js?v=20260411m"></script>
-<script defer src="render/brief.js?v=20260411m"></script>
-<script defer src="actions/pcs.js?v=20260411m"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411m"></script>
-<script src="07-post-load.js?v=20260411m" defer></script>
-<script src="08-post-actions.js?v=20260411m" defer></script>
-<script src="09-library.js?v=20260411m" defer></script>
-<script src="09-approval.js?v=20260411m" defer></script>
-<script src="04-router.js?v=20260411m" defer></script>
+<script src="06-post-create.js?v=20260411n" defer></script>
+<script defer src="render/dashboard.js?v=20260411n"></script>
+<script defer src="render/client.js?v=20260411n"></script>
+<script defer src="render/pipeline.js?v=20260411n"></script>
+<script defer src="render/brief.js?v=20260411n"></script>
+<script defer src="actions/pcs.js?v=20260411n"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411n"></script>
+<script src="07-post-load.js?v=20260411n" defer></script>
+<script src="08-post-actions.js?v=20260411n" defer></script>
+<script src="09-library.js?v=20260411n" defer></script>
+<script src="09-approval.js?v=20260411n" defer></script>
+<script src="04-router.js?v=20260411n" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -5542,11 +5542,9 @@ body.client-mode .stats-bar {
   color: var(--text-secondary);
   font-family: 'DM Sans', sans-serif;
   padding: var(--space-2) var(--space-4);
-  /* Ground the bar so it doesn't float between the image and the
-     engagement bar: a visible divider below + a real min-height
-     give it actual vertical presence, and its border-bottom
-     connects directly to the .eng-bar border-top. */
-  border-bottom: 1px solid #2A2A34;
+  /* Grounded via min-height + flex centering. No border-bottom —
+     .eng-bar already draws a border-top at the same #2A2A34 tone,
+     so adding one here caused a visible double line. */
   min-height: 36px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
One-line visual fix. PR #791 added `border-bottom: 1px solid #2A2A34` to `.stats-bar` to anchor it, but `.eng-bar` already has `border-top: 1px solid #2A2A34` at the exact same tone — the two borders landed on top of each other and rendered as a visible double line.

## Change
`styles.css` `body.client-mode .stats-bar`: removed the `border-bottom`. Kept `min-height: 36px`, `display: flex`, `align-items: center` from #791 so the bar still reads grounded — the `.eng-bar` top border alone is now the single dividing line between the two bars.

Comment refreshed to note why no border-bottom is needed here.

## Version bump
All 21 versioned resources: `?v=20260411m` → `?v=20260411n`.

## Not changed
- `render/client.js`
- `actions/pcs.js`
- CLAUDE.md

## Test plan
- [x] `./node_modules/.bin/vitest run` → **508/508 passing**
- [ ] Browser: only one `#2A2A34` divider line visible between the stats bar and engagement bar
- [ ] Stats bar still grounded (min-height 36 + flex centering preserved)

## Deployment notes
- Version bumped to `?v=20260411n` on all 21 resources
- Purge Cloudflare cache after merge
- Hard refresh on devices before testing

https://claude.ai/code/session_01D8fsKvkbJMjNmvSzvf7m6X