### PR TITLE
Notification panel: expand-in-place thread view + inline reply

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -413,6 +413,9 @@ var roleDisplayMap = {
 
 async function loadNotifications() {
   if (!localStorage.getItem('sb_access_token')) return;
+  // Reset the per-post thread cache on every panel load so the next expand
+  // picks up fresh server state (new comments, resolved flag flips, etc).
+  window._notifThreadCache = {};
   try {
     var _notifRole = window.AppState.user.effectiveRole || window.AppState.user.role || 'Admin';
     _notifRole = _notifRole.charAt(0).toUpperCase() + _notifRole.slice(1).toLowerCase();
@@ -424,7 +427,11 @@ async function loadNotifications() {
     if (!Array.isArray(data)) { console.error('Notifications load error:', data); return; }
     _notifData = data;
 
-    // Batch-fetch post_comments for every post that has a comment notification
+    // Batch-fetch post_comments for every post that has a comment notification.
+    // SELECT now pulls the extra fields the expand-in-place thread view needs:
+    // author_role (for the mini role tag), post_title (fallback for reply payload),
+    // resolved + resolved_at (to hide resolved comments from the thread),
+    // visibility (so client threads never surface agency-only rows).
     var commentPostIds = [];
     var seen = {};
     data.forEach(function(n) {
@@ -437,7 +444,7 @@ async function loadNotifications() {
     if (commentPostIds.length > 0) {
       try {
         var idList = commentPostIds.join(',');
-        var commentUrl = '/post_comments?post_id=in.(' + idList + ')&order=created_at.desc&select=id,post_id,author,message,created_at,mentioned_users';
+        var commentUrl = '/post_comments?post_id=in.(' + idList + ')&order=created_at.desc&select=id,post_id,author,author_role,message,created_at,mentioned_users,resolved,resolved_at,visibility,post_title';
         var comments = await apiFetch(commentUrl);
         if (Array.isArray(comments)) window._notifComments = comments;
       } catch (ce) {
@@ -459,6 +466,9 @@ async function loadNotifications() {
 // nchip-count-*, grouped-comment keys, response-time snippet).
 function renderNotifications(name, role) {
   var notifs = _notifData;
+  // Expand-in-place state — persisted across innerHTML rebuilds.
+  if (!window._notifExpandedSet) window._notifExpandedSet = new Set();
+  var _expandedSet = window._notifExpandedSet;
   var effectiveR = window.AppState.user.effectiveRole || window.AppState.user.role || role || 'Admin';
   var titleRole = effectiveR.charAt(0).toUpperCase() + effectiveR.slice(1).toLowerCase();
   var roleLabelEl = document.getElementById('notif-role-label');
@@ -660,7 +670,27 @@ function renderNotifications(name, role) {
       }
     }
 
-    // Meta row — time · icons · optional LinkedIn link on published
+    // Expand chip — only for grouped comment notifications (>1 comment).
+    // Lives inline in the meta row between the timestamp dot and the
+    // WhatsApp icon. CSS handles the collapsed/expanded/hover states.
+    var isExpandable = n.type === 'comment' && groupCount > 1;
+    var isExpanded = isExpandable && _expandedSet.has(n.id);
+    var expandChipHtml = '';
+    if (isExpandable) {
+      expandChipHtml =
+        '<button class="expand-chip" data-action="notif-expand"' +
+          ' data-notif-id="' + esc(n.id || '') + '" aria-label="Expand thread">' +
+          '<svg class="expand-chip-arrow" width="8" height="8" viewBox="0 0 8 8" fill="none" aria-hidden="true">' +
+            '<path d="M2 1l4 3-4 3z" fill="currentColor"/>' +
+          '</svg>' +
+          '<span class="expand-chip-count">' + groupCount + '</span>' +
+        '</button>';
+    }
+
+    // Meta row — time · [expand] · WhatsApp · trash · [LinkedIn]
+    // Flex `gap: 6px` on .notif-meta (see styles.css) gives uniform
+    // spacing between every child, so the dot separators themselves
+    // carry zero margin.
     var linkedinHtml = '';
     if (isPublished && post && post.linkedin_link) {
       linkedinHtml = '<span class="notif-meta-sep">\xB7</span>' +
@@ -674,6 +704,7 @@ function renderNotifications(name, role) {
 
     var metaRow = '<div class="notif-meta">' +
       '<span class="notif-time">' + esc(ts) + '</span>' +
+      (isExpandable ? '<span class="notif-meta-sep">\xB7</span>' + expandChipHtml : '') +
       '<span class="notif-meta-sep">\xB7</span>' +
       waBtn +
       delBtn +
@@ -694,24 +725,40 @@ function renderNotifications(name, role) {
     // notif-live-card retained as a marker class on published rows so the
     // tap delegate still finds them via closest('.notif-item, .notif-live-card').
     var liveMarker = isPublished ? ' notif-live-card' : '';
+    var expandableAttr = isExpandable ? ' data-expandable="1"' : '';
+    var expandedClass = isExpanded ? ' expanded' : '';
 
-    return '<div class="notif-item ' + tClass + liveMarker + (n.read ? ' read' : '') + '"' +
+    // Thread drawer — always emitted as a collapsed `<div class="thread-drawer">`
+    // for expandable rows, pre-populated with the current thread HTML if the
+    // notification is currently in _notifExpandedSet. CSS max-height:0 keeps
+    // it hidden until .notif-item.expanded flips it open.
+    var threadDrawerHtml = '';
+    if (isExpandable) {
+      var innerHtml = isExpanded ? _notifBuildThreadHtml(n, post, postTitle) : '';
+      threadDrawerHtml = '<div class="thread-drawer">' + innerHtml + '</div>';
+    }
+
+    return '<div class="notif-item ' + tClass + liveMarker + (n.read ? ' read' : '') + expandedClass + '"' +
       ' data-notif-id="' + esc(n.id || '') + '"' +
       ' data-post-id="' + esc(n.post_id || '') + '"' +
       ' data-notif-type="' + esc(n.type || '') + '"' +
+      expandableAttr +
       isBriefAttr + '>' +
-      '<div class="notif-av ' + avClass + '">' + esc(initial) + '</div>' +
-      '<div class="notif-body">' +
-        pubLabel +
-        '<div class="notif-text">' +
-          unreadDot +
-          '<strong>' + esc(actor) + '</strong> ' + esc(actionText) +
-          respTimeHtml +
+      '<div class="notif-item-row">' +
+        '<div class="notif-av ' + avClass + '">' + esc(initial) + '</div>' +
+        '<div class="notif-body">' +
+          pubLabel +
+          '<div class="notif-text">' +
+            unreadDot +
+            '<strong>' + esc(actor) + '</strong> ' + esc(actionText) +
+            respTimeHtml +
+          '</div>' +
+          previewHtml +
+          metaRow +
         '</div>' +
-        previewHtml +
-        metaRow +
+        thumbHtml +
       '</div>' +
-      thumbHtml +
+      threadDrawerHtml +
     '</div>';
   }
 
@@ -730,6 +777,293 @@ function renderNotifications(name, role) {
   }
   html += '<div class="notif-foot">That\u2019s everything</div>';
   scroll.innerHTML = html;
+}
+
+// ===================================================================
+// EXPAND-IN-PLACE THREAD VIEW
+// ===================================================================
+// Helpers used by renderNotifications + the panel click delegate.
+// window._notifExpandedSet — Set of expanded data-notif-id values,
+//   persisted across innerHTML rebuilds.
+// window._notifThreadCache — { [post_id]: htmlString } cache reset by
+//   loadNotifications() so repeat expands skip the filter+sort work.
+// ===================================================================
+
+// Inline send-arrow SVG used by the thread drawer reply input.
+var _NOTIF_SEND_SVG =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none"' +
+  ' stroke="currentColor" stroke-width="2" stroke-linecap="round"' +
+  ' stroke-linejoin="round" aria-hidden="true">' +
+    '<line x1="22" y1="2" x2="11" y2="13"/>' +
+    '<polygon points="22 2 15 22 11 13 2 9 22 2"/>' +
+  '</svg>';
+
+// Map an author name OR author_role to a mini-avatar colour class that
+// mirrors .notif-av. Kept local to the thread view so the agency-wide
+// _notifActorClass stays untouched.
+function _notifThreadAvClass(author, authorRole) {
+  var a = (author || '').toLowerCase();
+  var r = (authorRole || '').toLowerCase();
+  if (a === 'manisha' || a === 'shivangini' || r === 'client')    return 'nav-client';
+  if (a === 'chitra'  || r === 'servicing')                       return 'nav-chitra';
+  if (a === 'pranav'  || r === 'creative')                        return 'nav-pranav';
+  if (a === 'shubham' || r === 'admin')                           return 'nav-shubham';
+  return 'nav-system';
+}
+
+// Render the scrollable list of thread messages for a given notification.
+// Shows every comment on that post (not just the grouped actor's),
+// sorted ascending by created_at. Resolved comments are filtered out.
+// Relies on window._notifComments populated by loadNotifications.
+function _notifBuildThreadHtml(n, post, postTitle) {
+  var postId = n && n.post_id;
+  if (!postId) return '';
+  if (!window._notifThreadCache) window._notifThreadCache = {};
+  // Cached HTML uses the latest post_comments + optimistic appends.
+  // Cache is keyed per-post so two notifications on the same post share
+  // the same rendered thread and stay in sync.
+  if (window._notifThreadCache[postId]) return window._notifThreadCache[postId];
+
+  var list = (window._notifComments || [])
+    .filter(function(c) { return c.post_id === postId && c.resolved !== true; })
+    .slice()
+    .sort(function(a, b) {
+      var ta = a.created_at ? new Date(a.created_at).getTime() : 0;
+      var tb = b.created_at ? new Date(b.created_at).getTime() : 0;
+      return ta - tb;
+    });
+
+  var msgsHtml = '';
+  if (list.length === 0) {
+    msgsHtml = '<div class="thread-empty">No comments yet.</div>';
+  } else {
+    list.forEach(function(c) {
+      msgsHtml += _notifThreadMsgHtml(c);
+    });
+  }
+
+  // Reply input row + "Open full post" footer link.
+  var replyPlaceholder = 'Reply to ' + (postTitle || 'post') + '\u2026';
+  var replyHtml =
+    '<div class="thread-reply">' +
+      '<div class="reply-row">' +
+        '<textarea class="reply-input" rows="1"' +
+          ' data-post-id="' + esc(postId) + '"' +
+          ' placeholder="' + esc(replyPlaceholder) + '"></textarea>' +
+        '<button class="reply-send" data-action="notif-reply-send"' +
+          ' data-post-id="' + esc(postId) + '"' +
+          ' data-notif-id="' + esc(n.id || '') + '" aria-label="Send reply">' +
+          _NOTIF_SEND_SVG +
+        '</button>' +
+      '</div>' +
+      '<div class="reply-label">Posts as comment \xB7 visible to all</div>' +
+    '</div>' +
+    '<div class="thread-footer">' +
+      '<a class="thread-open-post" data-action="notif-open-post"' +
+        ' data-post-id="' + esc(postId) + '"' +
+        ' data-notif-id="' + esc(n.id || '') + '" href="#">Open full post \u2192</a>' +
+    '</div>';
+
+  var html =
+    '<div class="thread-area">' +
+      '<div class="thread-msgs">' + msgsHtml + '</div>' +
+      replyHtml +
+    '</div>';
+
+  window._notifThreadCache[postId] = html;
+  return html;
+}
+
+// Render a single thread message (mini avatar + header + body).
+function _notifThreadMsgHtml(c) {
+  var author = c.author || '';
+  var authorRole = c.author_role || '';
+  var avClass = _notifThreadAvClass(author, authorRole);
+  var initial = author ? author.charAt(0).toUpperCase() : '?';
+  var ts = _notifRelTime(c.created_at);
+  var roleTag = authorRole
+    ? '<span class="thread-role">' + esc(authorRole) + '</span>'
+    : '';
+  return '<div class="thread-msg">' +
+      '<div class="thread-av ' + avClass + '">' + esc(initial) + '</div>' +
+      '<div class="thread-content">' +
+        '<div class="thread-header">' +
+          '<span class="thread-author">' + esc(author) + '</span>' +
+          roleTag +
+          '<span class="thread-time">' + esc(ts) + '</span>' +
+        '</div>' +
+        '<div class="thread-message">' + esc(c.message || '') + '</div>' +
+      '</div>' +
+    '</div>';
+}
+
+// Toggle expand state for a comment notification card. Anchors scroll so
+// the tapped card's top edge stays at the same viewport position after
+// the thread drawer mounts, then updates _notifExpandedSet so the state
+// survives the next renderNotifications rebuild.
+function _notifToggleExpand(item) {
+  if (!item) return;
+  var notifId = item.getAttribute('data-notif-id');
+  if (!notifId) return;
+  if (!window._notifExpandedSet) window._notifExpandedSet = new Set();
+  var set = window._notifExpandedSet;
+  var scroll = document.getElementById('notif-list-scroll');
+  var preRect = item.getBoundingClientRect();
+  var preScrollTop = scroll ? scroll.scrollTop : 0;
+
+  if (set.has(notifId)) {
+    // Collapse — just strip the class; keep the drawer HTML in place so
+    // re-expand is instant. The drawer is display:none via max-height:0.
+    set.delete(notifId);
+    item.classList.remove('expanded');
+    return;
+  }
+
+  // Expand — mount the thread drawer content if it hasn't been built yet.
+  set.add(notifId);
+  var drawer = item.querySelector(':scope > .thread-drawer');
+  if (drawer && !drawer.innerHTML) {
+    var pid = item.getAttribute('data-post-id') || '';
+    var n = (window._notifData || _notifData || []).find(function(x) { return x.id === notifId; });
+    var posts = (window.AppState.posts && window.AppState.posts.all) || [];
+    var post = null;
+    for (var i = 0; i < posts.length; i++) {
+      if (posts[i].post_id === pid) { post = posts[i]; break; }
+    }
+    var postTitle = post && post.title ? post.title : (n && n.message ? n.message : pid);
+    drawer.innerHTML = _notifBuildThreadHtml(n || { id: notifId, post_id: pid }, post, postTitle);
+  }
+  item.classList.add('expanded');
+
+  // Scroll anchoring — after layout flushes, shift scrollTop so the card's
+  // top edge is back where it was pre-expand.
+  if (scroll) {
+    requestAnimationFrame(function() {
+      var postRect = item.getBoundingClientRect();
+      var delta = postRect.top - preRect.top;
+      if (delta !== 0) scroll.scrollTop = preScrollTop + delta;
+    });
+  }
+
+  // Auto-resize wiring for the reply textarea.
+  var ta = item.querySelector('.reply-input');
+  if (ta) {
+    ta.addEventListener('input', _notifReplyInputResize);
+  }
+}
+
+// Grow the reply textarea up to its CSS max-height as the user types,
+// and flip .active on the sibling send button once there is any text.
+function _notifReplyInputResize(e) {
+  var ta = e.currentTarget || e.target;
+  if (!ta) return;
+  ta.style.height = 'auto';
+  var next = Math.min(ta.scrollHeight, 80);
+  ta.style.height = next + 'px';
+  var row = ta.parentNode;
+  if (!row) return;
+  var btn = row.querySelector('.reply-send');
+  if (!btn) return;
+  if (ta.value && ta.value.trim().length > 0) btn.classList.add('active');
+  else btn.classList.remove('active');
+}
+
+// Submit a reply from the thread drawer. Posts to /post_comments with
+// the payload shape documented in CLAUDE.md §2 (post_comments schema).
+// We DO NOT fire the notify-comment fan-out POST from JS — the Supabase
+// edge function handles it (see CLAUDE.md §6), which avoids the existing
+// dual-writer duplicate-row problem.
+async function _notifSubmitReply(sendBtn) {
+  if (!sendBtn || sendBtn.dataset.submitting === '1') return;
+  var postId = sendBtn.getAttribute('data-post-id');
+  var notifId = sendBtn.getAttribute('data-notif-id');
+  var item = document.querySelector(
+    '.notif-item[data-notif-id="' + (notifId || '').replace(/"/g, '\\"') + '"]'
+  );
+  if (!item) return;
+  var ta = item.querySelector('.reply-input');
+  if (!ta) return;
+  var msg = (ta.value || '').trim();
+  if (!msg) return;
+
+  sendBtn.dataset.submitting = '1';
+  sendBtn.disabled = true;
+  ta.disabled = true;
+
+  var posts = (window.AppState.posts && window.AppState.posts.all) || [];
+  var post = null;
+  for (var i = 0; i < posts.length; i++) {
+    if (posts[i].post_id === postId) { post = posts[i]; break; }
+  }
+  // Fallback for post_title: look up the matching notification's message,
+  // which usually embeds the post title (e.g. "Chitra commented on <title>").
+  var notifMatch = _notifData.find(function(x) { return x.id === notifId; });
+  var postTitle = (post && post.title) || (notifMatch && notifMatch.message) || postId;
+
+  var authorName = (window.AppState.user && window.AppState.user.name) || 'Unknown';
+  var effRole = (window.AppState.user && window.AppState.user.effectiveRole) ||
+                (window.AppState.user && window.AppState.user.role) || 'Admin';
+  var authorRole = effRole.charAt(0).toUpperCase() + effRole.slice(1).toLowerCase();
+
+  // Parse any @mentions (very loose — matches the client/pcs parsers)
+  var mentioned = [];
+  var mRe = /@([A-Za-z][A-Za-z0-9_\-\s]*)/g;
+  var m;
+  while ((m = mRe.exec(msg)) !== null) {
+    var raw = (m[1] || '').trim();
+    if (raw) mentioned.push(raw);
+  }
+
+  var payload = {
+    post_id:         postId,
+    post_title:      postTitle,
+    author:          authorName,
+    author_role:     authorRole,
+    message:         msg,
+    visibility:      'all',
+    mentioned_users: mentioned,
+    reply_to:        null,
+    resolved:        false,
+    resolved_by:     null,
+    attachments:     '[]'
+  };
+
+  try {
+    var resp = await apiFetch('/post_comments', {
+      method: 'POST',
+      headers: { 'Prefer': 'return=representation' },
+      body: JSON.stringify(payload)
+    });
+    var created = Array.isArray(resp) && resp[0] ? resp[0] : null;
+    var row = created || Object.assign({}, payload, {
+      id: 'tmp-' + Date.now(),
+      created_at: new Date().toISOString()
+    });
+    // Append to the in-memory comment cache so subsequent expands see it.
+    if (!Array.isArray(window._notifComments)) window._notifComments = [];
+    window._notifComments.push(row);
+    // Bust the cache entry for this post so the next render is fresh,
+    // then append the new message directly to the open drawer.
+    if (window._notifThreadCache) delete window._notifThreadCache[postId];
+    var msgsBox = item.querySelector('.thread-msgs');
+    if (msgsBox) {
+      var empty = msgsBox.querySelector('.thread-empty');
+      if (empty && empty.parentNode) empty.parentNode.removeChild(empty);
+      msgsBox.insertAdjacentHTML('beforeend', _notifThreadMsgHtml(row));
+    }
+    ta.value = '';
+    ta.style.height = 'auto';
+    sendBtn.classList.remove('active');
+  } catch (err) {
+    console.error('[notif-reply] POST failed', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'notif-reply');
+    if (typeof showToast === 'function') showToast('Reply failed', 'error');
+  } finally {
+    delete sendBtn.dataset.submitting;
+    sendBtn.disabled = false;
+    ta.disabled = false;
+    ta.focus();
+  }
 }
 
 async function markNotifRead(id) {
@@ -1583,6 +1917,72 @@ function openNotifications() {
       if (e.target.closest('.notif-mi-btn')) return;
       if (e.target.closest('.notif-topbar-btn')) return;
       if (e.target.closest('.notif-li-link')) return;
+      // Expand-in-place thread view — the expand chip, the reply input,
+      // the send button, individual thread messages, and the "Open full
+      // post" link all live inside a .notif-item and would otherwise be
+      // swallowed by the item delegate below.
+      var expandBtn = e.target.closest('.expand-chip');
+      var replyInput = e.target.closest('.reply-input');
+      var replySend = e.target.closest('.reply-send');
+      var threadOpen = e.target.closest('.thread-open-post');
+      var threadMsg = e.target.closest('.thread-msg');
+      var threadArea = e.target.closest('.thread-area, .thread-reply, .thread-footer, .reply-label');
+
+      if (replyInput) return;                // let the textarea focus/type
+      if (replySend) {                       // submit the reply
+        e.stopPropagation();
+        _notifSubmitReply(replySend);
+        return;
+      }
+      if (threadOpen) {                      // "Open full post ->" link
+        e.preventDefault();
+        e.stopPropagation();
+        var _openItem = threadOpen.closest('.notif-item, .notif-live-card');
+        var _openPid = threadOpen.getAttribute('data-post-id') ||
+          (_openItem && _openItem.getAttribute('data-post-id'));
+        var _openNotifId = threadOpen.getAttribute('data-notif-id') ||
+          (_openItem && _openItem.getAttribute('data-notif-id'));
+        if (_openNotifId) markNotifRead(_openNotifId);
+        window._notifOpenedPCS = true;
+        closeNotifications();
+        setTimeout(function() {
+          var _role = (window.AppState.user.effectiveRole || '').toLowerCase();
+          if (_role === 'client') {
+            if (typeof window._openClientPostOverlay === 'function')
+              window._openClientPostOverlay(_openPid);
+          } else {
+            openPCS(_openPid, '');
+            setTimeout(function() {
+              if (typeof window._pcsTabSwitch === 'function')
+                window._pcsTabSwitch('client');
+            }, 300);
+          }
+        }, 150);
+        return;
+      }
+      if (expandBtn) {
+        e.stopPropagation();
+        var _chipItem = expandBtn.closest('.notif-item');
+        if (!_chipItem) return;
+        // Mark-read on first expand, mirrors the card-tap semantic.
+        if (!_chipItem.classList.contains('expanded')) {
+          var _nid = _chipItem.getAttribute('data-notif-id');
+          if (_nid) markNotifRead(_nid);
+          _chipItem.classList.add('read');
+          var _cDot = _chipItem.querySelector('.nnew-dot');
+          if (_cDot) _cDot.style.display = 'none';
+        }
+        _notifToggleExpand(_chipItem);
+        return;
+      }
+      if (threadMsg || threadArea) {
+        // Any click inside an already-expanded drawer that isn't on a
+        // tracked control should be ignored (don't open PCS, don't
+        // re-fire markNotifRead).
+        e.stopPropagation();
+        return;
+      }
+
       var item = e.target.closest('.notif-item, .notif-live-card');
       if (!item) return;
       e.stopPropagation();
@@ -1590,13 +1990,28 @@ function openNotifications() {
       var isBrief = item.getAttribute('data-is-brief') === '1' ||
         item.getAttribute('data-notif-type') === 'new_request';
       var notifId = item.getAttribute('data-notif-id');
+      var notifType = item.getAttribute('data-notif-type') || '';
+      var isExpandable = item.getAttribute('data-expandable') === '1';
+
+      // Comment notifications with a group (>1 comment) expand in place
+      // on body tap instead of routing into PCS/client overlay.
+      if (isExpandable && notifType === 'comment' && !isBrief) {
+        if (!item.classList.contains('expanded')) {
+          if (notifId) markNotifRead(notifId);
+          item.classList.add('read');
+          var _bDot = item.querySelector('.nnew-dot');
+          if (_bDot) _bDot.style.display = 'none';
+        }
+        _notifToggleExpand(item);
+        return;
+      }
+
       if (notifId) markNotifRead(notifId);
       // Instant visual mark-as-read
       item.classList.add('read');
       var _tapDot = item.querySelector('.notif-unread-dot');
       if (_tapDot) _tapDot.style.display = 'none';
       if (!pid) return;
-      var notifType = item.getAttribute('data-notif-type') || '';
       window._notifOpenedPCS = true;
       closeNotifications();
       setTimeout(function() {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Sorted (srtd.io)
 
-Last updated: 2026-04-11 (notification-panel-v6). Full history: `CLAUDE-archive-20260411.md`.
+Last updated: 2026-04-12 (notification-thread-view). Full history: `CLAUDE-archive-20260411.md`.
 
 ## 1 — WHAT IS SORTED
 
@@ -108,41 +108,30 @@ window.AppState = {
 - `AppState.pcs.post` is the SAME object as the row in `posts.all`. Apply server responses via `Object.assign(post, serverRow)`; do NOT replace the reference.
 
 ### _isSaving lock + 10-second safety net (08-post-actions.js)
-- Before every PATCH: set `post._isSaving = true` and call `_startSaveTimeout(post, postId)`.
-- On BOTH success and catch paths: `_clearSaveTimeout(post)` then `post._isSaving = false`.
-- If a PATCH hangs > 10s (`_SAVE_TIMEOUT_MS = 10000`) the timer force-clears `_isSaving`, logs `[SAVE TIMEOUT]`, and calls `scheduleRender()`. A force-cleared post can be saved again immediately.
-- `apiFetch` has NO timeout and NO AbortController — this timer is the only protection against indefinite hangs. Wired into `quickStage`, `clientApprove`, `_executeStageChange`/`Async`, `updatePost`.
+- Before every PATCH: `post._isSaving = true` + `_startSaveTimeout(post, postId)`. On success AND catch paths: `_clearSaveTimeout(post)` then `post._isSaving = false`.
+- If a PATCH hangs > 10s (`_SAVE_TIMEOUT_MS`) the timer force-clears the flag, logs `[SAVE TIMEOUT]`, and calls `scheduleRender()`. Force-cleared posts can be saved again immediately. `apiFetch` has no timeout — this is the only indefinite-hang guard. Wired into `quickStage`, `clientApprove`, `_executeStageChange`/`Async`, `updatePost`.
 
 ### Client 30s polling (`startClientRealtime` in 07-post-load.js)
-- Installed from `activateRole()` at 03-auth.js for every Client path; singleton via `window._clientPollTimer`. Cleared by `stopClientRealtime()`, which is called from `stopRealtime()` — so `logout()` / `_clearSessionAndLogin()` teardowns cascade automatically.
-- Interval body guards IN ORDER: `document.hidden`, `sb_access_token`, `window._isLoadingClientPosts` (in-flight), and an active-typing check (`document.activeElement` is INPUT / TEXTAREA / contentEditable). Any guard hit → return without fetching.
-- Delegates to `loadPostsForClient(true)`. The boolean `skipRenderIfUnchanged` flag makes the fetch re-render only when `_clientPostsFingerprint(posts.all) !== window._lastClientFp`. Initial load (no arg) renders unconditionally and seeds `_lastClientFp`.
-- `_clientPostsFingerprint` extends `_postsFingerprint` with per-post `post_comments.length` so new comments trigger re-render (not just stage flips).
-- `loadPostsForClient` skips overwriting `post.post_comments` for any post currently flagged `_commentSaving === true` (object-level lock set by `_handleSubmitComment` in render/client.js). This protects the optimistic comment row from poll clobber.
-- `_teardownClientTokenTimer()` in 03-auth.js clears the 50-min client token interval on logout (previously leaked across logout/login cycles).
-- `renderClientView` wires cv click listeners exactly ONCE via `cv._clientEventsWired` (render/client.js ~L2073). cv is persistent across re-renders (only innerHTML swaps), so unguarded `addEventListener` used to stack on every poll and break symmetric toggles like `_clientToggleComments`. Always guard cv-level listeners.
-- Client @mention roster is fetched live from `/user_roles?select=name,email,role` on first render, cached in `window._clientMentionRoster` via `_fetchClientMentionRoster()` (render/client.js). `_clientToggleMention` and `_handleSubmitComment`'s mention-notification loop both read from that cache — no more hardcoded roster arrays.
+- Singleton via `window._clientPollTimer`, installed from `activateRole()` (03-auth.js) and cleared by `stopClientRealtime()` (called by `stopRealtime()` → cascades on logout). `_teardownClientTokenTimer()` clears the 50-min token interval.
+- Interval guards (in order): `document.hidden`, `sb_access_token`, `window._isLoadingClientPosts`, active-typing (input/textarea/contenteditable). Any hit → return.
+- Delegates to `loadPostsForClient(true)` with `skipRenderIfUnchanged` — re-renders only when `_clientPostsFingerprint(posts.all) !== window._lastClientFp`. Fingerprint extends `_postsFingerprint` with per-post `post_comments.length`.
+- `loadPostsForClient` skips overwriting `post.post_comments` when `_commentSaving === true` — object-level lock set by `_handleSubmitComment` (render/client.js) so in-flight optimistic rows aren't clobbered.
+- `renderClientView` guards cv click listeners via `cv._clientEventsWired` (cv persists across re-renders, unguarded `addEventListener` stacks on every poll).
+- Client @mention roster fetched live from `/user_roles`, cached in `window._clientMentionRoster` via `_fetchClientMentionRoster()`.
 
 ### Render pipeline
-- `setStage(post, stage)` is a PURE logger — mutates `post.stage` and appends to activity log. It does NOT touch `_isSaving`, does NOT fire notifications, does NOT render. Safe for rollback paths.
-- `scheduleRender()` DEFERS when `AppState.ui.modalOpen === true`, flipping `window._deferredRender = true`. `_drainDeferredRender()` fires the queued render on modal close AND drains the agency poll stash via `_drainPollStash()`.
-- `_postsFingerprint()` is a cheap hash of `posts.all`. Renderers skip rebuild when the fingerprint is unchanged — always mutate via `setAll` so the fingerprint changes.
-- `_renderBackgroundViews()` re-renders dashboard + pipeline + client feed without tearing down PCS — call after a successful PATCH.
-- PCS render goes through `_renderPCS()`. Do not mutate PCS DOM from other modules. `09-library.js` is the one exception (opens PCS without the router).
+- `setStage(post, stage)` is a PURE logger — mutates `post.stage`, appends activity log. Does NOT touch `_isSaving`, fire notifications, or render. Safe for rollback.
+- `scheduleRender()` DEFERS when `AppState.ui.modalOpen === true` → `window._deferredRender = true`. `_drainDeferredRender()` fires the queued render on modal close + drains the poll stash.
+- `_postsFingerprint()` is a cheap hash of `posts.all`. Renderers skip rebuild when unchanged — always mutate via `setAll`. `_renderBackgroundViews()` re-renders dashboard/pipeline/client feed without tearing down PCS. PCS render goes through `_renderPCS()`; `09-library.js` is the one exception.
 
 ### Agency poll fetch-and-stash (`startRealtime` in 07-post-load.js)
-- The 15s agency poll NO LONGER skips while a modal is open. It fetches, normalises, and if the fingerprint differs, stashes the fresh array in `window._postsPollStash` (+ `window._postsPollStashFp`). Latest-wins, no queue — subsequent polls overwrite the stash.
-- `_drainPollStash()` in 07-post-load.js reads the stash, clears it, runs `mergePosts(stash)`, `scheduleRender()`, and `updateNotifBadge()`. It is a no-op when the stash is null.
-- `_drainDeferredRender()` in 10-ui.js now calls `_drainPollStash()` unconditionally after its existing safeRender debounce — so every modal-close site that drains also picks up stashed poll data.
-- Drain sites (all call `_drainDeferredRender` after setting `modalOpen = false`): `forcePCSReset` (actions/pcs.js:156), `closeAdminEdit` (08-post-actions.js:195), `closeNewPostModal` (06-post-create.js:231), `closeNotifications` (10-ui.js), `closePipelineFilter` (10-ui.js), `_lbClose` (render/client.js), client post overlay close + back-to-notifs paths (render/client.js).
-- The client 30s poll (`startClientRealtime`) still has NO stash. It uses the active-typing guard + `_clientPostsFingerprint` to avoid clobbering open inputs, and does not need a modal gate.
+- 15s agency poll fetches regardless of modal state. If fingerprint differs, stashes the array into `window._postsPollStash` (+ `_postsPollStashFp`). Latest-wins, no queue.
+- `_drainPollStash()` reads the stash, clears it, runs `mergePosts(stash)`, `scheduleRender()`, `updateNotifBadge()` — no-op when stash is null.
+- `_drainDeferredRender()` calls `_drainPollStash()` unconditionally after its safeRender debounce, so every modal-close drain site also flushes poll data. Drain sites: `forcePCSReset` (actions/pcs.js), `closeAdminEdit` / `closeNewPostModal`, `closeNotifications` / `closePipelineFilter` (10-ui.js), `_lbClose` and client post overlay close (render/client.js).
+- Client 30s poll has NO stash — active-typing guard + `_clientPostsFingerprint` are enough.
 
 ### Runtime-enriched fields (NOT in DB — added by loadPosts)
-- `_commentCount` (int), `_clientCommentAt` (ISO | null) — set after batch comment fetch.
-- `_isRequest` (true) — set on rows merged from `requests`. Brief / assign / close / reopen all branch on this to route API calls to `/requests` vs `/posts`.
-- `_isSaving` (bool) — optimistic save lock.
-- `_saveTimer` — timer handle set by `_startSaveTimeout`, deleted by `_clearSaveTimeout`.
-- `_commentSaving` (bool) — set by `_handleSubmitComment` (render/client.js) while a client comment POST is in flight; `loadPostsForClient` honours it and will not overwrite that post's `post_comments` until the insert resolves.
+- `_commentCount` (int), `_clientCommentAt` (ISO|null) — set after batch comment fetch. `_isRequest` (true) — set on rows merged from `requests`; brief/assign/close/reopen branch on this to route `/requests` vs `/posts`. `_isSaving` (bool) + `_saveTimer` — optimistic save lock. `_commentSaving` (bool) — set by `_handleSubmitComment` during an in-flight insert; `loadPostsForClient` honours it so the optimistic row isn't clobbered.
 
 ### Design system
 - Zero border-radius on inputs/buttons. NO `rgba()` — use 8-digit hex (#RRGGBBAA). Approved exceptions: `.pcs-more-ov`, `.pcs-more-l`, SVG fill at index.html:1140.
@@ -151,33 +140,19 @@ window.AppState = {
 - Use `100dvh`, never `100vh` (iOS Safari address bar).
 - Image compression: posts max 1200px q0.82, comments max 800px q0.80, save as .jpg.
 
-### Notification panel v6 (10-ui.js `renderNotifications`)
-- Visual-only rewrite. Data fetch (`loadNotifications`), badge (`updateNotifBadge`), mark-read (`markNotifRead`, `markAllNotificationsRead`), delete (`deleteNotification`), and the `openNotifications`/`closeNotifications` tap-delegate + chip-filter click handler are UNCHANGED. Do not modify them when tweaking the visual layer.
-- Header row1 is a mono role label (`effectiveRole.toUpperCase() + ' · SORTED'`) on the left and two plain-text buttons on the right: `Mark read | Close` (`.notif-topbar-btn`, pipe `.notif-topbar-sep`). No boxed buttons, no borders. `data-action="mark-all-read"` / `data-action="close-notifications"` unchanged.
-- Header row2 is a single large greeting: `Hey, <AppState.user.name>` (DM Sans 22px 700 #E8E8F0) with the name portion in gold #C8A84B. No summary lines, no counters in the header. Greeting name pulls ONLY from `AppState.user.name` — no hardcoded person map.
-- Role label text is fed from `AppState.user.effectiveRole` (title-cased → uppercased). `roleDisplayMap` is intentionally no longer read by the renderer (left in place as dead metadata).
-- Filter tabs (`.notif-chips > .notif-chip`) are plain text, not chips: 10px IBM Plex Mono, marginRight 20px, border-bottom 1px #18182A on the row, 500 #404050 inactive / 700 #E0E0EC active. Counts render in the same `nchip-count-*` spans (#333340 inactive, #C8A84B active). Tabs are: All, Mentions, Comments, Moves (Live tab dropped from UI; the `live` branch inside `_notifChipMatch` is retained so tests pass and an admin can re-enable the tab later).
-- `renderNotifications` re-applies the active class across the tab row each call — this is redundant with the chip-row click delegate but keeps the UI in sync when the filter is flipped programmatically.
-- Cards: flex row, `.notif-item` is the ONLY card class; published rows get an additional `notif-live-card` marker class so the tap delegate `closest('.notif-item, .notif-live-card')` still finds them. Background is ALWAYS transparent regardless of read state — read and unread items are visually identical, and the 5px gold dot (`.nnew-dot`) before the actor name is the ONLY unread indicator. No background swap, no opacity change, no color differences between read and unread. No left color bar, no hover swap. Border-bottom 1px #14141E.
-- Avatars (`.notif-av`): 32px solid-fill circles, white letter, no border/ring. Palette: `.nav-client` #FF4B4B, `.nav-chitra` #22D3EE, `.nav-pranav` #9b87f5, `.nav-shubham` #C8A84B, `.nav-system` #555566 (same class mapping returned by `_notifActorClass`).
-- Unread indicator is an inline `<span class="nnew-dot">` gold 5px dot rendered before the actor name (the old `.notif-unread-dot` absolute-positioned dot is gone). Read items omit the span entirely.
-- Meta row (`.notif-meta`): time · icons · optional LinkedIn link. Icons are inline SVG (WhatsApp 11×11, trash 10×10) centered inside `.notif-mi-btn` 32×32 tap targets that retain `data-action="notif-wa"` / `data-action="notif-delete"`. Buttons use negative vertical margin (`-8px 0`) so the 32px tap area doesn't inflate the meta row; the two icon buttons are separated by a 16px `margin-left` via `.notif-mi-btn + .notif-mi-btn`. SVG children are `pointer-events:none` so every click resolves to the button, which keeps `closest('.notif-mi-btn')` reliable. The panel tap delegate in `openNotifications` skips `.notif-mi-btn`, `.notif-topbar-btn`, and `.notif-li-link` so those buttons/links reach the Action Router instead of opening PCS. LinkedIn link is rendered only when the underlying post has `linkedin_link` and carries inline `onclick="event.stopPropagation()"` belt-and-braces so the surrounding item tap never fires.
-- Published cards: no bordered badge. A `.notif-pub-label` div (`✓ PUBLISHED`, 8px gold-green #3ECF8E) sits above the main text line, and `actionText` is `published <title>`. All other structure is identical to non-published items.
-- Thumbnails (`.notif-thumb`) render ONLY when the linked post has `images[0]`. No 44×44 placeholder for imageless cards; the body simply stretches. Thumbs are 44×44, border-radius 6px, object-fit cover, background #14141E.
-- Day labels (`.notif-day-label`): 8px mono 700 #333340 with 1.6px letter-spacing. Today section has a `.ndl-first` modifier with top padding 14px; Yesterday/Earlier use 18px.
-- Footer: `That's everything` centered in `.notif-foot` (8px mono #222230) — appended after the last day group.
-- The overlay shell (`#notif-overlay` + `#panel-updates`) is unchanged structurally: background `#0a0a0f`, inner panel `#0e0e16`, max-width 480px, full-height flex column. `closeNotifications()` still calls `_drainDeferredRender()`.
-- Tests: all structural class names + source patterns the static-analysis tests grep for (`notif-item`, `notif-live-card`, `nchip-count-*`, grouped-comment key `(n.post_id||'') + '|' + (n.actor||'')`, response-time `notif-resp-time` block, `Today`/`Yesterday`/`Earlier`, `"left " + n + " comments on "` template) are preserved verbatim. 508/508 unit tests still pass after the rewrite.
+### Notification panel (10-ui.js `renderNotifications`)
+- `loadNotifications`, `updateNotifBadge`, `markNotifRead`, `markAllNotificationsRead`, `deleteNotification`, `openNotifications`, `closeNotifications` stay stable — tweak visuals in `renderNotifications` / `_buildItem` only.
+- Header: mono `<effectiveRole> · SORTED` label + plain-text `Mark read | Close`; greeting row `Hey, <AppState.user.name>` (name gold). Name/role pull ONLY from `AppState.user` — no hardcoded map.
+- Tabs (`.notif-chips > .notif-chip`): text-only (All / Mentions / Comments / Moves), counts in `nchip-count-*` spans. Active class reapplied by the renderer on every pass.
+- Cards: `.notif-item` is the single card class; published rows get `notif-live-card` as a marker so the tap delegate `closest('.notif-item, .notif-live-card')` still resolves. Background always transparent — read and unread items look identical. Inline `<span class="nnew-dot">` (gold 5px) before the actor name is the ONLY unread indicator. Avatars solid-fill 32px (no border/ring). Published cards render a `.notif-pub-label` eyebrow (`✓ PUBLISHED`) above the main text line.
+- Meta row (`.notif-meta`): flex with `gap: 6px` — every child (timestamp, separator dots, expand chip, WA/trash icon buttons, LinkedIn link) sits exactly 6px apart. `.notif-mi-btn` is a 32×32 tap target around an 11×10 SVG with `-8px 0` vertical margin so the row stays compact. SVG children are `pointer-events:none`. Skip list in the panel tap delegate includes `.notif-mi-btn`, `.notif-topbar-btn`, `.notif-li-link`, and the thread-view controls below.
+- **Expand-in-place thread view** — for comment notifications with `_groupCount > 1`, `_buildItem` emits a gold `.expand-chip` inline in the meta row AND a collapsed `.thread-drawer` below the row. Tap on the card body OR the chip toggles `.notif-item.expanded`, mounts the thread HTML into the drawer, anchors scroll so the tapped card stays in place, and marks the notif as read on first expand (not on re-collapse). State is persisted across `scroll.innerHTML` rebuilds via `window._notifExpandedSet` (Set of notif IDs). Thread content is built from `window._notifComments` (now SELECT'd with `author_role,resolved,resolved_at,visibility,post_title`), filtered `post_id === n.post_id && !resolved`, sorted ASC by `created_at`; results are cached per post in `window._notifThreadCache` (cleared at the top of `loadNotifications`). The drawer contains a `.reply-input` + `.reply-send` row and an `Open full post →` footer link. Replies POST to `/post_comments` ONLY — the JS fan-out is intentionally skipped so `notify-comment` (edge) is the single writer and there are no duplicate notification rows. Reply author is always `AppState.user.name`, author_role is `effectiveRole` title-cased, so the same code path works for both agency and client users. The panel tap delegate skips `.expand-chip`, `.reply-input`, `.reply-send`, `.thread-msg`, `.thread-area`, `.thread-reply`, `.thread-footer`, `.reply-label`, and routes `.thread-open-post` clicks through `closeNotifications()` + `openPCS` / `_openClientPostOverlay`.
+- Tests: structural class names + source patterns (`notif-item`, `notif-live-card`, `nchip-count-*`, grouped key `(n.post_id||'') + '|' + (n.actor||'')`, `notif-resp-time`, day labels, `"left " + n + " comments on "`) are preserved verbatim. 508/508 unit tests still pass.
 
 ### Misc gotchas
-- `_commentInputHtml()` only renders for stages `awaiting_approval` + `awaiting_brand_input` and MUST be called inside `_cardHtml()` or the input never exists.
-- `apiFetch()` never calls `logout()` on 401 by design — refresh flow handles it.
-- Silent `.catch(()=>{})` is a bug — always `window.logError`.
-- 15-second poll interval (agency, startRealtime). 30-second poll interval (client, startClientRealtime). 50-minute token refresh.
-- Client DB role takes absolute priority over `pcs_role_preview`.
-- Deep link: `srtd.io/?open=POST_ID` → stored in `window._pendingOpenPost`, fired after loadPosts.
-- PCS document-click-close listener skips close when the active dropdown contains `input[type="date"]` (native calendar interaction).
-- `_cardClickDelegate` (07-post-load.js) guards `e.target.closest('input, textarea, button, [contenteditable="true"], a, [role="button"]')` — don't narrow the guard.
+- `_commentInputHtml()` only renders for `awaiting_approval`/`awaiting_brand_input` and MUST be called inside `_cardHtml()`. `apiFetch()` never calls `logout()` on 401 by design — refresh flow handles it. Silent `.catch(()=>{})` is a bug — always `window.logError`.
+- Polling: 15s agency (`startRealtime`), 30s client (`startClientRealtime`), 50min token refresh. Client DB role takes priority over `pcs_role_preview`. Deep link `srtd.io/?open=POST_ID` → `window._pendingOpenPost` fired after loadPosts.
+- PCS document-click-close skips close when the active dropdown contains `input[type="date"]`. `_cardClickDelegate` (07-post-load.js) guards `input, textarea, button, [contenteditable="true"], a, [role="button"]` — don't narrow.
 - Image download: `_pcsLbDownload` + `_pcsSaveAllPhotos` must strip BOTH `https://images.srtd.io/` and legacy `pub-*.r2.dev` prefix before hitting the R2 worker `/download?key=`.
 
 ## 5 — AUTH AND ROLES
@@ -211,7 +186,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 21 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 20 scripts). Current: `?v=20260411g`.
+1. Bump ALL 21 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 20 scripts). Current: `?v=20260412a`.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260411g">
+ <link rel="stylesheet" href="styles.css?v=20260412a">
 
 </head>
 <body>
@@ -1081,27 +1081,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260411g"></script>
-<script src="00-appstate-compat.js?v=20260411g"></script>
-<script src="01-config.js?v=20260411g" defer></script>
-<script src="02-session.js?v=20260411g" defer></script>
-<script src="utils.js?v=20260411g" defer></script>
-<script src="03-auth.js?v=20260411g" defer></script>
-<script src="05-api.js?v=20260411g" defer></script>
-<script src="10-ui.js?v=20260411g" defer></script>
+<script src="00-appstate.js?v=20260412a"></script>
+<script src="00-appstate-compat.js?v=20260412a"></script>
+<script src="01-config.js?v=20260412a" defer></script>
+<script src="02-session.js?v=20260412a" defer></script>
+<script src="utils.js?v=20260412a" defer></script>
+<script src="03-auth.js?v=20260412a" defer></script>
+<script src="05-api.js?v=20260412a" defer></script>
+<script src="10-ui.js?v=20260412a" defer></script>
 
-<script src="06-post-create.js?v=20260411g" defer></script>
-<script defer src="render/dashboard.js?v=20260411g"></script>
-<script defer src="render/client.js?v=20260411g"></script>
-<script defer src="render/pipeline.js?v=20260411g"></script>
-<script defer src="render/brief.js?v=20260411g"></script>
-<script defer src="actions/pcs.js?v=20260411g"></script>
-<script defer src="actions/pcs-longpress.js?v=20260411g"></script>
-<script src="07-post-load.js?v=20260411g" defer></script>
-<script src="08-post-actions.js?v=20260411g" defer></script>
-<script src="09-library.js?v=20260411g" defer></script>
-<script src="09-approval.js?v=20260411g" defer></script>
-<script src="04-router.js?v=20260411g" defer></script>
+<script src="06-post-create.js?v=20260412a" defer></script>
+<script defer src="render/dashboard.js?v=20260412a"></script>
+<script defer src="render/client.js?v=20260412a"></script>
+<script defer src="render/pipeline.js?v=20260412a"></script>
+<script defer src="render/brief.js?v=20260412a"></script>
+<script defer src="actions/pcs.js?v=20260412a"></script>
+<script defer src="actions/pcs-longpress.js?v=20260412a"></script>
+<script src="07-post-load.js?v=20260412a" defer></script>
+<script src="08-post-actions.js?v=20260412a" defer></script>
+<script src="09-library.js?v=20260412a" defer></script>
+<script src="09-approval.js?v=20260412a" defer></script>
+<script src="04-router.js?v=20260412a" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4054,9 +4054,14 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 
 /* ── META ROW ── */
+/* Meta row — uniform 6px gap between every child. All child margins are
+   zero; the parent gap is the single source of truth for spacing, so
+   every item (timestamp, dot, expand chip, WA button, trash button,
+   LinkedIn link) sits exactly 6px apart. */
 .notif-meta {
   display: flex;
   align-items: center;
+  gap: 6px;
   margin-top: 4px;
 }
 .notif-time {
@@ -4070,16 +4075,14 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 9px;
   color: #222230;
-  margin: 0 5px;
+  margin: 0;
   user-select: none;
 }
 
 /* Meta-row icon buttons — 32x32 tap target centered around the small
-   SVG, with a 16px visual gap between WhatsApp and trash. Negative
-   vertical margin keeps the meta row compact even though the buttons
-   are 32px tall. Child SVG uses pointer-events:none so every click
-   hits the button itself, not the path, which keeps closest('.notif-mi-btn')
-   reliable in the panel tap delegate skip list. */
+   SVG. Negative vertical margin keeps the meta row compact even though
+   the buttons are 32px tall. Horizontal spacing is handled by the
+   parent `.notif-meta { gap: 6px }` so the buttons carry zero margin. */
 .notif-mi-btn {
   width: 32px;
   height: 32px;
@@ -4094,8 +4097,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   margin: -8px 0;
   -webkit-tap-highlight-color: transparent;
 }
-.notif-mi-btn + .notif-mi-btn { margin-left: 16px; }
-.notif-mi-btn:last-of-type { margin-right: 0; }
 .notif-mi-btn svg {
   display: block;
   pointer-events: none;
@@ -4167,6 +4168,250 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   text-align: center;
   padding: 28px 18px;
 }
+
+/* ===================================================
+   EXPAND-IN-PLACE THREAD VIEW (v6.2)
+   =================================================== */
+/* CLAUDE.md §4 forbids rgba() — every translucent colour in this
+   section is the 8-digit hex equivalent of the design spec's rgba(). */
+
+/* The .notif-item wrapper now carries its row content inside
+   .notif-item-row so the thread drawer can slot in directly below
+   without breaking the flex row layout. */
+.notif-item-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+}
+.notif-item { flex-direction: column; }
+
+/* Expanded card gets a subtle gold left border + a faint gold wash
+   so you can see which card owns the open drawer at a glance. */
+.notif-item.expanded {
+  border-left: 2px solid #C8A84B4D;
+  padding-left: 16px;
+}
+.notif-item.expanded .notif-item-row { padding-right: 2px; }
+
+/* ── EXPAND CHIP ── */
+/* Collapsed state — tiny gold-tinted pill in the meta row. */
+.expand-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  height: 18px;
+  padding: 1px 6px;
+  margin: -8px 0;           /* match the meta-icon negative margin */
+  background: #C8A84B14;    /* rgba(200,168,75,0.08) */
+  border: 1px solid #C8A84B1A; /* rgba(200,168,75,0.10) */
+  color: #C8A84B80;         /* rgba(200,168,75,0.50) */
+  border-radius: 4px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.expand-chip:hover {
+  background: #C8A84B24;    /* rgba(200,168,75,0.14) */
+  color: #C8A84BCC;         /* rgba(200,168,75,0.80) */
+}
+.expand-chip-arrow {
+  display: block;
+  transition: transform 0.25s ease;
+  pointer-events: none;
+}
+.expand-chip-count { pointer-events: none; }
+.expand-chip svg { pointer-events: none; }
+
+/* Expanded state — flipped triangle + filled gold, count hidden. */
+.notif-item.expanded .expand-chip {
+  background: #C8A84B1F;    /* rgba(200,168,75,0.12) */
+  color: #C8A84B;
+  border-color: #C8A84B33;  /* rgba(200,168,75,0.20) */
+}
+.notif-item.expanded .expand-chip-arrow { transform: rotate(90deg); }
+.notif-item.expanded .expand-chip-count { display: none; }
+
+/* ── THREAD DRAWER ── */
+/* Collapsed: max-height 0; opened by .notif-item.expanded. Using
+   max-height for the transition keeps the drawer cheap to animate. */
+.thread-drawer {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease, margin-top 0.3s ease, padding 0.3s ease;
+  margin: 0;
+}
+.notif-item.expanded .thread-drawer {
+  max-height: 800px;
+  margin-top: 10px;
+}
+.thread-area {
+  background: #C8A84B0A;    /* rgba(200,168,75,0.04) */
+  border-radius: 8px;
+  padding: 10px;
+}
+.thread-msgs {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── THREAD MESSAGE ── */
+.thread-msg {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid #FFFFFF0A; /* rgba(255,255,255,0.04) */
+}
+.thread-msg:last-child { border-bottom: none; }
+.thread-av {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  color: #FFFFFF;
+  border: none;
+  margin-top: 1px;
+}
+.thread-av.nav-system {
+  background: #666666;
+}
+.thread-content {
+  flex: 1;
+  min-width: 0;
+}
+.thread-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.thread-author {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: #FFFFFFD9;         /* rgba(255,255,255,0.85) */
+}
+.thread-role {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  font-weight: 500;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: #FFFFFF0F;    /* rgba(255,255,255,0.06) */
+  color: #FFFFFF59;         /* rgba(255,255,255,0.35) */
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+.thread-time {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: #FFFFFF40;         /* rgba(255,255,255,0.25) */
+  margin-left: auto;
+  white-space: nowrap;
+}
+.thread-message {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+  color: #FFFFFFCC;         /* rgba(255,255,255,0.80) */
+  margin-top: 3px;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+.thread-empty {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  color: #FFFFFF40;
+  padding: 6px 0;
+  text-align: center;
+}
+
+/* ── REPLY INPUT ── */
+.thread-reply {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid #FFFFFF0A;
+}
+.reply-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+.reply-input {
+  flex: 1;
+  min-height: 38px;
+  max-height: 80px;
+  padding: 9px 12px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  line-height: 1.3;
+  color: #FFFFFFE6;         /* rgba(255,255,255,0.90) */
+  background: #FFFFFF0D;    /* rgba(255,255,255,0.05) */
+  border: 1px solid #FFFFFF14; /* rgba(255,255,255,0.08) */
+  border-radius: 8px;
+  resize: none;
+  outline: none;
+  -webkit-appearance: none;
+  transition: border-color 0.2s ease;
+  overflow-y: auto;
+}
+.reply-input::placeholder { color: #FFFFFF33; } /* rgba(255,255,255,0.20) */
+.reply-input:focus { border-color: #C8A84B66; } /* rgba(200,168,75,0.40) */
+.reply-input:disabled { opacity: 0.6; }
+.reply-send {
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #FFFFFF0F;    /* rgba(255,255,255,0.06) */
+  border: none;
+  border-radius: 8px;
+  color: #FFFFFF33;         /* rgba(255,255,255,0.20) — empty state */
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.reply-send.active {
+  background: #C8A84B26;    /* rgba(200,168,75,0.15) */
+  color: #C8A84B;
+}
+.reply-send:disabled { opacity: 0.5; cursor: default; }
+.reply-send svg { display: block; pointer-events: none; }
+.reply-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: #FFFFFF33;
+  margin-top: 6px;
+  letter-spacing: 0.2px;
+}
+
+/* ── THREAD FOOTER (Open full post link) ── */
+.thread-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+.thread-open-post {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+  color: #C8A84B;
+  text-decoration: none;
+  cursor: pointer;
+}
+.thread-open-post:hover { color: #E4C666; }
 
 /* PCS back-to-notifications button */
 .pcs-back-notif-btn {


### PR DESCRIPTION
## Summary

Grouped comment notifications (`_groupCount > 1`) now expand the card in place and mount a thread drawer directly below, instead of closing the panel and opening PCS. The drawer shows every non-resolved comment on the post, sorted oldest-first, with an inline reply input that posts straight to `/post_comments`. Agency and client users share the same code path — reply `author_role` is derived from `AppState.user.effectiveRole`.

## Files changed (4)

### 10-ui.js
- `renderNotifications` now initialises `window._notifExpandedSet` (a `Set` of notif IDs) so expand state survives `scroll.innerHTML` rebuilds.
- `loadNotifications` clears `window._notifThreadCache` on every load and widens the `/post_comments` SELECT to include `author_role, resolved, resolved_at, visibility, post_title`.
- `_buildItem` emits a gold `.expand-chip` in the meta row for expandable comment notifications AND a collapsed `<div class="thread-drawer">` below the main row. Published rows still fold into `.notif-item` with the `notif-live-card` marker class.
- **New helpers**: `_notifBuildThreadHtml`, `_notifThreadMsgHtml`, `_notifThreadAvClass`, `_notifToggleExpand`, `_notifReplyInputResize`, `_notifSubmitReply`. The reply POST deliberately omits the JS notification fan-out — the `notify-comment` edge function is the single writer (avoids the existing dual-writer duplicate-row problem).
- Panel tap delegate: skip list gains `.expand-chip`, `.reply-input`, `.reply-send`, `.thread-msg`, `.thread-area`, `.thread-reply`, `.thread-footer`, `.reply-label`, `.thread-open-post`. Comment cards with `data-expandable="1"` expand in place on body tap OR chip tap; the chip rotates its arrow SVG 90°. Scroll position is anchored across the expand via `requestAnimationFrame`.

### styles.css
- `.notif-meta` switched to `display: flex; gap: 6px`. Every child (timestamp / sep dot / expand chip / WA button / trash button / LinkedIn link) sits exactly **6px** apart. All per-child margins stripped.
- New classes: `.notif-item-row`, `.notif-item.expanded`, `.expand-chip` (+ arrow, count, hover, expanded states), `.thread-drawer`, `.thread-area`, `.thread-msg/.thread-av/.thread-content/.thread-header/.thread-author/.thread-role/.thread-time/.thread-message/.thread-empty`, `.thread-reply/.reply-row/.reply-input/.reply-send/.reply-label`, `.thread-footer/.thread-open-post`.
- Every `rgba()` value from the design spec was converted to 8-digit hex `#RRGGBBAA` to stay compliant with CLAUDE.md §4 design rules. Semantics are identical.

### index.html
- All 21 `?v=` version strings bumped `20260411g → 20260412a`.

### CLAUDE.md
- Notification panel section in §4 rewritten to document the expand-in-place thread view, `window._notifExpandedSet`, `window._notifThreadCache`, the SELECT widen, the single-writer reply flow, and the panel delegate skip list additions.
- Trimmed a few verbose sections (client-poll, render-pipeline, misc gotchas, runtime-enriched fields) to keep the file under 200 lines total (now 198).

## Discoveries from the audit pass

- **render/client.js does NOT have a separate notification panel.** Both the client toolbar bell (render/client.js:926) and the back-to-notif button (render/client.js:2338) call `window.openNotifications()` from 10-ui.js. The client-specific branch is already inside the existing panel tap delegate (`_isClient` block). So the single-file implementation in 10-ui.js automatically works for both agency and client users.
- **The reply path is role-aware without branching**: `author_role` is computed from `AppState.user.effectiveRole`, so agency users post with `'Admin' / 'Servicing' / 'Creative'` and client users post with `'Client'` automatically.
- **Single writer for notification fan-out**: the new reply skips the JS `POST /notifications` loop that `actions/pcs.js:2451-2485` and `render/client.js:1614-1670` still do. This keeps the thread-view replies from contributing to the duplicate-notification noise and defers entirely to the `notify-comment` edge function documented in CLAUDE.md §6.

## What did NOT change

- `loadNotifications`'s fetch/auth logic (only the SELECT widened)
- `updateNotifBadge`, `markNotifRead`, `markAllNotificationsRead`, `deleteNotification`
- `openNotifications` / `closeNotifications` overlay shell (only the delegate skip list + a new branch for expandable comments)
- The existing `data-action="notif-wa" / "notif-delete" / "mark-all-read" / "close-notifications"` routing
- `render/client.js` (confirmed during audit — clients share the 10-ui.js panel)
- Edge-function inserts, email fan-out, the agency poll stash

## Test plan

- [x] `npx vitest run` → **508/508 passing** (21 files)
- [ ] Open notification panel, find a grouped comment notification (e.g. "Chitra left 3 comments on X")
- [ ] Verify the gold expand chip shows the count (`3`)
- [ ] Tap the card body — verify the card expands, scroll anchors the tapped card, thread drawer slides open with all comments on that post sorted oldest-first
- [ ] Verify the expand chip arrow rotates 90° and the count disappears
- [ ] Type a reply — send button flips gold, textarea auto-resizes up to 80px
- [ ] Tap send — verify the new message appears in the drawer immediately, input clears, no panel close
- [ ] Tap "Open full post →" — verify panel closes and PCS opens (client overlay for clients)
- [ ] Collapse the card, expand again — verify cached thread state
- [ ] Change filter tab, re-apply filter — verify expanded card stays expanded after `scroll.innerHTML` rebuild (`_notifExpandedSet` persistence)
- [ ] Mark-all-read / delete still work on other cards
- [ ] Client side: log in as a client user, verify the same expand + reply flow works and posts with `author_role: 'Client'`
- [ ] Check that the WhatsApp + trash icons in the meta row still reach their handlers (uniform 6px gap should not break clicks)

## Deploy

- Version strings: `?v=20260412a` (all 21 resources bumped)
- After merge: Cloudflare dash → srtd.io → Caching → Purge Everything, then hard refresh every device

https://claude.ai/code/session_01EG1A1nddNwM3t9JEhGiJGX