### PR TITLE
Notification meta row: nest LINKEDIN link inside .meta-actions

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -725,8 +725,7 @@ function renderNotifications(name, role) {
     var metaRow = '<div class="notif-meta">' +
       '<span class="notif-time">' + esc(ts) + '</span>' +
       (isExpandable ? expandChipHtml : '') +
-      '<div class="meta-actions">' + waBtn + delBtn + '</div>' +
-      linkedinHtml +
+      '<div class="meta-actions">' + waBtn + delBtn + linkedinHtml + '</div>' +
       '</div>';
 
     var pubLabel = isPublished

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 21 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 20 scripts). Current: `?v=20260412d`.
+1. Bump ALL 21 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 20 scripts). Current: `?v=20260412e`.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260412d">
+ <link rel="stylesheet" href="styles.css?v=20260412e">
 
 </head>
 <body>
@@ -1081,27 +1081,27 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260412d"></script>
-<script src="00-appstate-compat.js?v=20260412d"></script>
-<script src="01-config.js?v=20260412d" defer></script>
-<script src="02-session.js?v=20260412d" defer></script>
-<script src="utils.js?v=20260412d" defer></script>
-<script src="03-auth.js?v=20260412d" defer></script>
-<script src="05-api.js?v=20260412d" defer></script>
-<script src="10-ui.js?v=20260412d" defer></script>
+<script src="00-appstate.js?v=20260412e"></script>
+<script src="00-appstate-compat.js?v=20260412e"></script>
+<script src="01-config.js?v=20260412e" defer></script>
+<script src="02-session.js?v=20260412e" defer></script>
+<script src="utils.js?v=20260412e" defer></script>
+<script src="03-auth.js?v=20260412e" defer></script>
+<script src="05-api.js?v=20260412e" defer></script>
+<script src="10-ui.js?v=20260412e" defer></script>
 
-<script src="06-post-create.js?v=20260412d" defer></script>
-<script defer src="render/dashboard.js?v=20260412d"></script>
-<script defer src="render/client.js?v=20260412d"></script>
-<script defer src="render/pipeline.js?v=20260412d"></script>
-<script defer src="render/brief.js?v=20260412d"></script>
-<script defer src="actions/pcs.js?v=20260412d"></script>
-<script defer src="actions/pcs-longpress.js?v=20260412d"></script>
-<script src="07-post-load.js?v=20260412d" defer></script>
-<script src="08-post-actions.js?v=20260412d" defer></script>
-<script src="09-library.js?v=20260412d" defer></script>
-<script src="09-approval.js?v=20260412d" defer></script>
-<script src="04-router.js?v=20260412d" defer></script>
+<script src="06-post-create.js?v=20260412e" defer></script>
+<script defer src="render/dashboard.js?v=20260412e"></script>
+<script defer src="render/client.js?v=20260412e"></script>
+<script defer src="render/pipeline.js?v=20260412e"></script>
+<script defer src="render/brief.js?v=20260412e"></script>
+<script defer src="actions/pcs.js?v=20260412e"></script>
+<script defer src="actions/pcs-longpress.js?v=20260412e"></script>
+<script src="07-post-load.js?v=20260412e" defer></script>
+<script src="08-post-actions.js?v=20260412e" defer></script>
+<script src="09-library.js?v=20260412e" defer></script>
+<script src="09-approval.js?v=20260412e" defer></script>
+<script src="04-router.js?v=20260412e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4123,6 +4123,11 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   letter-spacing: 0.5px;
 }
 .notif-li-link:hover { color: #3B8DE3; }
+/* Extra breathing room between the trash icon button and the
+   "LINKEDIN →" text inside the .meta-actions flex group. The
+   group's own gap:2px is tight and intentional for the icon pair;
+   the text link needs a bit more space to not crowd the icons. */
+.meta-actions .notif-li-link { margin-left: 4px; }
 
 /* Response time (inline pill kept for tests) */
 .notif-resp-time { color: #3ECF8E; font-size: 11px; margin-left: 4px; }


### PR DESCRIPTION
## Summary

Fixes the LinkedIn link layout on published notification cards. The link now sits inside the `.meta-actions` flex group alongside the WhatsApp + trash icons so the whole right-side cluster is flush to the row edge.

## Audit confirmation

`10-ui.js:728-729` inside `_buildItem` was concatenating `linkedinHtml` AFTER the closing `</div>` of `.meta-actions`, so it was a sibling of the icon group inside `.notif-meta`. Because `.meta-actions` uses `margin-left: auto`, the auto margin only consumed the space to the LEFT of the icon group — the link still sat further right, pushing the WA + trash cluster away from the row's right edge and breaking the visual grouping.

**Before:**

```
<div class="notif-meta">
  <span class="notif-time">2h</span>
  <div class="meta-actions"><button WA><button trash></div>
  <a class="notif-li-link">LINKEDIN →</a>
</div>
```

**After:**

```
<div class="notif-meta">
  <span class="notif-time">2h</span>
  <div class="meta-actions"><button WA><button trash><a class="notif-li-link">LINKEDIN →</a></div>
</div>
```

## Files changed (4)

- **10-ui.js** — one-liner in `_buildItem` (line 728): move `linkedinHtml` inside the `.meta-actions` div.
- **styles.css** — new rule `.meta-actions .notif-li-link { margin-left: 4px }` so the text link doesn't crowd the 28px trash button. The icon pair keeps its tight 2px gap; the text sibling gets 4px of breathing room.
- **index.html** — 21 `?v=` strings bumped `20260412d → 20260412e` (note: current version was already `20260412d` from PR #804, so next letter is `e`, not `d`).
- **CLAUDE.md** — §7 current-version line bumped to match. No content changes.

## Test plan

- [x] `npx vitest run` → **508/508 passing** (21 files, 15.07s)
- [ ] View a published notification card — verify WhatsApp, trash, and LINKEDIN → all sit tight together on the right edge of the meta row
- [ ] Tap LINKEDIN → verify it opens LinkedIn in a new tab without also opening PCS (the existing `onclick="event.stopPropagation()"` is untouched)
- [ ] Tap WA or trash on a published card — verify they still reach the Action Router via the `.notif-mi-btn` skip-list entry

## Deploy

- Version strings: `?v=20260412e` (all 21 resources)
- After merge: Cloudflare dash → srtd.io → Caching → Purge Everything, then hard refresh every device

https://claude.ai/code/session_01EG1A1nddNwM3t9JEhGiJGX