### PR TITLE
Switch logging identifiers from name to email + backwards-compat renderers

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -132,7 +132,7 @@ async function quickStage(postId, newStage) {
     const actor = resolveActor();
     const rows = await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
       method: 'PATCH',
-      body: JSON.stringify({ stage: toDbStage(newStage), updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: actor }),
+      body: JSON.stringify({ stage: toDbStage(newStage), updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: window.AppState.user.email || actor }),
     });
     console.log('[PCS] DB WRITE SUCCESS:', postId, newStage, Date.now());
     // Apply server response
@@ -144,7 +144,7 @@ async function quickStage(postId, newStage) {
     _clearSaveTimeout(post);
     post._isSaving = false;
     scheduleRender();
-    await logActivity({ post_id: postId, actor: actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}`, old_stage: oldStage, new_stage: newStage });
+    await logActivity({ post_id: postId, actor: window.AppState.user.email || actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}`, old_stage: oldStage, new_stage: newStage });
     var _qsRecipients = _stageRecipients(newStage);
     if (_qsRecipients.length) window._sendStageNotif(postId, getTitle(post), newStage, _qsRecipients, actor);
     showUndoToast('Moved to ' + _stageLabel(newStage), function() { quickStage(postId, oldStage); });
@@ -241,7 +241,7 @@ async function saveAdminEdit() {
       body: JSON.stringify(_payload),
     });
     console.log('[saveAdminEdit] API SUCCESS for', postId);
-    await logActivity({ post_id: postId, actor: 'Admin', actor_role: 'Admin', action: 'Full edit saved' });
+    await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Admin', actor_role: 'Admin', action: 'Full edit saved' });
     closeAdminEdit();
     await loadPosts();
     showToast('Post saved ok', 'success');
@@ -301,7 +301,7 @@ async function clientApprove(postId, btn) {
       scheduleRender();
       _renderBackgroundViews();
       // Non-critical side effects
-      await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled', old_stage: oldStage, new_stage: 'scheduled' });
+      await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled', old_stage: oldStage, new_stage: 'scheduled' });
       window._sendStageNotif(postId, getTitle(post), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || 'Client');
     } catch (err) {
       _clearSaveTimeout(post);
@@ -322,7 +322,7 @@ async function clientAcknowledge(postId) {
         method: 'PATCH',
         body: JSON.stringify({ stage: 'in_production', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString() }),
       });
-      await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Acknowledged  -  sending via WhatsApp' });
+      await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Client', actor_role: 'Client', action: 'Acknowledged  -  sending via WhatsApp' });
       var _ackPost = getPostById(postId);
       window._sendStageNotif(postId, (_ackPost ? getTitle(_ackPost) : postId), 'in_production', ['Creative'], window.AppState.user.name || 'Client');
       showToast('Got it! The team has been notified.', 'success');
@@ -413,7 +413,7 @@ async function submitClientRequest() {
       target_date:  reqDate,
       images:       imageUrls.length ? imageUrls : [],
       drive_link:   window._reqDriveLink || null,
-      created_by:   window.AppState.user.name || window.AppState.user.email || email,
+      created_by:   window.AppState.user.email || email,
       status:       'pending'
     };
 
@@ -478,7 +478,7 @@ async function flagIssue(postId) {
       method: 'PATCH',
       body: JSON.stringify({ client_feedback: `! ${msg}`, updated_at: new Date().toISOString() }),
     });
-    await logActivity({ post_id: postId, actor: window.AppState.user.role, actor_role: window.AppState.user.role, action: `Issue flagged: ${msg.substring(0,80)}` });
+    await logActivity({ post_id: postId, actor: window.AppState.user.email || window.AppState.user.role, actor_role: window.AppState.user.role, action: `Issue flagged: ${msg.substring(0,80)}` });
     showToast('Issue flagged  -  team has been notified', 'success');
     await loadPosts();
   } catch (err) { showToast('Failed  -  try again', 'error'); window.logError && window.logError(err && err.message, err && err.stack, 'flag-issue'); }
@@ -498,7 +498,7 @@ async function deletePost(postId) {
   if (btn) btn.disabled = true;
   try {
     await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, { method: 'DELETE' });
-    await logActivity({ post_id: postId, actor: 'Admin', actor_role: 'Admin', action: `Post deleted: ${title}` });
+    await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Admin', actor_role: 'Admin', action: `Post deleted: ${title}` });
     closeAdminEdit();
     var next423 = window.AppState.posts.all.filter(function(p) {
       return getPostId(p) !== postId;
@@ -560,7 +560,7 @@ function _confirmPublish(postId) {
     window.AppState.posts.setAll(_next_408);
     await logActivity({
       post_id: postId,
-      actor: window.AppState.user.name || 'Shubham',
+      actor: window.AppState.user.email || window.AppState.user.name || 'Shubham',
       actor_role: window.AppState.user.effectiveRole || 'Admin',
       action: 'published',
       old_stage: _pubOldStage,
@@ -629,7 +629,7 @@ async function _executeStageChangeAsync(post, postId, newStage, previousStage) {
 
     const rows = await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
       method: 'PATCH',
-      body: JSON.stringify({ stage: toDbStage(newStage), updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: actor }),
+      body: JSON.stringify({ stage: toDbStage(newStage), updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: window.AppState.user.email || actor }),
     });
 
     console.log('[PCS] DB WRITE SUCCESS:', postId, newStage, Date.now());
@@ -663,7 +663,7 @@ async function _executeStageChangeAsync(post, postId, newStage, previousStage) {
   }
 
   // -- NON-CRITICAL  -  completely outside DB try/catch --
-  try { await logActivity({ post_id: postId, actor: actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}`, old_stage: previousStage, new_stage: newStage }); } catch(e) { console.warn('[PCS] logActivity failed:', e); }
+  try { await logActivity({ post_id: postId, actor: window.AppState.user.email || actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}`, old_stage: previousStage, new_stage: newStage }); } catch(e) { console.warn('[PCS] logActivity failed:', e); }
   try { var _esRecipients = _stageRecipients(newStage); if (_esRecipients.length) window._sendStageNotif(postId, getTitle(post), newStage, _esRecipients, actor); } catch(e) { console.warn('[PCS] stage notif failed:', e); }
   try { showUndoToast(`Moved to ${newStage}`, () => _executeStageChange(postId, previousStage)); } catch(e) { console.warn('[PCS] showUndoToast failed:', e); }
 }

--- a/09-approval.js
+++ b/09-approval.js
@@ -145,7 +145,7 @@ async function submitApproval(type, postId, btn) {
           method: 'PATCH',
           body: JSON.stringify({ stage: 'in_production', client_feedback: text, updated_at: new Date().toISOString() }),
         });
-        await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: `Changes requested: ${text.substring(0,80)}` });
+        await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Client', actor_role: 'Client', action: `Changes requested: ${text.substring(0,80)}` });
         if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, postId, 'in_production', ['Admin', 'Creative'], window.AppState.user.name || window.currentUserName || 'Client');
         const c = document.getElementById('approval-confirmation');
         if (c) { c.style.display = ''; c.textContent = 'Changes sent  -  the team will review it.'; }
@@ -164,9 +164,9 @@ async function submitApproval(type, postId, btn) {
       try {
         await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
           method: 'PATCH',
-          body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: 'Client' }),
+          body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: window.AppState.user.email || 'Client' }),
         });
-        await logActivity({ post_id: postId, actor: 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
+        await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
         if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, esc(title), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || window.currentUserName || 'Client');
         const c = document.getElementById('approval-confirmation');
         if (c) { c.style.display = ''; c.textContent = 'ok Approved! The team has been notified.'; }

--- a/10-ui.js
+++ b/10-ui.js
@@ -933,7 +933,8 @@ function _notifThreadMsgHtml(c) {
   var author = c.author || '';
   var authorRole = c.author_role || '';
   var avClass = _notifThreadAvClass(author, authorRole);
-  var initial = author ? author.charAt(0).toUpperCase() : '?';
+  var _authorDisplay = (typeof getDisplayName === 'function') ? getDisplayName(author) : author;
+  var initial = _authorDisplay ? _authorDisplay.charAt(0).toUpperCase() : '?';
   var ts = _notifRelTime(c.created_at);
   var roleTag = authorRole
     ? '<span class="thread-role">' + esc(authorRole) + '</span>'
@@ -942,7 +943,7 @@ function _notifThreadMsgHtml(c) {
       '<div class="thread-av ' + avClass + '">' + esc(initial) + '</div>' +
       '<div class="thread-content">' +
         '<div class="thread-header">' +
-          '<span class="thread-author">' + esc(author) + '</span>' +
+          '<span class="thread-author">' + esc(_authorDisplay) + '</span>' +
           roleTag +
           '<span class="thread-time">' + esc(ts) + '</span>' +
         '</div>' +
@@ -1054,7 +1055,7 @@ async function _notifSubmitReply(sendBtn) {
   var notifMatch = _notifData.find(function(x) { return x.id === notifId; });
   var postTitle = (post && post.title) || (notifMatch && notifMatch.message) || postId;
 
-  var authorName = (window.AppState.user && window.AppState.user.name) || 'Unknown';
+  var authorName = (window.AppState.user && window.AppState.user.email) || (window.AppState.user && window.AppState.user.name) || 'Unknown';
   var effRole = (window.AppState.user && window.AppState.user.effectiveRole) ||
                 (window.AppState.user && window.AppState.user.role) || 'Admin';
   var authorRole = effRole.charAt(0).toUpperCase() + effRole.slice(1).toLowerCase();
@@ -1866,7 +1867,7 @@ async function _fabAssignTask(postId, assignee, message) {
       }),
     });
     showToast('Task assigned OK', 'success');
-    await logActivity({ post_id: postId, actor: resolveActor(), actor_role: window.AppState.user.effectiveRole || 'Admin', action: 'Assigned task to ' + assignee });
+    await logActivity({ post_id: postId, actor: window.AppState.user.email || resolveActor(), actor_role: window.AppState.user.effectiveRole || 'Admin', action: 'Assigned task to ' + assignee });
     if (typeof loadTasks === 'function') loadTasks();
   } catch (err) {
     console.error('[AssignTask] FAILED:', err);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413b`.
+1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413c`.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1109,7 +1109,8 @@ window.loadPcsComments = async function(postId) {
           '<div class="pcs-deleted-msg">This message was deleted.</div>' +
           '</div><div class="pcs-cmt-rt"></div></div>';
       }
-      var _initial = (c.author||'?').charAt(0).toUpperCase();
+      var _authorDisplay = (typeof getDisplayName === 'function') ? getDisplayName(c.author) : (c.author||'?');
+      var _initial = _authorDisplay.charAt(0).toUpperCase();
       var _taskObj = _parseTask(c);
       var _isTask = !!_taskObj;
       var _taskPrefix = _isTask
@@ -1160,7 +1161,7 @@ window.loadPcsComments = async function(postId) {
             '<div class="pcs-cmt-reply-tag">&#8629; <span class="pcs-reply-name">' + esc(c.reply_to_author) + '</span></div>'
             : '') +
           '<div class="pcs-comment-meta">' +
-            '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
+            '<span class="pcs-comment-author">' + esc(_authorDisplay) + '</span>' +
             '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
           '</div>' +
           '<div class="pcs-comment-text' + (_isTask ? ' pcs-task-text' : '') +
@@ -1236,7 +1237,8 @@ window.loadPcsComments = async function(postId) {
           '<div class="pcs-deleted-msg">This message was deleted.</div>' +
           '</div><div class="pcs-cmt-rt"></div></div>';
       }
-      var _initial = (c.author||'?').charAt(0).toUpperCase();
+      var _authorDisplay = (typeof getDisplayName === 'function') ? getDisplayName(c.author) : (c.author||'?');
+      var _initial = _authorDisplay.charAt(0).toUpperCase();
       var _vis = (c.visibility||'all').toUpperCase();
       if (_vis === 'SERVICING') _vis = 'SERV';
       if (_vis === 'CREATIVE') _vis = 'CREAT';
@@ -1302,7 +1304,7 @@ window.loadPcsComments = async function(postId) {
             '<div class="pcs-cmt-reply-tag">&#8629; <span class="pcs-reply-name">' + esc(c.reply_to_author) + '</span></div>'
             : '') +
           '<div class="pcs-comment-meta">' +
-            '<span class="pcs-comment-author">' + esc(c.author) + '</span>' +
+            '<span class="pcs-comment-author">' + esc(_authorDisplay) + '</span>' +
             '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
             _visTag +
           '</div>' +
@@ -1523,7 +1525,7 @@ window.pcsDoDelete = async function() {
       await apiFetch(`/posts?post_id=eq.${encodeURIComponent(id)}`, { method: 'DELETE' });
       logActivity({
         post_id: id,
-        actor: window.AppState.user.name || 'Admin',
+        actor: window.AppState.user.email || 'Admin',
         actor_role: 'Admin',
         action: 'deleted post'
       });
@@ -2206,7 +2208,7 @@ window._saveCaptionEdit = async function(postId) {
         action:     'caption_updated',
         old_value:  oldCaption.slice(0, 1000),
         new_value:  newCaption.slice(0, 1000),
-        changed_by: (window.AppState.user.name || window.AppState.user.email || 'team'),
+        changed_by: (window.AppState.user.email || window.AppState.user.name || 'team'),
         changed_at: new Date().toISOString()
       })
     });
@@ -2296,7 +2298,7 @@ window.submitPcsComment = async function(postId, message, visibility, isTask, is
   });
   var _realPostId = _post ? _post.post_id : postId;
   var _title = _post ? (_post.title || postId) : postId;
-  var _author = window.AppState.user.name || 'Team';
+  var _author = window.AppState.user.email || window.AppState.user.name || 'Team';
   var _role = (window.AppState.user.effectiveRole || 'Admin');
   var _roleLower = _role.toLowerCase();
 
@@ -2533,7 +2535,7 @@ window.toggleTaskResolve = function(commentId, postId, isInternalNote) {
     var _isResolved = !!(rows && rows[0] && rows[0].resolved);
     var _payload = _isResolved
       ? { resolved: false, resolved_by: null, resolved_at: null }
-      : { resolved: true, resolved_by: window.AppState.user.name || 'Admin', resolved_at: new Date().toISOString() };
+      : { resolved: true, resolved_by: window.AppState.user.email || window.AppState.user.name || 'Admin', resolved_at: new Date().toISOString() };
     return apiFetch(_endpoint, {
       method: 'PATCH',
       headers: {'Prefer': 'return=minimal'},
@@ -2807,7 +2809,7 @@ window._pcsAddReaction = function(commentId, emoji, reactEl) {
     try {
       var _postIdEl = document.getElementById('pcs-post-id');
       var _postId = _postIdEl ? _postIdEl.value : '';
-      var _name = (window.AppState.user.name || '');
+      var _name = (window.AppState.user.email || window.AppState.user.name || '');
       var _role = (window.AppState.user.effectiveRole || 'Admin');
       var _normalRole = _role.charAt(0).toUpperCase() + _role.slice(1).toLowerCase();
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413b">
+ <link rel="stylesheet" href="styles.css?v=20260413c">
 
 </head>
 <body>
@@ -1081,28 +1081,28 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413b"></script>
-<script src="00-appstate-compat.js?v=20260413b"></script>
-<script src="01-config.js?v=20260413b" defer></script>
-<script src="02-session.js?v=20260413b" defer></script>
-<script src="utils.js?v=20260413b" defer></script>
-<script src="12-profiles.js?v=20260413b" defer></script>
-<script src="03-auth.js?v=20260413b" defer></script>
-<script src="05-api.js?v=20260413b" defer></script>
-<script src="10-ui.js?v=20260413b" defer></script>
+<script src="00-appstate.js?v=20260413c"></script>
+<script src="00-appstate-compat.js?v=20260413c"></script>
+<script src="01-config.js?v=20260413c" defer></script>
+<script src="02-session.js?v=20260413c" defer></script>
+<script src="utils.js?v=20260413c" defer></script>
+<script src="12-profiles.js?v=20260413c" defer></script>
+<script src="03-auth.js?v=20260413c" defer></script>
+<script src="05-api.js?v=20260413c" defer></script>
+<script src="10-ui.js?v=20260413c" defer></script>
 
-<script src="06-post-create.js?v=20260413b" defer></script>
-<script defer src="render/dashboard.js?v=20260413b"></script>
-<script defer src="render/client.js?v=20260413b"></script>
-<script defer src="render/pipeline.js?v=20260413b"></script>
-<script defer src="render/brief.js?v=20260413b"></script>
-<script defer src="actions/pcs.js?v=20260413b"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413b"></script>
-<script src="07-post-load.js?v=20260413b" defer></script>
-<script src="08-post-actions.js?v=20260413b" defer></script>
-<script src="09-library.js?v=20260413b" defer></script>
-<script src="09-approval.js?v=20260413b" defer></script>
-<script src="04-router.js?v=20260413b" defer></script>
+<script src="06-post-create.js?v=20260413c" defer></script>
+<script defer src="render/dashboard.js?v=20260413c"></script>
+<script defer src="render/client.js?v=20260413c"></script>
+<script defer src="render/pipeline.js?v=20260413c"></script>
+<script defer src="render/brief.js?v=20260413c"></script>
+<script defer src="actions/pcs.js?v=20260413c"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413c"></script>
+<script src="07-post-load.js?v=20260413c" defer></script>
+<script src="08-post-actions.js?v=20260413c" defer></script>
+<script src="09-library.js?v=20260413c" defer></script>
+<script src="09-approval.js?v=20260413c" defer></script>
+<script src="04-router.js?v=20260413c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -460,7 +460,7 @@ window._assignBrief = function(postId, ownerName, isReassign) {
   var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
   if (!post) return;
 
-  var actorName = window.AppState.user.name || 'Unknown';
+  var actorName = window.AppState.user.email || window.AppState.user.name || 'Unknown';
   var actorRole = window.AppState.user.effectiveRole || 'Admin';
   var actionLabel = (isReassign ? 'Brief reassigned to ' : 'Brief assigned to ') + ownerName;
   var toastMsg = (isReassign ? 'Reassigned to ' : 'Assigned to ') + ownerName;

--- a/render/client.js
+++ b/render/client.js
@@ -623,7 +623,8 @@ console.log('LOADED:', 'render/client.js');
       '</div>';
     }
     var palette = _clientAvatarColors(c.author_role);
-    var initial = (c.author || '?').charAt(0).toUpperCase();
+    var _authorDisplay = (typeof getDisplayName === 'function') ? getDisplayName(c.author) : (c.author || '?');
+    var initial = _authorDisplay.charAt(0).toUpperCase();
     var roleLabel = _esc((c.author_role || '').toUpperCase());
     var ts = _relativeTime(c.created_at);
     var avatarStyle = 'width:' + avSize + 'px;height:' + avSize + 'px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:' + avFontPx + 'px;font-weight:700;color:' + palette.fg + ';background:' + palette.bg + ';';
@@ -636,7 +637,7 @@ console.log('LOADED:', 'render/client.js');
           '<circle cx="9" cy="9" r="7"/>' +
           '<polyline points="6,9 8.5,11.5 12.5,6.5"/>' +
         '</svg>' +
-        '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#3ECF8E;font-weight:500;">Resolved by ' + _esc(c.resolved_by) + '</span>' +
+        '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#3ECF8E;font-weight:500;">Resolved by ' + _esc((typeof getDisplayName === 'function') ? getDisplayName(c.resolved_by) : c.resolved_by) + '</span>' +
       '</div>';
     }
     var replyTagHtml = (isReply && parentAuthor)
@@ -666,7 +667,7 @@ console.log('LOADED:', 'render/client.js');
       '<div style="flex:1;min-width:0;">' +
         replyTagHtml +
         '<div style="display:flex;align-items:center;flex-wrap:nowrap;gap:6px;">' +
-          '<span style="font-family:\'DM Sans\',sans-serif;font-weight:700;font-size:14px;color:#FFFFFF;">' + _esc(c.author) + '</span>' +
+          '<span style="font-family:\'DM Sans\',sans-serif;font-weight:700;font-size:14px;color:#FFFFFF;">' + _esc(_authorDisplay) + '</span>' +
           '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;font-weight:600;text-transform:uppercase;color:#A0A0B0;">' + roleLabel + '</span>' +
           dotsBtnHtml +
         '</div>' +
@@ -1521,7 +1522,7 @@ console.log('LOADED:', 'render/client.js');
     var savedValue = input.value;
     input.value = '';
 
-    var authorName = window.AppState.user.name || 'Client';
+    var authorName = window.AppState.user.email || window.AppState.user.name || 'Client';
     var _mentioned = _parseMentions(message);
     var post = (window.AppState.posts.all || []).find(function (p) {
       return p.post_id === postId || p.id === postId;

--- a/render/pipeline.js
+++ b/render/pipeline.js
@@ -620,7 +620,7 @@ window.executeBatchAction = async function(targetStage) {
         stage: dbStage,
         status_changed_at: now,
         updated_at: now,
-        updated_by: actor
+        updated_by: window.AppState.user.email || actor
       }),
     });
 

--- a/tests/session-resilience.test.js
+++ b/tests/session-resilience.test.js
@@ -178,7 +178,7 @@ describe('BONUS — clientApprove guardAction + approval payload', function() {
   it('24. submitApproval approved PATCH includes updated_by Client', function() {
     var approvedMatch = approvalSrc.match(/type === 'approved'[\s\S]{0,400}/);
     expect(approvedMatch).toBeTruthy();
-    expect(approvedMatch[0]).toContain("updated_by: 'Client'");
+    expect(approvedMatch[0]).toContain("updated_by: window.AppState.user.email || 'Client'");
   });
 
   it('25. _clearSessionAndLogin is exported to window', function() {


### PR DESCRIPTION
## Summary

- **Switch all DB write identifiers from name to email** — `author`, `actor`, `updated_by`, `created_by`, `changed_by`, `resolved_by` fields now use `AppState.user.email` as primary with name fallback for safety.
- **Backwards-compatible renderers** — All comment/note author displays now use `getDisplayName()` which resolves emails to display names from profiles cache, while passing through legacy name values unchanged. Covers PCS comments (2 sites), PCS internal notes (2 sites), client feed comments + resolved_by, and notification thread messages.
- **Exception: notification `actor` stays as name** — Edge functions compose email text using actor. That change requires server-side coordination in a future PR.

## Write sites changed (10 files, ~30 sites)
| Field | Files |
|-------|-------|
| `activity_log.actor` | 08-post-actions.js (7), 09-approval.js (2), 10-ui.js (1), actions/pcs.js (2), render/brief.js (2) |
| `posts.updated_by` | 08-post-actions.js (2), render/pipeline.js (1) |
| `posts.created_by` | 08-post-actions.js (1) |
| `audit_log.changed_by` | actions/pcs.js (1) |
| `post_comments.author` | 10-ui.js (1), render/client.js (1), actions/pcs.js (1) |
| `internal_notes.author` | actions/pcs.js (1) |
| `post_comment_reactions.author` | actions/pcs.js (1) |
| `resolved_by` | actions/pcs.js (1) |

## Render sites updated
| Location | Change |
|----------|--------|
| actions/pcs.js `_renderSingleClient` | `getDisplayName(c.author)` for initial + name |
| actions/pcs.js `_renderSingleNote` | `getDisplayName(c.author)` for initial + name |
| render/client.js comment render | `getDisplayName(c.author)` for initial + name + resolved_by |
| 10-ui.js `_notifThreadMsgHtml` | `getDisplayName(author)` for initial + name |

## Test plan
- [x] 508/508 unit tests passing (updated test 24 in session-resilience.test.js)
- [x] 40/40 e2e-critical tests passing
- [ ] Verify old comments (name author) display correctly — no change in appearance
- [ ] Verify new comments use email as author in DB
- [ ] Verify PCS comment avatars + names render correctly for both old and new data
- [ ] After merge: Cloudflare → srtd.io → Caching → Purge Everything

https://claude.ai/code/session_01Dv2GxsRnzkhHXKaEFypA7i