### PR TITLE
fix(client): Comment button glow matches SEND REQUEST look

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411n">
+ <link rel="stylesheet" href="styles.css?v=20260411o">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411n"></script>
-<script src="00-appstate-compat.js?v=20260411n"></script>
-<script src="01-config.js?v=20260411n" defer></script>
-<script src="02-session.js?v=20260411n" defer></script>
-<script src="utils.js?v=20260411n" defer></script>
-<script src="03-auth.js?v=20260411n" defer></script>
-<script src="05-api.js?v=20260411n" defer></script>
-<script src="10-ui.js?v=20260411n" defer></script>
+<script src="00-appstate.js?v=20260411o"></script>
+<script src="00-appstate-compat.js?v=20260411o"></script>
+<script src="01-config.js?v=20260411o" defer></script>
+<script src="02-session.js?v=20260411o" defer></script>
+<script src="utils.js?v=20260411o" defer></script>
+<script src="03-auth.js?v=20260411o" defer></script>
+<script src="05-api.js?v=20260411o" defer></script>
+<script src="10-ui.js?v=20260411o" defer></script>
 
-<script src="06-post-create.js?v=20260411n" defer></script>
-<script defer src="render/dashboard.js?v=20260411n"></script>
-<script defer src="render/client.js?v=20260411n"></script>
-<script defer src="render/pipeline.js?v=20260411n"></script>
-<script defer src="render/brief.js?v=20260411n"></script>
-<script defer src="actions/pcs.js?v=20260411n"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411n"></script>
-<script src="07-post-load.js?v=20260411n" defer></script>
-<script src="08-post-actions.js?v=20260411n" defer></script>
-<script src="09-library.js?v=20260411n" defer></script>
-<script src="09-approval.js?v=20260411n" defer></script>
-<script src="04-router.js?v=20260411n" defer></script>
+<script src="06-post-create.js?v=20260411o" defer></script>
+<script defer src="render/dashboard.js?v=20260411o"></script>
+<script defer src="render/client.js?v=20260411o"></script>
+<script defer src="render/pipeline.js?v=20260411o"></script>
+<script defer src="render/brief.js?v=20260411o"></script>
+<script defer src="actions/pcs.js?v=20260411o"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411o"></script>
+<script src="07-post-load.js?v=20260411o" defer></script>
+<script src="08-post-actions.js?v=20260411o" defer></script>
+<script src="09-library.js?v=20260411o" defer></script>
+<script src="09-approval.js?v=20260411o" defer></script>
+<script src="04-router.js?v=20260411o" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -797,7 +797,7 @@ console.log('LOADED:', 'render/client.js');
         '<span role="button" aria-label="mention" onclick="window._clientToggleMention(\'' + pid + '\')" style="cursor:pointer;display:inline-flex;align-items:center;">' + ICON_MENTION_SVG + '</span>' +
       '</div>' +
       /* Comment button is now the sole submit trigger for this bar */
-      '<button data-action="submitComment" data-id="' + pid + '" style="background:#2A2A34;border:none;border-radius:20px;padding:8px 20px;font-size:13px;font-weight:600;color:#555560;cursor:default;font-family:\'DM Sans\',sans-serif;">Comment</button>' +
+      '<button data-action="submitComment" data-id="' + pid + '" style="background:#2A2A34;border:1px solid transparent;border-radius:20px;padding:8px 20px;font-size:13px;font-weight:600;color:#555560;cursor:default;font-family:\'DM Sans\',sans-serif;">Comment</button>' +
     '</div>' +
     /* Row 4 — image preview strip (hidden by default; JS flips to flex) */
     '<div id="client-img-preview-' + pid + '" style="display:none;gap:6px;flex-wrap:wrap;padding:0 14px 8px 59px;"></div>' +
@@ -2123,11 +2123,16 @@ console.log('LOADED:', 'render/client.js');
             window._clientFeedPendingImgs[pid] &&
             window._clientFeedPendingImgs[pid].length > 0;
           if (hasContent || hasPendingImgs) {
-            btn.style.background = '#C4A44A';
-            btn.style.color = '#000000';
+            // SEND REQUEST–matching look: transparent fill + gold
+            // outline + gold text. Border is always present so the
+            // button's bounding box doesn't jump between states.
+            btn.style.background = 'transparent';
+            btn.style.border = '1px solid #C4A44A';
+            btn.style.color = '#C4A44A';
             btn.style.cursor = 'pointer';
           } else {
             btn.style.background = '#2A2A34';
+            btn.style.border = '1px solid transparent';
             btn.style.color = '#555560';
             btn.style.cursor = 'default';
           }


### PR DESCRIPTION
## Summary
This PR carries **FIX 2 only**. FIX 1 (stats-bar / eng-bar double border) already landed in main via PR #792 earlier in this session — `.stats-bar` no longer has a `border-bottom`. Confirmed on pull: `main` sits at `c601fe6 Merge pull request #792` and `grep 'border-bottom' styles.css` around `.stats-bar` returns nothing.

## Change — Comment button glow matches the SEND REQUEST look

### `render/client.js` `_commentInputHtml` (~L800)
Initial inline style on the submit button now includes `border:1px solid transparent` so the button's bounding box is stable between idle and active states. Without this, the 1px outline that appears on active would make the button grow 2px and visibly jump when the user starts typing.

```diff
- style="background:#2A2A34;border:none;border-radius:20px;padding:8px 20px;…"
+ style="background:#2A2A34;border:1px solid transparent;border-radius:20px;padding:8px 20px;…"
```

### `render/client.js` `_wireCommentInputFocus` input listener (~L2120)
The active state (user has typed content OR has pending images) now renders as a hollow gold outline instead of a solid gold fill:

```diff
  if (hasContent || hasPendingImgs) {
-   btn.style.background = '#C4A44A';
-   btn.style.color = '#000000';
-   btn.style.cursor = 'pointer';
+   btn.style.background = 'transparent';
+   btn.style.border = '1px solid #C4A44A';
+   btn.style.color = '#C4A44A';
+   btn.style.cursor = 'pointer';
  } else {
    btn.style.background = '#2A2A34';
+   btn.style.border = '1px solid transparent';
    btn.style.color = '#555560';
    btn.style.cursor = 'default';
  }
```

Matches the `SEND REQUEST` button treatment in the request form (dark fill + gold outline + gold text). Both idle and active states carry an explicit 1px border so there is no layout shift.

## Version bump
All 21 versioned resources: `?v=20260411n` → `?v=20260411o`.

Note: `n` was consumed by PR #792 earlier in this session; the next available letter is `o`. This matches the main branch state at the time of push.

## What this PR does NOT change
- `actions/pcs.js`
- `_handleSubmitComment`, `_wireEvents`, `_clientToggleComments`, `_clientEditComment`, `_clientDeleteComment`
- Comment section rendering, card layout
- CLAUDE.md

## Test plan
- [x] `./node_modules/.bin/vitest run` → **508/508 passing**
- [x] `node -c render/client.js` → OK
- [ ] Fresh load: button renders dark with invisible 1px border at current size
- [ ] Typing a character: button fill goes transparent, gold outline appears, gold text, cursor pointer — no size jump
- [ ] Clearing the input: button returns to dim grey with invisible border — no size jump
- [ ] Uploading a photo with empty text still glows gold (pending-images path)
- [ ] Submit still works end-to-end
- [ ] No visual regression on the stats bar / engagement bar (FIX 1 already in main)

## Deployment notes
- Version bumped to `?v=20260411o` on all 21 resources
- Purge Cloudflare cache after merge
- Hard refresh on devices before testing

https://claude.ai/code/session_01D8fsKvkbJMjNmvSzvf7m6X