### PR TITLE
Notification panel v6 visual redesign

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -453,17 +453,20 @@ async function loadNotifications() {
   }
 }
 
+// v6 design — visual-only rewrite. Data fetch, click routing, mark-read,
+// and delete paths are untouched. Structural class names + source
+// patterns preserved for unit tests (notif-item, notif-live-card,
+// nchip-count-*, grouped-comment keys, response-time snippet).
 function renderNotifications(name, role) {
   var notifs = _notifData;
   var effectiveR = window.AppState.user.effectiveRole || window.AppState.user.role || role || 'Admin';
-  var display = roleDisplayMap[effectiveR] || roleDisplayMap[role] || { name: name, label: role };
-  var displayName = display.name;
-  var titleRole = (role || 'Admin');
-  titleRole = titleRole.charAt(0).toUpperCase() + titleRole.slice(1).toLowerCase();
+  var titleRole = effectiveR.charAt(0).toUpperCase() + effectiveR.slice(1).toLowerCase();
   var roleLabelEl = document.getElementById('notif-role-label');
   if (roleLabelEl) roleLabelEl.textContent = titleRole.toUpperCase() + ' \xB7 SORTED';
+  // Greeting name comes ONLY from AppState.user.name — no hardcoded fallbacks.
+  var displayName = (window.AppState.user && window.AppState.user.name) || name || 'there';
   var nameEl = document.getElementById('notif-name');
-  if (nameEl) nameEl.textContent = displayName || name || 'there';
+  if (nameEl) nameEl.textContent = displayName;
 
   var posts = (window.AppState.posts && window.AppState.posts.all) || [];
   function postFor(pid) {
@@ -486,7 +489,7 @@ function renderNotifications(name, role) {
     });
   }
 
-  // Chip counts
+  // Tab counts
   var allCount     = notifs.length;
   var mentionCount = 0;
   notifs.forEach(function(n) {
@@ -497,16 +500,26 @@ function renderNotifications(name, role) {
   function _setChipCount(id, value) {
     var el = document.getElementById(id);
     if (!el) return;
-    if (value > 0) { el.textContent = value; el.style.display = ''; }
-    else { el.textContent = ''; el.style.display = 'none'; }
+    el.textContent = value > 0 ? String(value) : '';
+    el.style.display = '';
   }
   _setChipCount('nchip-count-all', allCount);
   _setChipCount('nchip-count-mentions', mentionCount);
   _setChipCount('nchip-count-comments', commentCount);
   _setChipCount('nchip-count-moves', movesCount);
 
-  // Filter
+  // Reflect active tab state on the text-tab row (v6 has no chip dots)
   var filter = _notifChipFilter || 'all';
+  var _tabsEl = document.getElementById('notif-chips');
+  if (_tabsEl) {
+    var _tabs = _tabsEl.querySelectorAll('.notif-chip');
+    for (var _ti = 0; _ti < _tabs.length; _ti++) {
+      var _tb = _tabs[_ti];
+      if ((_tb.dataset.filter || 'all') === filter) _tb.classList.add('active');
+      else _tb.classList.remove('active');
+    }
+  }
+
   var filtered = notifs.filter(function(n) { return _notifChipMatch(filter, n, mentionPostIds); });
   // Filter out System actor (noise)
   filtered = filtered.filter(function(n) {
@@ -536,23 +549,19 @@ function renderNotifications(name, role) {
     if (!commentGroupMap[key]) commentGroupMap[key] = [];
     commentGroupMap[key].push(n);
   });
-  // Flatten grouped comments back into the list, keeping the newest per group.
-  // commentGroups: array of { head: notification, count: N, groupId: key }
   var groupedList = nonCommentList.slice();
   Object.keys(commentGroupMap).forEach(function(k) {
     var arr = commentGroupMap[k];
-    // arr already ordered by fetched desc because notifs came in desc order
     arr[0]._groupCount = arr.length;
     groupedList.push(arr[0]);
   });
-  // Re-sort by created_at desc to maintain original ordering across types
   groupedList.sort(function(a, b) {
     var ta = a.created_at ? new Date(a.created_at).getTime() : 0;
     var tb = b.created_at ? new Date(b.created_at).getTime() : 0;
     return tb - ta;
   });
 
-  // Group by day
+  // Day grouping
   var todayStr     = new Date().toDateString();
   var yesterdayStr = new Date(Date.now() - 86400000).toDateString();
   var groups = { today: [], yesterday: [], earlier: [] };
@@ -563,9 +572,20 @@ function renderNotifications(name, role) {
     else groups.earlier.push(n);
   });
 
+  // Meta-row SVG icons (inline so color can differ per unread/read via CSS)
+  var WA_ICON = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" aria-hidden="true">' +
+    '<path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z" fill="currentColor"/>' +
+    '<path d="M12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.66 1.438 5.168L2 22l4.832-1.438A9.955 9.955 0 0012 22c5.523 0 10-4.477 10-10S17.523 2 12 2zm0 18a7.96 7.96 0 01-4.108-1.14l-.288-.173-2.98.78.795-2.903-.19-.3A7.96 7.96 0 014 12c0-4.411 3.589-8 8-8s8 3.589 8 8-3.589 8-8 8z" fill="currentColor"/>' +
+    '</svg>';
+  var TRASH_ICON = '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<polyline points="3 6 5 6 21 6"/>' +
+    '<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>' +
+    '</svg>';
+
   function _buildItem(n) {
     var post = postFor(n.post_id);
-    var postThumb = post && Array.isArray(post.images) && post.images[0] ? post.images[0] : '';
+    var postHasImage = !!(post && Array.isArray(post.images) && post.images[0]);
+    var postThumb = postHasImage ? post.images[0] : '';
     var postTitle = '';
     if (post && post.title) {
       postTitle = post.title;
@@ -588,20 +608,6 @@ function renderNotifications(name, role) {
     var initial = actor ? actor.charAt(0).toUpperCase() : '?';
     var ts = _notifRelTime(n.created_at);
 
-    // Action buttons
-    var actionsHtml = '';
-    if (n.post_id) {
-      actionsHtml = '<div class="notif-actions">' +
-        '<button class="notif-action-btn nab-wa" data-action="notif-wa" data-post-id="' + esc(n.post_id) + '">\u2197 WHATSAPP</button>' +
-        '<span class="notif-action-sep">\xB7</span>' +
-        '<button class="notif-action-btn nab-del" data-action="notif-delete" data-notif-id="' + esc(n.id || '') + '">DELETE</button>' +
-        '</div>';
-    } else {
-      actionsHtml = '<div class="notif-actions">' +
-        '<button class="notif-action-btn nab-del" data-action="notif-delete" data-notif-id="' + esc(n.id || '') + '">DELETE</button>' +
-        '</div>';
-    }
-
     // Response time for approval-resolved notifications
     var respTimeHtml = '';
     if (n.post_id && n.type === 'scheduled') {
@@ -621,45 +627,22 @@ function renderNotifications(name, role) {
       }
     }
 
-    // Live card (published)
-    if (n.type === 'published') {
-      return '<div class="notif-live-card"' +
-          ' data-notif-id="' + esc(n.id || '') + '"' +
-          ' data-post-id="' + esc(n.post_id || '') + '"' +
-          ' data-notif-type="published">' +
-          '<div class="notif-unread-dot"></div>' +
-          '<div class="notif-live-av">' + esc(initial) + '</div>' +
-          '<div class="notif-live-body">' +
-            '<div class="notif-live-tag">\u2713 POST IS LIVE</div>' +
-            '<div class="notif-live-title">' + esc(postTitle) + '</div>' +
-            '<div class="notif-live-sub">' +
-              [esc(actor), esc(ts), 'VIEW ON LINKEDIN \u2192']
-                .filter(function(s) { return s && s.length > 0; })
-                .join(' \xB7 ') +
-            '</div>' +
-            actionsHtml +
-          '</div>' +
-          '<div class="notif-thumb-wrap">' +
-            (postThumb
-              ? '<img class="notif-thumb" src="' + esc(postThumb) + '" onerror="this.style.display=\'none\'">'
-              : '<div class="notif-thumb"></div>') +
-          '</div>' +
-        '</div>';
-    }
-
     var isMention = n.type === 'comment' && n.post_id && mentionPostIds.has(n.post_id);
     var tClass = _notifTypeClass(n, isMention);
-
-    // Grouped comment copy
+    var isPublished = n.type === 'published';
     var groupCount = n._groupCount || 1;
+
+    // Action text (published has its own label above the main line)
     var actionText;
-    if (groupCount > 1) {
+    if (isPublished) {
+      actionText = 'published ' + (postTitle || 'post');
+    } else if (groupCount > 1) {
       actionText = 'left ' + groupCount + ' comments on ' + (postTitle || 'post');
     } else {
       actionText = _notifActionText(n);
     }
 
-    // Latest comment preview (only for comment notifications)
+    // Comment preview — no quotes, no italics, ellipsized in CSS
     var previewHtml = '';
     if (n.type === 'comment') {
       var latest = null;
@@ -671,40 +654,70 @@ function renderNotifications(name, role) {
         var msgPrev = latest.message.length > 80
           ? latest.message.slice(0, 80) + '...'
           : latest.message;
-        previewHtml = '<div class="notif-preview">&ldquo;' + esc(msgPrev) + '&rdquo;' +
+        previewHtml = '<div class="notif-preview">' + esc(msgPrev) +
           (groupCount > 1 ? '<span class="notif-more">+' + (groupCount - 1) + ' more</span>' : '') +
           '</div>';
       }
     }
 
+    // Meta row — time · icons · optional LinkedIn link on published
+    var linkedinHtml = '';
+    if (isPublished && post && post.linkedin_link) {
+      linkedinHtml = '<span class="notif-meta-sep">\xB7</span>' +
+        '<a class="notif-li-link" href="' + esc(post.linkedin_link) + '" target="_blank" rel="noopener"' +
+        ' onclick="event.stopPropagation();">LINKEDIN \u2192</a>';
+    }
+    var waBtn = n.post_id
+      ? '<button class="notif-mi-btn" data-action="notif-wa" data-post-id="' + esc(n.post_id) + '" aria-label="Share on WhatsApp">' + WA_ICON + '</button>'
+      : '';
+    var delBtn = '<button class="notif-mi-btn" data-action="notif-delete" data-notif-id="' + esc(n.id || '') + '" aria-label="Delete">' + TRASH_ICON + '</button>';
+
+    var metaRow = '<div class="notif-meta">' +
+      '<span class="notif-time">' + esc(ts) + '</span>' +
+      '<span class="notif-meta-sep">\xB7</span>' +
+      waBtn +
+      delBtn +
+      linkedinHtml +
+      '</div>';
+
+    var pubLabel = isPublished
+      ? '<div class="notif-pub-label">\u2713 PUBLISHED</div>'
+      : '';
+
+    var unreadDot = n.read ? '' : '<span class="nnew-dot" aria-hidden="true"></span>';
+
+    var thumbHtml = postHasImage
+      ? '<div class="notif-thumb-wrap"><img class="notif-thumb" src="' + esc(postThumb) + '" onerror="this.style.display=\'none\'"></div>'
+      : '';
+
     var isBriefAttr = n.type === 'new_request' ? ' data-is-brief="1"' : '';
-    return '<div class="notif-item ' + tClass + (n.read ? ' read' : '') + '"' +
+    // notif-live-card retained as a marker class on published rows so the
+    // tap delegate still finds them via closest('.notif-item, .notif-live-card').
+    var liveMarker = isPublished ? ' notif-live-card' : '';
+
+    return '<div class="notif-item ' + tClass + liveMarker + (n.read ? ' read' : '') + '"' +
       ' data-notif-id="' + esc(n.id || '') + '"' +
       ' data-post-id="' + esc(n.post_id || '') + '"' +
       ' data-notif-type="' + esc(n.type || '') + '"' +
       isBriefAttr + '>' +
-      '<div class="notif-unread-dot"></div>' +
       '<div class="notif-av ' + avClass + '">' + esc(initial) + '</div>' +
       '<div class="notif-body">' +
+        pubLabel +
         '<div class="notif-text">' +
+          unreadDot +
           '<strong>' + esc(actor) + '</strong> ' + esc(actionText) +
           respTimeHtml +
-          '<span class="notif-time-inline"> \xB7 ' + esc(ts) + '</span>' +
         '</div>' +
         previewHtml +
-        actionsHtml +
+        metaRow +
       '</div>' +
-      '<div class="notif-thumb-wrap">' +
-        (postThumb
-          ? '<img class="notif-thumb" src="' + esc(postThumb) + '" onerror="this.style.display=\'none\'">'
-          : '<div class="notif-thumb"></div>') +
-      '</div>' +
+      thumbHtml +
     '</div>';
   }
 
   var html = '';
   if (groups.today.length > 0) {
-    html += '<div class="notif-day-label">Today</div>';
+    html += '<div class="notif-day-label ndl-first">Today</div>';
     groups.today.forEach(function(n) { html += _buildItem(n); });
   }
   if (groups.yesterday.length > 0) {
@@ -715,6 +728,7 @@ function renderNotifications(name, role) {
     html += '<div class="notif-day-label">Earlier</div>';
     groups.earlier.forEach(function(n) { html += _buildItem(n); });
   }
+  html += '<div class="notif-foot">That\u2019s everything</div>';
   scroll.innerHTML = html;
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Sorted (srtd.io)
 
-Last updated: 2026-04-11 (resolved-at). Full history: `CLAUDE-archive-20260411.md`.
+Last updated: 2026-04-11 (notification-panel-v6). Full history: `CLAUDE-archive-20260411.md`.
 
 ## 1 — WHAT IS SORTED
 
@@ -72,7 +72,7 @@ Root:
 - `08-post-actions.js` — quickStage, updatePost, clientApprove, _confirmPublish, _sendStageNotif, _startSaveTimeout/_clearSaveTimeout
 - `09-approval.js` — client approval flow, submitApproval
 - `09-library.js` — library view (calls `_renderPCS` directly — keep on window.*)
-- `10-ui.js` — toasts, notifications panel, switchTab, Action Router, click telemetry flush
+- `10-ui.js` — toasts, notifications panel (v6 redesign — see §4 “Notification panel v6”), switchTab, Action Router, click telemetry flush
 
 render/:
 - `render/dashboard.js` — dashboard, scoreboard, runway/stage sheets
@@ -151,6 +151,24 @@ window.AppState = {
 - Use `100dvh`, never `100vh` (iOS Safari address bar).
 - Image compression: posts max 1200px q0.82, comments max 800px q0.80, save as .jpg.
 
+### Notification panel v6 (10-ui.js `renderNotifications`)
+- Visual-only rewrite. Data fetch (`loadNotifications`), badge (`updateNotifBadge`), mark-read (`markNotifRead`, `markAllNotificationsRead`), delete (`deleteNotification`), and the `openNotifications`/`closeNotifications` tap-delegate + chip-filter click handler are UNCHANGED. Do not modify them when tweaking the visual layer.
+- Header row1 is a mono role label (`effectiveRole.toUpperCase() + ' · SORTED'`) on the left and two plain-text buttons on the right: `Mark read | Close` (`.notif-topbar-btn`, pipe `.notif-topbar-sep`). No boxed buttons, no borders. `data-action="mark-all-read"` / `data-action="close-notifications"` unchanged.
+- Header row2 is a single large greeting: `Hey, <AppState.user.name>` (DM Sans 22px 700 #E8E8F0) with the name portion in gold #C8A84B. No summary lines, no counters in the header. Greeting name pulls ONLY from `AppState.user.name` — no hardcoded person map.
+- Role label text is fed from `AppState.user.effectiveRole` (title-cased → uppercased). `roleDisplayMap` is intentionally no longer read by the renderer (left in place as dead metadata).
+- Filter tabs (`.notif-chips > .notif-chip`) are plain text, not chips: 10px IBM Plex Mono, marginRight 20px, border-bottom 1px #18182A on the row, 500 #404050 inactive / 700 #E0E0EC active. Counts render in the same `nchip-count-*` spans (#333340 inactive, #C8A84B active). Tabs are: All, Mentions, Comments, Moves (Live tab dropped from UI; the `live` branch inside `_notifChipMatch` is retained so tests pass and an admin can re-enable the tab later).
+- `renderNotifications` re-applies the active class across the tab row each call — this is redundant with the chip-row click delegate but keeps the UI in sync when the filter is flipped programmatically.
+- Cards: flex row, `.notif-item` is the ONLY card class; published rows get an additional `notif-live-card` marker class so the tap delegate `closest('.notif-item, .notif-live-card')` still finds them. Unread background `#141420`, read background `transparent`, no opacity change between states, no left color bar, no hover swap. Border-bottom 1px #14141E.
+- Avatars (`.notif-av`): 32px solid-fill circles, white letter, no border/ring. Palette: `.nav-client` #FF4B4B, `.nav-chitra` #22D3EE, `.nav-pranav` #9b87f5, `.nav-shubham` #C8A84B, `.nav-system` #555566 (same class mapping returned by `_notifActorClass`).
+- Unread indicator is an inline `<span class="nnew-dot">` gold 5px dot rendered before the actor name (the old `.notif-unread-dot` absolute-positioned dot is gone). Read items omit the span entirely.
+- Meta row (`.notif-meta`): time · icons · optional LinkedIn link. Icons are inline SVG (WhatsApp 11×11, trash 10×10) wrapped in `.notif-mi-btn` buttons that retain `data-action="notif-wa"` / `data-action="notif-delete"`. Icon color drives from `currentColor` so `.notif-item.read .notif-mi-btn` flips them to #2A2A36 without touching markup. LinkedIn link is rendered only when the underlying post has `linkedin_link` and carries inline `onclick="event.stopPropagation()"` so the surrounding item tap still fires mark-read but the browser navigates to LinkedIn.
+- Published cards: no bordered badge. A `.notif-pub-label` div (`✓ PUBLISHED`, 8px gold-green #3ECF8E) sits above the main text line, and `actionText` is `published <title>`. All other structure is identical to non-published items.
+- Thumbnails (`.notif-thumb`) render ONLY when the linked post has `images[0]`. No 44×44 placeholder for imageless cards; the body simply stretches. Thumbs are 44×44, border-radius 6px, object-fit cover, background #14141E.
+- Day labels (`.notif-day-label`): 8px mono 700 #333340 with 1.6px letter-spacing. Today section has a `.ndl-first` modifier with top padding 14px; Yesterday/Earlier use 18px.
+- Footer: `That's everything` centered in `.notif-foot` (8px mono #222230) — appended after the last day group.
+- The overlay shell (`#notif-overlay` + `#panel-updates`) is unchanged structurally: background `#0a0a0f`, inner panel `#0e0e16`, max-width 480px, full-height flex column. `closeNotifications()` still calls `_drainDeferredRender()`.
+- Tests: all structural class names + source patterns the static-analysis tests grep for (`notif-item`, `notif-live-card`, `nchip-count-*`, grouped-comment key `(n.post_id||'') + '|' + (n.actor||'')`, response-time `notif-resp-time` block, `Today`/`Yesterday`/`Earlier`, `"left " + n + " comments on "` template) are preserved verbatim. 508/508 unit tests still pass after the rewrite.
+
 ### Misc gotchas
 - `_commentInputHtml()` only renders for stages `awaiting_approval` + `awaiting_brand_input` and MUST be called inside `_cardHtml()` or the input never exists.
 - `apiFetch()` never calls `logout()` on 401 by design — refresh flow handles it.
@@ -193,7 +211,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 21 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 20 scripts). Current: `?v=20260411q`.
+1. Bump ALL 21 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 20 scripts). Current: `?v=20260411f`.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411q">
+ <link rel="stylesheet" href="styles.css?v=20260411f">
 
 </head>
 <body>
@@ -392,18 +392,20 @@
     <div class="notif-topbar">
       <div class="notif-topbar-row1">
         <div class="notif-role-label" id="notif-role-label">ADMIN &middot; SORTED</div>
-        <button class="notif-close-btn" data-action="close-notifications">&#x2715; CLOSE</button>
+        <div class="notif-topbar-actions">
+          <button class="notif-topbar-btn" data-action="mark-all-read">Mark read</button>
+          <span class="notif-topbar-sep">|</span>
+          <button class="notif-topbar-btn" data-action="close-notifications">Close</button>
+        </div>
       </div>
       <div class="notif-topbar-row2">
         <div class="notif-hey">Hey, <span id="notif-name">there</span></div>
-        <button class="mark-all-btn" data-action="mark-all-read">MARK ALL READ</button>
       </div>
       <div class="notif-chips" id="notif-chips">
-        <button class="notif-chip active" data-filter="all">ALL <span class="notif-chip-count" id="nchip-count-all"></span></button>
-        <button class="notif-chip nch-gold" data-filter="mentions"><span class="notif-chip-dot"></span>MENTIONS <span class="notif-chip-count" id="nchip-count-mentions"></span></button>
-        <button class="notif-chip nch-cyan" data-filter="comments"><span class="notif-chip-dot"></span>COMMENTS <span class="notif-chip-count" id="nchip-count-comments"></span></button>
-        <button class="notif-chip nch-purple" data-filter="moves"><span class="notif-chip-dot"></span>MOVES <span class="notif-chip-count" id="nchip-count-moves"></span></button>
-        <button class="notif-chip nch-green" data-filter="live"><span class="notif-chip-dot"></span>LIVE</button>
+        <button class="notif-chip active" data-filter="all">All<span class="notif-chip-count" id="nchip-count-all"></span></button>
+        <button class="notif-chip" data-filter="mentions">Mentions<span class="notif-chip-count" id="nchip-count-mentions"></span></button>
+        <button class="notif-chip" data-filter="comments">Comments<span class="notif-chip-count" id="nchip-count-comments"></span></button>
+        <button class="notif-chip" data-filter="moves">Moves<span class="notif-chip-count" id="nchip-count-moves"></span></button>
       </div>
     </div>
     <div class="notif-hdr-line"></div>
@@ -1079,27 +1081,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411q"></script>
-<script src="00-appstate-compat.js?v=20260411q"></script>
-<script src="01-config.js?v=20260411q" defer></script>
-<script src="02-session.js?v=20260411q" defer></script>
-<script src="utils.js?v=20260411q" defer></script>
-<script src="03-auth.js?v=20260411q" defer></script>
-<script src="05-api.js?v=20260411q" defer></script>
-<script src="10-ui.js?v=20260411q" defer></script>
+<script src="00-appstate.js?v=20260411f"></script>
+<script src="00-appstate-compat.js?v=20260411f"></script>
+<script src="01-config.js?v=20260411f" defer></script>
+<script src="02-session.js?v=20260411f" defer></script>
+<script src="utils.js?v=20260411f" defer></script>
+<script src="03-auth.js?v=20260411f" defer></script>
+<script src="05-api.js?v=20260411f" defer></script>
+<script src="10-ui.js?v=20260411f" defer></script>
 
-<script src="06-post-create.js?v=20260411q" defer></script>
-<script defer src="render/dashboard.js?v=20260411q"></script>
-<script defer src="render/client.js?v=20260411q"></script>
-<script defer src="render/pipeline.js?v=20260411q"></script>
-<script defer src="render/brief.js?v=20260411q"></script>
-<script defer src="actions/pcs.js?v=20260411q"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411q"></script>
-<script src="07-post-load.js?v=20260411q" defer></script>
-<script src="08-post-actions.js?v=20260411q" defer></script>
-<script src="09-library.js?v=20260411q" defer></script>
-<script src="09-approval.js?v=20260411q" defer></script>
-<script src="04-router.js?v=20260411q" defer></script>
+<script src="06-post-create.js?v=20260411f" defer></script>
+<script defer src="render/dashboard.js?v=20260411f"></script>
+<script defer src="render/client.js?v=20260411f"></script>
+<script defer src="render/pipeline.js?v=20260411f"></script>
+<script defer src="render/brief.js?v=20260411f"></script>
+<script defer src="actions/pcs.js?v=20260411f"></script>
+<script defer src="actions/pcs-longpress.js?v=20260411f"></script>
+<script src="07-post-load.js?v=20260411f" defer></script>
+<script src="08-post-actions.js?v=20260411f" defer></script>
+<script src="09-library.js?v=20260411f" defer></script>
+<script src="09-approval.js?v=20260411f" defer></script>
+<script src="04-router.js?v=20260411f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -3812,11 +3812,14 @@ input[type="date"]::-webkit-calendar-picker-indicator {
    =================================================== */
 
 /* ── NOTIFICATION PANEL OVERLAY ── */
+/* ===================================================
+   NOTIFICATION PANEL — v6 redesign
+   =================================================== */
 #notif-overlay {
   position: fixed;
   inset: 0;
   z-index: 1300;
-  background: #0d0d12;
+  background: #0a0a0f;
   display: flex;
   align-items: stretch;
   justify-content: center;
@@ -3827,7 +3830,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   max-width: 480px;
   height: 100%;
   overflow: hidden;
-  background: #0d0d12;
+  background: #0e0e16;
   display: flex;
   flex-direction: column;
 }
@@ -3835,91 +3838,67 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 /* ── HEADER ── */
 .notif-topbar {
   flex-shrink: 0;
-  padding: 12px 18px 0;
-  overflow: hidden;
-  position: relative;
+  padding: 18px 18px 0;
 }
-.notif-topbar::after {
-  content: '';
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 52px;
-  height: 38px;
-  background: linear-gradient(to right, transparent, #0d0d12 80%);
-  pointer-events: none;
-  z-index: 2;
-}
-
 .notif-topbar-row1 {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 5px;
+  margin-bottom: 6px;
 }
 .notif-role-label {
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  letter-spacing: .12em;
-  color: #8E8E93;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  color: #333340;
   text-transform: uppercase;
 }
-.notif-close-btn {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  letter-spacing: .08em;
-  color: #8E8E93;
-  background: none;
-  border: 1px solid #191924;
-  padding: 4px 10px;
-  cursor: pointer;
-  position: relative;
-}
-.notif-close-btn::after {
-  content: '';
-  position: absolute;
-  inset: -14px -18px;
-}
-.notif-close-btn:hover { color: #9090A0; border-color: #191924; }
-
-.notif-topbar-row2 {
+.notif-topbar-actions {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 10px;
+  gap: 6px;
+}
+.notif-topbar-btn {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  font-weight: 600;
+  color: #444455;
+  background: none;
+  border: none;
+  padding: 2px 0;
+  cursor: pointer;
+  text-transform: none;
+}
+.notif-topbar-btn:hover { color: #9090A0; }
+.notif-topbar-sep {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #222230;
+  user-select: none;
+}
+
+.notif-topbar-row2 {
+  margin-bottom: 14px;
 }
 .notif-hey {
   font-family: 'DM Sans', sans-serif;
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 700;
-  color: #F0F0F2;
+  color: #E8E8F0;
   line-height: 1.1;
-  flex: 1;
 }
 .notif-hey span { color: #C8A84B; }
 
-.mark-all-btn {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  letter-spacing: .08em;
-  color: #8E8E93;
-  background: none;
-  border: 1px solid #191924;
-  padding: 5px 10px;
-  cursor: pointer;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-.mark-all-btn:hover { color: #9090A0; }
+/* Legacy header button classes (no longer rendered, kept harmless) */
+.notif-close-btn, .mark-all-btn { display: none; }
 
-/* ── CHIPS ── */
+/* ── FILTER TABS (text, no chips) ── */
 .notif-chips {
   display: flex;
-  gap: 6px;
+  border-bottom: 1px solid #18182A;
+  padding: 0 0 8px 0;
   overflow-x: auto;
-  padding-bottom: 10px;
-  padding-right: 52px;
   scrollbar-width: none;
   -webkit-overflow-scrolling: touch;
 }
@@ -3928,40 +3907,33 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .notif-chip {
   flex-shrink: 0;
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  letter-spacing: .08em;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.5px;
   text-transform: uppercase;
-  padding: 5px 12px;
-  border-radius: 20px;
-  cursor: pointer;
-  border: 1px solid #191924;
-  color: #8E8E93;
+  color: #404050;
   background: none;
+  border: none;
+  padding: 0;
+  margin-right: 20px;
+  cursor: pointer;
   white-space: nowrap;
-  display: flex;
-  align-items: center;
-  gap: 5px;
 }
-.notif-chip.active           { background: #0d0d12; border-color: #191924; color: #F0F0F2; }
-.notif-chip.nch-gold.active  { border-color: #C8A84B40; color: #C8A84B; background: #C8A84B0a; }
-.notif-chip.nch-cyan.active  { border-color: #22D3EE40; color: #22D3EE; background: #22D3EE0a; }
-.notif-chip.nch-purple.active{ border-color: #9b87f540; color: #9b87f5; background: #9b87f50a; }
-.notif-chip.nch-green.active { border-color: #3ECF8E40; color: #3ECF8E; background: #3ECF8E0a; }
-
-.notif-chip-dot {
-  width: 5px; height: 5px;
-  border-radius: 50%;
-  background: currentColor;
-  flex-shrink: 0;
+.notif-chip.active {
+  font-weight: 700;
+  color: #E0E0EC;
 }
 .notif-chip-count {
-  font-size: 8px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
   font-weight: 700;
-  opacity: 0.8;
+  color: #333340;
+  margin-left: 4px;
 }
+.notif-chip.active .notif-chip-count { color: #C8A84B; }
 
 /* ── DIVIDER ── */
-.notif-hdr-line { height: 1px; background: #191924; flex-shrink: 0; }
+.notif-hdr-line { display: none; }
 
 /* ── SCROLL ── */
 .notif-scroll {
@@ -3976,246 +3948,213 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .notif-day-label {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 8px;
-  letter-spacing: .1em;
-  color: #8E8E93;
+  font-weight: 700;
+  letter-spacing: 1.6px;
+  color: #333340;
   text-transform: uppercase;
-  padding: 8px 18px 6px;
-  border-bottom: 1px dotted #191924;
+  padding: 18px 18px 8px;
 }
+.notif-day-label.ndl-first { padding-top: 14px; }
 
 /* ── NOTIFICATION ITEM ── */
 .notif-item {
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
-  padding: 10px 14px 10px 18px;
-  border-bottom: 1px solid #191924;
+  padding: 11px 18px;
+  border-bottom: 1px solid #14141E;
   cursor: pointer;
-  background: #0d0d12;
-  min-height: 56px;
+  background: #141420;
 }
-.notif-item:hover { background: #0d0d12; }
+/* READ state — background swap only. No opacity change. */
+.notif-item.read { background: transparent; }
 
-/* READ state — ONLY difference is dot visibility. Zero opacity changes. */
-.notif-item.read { background: #0d0d12; }
-.notif-item:not(.read) { background: #0d0d12; }
-
-/* Unread dot - absolute positioned, never affects flex layout */
-.notif-unread-dot {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: #C8A84B;
-  pointer-events: none;
-  display: block;
-}
-.notif-item.read .notif-unread-dot { display: none; }
-
-/* LEFT COLOR BAR */
-.notif-item::before {
-  content: '';
-  position: absolute;
-  left: 0; top: 0; bottom: 0;
-  width: 3px;
-}
-.notif-item.ntype-comment::before  { background: #22D3EE; }
-.notif-item.ntype-approval::before { background: #FF4B4B; }
-.notif-item.ntype-live::before     { background: #3ECF8E; }
-.notif-item.ntype-stage::before    { background: #9b87f5; }
-.notif-item.ntype-mention::before  { background: #C8A84B; }
-
-/* AVATAR - 34px circle, aligned to top */
+/* ── AVATAR ── */
 .notif-av {
-  width: 34px; height: 34px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 11px;
-  font-weight: 600;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: #FFFFFF;
+  border: none;
   align-self: flex-start;
-  margin-top: 2px;
+  margin-top: 1px;
 }
-.nav-manisha, .nav-client    { background: #FF4B4B18; border: 1px solid #FF4B4B44; color: #FF4B4B; }
-.nav-chitra, .nav-servicing  { background: #22D3EE18; border: 1px solid #22D3EE44; color: #22D3EE; }
-.nav-pranav, .nav-creative   { background: #9b87f518; border: 1px solid #9b87f544; color: #9b87f5; }
-.nav-admin, .nav-shubham     { background: #C8A84B18; border: 1px solid #C8A84B44; color: #C8A84B; }
-.nav-system                  { background: #F6A62318; border: 1px solid #F6A62344; color: #F6A623; }
+.nav-manisha, .nav-client    { background: #FF4B4B; border: none; color: #FFFFFF; }
+.nav-chitra,  .nav-servicing { background: #22D3EE; border: none; color: #FFFFFF; }
+.nav-pranav,  .nav-creative  { background: #9b87f5; border: none; color: #FFFFFF; }
+.nav-admin,   .nav-shubham   { background: #C8A84B; border: none; color: #FFFFFF; }
+.nav-system                  { background: #555566; border: none; color: #FFFFFF; }
 
-/* MESSAGE BODY */
+/* ── BODY ── */
 .notif-body { flex: 1; min-width: 0; }
 
+.notif-pub-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  color: #3ECF8E;
+  margin-bottom: 3px;
+  text-transform: uppercase;
+}
+
+/* ── MAIN TEXT ── */
 .notif-text {
   font-family: 'DM Sans', sans-serif;
-  font-size: 11px;
-  font-weight: 400;
-  color: #9090A0;
-  line-height: 1.4;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #D8D8E4;
 }
-.notif-item:not(.read) .notif-text { color: #F0F0F2; }
-.notif-text strong { font-weight: 600; }
+.notif-text strong {
+  font-weight: 600;
+  color: #F0F0F8;
+}
+.notif-item.read .notif-text { color: #707080; }
+.notif-item.read .notif-text strong { color: #888898; }
 
-.notif-time-inline {
-  color: #8E8E93;
-  font-size: 11px;
-  white-space: nowrap;
+/* Inline unread gold dot */
+.nnew-dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #C8A84B;
+  margin-right: 5px;
+  vertical-align: middle;
 }
 
-/* COMMENT PREVIEW - 9px italic, hierarchy below main text */
+/* ── COMMENT PREVIEW ── */
 .notif-preview {
   font-family: 'DM Sans', sans-serif;
-  font-size: 9px;
-  font-style: italic;
-  color: #8E8E93;
+  font-size: 11px;
+  font-style: normal;
+  color: #6A6A80;
   line-height: 1.4;
   margin-top: 3px;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
 }
-.notif-item:not(.read) .notif-preview { color: #9090A0; }
+.notif-item.read .notif-preview { color: #444452; }
 
 .notif-more {
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  color: #22D3EE;
+  font-size: 9px;
+  color: inherit;
   font-weight: 600;
-  margin-left: 3px;
+  margin-left: 6px;
   font-style: normal;
 }
 
-/* THUMBNAIL - always right side, 44x44 */
+/* ── META ROW ── */
+.notif-meta {
+  display: flex;
+  align-items: center;
+  margin-top: 6px;
+}
+.notif-time {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  font-weight: 500;
+  color: #4A4A5C;
+  white-space: nowrap;
+}
+.notif-item.read .notif-time { color: #333340; }
+.notif-meta-sep {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #222230;
+  margin: 0 5px;
+  user-select: none;
+}
+.notif-mi-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0 8px 0 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  color: #3A3A4C;
+}
+.notif-mi-btn:last-of-type { margin-right: 0; }
+.notif-mi-btn svg { display: block; }
+.notif-item.read .notif-mi-btn { color: #2A2A36; }
+.notif-li-link {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  font-weight: 600;
+  color: #0A66C2;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.notif-li-link:hover { color: #3B8DE3; }
+
+/* Response time (inline pill kept for tests) */
+.notif-resp-time { color: #3ECF8E; font-size: 11px; margin-left: 4px; }
+
+/* ── THUMBNAIL (only rendered when post has an image) ── */
 .notif-thumb-wrap { flex-shrink: 0; }
 .notif-thumb {
-  width: 44px; height: 44px;
+  width: 44px;
+  height: 44px;
   object-fit: cover;
-  background: #191924;
-  border-radius: 2px;
+  background: #14141E;
+  border-radius: 6px;
   display: block;
 }
 
-/* LIVE CARD - special green background, same layout as all other items */
-.notif-live-card {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 14px 10px 18px;
-  border-bottom: 1px solid #191924;
-  background: #091410;
-  cursor: pointer;
-  min-height: 56px;
-}
-.notif-live-card::before {
-  content: '';
-  position: absolute;
-  left: 0; top: 0; bottom: 0;
-  width: 3px;
-  background: #3ECF8E;
-}
-.notif-live-av {
-  width: 34px; height: 34px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 11px;
-  font-weight: 600;
-  background: #3ECF8E18;
-  border: 1px solid #3ECF8E44;
-  color: #3ECF8E;
-  align-self: flex-start;
-  margin-top: 2px;
-}
-.notif-live-body { flex: 1; min-width: 0; }
-.notif-live-tag {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  letter-spacing: .08em;
-  color: #3ECF8E;
-  margin-bottom: 2px;
-}
-.notif-live-title {
-  font-family: 'DM Sans', sans-serif;
-  font-size: 11px;
-  font-weight: 600;
-  color: #F0F0F2;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.notif-live-sub {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  color: #8E8E93;
-  letter-spacing: .04em;
-  margin-top: 2px;
-}
-
-/* EMPTY STATE */
+/* ── EMPTY STATE ── */
 .notif-empty-state {
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 48px 24px;
   text-align: center;
-  gap: 8px;
+  gap: 6px;
 }
 .notif-empty-icon {
-  width: 40px; height: 40px;
-  border-radius: 50%;
-  background: #3ECF8E12;
-  border: 1px solid #3ECF8E30;
+  width: 32px;
+  height: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
-  color: #3ECF8E;
-  margin-bottom: 6px;
+  font-size: 18px;
+  color: #222230;
+  margin-bottom: 4px;
 }
-.notif-empty-title { font-family: 'DM Sans', sans-serif; font-size: 15px; font-weight: 600; color: #F0F0F2; }
-.notif-empty-sub   { font-family: 'IBM Plex Mono', monospace; font-size: 9px; color: #8E8E93; letter-spacing: .06em; line-height: 1.6; }
-.notif-empty-stat  { font-family: 'IBM Plex Mono', monospace; font-size: 9px; color: #3ECF8E; letter-spacing: .06em; margin-top: 4px; }
+.notif-empty-title {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: #222230;
+}
+.notif-empty-sub {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #222230;
+  letter-spacing: .12em;
+}
 
-/* Action buttons row */
-.notif-actions {
-  display: flex;
-  align-items: center;
-  gap: 0;
-  margin-top: 6px;
-}
-.notif-action-btn {
+/* ── FOOTER ── */
+.notif-foot {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 8px;
-  letter-spacing: .06em;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
+  color: #222230;
+  letter-spacing: 1.2px;
   text-transform: uppercase;
+  text-align: center;
+  padding: 28px 18px;
 }
-.notif-action-btn.nab-wa  { color: #3ECF8E; }
-.notif-action-btn.nab-wa:hover { color: #5EFFA8; }
-.notif-action-btn.nab-del { color: #8E8E93; margin-left: 10px; }
-.notif-action-btn.nab-del:hover { color: #FF4B4B; }
-.notif-action-sep { color: #333344; margin: 0 6px; font-size: 8px; font-family: 'IBM Plex Mono', monospace; }
-
-/* Response time inline */
-.notif-resp-time { color: #3ECF8E; font-size: 11px; }
 
 /* PCS back-to-notifications button */
 .pcs-back-notif-btn {


### PR DESCRIPTION
## Summary

Visual-only rewrite of `renderNotifications` + the `#panel-updates` topbar to match the approved v6 design. Data fetch, click routing, mark-read, delete, badge, and `openNotifications` / `closeNotifications` paths are all untouched.

## Files changed (4)

- **10-ui.js** — `renderNotifications` rewritten. Meta-row inline SVG icons (WhatsApp + trash) replace the old `.notif-actions` button row. Published cards fold into the shared `.notif-item` layout with a `notif-live-card` marker class so the existing tap delegate still finds them. Greeting name reads only from `AppState.user.name`; role label reads only from `AppState.user.effectiveRole`. Helper functions `_notifRelTime`, `_notifActionText`, `_notifTypeClass`, `_notifActorClass`, `_notifChipMatch` left untouched (tests extract and execute them).
- **styles.css** — notification section fully replaced. Removed: old `.notif-item::before` color bars, `.notif-unread-dot` absolute dot, avatar borders/tints, `.notif-actions` button strip, boxed `.notif-close-btn` / `.mark-all-btn`, old chip palette. Added: v6 header layout, text-tab filter row, inline `.nnew-dot` unread marker, solid-fill avatars, `.notif-meta` row, `.notif-pub-label`, `.notif-foot`.
- **index.html** — `#panel-updates` topbar replaced with the v6 markup (plain-text `Mark read | Close` buttons, single 22px greeting row, four text tabs: All / Mentions / Comments / Moves). All 21 `?v=` version strings bumped `20260411q → 20260411f`.
- **CLAUDE.md** — new `Notification panel v6` subsection under §4, updated current-version string in §7, bumped the "Last updated" header.

## What did NOT change

- `loadNotifications`, `updateNotifBadge`, `markNotifRead`, `markAllNotificationsRead`, `deleteNotification`
- `openNotifications` / `closeNotifications` (still calls `_drainDeferredRender` on close)
- The panel click delegate, chip click delegate, and every `data-action="notif-wa" / "notif-delete" / "mark-all-read" / "close-notifications"` routing case
- Edge-function inserts, dual-writer behavior, email fan-out
- Any file besides `10-ui.js`, `styles.css`, `index.html`, `CLAUDE.md`

## Design spec compliance

- Header: mono role label (`effectiveRole.toUpperCase() + " · SORTED"`) + `Mark read | Close` text buttons (pipe separator `#222230`)
- Greeting: `Hey, <AppState.user.name>` DM Sans 22px 700 `#E8E8F0`, name portion `#C8A84B`
- Filter tabs: flex row, border-bottom `#18182A`, inactive `#404050` / active `#E0E0EC`, inactive count `#333340` / active count `#C8A84B`
- Day labels: mono 8px 700 `#333340`, letter-spacing 1.6px, `ndl-first` 14px top padding
- Cards: unread `#141420`, read `transparent`, no opacity change, no left color bar, border-bottom `#14141E`
- Avatars: 32×32, solid fill, no border — Client `#FF4B4B`, Servicing `#22D3EE`, Creative `#9b87f5`, Admin `#C8A84B`, system `#555566`
- Main text: DM Sans 12px, unread strong `#F0F0F8`, read strong `#888898`
- Unread gold dot: 5px inline `#C8A84B` before the actor name
- Comment preview: DM Sans 11px, no quotes/italics, ellipsized, unread `#6A6A80` / read `#444452`, `+N more` mono 9px 600
- Meta row: time (mono 9px, unread `#4A4A5C` / read `#333340`), `·` separator `#222230`, WhatsApp 11×11 SVG + trash 10×10 SVG (unread `#3A3A4C` / read `#2A2A36`), LinkedIn link mono 8px 600 `#0A66C2`
- Published: `✓ PUBLISHED` label mono 8px 700 `#3ECF8E` above the main text line
- Thumbnail: 44×44 border-radius 6px, only rendered when `post.images[0]` exists
- Footer: `That's everything` mono 8px `#222230` padding 28px

## Test plan

- [x] `npx vitest run` → **508/508 passing** (21 files, 12.29s)
- [ ] Open notification panel in production, verify data renders
- [ ] Click All / Mentions / Comments / Moves tabs, verify filter + active state
- [ ] Click a notification, verify it marks as read and opens the correct post (agency PCS, client overlay, or brief sheet)
- [ ] Click `Mark read`, verify all rows flip to read state
- [ ] Click WhatsApp icon on a notif, verify share sheet
- [ ] Click trash icon on a notif, verify delete fade-out
- [ ] Click a published notif's `LINKEDIN →` link, verify it opens LinkedIn without also opening the post
- [ ] Close panel, verify `_drainDeferredRender()` still flushes any stashed poll data

## Deploy

- Version strings: `?v=20260411f` (all 21 resources)
- After merge: Cloudflare Dash → srtd.io → Caching → Purge Everything, then hard refresh

https://claude.ai/code/session_01EG1A1nddNwM3t9JEhGiJGX