### PR TITLE
fix(client): hero+stack image grid container to 1:1 square

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411o">
+ <link rel="stylesheet" href="styles.css?v=20260411p">
 
 </head>
 <body>
@@ -1079,27 +1079,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411o"></script>
-<script src="00-appstate-compat.js?v=20260411o"></script>
-<script src="01-config.js?v=20260411o" defer></script>
-<script src="02-session.js?v=20260411o" defer></script>
-<script src="utils.js?v=20260411o" defer></script>
-<script src="03-auth.js?v=20260411o" defer></script>
-<script src="05-api.js?v=20260411o" defer></script>
-<script src="10-ui.js?v=20260411o" defer></script>
+<script src="00-appstate.js?v=20260411p"></script>
+<script src="00-appstate-compat.js?v=20260411p"></script>
+<script src="01-config.js?v=20260411p" defer></script>
+<script src="02-session.js?v=20260411p" defer></script>
+<script src="utils.js?v=20260411p" defer></script>
+<script src="03-auth.js?v=20260411p" defer></script>
+<script src="05-api.js?v=20260411p" defer></script>
+<script src="10-ui.js?v=20260411p" defer></script>
 
-<script src="06-post-create.js?v=20260411o" defer></script>
-<script defer src="render/dashboard.js?v=20260411o"></script>
-<script defer src="render/client.js?v=20260411o"></script>
-<script defer src="render/pipeline.js?v=20260411o"></script>
-<script defer src="render/brief.js?v=20260411o"></script>
-<script defer src="actions/pcs.js?v=20260411o"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411o"></script>
-<script src="07-post-load.js?v=20260411o" defer></script>
-<script src="08-post-actions.js?v=20260411o" defer></script>
-<script src="09-library.js?v=20260411o" defer></script>
-<script src="09-approval.js?v=20260411o" defer></script>
-<script src="04-router.js?v=20260411o" defer></script>
+<script src="06-post-create.js?v=20260411p" defer></script>
+<script defer src="render/dashboard.js?v=20260411p"></script>
+<script defer src="render/client.js?v=20260411p"></script>
+<script defer src="render/pipeline.js?v=20260411p"></script>
+<script defer src="render/brief.js?v=20260411p"></script>
+<script defer src="actions/pcs.js?v=20260411p"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411p"></script>
+<script src="07-post-load.js?v=20260411p" defer></script>
+<script src="08-post-actions.js?v=20260411p" defer></script>
+<script src="09-library.js?v=20260411p" defer></script>
+<script src="09-approval.js?v=20260411p" defer></script>
+<script src="04-router.js?v=20260411p" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -270,7 +270,7 @@ console.log('LOADED:', 'render/client.js');
     if (n >= 3) {
       var extra = n - 3;
       var overlay = extra > 0 ? _overlayHtml(extra) : '';
-      return '<div class="img-trio" style="display:flex;gap:2px;padding:0;margin:0;aspect-ratio:5/3;user-select:none;-webkit-user-select:none;">' +
+      return '<div class="img-trio" style="display:flex;gap:2px;padding:0;margin:0;aspect-ratio:1/1;user-select:none;-webkit-user-select:none;">' +
         '<div style="flex:0 0 calc(60% - 1px);position:relative;overflow:hidden;">' +
           wrap(imgs[0], 0, '') +
         '</div>' +


### PR DESCRIPTION
## Summary
- `_imgGridHtml` hero+stack outer container aspect-ratio changed from `5/3` to `1/1`.
- With a square container and the existing `flex:0 0 calc(60% - 1px)` hero, the hero becomes a square on the left and the two stacked right-column cells each become 1:2 rectangles (half the hero height). Matches the intended LinkedIn proportion.
- Version bumped to `?v=20260411p` across all 21 resources.

## Scope
- `render/client.js` — single `aspect-ratio` value flipped in the `n >= 3` branch (this branch handles both 3-image and 4+ cases after PR #794 merged them).
- `index.html` — `?v=20260411o` → `?v=20260411p` ×21.

## Untouched
- 60/40 flex split
- Edge-to-edge, zero border-radius
- `+N / more` overlay styling
- PCS image rendering, lightbox system, comment rendering, CLAUDE.md

## Test plan
- [x] `npx vitest run` — 508/508 passing across 21 test files
- [ ] 3 images: square container, square hero left, two 1:2 stacked right
- [ ] 4 images: same layout with `+1 more` overlay on the third cell
- [ ] 5+ images: `+N more` overlay
- [ ] Tap opens lightbox, swipe + keyboard nav unchanged

> Note: this PR stacks on top of unmerged PR #794. If #794 is merged first, this diff shrinks to the single `aspect-ratio` line + version bump.

https://claude.ai/code/session_0175UHqWxjxDWwiasHpvNQrJ