### PR TITLE
Notification thread view: 3 post-ship visual fixes

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -687,13 +687,16 @@ function renderNotifications(name, role) {
         '</button>';
     }
 
-    // Meta row — time · [expand] · WhatsApp · trash · [LinkedIn]
-    // Flex `gap: 6px` on .notif-meta (see styles.css) gives uniform
-    // spacing between every child, so the dot separators themselves
-    // carry zero margin.
+    // Meta row — time [expand] WhatsApp trash [LinkedIn]
+    // Flex `gap: 6px` on .notif-meta (see styles.css) is the ONLY
+    // source of spacing between children, so every pair of siblings
+    // sits exactly 6px apart. No .notif-meta-sep dot spans are
+    // emitted anywhere in the row — they used to sit between some
+    // items and not others, which made the perceived gap jump
+    // between ~6px and ~16px across the row.
     var linkedinHtml = '';
     if (isPublished && post && post.linkedin_link) {
-      linkedinHtml = '<span class="notif-meta-sep">\xB7</span>' +
+      linkedinHtml =
         '<a class="notif-li-link" href="' + esc(post.linkedin_link) + '" target="_blank" rel="noopener"' +
         ' onclick="event.stopPropagation();">LINKEDIN \u2192</a>';
     }
@@ -704,8 +707,7 @@ function renderNotifications(name, role) {
 
     var metaRow = '<div class="notif-meta">' +
       '<span class="notif-time">' + esc(ts) + '</span>' +
-      (isExpandable ? '<span class="notif-meta-sep">\xB7</span>' + expandChipHtml : '') +
-      '<span class="notif-meta-sep">\xB7</span>' +
+      (isExpandable ? expandChipHtml : '') +
       waBtn +
       delBtn +
       linkedinHtml +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Sorted (srtd.io)
 
-Last updated: 2026-04-12 (notification-thread-view). Full history: `CLAUDE-archive-20260411.md`.
+Last updated: 2026-04-12 (notif-thread-view-fixes). Full history: `CLAUDE-archive-20260411.md`.
 
 ## 1 — WHAT IS SORTED
 
@@ -50,9 +50,7 @@ NO `comments` column on posts. Never write to it.
 
 **tasks** — PK id(bigint). Cols: assigned_to, message, due_date, done(bool), created_at. RLS unrestricted.
 
-**click_log** — telemetry sink (session_id, etc.) fed by `_flushClickBuffer`.
-
-Storage: R2 bucket `sorted-images`. Public CDN `https://images.srtd.io/` (preferred) or legacy `pub-6a2a4aa8073d454ab9aeee69ef841635.r2.dev`.
+**click_log** — telemetry sink (session_id, etc.) fed by `_flushClickBuffer`. Storage: R2 bucket `sorted-images`, CDN `https://images.srtd.io/` (legacy `pub-6a2a4aa8073d454ab9aeee69ef841635.r2.dev`).
 
 ## 3 — FILE MAP
 
@@ -145,8 +143,10 @@ window.AppState = {
 - Header: mono `<effectiveRole> · SORTED` label + plain-text `Mark read | Close`; greeting row `Hey, <AppState.user.name>` (name gold). Name/role pull ONLY from `AppState.user` — no hardcoded map.
 - Tabs (`.notif-chips > .notif-chip`): text-only (All / Mentions / Comments / Moves), counts in `nchip-count-*` spans. Active class reapplied by the renderer on every pass.
 - Cards: `.notif-item` is the single card class; published rows get `notif-live-card` as a marker so the tap delegate `closest('.notif-item, .notif-live-card')` still resolves. Background always transparent — read and unread items look identical. Inline `<span class="nnew-dot">` (gold 5px) before the actor name is the ONLY unread indicator. Avatars solid-fill 32px (no border/ring). Published cards render a `.notif-pub-label` eyebrow (`✓ PUBLISHED`) above the main text line.
-- Meta row (`.notif-meta`): flex with `gap: 6px` — every child (timestamp, separator dots, expand chip, WA/trash icon buttons, LinkedIn link) sits exactly 6px apart. `.notif-mi-btn` is a 32×32 tap target around an 11×10 SVG with `-8px 0` vertical margin so the row stays compact. SVG children are `pointer-events:none`. Skip list in the panel tap delegate includes `.notif-mi-btn`, `.notif-topbar-btn`, `.notif-li-link`, and the thread-view controls below.
-- **Expand-in-place thread view** — for comment notifications with `_groupCount > 1`, `_buildItem` emits a gold `.expand-chip` inline in the meta row AND a collapsed `.thread-drawer` below the row. Tap on the card body OR the chip toggles `.notif-item.expanded`, mounts the thread HTML into the drawer, anchors scroll so the tapped card stays in place, and marks the notif as read on first expand (not on re-collapse). State is persisted across `scroll.innerHTML` rebuilds via `window._notifExpandedSet` (Set of notif IDs). Thread content is built from `window._notifComments` (now SELECT'd with `author_role,resolved,resolved_at,visibility,post_title`), filtered `post_id === n.post_id && !resolved`, sorted ASC by `created_at`; results are cached per post in `window._notifThreadCache` (cleared at the top of `loadNotifications`). The drawer contains a `.reply-input` + `.reply-send` row and an `Open full post →` footer link. Replies POST to `/post_comments` ONLY — the JS fan-out is intentionally skipped so `notify-comment` (edge) is the single writer and there are no duplicate notification rows. Reply author is always `AppState.user.name`, author_role is `effectiveRole` title-cased, so the same code path works for both agency and client users. The panel tap delegate skips `.expand-chip`, `.reply-input`, `.reply-send`, `.thread-msg`, `.thread-area`, `.thread-reply`, `.thread-footer`, `.reply-label`, and routes `.thread-open-post` clicks through `closeNotifications()` + `openPCS` / `_openClientPostOverlay`.
+- Meta row (`.notif-meta`): flex `gap: 6px` is the ONLY source of spacing — every child (timestamp, expand chip, WA/trash icon buttons, LinkedIn link) sits exactly 6px apart. No `.notif-meta-sep` dot spans are emitted anywhere in the row. `.notif-mi-btn` is a 32×32 tap target around an 11×10 SVG with `-8px 0` vertical margin so the row stays compact. SVG children are `pointer-events:none`. Skip list in the panel tap delegate includes `.notif-mi-btn`, `.notif-topbar-btn`, `.notif-li-link`, and the thread-view controls below.
+- **Expand-in-place thread view** — for comment notifications with `_groupCount > 1`, `_buildItem` emits a gold `.expand-chip` inline in the meta row AND a collapsed `.thread-drawer` below the row. Tap on the card body OR the chip toggles `.notif-item.expanded`, mounts the thread HTML into the drawer, anchors scroll so the tapped card stays in place, and marks the notif as read on first expand (not on re-collapse). State is persisted across `scroll.innerHTML` rebuilds via `window._notifExpandedSet` (Set of notif IDs). Thread content is built from `window._notifComments` (SELECT'd with `author_role,resolved,resolved_at,visibility,post_title`), filtered `post_id === n.post_id && !resolved`, sorted ASC by `created_at`; results are cached per post in `window._notifThreadCache` (cleared at the top of `loadNotifications`).
+- Drawer visuals: `.thread-area` carries `background: #C8A84B12` + `border: 1px solid #C8A84B1A` + `border-radius: 8px` so the drawer is visually contained — the earlier 4% gold wash was too faint and the thread messages visually merged with the notification cards below. `.notif-item.expanded` adds `padding-bottom: 12px` + `margin-bottom: 4px` so the drawer can't touch the next card. `.notif-item.expanded .thread-drawer` uses `max-height: 3000px` (bumped from 800px) so the reply row + `Open full post →` link are never clipped on long threads. `.thread-reply` uses a `border-top: 1px solid #C8A84B26` divider so the reply row is visually distinct from the messages.
+- The drawer contains a `.reply-input` + `.reply-send` row and an `Open full post →` footer link. Replies POST to `/post_comments` ONLY — the JS fan-out is intentionally skipped so `notify-comment` (edge) is the single writer and there are no duplicate notification rows. Reply author is always `AppState.user.name`, author_role is `effectiveRole` title-cased, so the same code path works for both agency and client users. The panel tap delegate skips `.expand-chip`, `.reply-input`, `.reply-send`, `.thread-msg`, `.thread-area`, `.thread-reply`, `.thread-footer`, `.reply-label`, and routes `.thread-open-post` clicks through `closeNotifications()` + `openPCS` / `_openClientPostOverlay`.
 - Tests: structural class names + source patterns (`notif-item`, `notif-live-card`, `nchip-count-*`, grouped key `(n.post_id||'') + '|' + (n.actor||'')`, `notif-resp-time`, day labels, `"left " + n + " comments on "`) are preserved verbatim. 508/508 unit tests still pass.
 
 ### Misc gotchas
@@ -186,7 +186,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 21 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 20 scripts). Current: `?v=20260412a`.
+1. Bump ALL 21 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 20 scripts). Current: `?v=20260412b`.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260412a">
+ <link rel="stylesheet" href="styles.css?v=20260412b">
 
 </head>
 <body>
@@ -1081,27 +1081,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260412a"></script>
-<script src="00-appstate-compat.js?v=20260412a"></script>
-<script src="01-config.js?v=20260412a" defer></script>
-<script src="02-session.js?v=20260412a" defer></script>
-<script src="utils.js?v=20260412a" defer></script>
-<script src="03-auth.js?v=20260412a" defer></script>
-<script src="05-api.js?v=20260412a" defer></script>
-<script src="10-ui.js?v=20260412a" defer></script>
+<script src="00-appstate.js?v=20260412b"></script>
+<script src="00-appstate-compat.js?v=20260412b"></script>
+<script src="01-config.js?v=20260412b" defer></script>
+<script src="02-session.js?v=20260412b" defer></script>
+<script src="utils.js?v=20260412b" defer></script>
+<script src="03-auth.js?v=20260412b" defer></script>
+<script src="05-api.js?v=20260412b" defer></script>
+<script src="10-ui.js?v=20260412b" defer></script>
 
-<script src="06-post-create.js?v=20260412a" defer></script>
-<script defer src="render/dashboard.js?v=20260412a"></script>
-<script defer src="render/client.js?v=20260412a"></script>
-<script defer src="render/pipeline.js?v=20260412a"></script>
-<script defer src="render/brief.js?v=20260412a"></script>
-<script defer src="actions/pcs.js?v=20260412a"></script>
-<script defer src="actions/pcs-longpress.js?v=20260412a"></script>
-<script src="07-post-load.js?v=20260412a" defer></script>
-<script src="08-post-actions.js?v=20260412a" defer></script>
-<script src="09-library.js?v=20260412a" defer></script>
-<script src="09-approval.js?v=20260412a" defer></script>
-<script src="04-router.js?v=20260412a" defer></script>
+<script src="06-post-create.js?v=20260412b" defer></script>
+<script defer src="render/dashboard.js?v=20260412b"></script>
+<script defer src="render/client.js?v=20260412b"></script>
+<script defer src="render/pipeline.js?v=20260412b"></script>
+<script defer src="render/brief.js?v=20260412b"></script>
+<script defer src="actions/pcs.js?v=20260412b"></script>
+<script defer src="actions/pcs-longpress.js?v=20260412b"></script>
+<script src="07-post-load.js?v=20260412b" defer></script>
+<script src="08-post-actions.js?v=20260412b" defer></script>
+<script src="09-library.js?v=20260412b" defer></script>
+<script src="09-approval.js?v=20260412b" defer></script>
+<script src="04-router.js?v=20260412b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4187,10 +4187,15 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .notif-item { flex-direction: column; }
 
 /* Expanded card gets a subtle gold left border + a faint gold wash
-   so you can see which card owns the open drawer at a glance. */
+   so you can see which card owns the open drawer at a glance. The
+   extra padding-bottom + margin-bottom keep the thread-area off the
+   next card's top edge so the drawer never visually merges with the
+   notification rows below. */
 .notif-item.expanded {
   border-left: 2px solid #C8A84B4D;
   padding-left: 16px;
+  padding-bottom: 12px;
+  margin-bottom: 4px;
 }
 .notif-item.expanded .notif-item-row { padding-right: 2px; }
 
@@ -4245,11 +4250,17 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   margin: 0;
 }
 .notif-item.expanded .thread-drawer {
-  max-height: 800px;
+  /* 3000px is high enough to fit any realistic thread (messages +
+     reply row + footer link) without clipping, while still keeping
+     the max-height transition smooth. `max-height: none` would break
+     the animation; the outer #notif-list-scroll container handles
+     actual overflow. */
+  max-height: 3000px;
   margin-top: 10px;
 }
 .thread-area {
-  background: #C8A84B0A;    /* rgba(200,168,75,0.04) */
+  background: #C8A84B12;    /* rgba(200,168,75,0.07) — stronger gold wash for boundary */
+  border: 1px solid #C8A84B1A; /* rgba(200,168,75,0.10) — visible containment */
   border-radius: 8px;
   padding: 10px;
 }
@@ -4340,7 +4351,9 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .thread-reply {
   margin-top: 10px;
   padding-top: 10px;
-  border-top: 1px solid #FFFFFF0A;
+  /* Stronger gold divider so the reply row is visually distinct from
+     the messages above it (was #FFFFFF0A — 4% white, invisible). */
+  border-top: 1px solid #C8A84B26; /* rgba(200,168,75,0.15) */
 }
 .reply-row {
   display: flex;


### PR DESCRIPTION
## Summary

Three post-ship visual fixes for the notification thread view landed in PR #801. All three come from the audit in the prior turn — `10-ui.js` and `styles.css` only.

**Note on scope**: the audit confirmed a 4th issue (expand chip only showing on the narrow `post_id + actor + day` grouping match). That one is deferred — it needs a grouping-key change that warrants its own PR.

## Files changed (4)

### styles.css (Fix 1 + Fix 2)

**Fix 1 — thread drawer visual containment**
- `.thread-area` background `#C8A84B0A` → `#C8A84B12` and a new `border: 1px solid #C8A84B1A` so the drawer has a real edge on the `#0e0e16` panel. The old 4% gold wash was invisible, which made the thread messages visually merge with the notification cards below.
- `.notif-item.expanded` gains `padding-bottom: 12px` + `margin-bottom: 4px` so the drawer can't touch the next card's top edge.
- `.thread-reply` border-top `#FFFFFF0A` → `#C8A84B26` so the reply row is visually distinct from the messages above it.

**Fix 2 — reply row clipped by max-height**
- `.notif-item.expanded .thread-drawer` `max-height: 800px` → `max-height: 3000px`. The old 800px cap plus `overflow: hidden` was clipping the reply textarea, send button, "Posts as comment · visible to all" label, and "Open full post →" link on threads with more than ~10 messages. 3000px fits any realistic thread while keeping the collapse/expand transition animated (`max-height: none` would break the animation).

### 10-ui.js (Fix 3)

**Meta row spacing equidistant**
- `_buildItem` no longer emits any `.notif-meta-sep` dot separator spans in the meta row. The flex `gap: 6px` on `.notif-meta` is now the single source of spacing. Previously the dots sat between some pairs (`time → chip`, `chip → WA`) but not others (`WA → trash`), so the perceived gap jumped between ~6px and ~16px across the row. The `linkedinHtml` builder also drops its leading sep dot for the same reason.

### index.html

- 21 `?v=` strings bumped `20260412a → 20260412b`.

### CLAUDE.md

- Notification-panel section updated to reflect the dot-free meta row and the new thread-drawer CSS (`.thread-area` visible border, `padding-bottom` on expanded card, `max-height: 3000px`, `.thread-reply` gold divider).
- Still under 200 lines (now 198).

## What did NOT change

- `loadNotifications`, `updateNotifBadge`, `markNotifRead`, `markAllNotificationsRead`, `deleteNotification`
- `openNotifications` / `closeNotifications`
- Panel tap delegate click routing (skip list is intact)
- `_notifBuildThreadHtml`, `_notifSubmitReply`, `_notifToggleExpand` — reply POST flow is untouched
- `window._notifExpandedSet` / `window._notifThreadCache` state machine
- Grouping logic (`commentGroupMap`) — see note about Issue 4 above

## Test plan

- [x] `npx vitest run` → **508/508 passing** (21 files, 16.70s)
- [ ] Expand a grouped comment on a post with 3+ messages — verify the drawer has a visible gold border and a distinct body
- [ ] Expand a grouped comment on a post with 10+ messages — verify the reply textarea, send button, "Posts as comment" label and "Open full post →" link are all visible without clipping
- [ ] Tap the reply row, type a message, tap send — verify the reply appears in the drawer and no duplicate notification rows appear
- [ ] Visually verify the meta row spacing: timestamp, expand chip, WA, trash are all 6px apart with no stray `·` characters between them
- [ ] Collapse a card, expand again — verify the transition still animates smoothly with the new 3000px max-height cap

## Deploy

- Version strings: `?v=20260412b`
- After merge: Cloudflare dash → srtd.io → Caching → Purge Everything, then hard refresh every device

https://claude.ai/code/session_01EG1A1nddNwM3t9JEhGiJGX