### PR TITLE
Client feed image grid aligned to PCS LinkedIn-style layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411n">
+ <link rel="stylesheet" href="styles.css?v=20260411o">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411n"></script>
-<script src="00-appstate-compat.js?v=20260411n"></script>
-<script src="01-config.js?v=20260411n" defer></script>
-<script src="02-session.js?v=20260411n" defer></script>
-<script src="utils.js?v=20260411n" defer></script>
-<script src="03-auth.js?v=20260411n" defer></script>
-<script src="05-api.js?v=20260411n" defer></script>
-<script src="10-ui.js?v=20260411n" defer></script>
+<script src="00-appstate.js?v=20260411o"></script>
+<script src="00-appstate-compat.js?v=20260411o"></script>
+<script src="01-config.js?v=20260411o" defer></script>
+<script src="02-session.js?v=20260411o" defer></script>
+<script src="utils.js?v=20260411o" defer></script>
+<script src="03-auth.js?v=20260411o" defer></script>
+<script src="05-api.js?v=20260411o" defer></script>
+<script src="10-ui.js?v=20260411o" defer></script>
 
-<script src="06-post-create.js?v=20260411n" defer></script>
-<script defer src="render/dashboard.js?v=20260411n"></script>
-<script defer src="render/client.js?v=20260411n"></script>
-<script defer src="render/pipeline.js?v=20260411n"></script>
-<script defer src="render/brief.js?v=20260411n"></script>
-<script defer src="actions/pcs.js?v=20260411n"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411n"></script>
-<script src="07-post-load.js?v=20260411n" defer></script>
-<script src="08-post-actions.js?v=20260411n" defer></script>
-<script src="09-library.js?v=20260411n" defer></script>
-<script src="09-approval.js?v=20260411n" defer></script>
-<script src="04-router.js?v=20260411n" defer></script>
+<script src="06-post-create.js?v=20260411o" defer></script>
+<script defer src="render/dashboard.js?v=20260411o"></script>
+<script defer src="render/client.js?v=20260411o"></script>
+<script defer src="render/pipeline.js?v=20260411o"></script>
+<script defer src="render/brief.js?v=20260411o"></script>
+<script defer src="actions/pcs.js?v=20260411o"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411o"></script>
+<script src="07-post-load.js?v=20260411o" defer></script>
+<script src="08-post-actions.js?v=20260411o" defer></script>
+<script src="09-library.js?v=20260411o" defer></script>
+<script src="09-approval.js?v=20260411o" defer></script>
+<script src="04-router.js?v=20260411o" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -233,7 +233,7 @@ console.log('LOADED:', 'render/client.js');
 
     var imgsJson = _esc(JSON.stringify(imgs));
     var wrap = function (src, idx, css, overlay) {
-      return '<div class="lb-trigger-cell" style="' + css + 'position:relative;display:block;width:100%;height:100%;overflow:hidden;background:#111;">' +
+      return '<div class="lb-trigger-cell" style="' + css + 'position:relative;display:block;width:100%;height:100%;overflow:hidden;background:#111;border-radius:0;">' +
         '<img src="' + _esc(src) + '"' +
         ' data-action="openLightbox"' +
         ' data-images=\'' + imgsJson + '\'' +
@@ -244,38 +244,46 @@ console.log('LOADED:', 'render/client.js');
         (overlay || '') + '</div>';
     };
 
+    /* +N overlay (PCS-style: big number + small "more" label). Used by 4+ case. */
+    var _overlayHtml = function (extra) {
+      return '<div class="client-img-overlay" style="position:absolute;inset:0;background:rgba(8,8,8,0.72);backdrop-filter:blur(2px);-webkit-backdrop-filter:blur(2px);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px;pointer-events:none;">' +
+        '<div style="font-size:22px;font-weight:700;color:#ffffff;line-height:1;">+' + extra + '</div>' +
+        '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:7px;color:rgba(255,255,255,0.5);letter-spacing:0.14em;text-transform:uppercase;">more</div>' +
+        '</div>';
+    };
+
     if (n === 1) {
-      return '<div class="img-single" style="padding:0 14px;margin-top:10px;user-select:none;-webkit-user-select:none;">' +
-        wrap(imgs[0], 0, 'aspect-ratio:4/3;border-radius:8px;') +
+      return '<div class="img-single" style="padding:0;margin:0;user-select:none;-webkit-user-select:none;">' +
+        wrap(imgs[0], 0, 'aspect-ratio:1/1;') +
         '</div>';
     }
 
     if (n === 2) {
-      return '<div class="img-duo" style="display:grid;grid-template-columns:1fr 1fr;gap:2px;padding:0 14px;margin-top:10px;user-select:none;-webkit-user-select:none;">' +
-        wrap(imgs[0], 0, 'aspect-ratio:1/1;border-radius:8px 0 0 8px;') +
-        wrap(imgs[1], 1, 'aspect-ratio:1/1;border-radius:0 8px 8px 0;') +
+      return '<div class="img-duo" style="display:grid;grid-template-columns:1fr 1fr;gap:2px;padding:0;margin:0;user-select:none;-webkit-user-select:none;">' +
+        wrap(imgs[0], 0, 'aspect-ratio:1/1;') +
+        wrap(imgs[1], 1, 'aspect-ratio:1/1;') +
         '</div>';
     }
 
-    if (n === 3) {
-      return '<div class="img-trio" style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:1fr 1fr;gap:2px;padding:0 14px;margin-top:10px;aspect-ratio:5/3;user-select:none;-webkit-user-select:none;">' +
-        wrap(imgs[0], 0, 'grid-row:1/3;border-radius:8px 0 0 8px;') +
-        wrap(imgs[1], 1, 'border-radius:0 8px 0 0;') +
-        wrap(imgs[2], 2, 'border-radius:0 0 8px 0;') +
-        '</div>';
-    }
-
-    /* 4+ : 2x2 grid with +N overlay on last cell */
-    var extra = n > 4 ? n - 4 : 0;
-    var overlayHtml = extra > 0
-      ? '<div style="position:absolute;inset:0;background:rgba(8,8,8,0.72);backdrop-filter:blur(2px);display:flex;align-items:center;justify-content:center;font-family:\'DM Sans\',sans-serif;font-size:20px;font-weight:700;color:#fff;pointer-events:none;">+' + extra + '</div>'
-      : '';
-    return '<div class="img-quad" style="display:grid;grid-template-columns:1fr 1fr;grid-template-rows:1fr 1fr;gap:2px;padding:0 14px;margin-top:10px;aspect-ratio:1/1;user-select:none;-webkit-user-select:none;">' +
-      wrap(imgs[0], 0, 'border-radius:8px 0 0 0;') +
-      wrap(imgs[1], 1, 'border-radius:0 8px 0 0;') +
-      wrap(imgs[2], 2, 'border-radius:0 0 0 8px;') +
-      wrap(imgs[3] || imgs[2], 3, 'border-radius:0 0 8px 0;', overlayHtml) +
+    /* 3 and 4+ share the same hero+stack flex layout (PCS .pcs-pg-3 / .pcs-pg-3plus parity).
+       4+ adds a +N overlay on cell 2. */
+    if (n >= 3) {
+      var extra = n - 3;
+      var overlay = extra > 0 ? _overlayHtml(extra) : '';
+      return '<div class="img-trio" style="display:flex;gap:2px;padding:0;margin:0;aspect-ratio:5/3;user-select:none;-webkit-user-select:none;">' +
+        '<div style="flex:0 0 calc(60% - 1px);position:relative;overflow:hidden;">' +
+          wrap(imgs[0], 0, '') +
+        '</div>' +
+        '<div style="flex:1;display:flex;flex-direction:column;gap:2px;">' +
+          '<div style="flex:1;position:relative;overflow:hidden;">' +
+            wrap(imgs[1], 1, '') +
+          '</div>' +
+          '<div style="flex:1;position:relative;overflow:hidden;">' +
+            wrap(imgs[2], 2, '', overlay) +
+          '</div>' +
+        '</div>' +
       '</div>';
+    }
   }
 
   /* ---- metadata rows ---- */

--- a/styles.css
+++ b/styles.css
@@ -5561,14 +5561,13 @@ body.client-mode .section-label {
 }
 
 body.client-mode .img-single {
-  max-height: 480px;
   width: 100%;
-  object-fit: cover;
   display: block;
 }
 
 body.client-mode .img-duo {
-  max-height: 400px;
+  width: 100%;
+  display: grid;
 }
 
 .lb-trigger-cell img {


### PR DESCRIPTION
## Summary
- Client feed `_imgGridHtml` now matches PCS `.pcs-pg-*` layouts: single image is 1:1 (was 4:3), 3+ uses hero-left (60%) + stack-right (40%) flex, 4+ shows a `+N / more` overlay on the third cell instead of a 2x2 grid.
- All cells are edge-to-edge with zero border-radius. Outer wrapper padding/margin removed.
- `body.client-mode .img-single` and `.img-duo` CSS cleaned up: dropped `max-height` (was targeting the wrapper div; silently wrong) and the no-op `object-fit`.
- Version bumped to `?v=20260411o` across all 21 resources.

## Changes
- `render/client.js` — `_imgGridHtml` rewrite (n===1 square, n===2 duo, n>=3 unified hero+stack with conditional +N overlay). `wrap()` helper gains explicit `border-radius:0` and preserves `lb-trigger-cell` class + `data-action`/`data-images`/`data-index`. New `_overlayHtml(extra)` helper mirrors PCS `.pcs-more-ov/n/l` styling.
- `styles.css` — `body.client-mode .img-single` and `.img-duo` stripped of max-heights and the no-op `object-fit:cover`.
- `index.html` — all 21 `?v=20260411n` bumped to `?v=20260411o`.

## Untouched (per instructions)
- PCS image rendering (`actions/pcs.js`)
- Lightbox system (`_lbOpen`, `_lbClose`, `_wireLightboxTouch`, `_pcsOpenLightbox`)
- Comment image rendering
- CLAUDE.md

## Test plan
- [x] `npx vitest run` — 508/508 passing across 21 test files
- [ ] 1 image: square (1:1), edge-to-edge, no rounded corners
- [ ] 2 images: side by side squares, 2px gap, edge-to-edge
- [ ] 3 images: hero left (60%) + 2 stacked right (40%)
- [ ] 4 images: hero + 2 stacked with `+1 more` overlay
- [ ] 5+ images: hero + 2 stacked with `+N more` overlay
- [ ] Tapping any image opens the client lightbox
- [ ] Lightbox swipe + keyboard nav still work
- [ ] No horizontal padding around images in client card

https://claude.ai/code/session_0175UHqWxjxDWwiasHpvNQrJ