### PR TITLE
Replace resolveActor() hardcoded names with email

### DIFF
--- a/12-profiles.js
+++ b/12-profiles.js
@@ -145,3 +145,9 @@ function renderAvatar(emailOrName, role, size, opts) {
     initial +
     '</div>';
 }
+
+function displayNameSafe(nameOrEmail) {
+  if (!nameOrEmail) return 'Unknown';
+  if (nameOrEmail.indexOf('@') >= 0) return getDisplayName(nameOrEmail);
+  return nameOrEmail;
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413c`.
+1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413d`.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413c">
+ <link rel="stylesheet" href="styles.css?v=20260413d">
 
 </head>
 <body>
@@ -1081,28 +1081,28 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413c"></script>
-<script src="00-appstate-compat.js?v=20260413c"></script>
-<script src="01-config.js?v=20260413c" defer></script>
-<script src="02-session.js?v=20260413c" defer></script>
-<script src="utils.js?v=20260413c" defer></script>
-<script src="12-profiles.js?v=20260413c" defer></script>
-<script src="03-auth.js?v=20260413c" defer></script>
-<script src="05-api.js?v=20260413c" defer></script>
-<script src="10-ui.js?v=20260413c" defer></script>
+<script src="00-appstate.js?v=20260413d"></script>
+<script src="00-appstate-compat.js?v=20260413d"></script>
+<script src="01-config.js?v=20260413d" defer></script>
+<script src="02-session.js?v=20260413d" defer></script>
+<script src="utils.js?v=20260413d" defer></script>
+<script src="12-profiles.js?v=20260413d" defer></script>
+<script src="03-auth.js?v=20260413d" defer></script>
+<script src="05-api.js?v=20260413d" defer></script>
+<script src="10-ui.js?v=20260413d" defer></script>
 
-<script src="06-post-create.js?v=20260413c" defer></script>
-<script defer src="render/dashboard.js?v=20260413c"></script>
-<script defer src="render/client.js?v=20260413c"></script>
-<script defer src="render/pipeline.js?v=20260413c"></script>
-<script defer src="render/brief.js?v=20260413c"></script>
-<script defer src="actions/pcs.js?v=20260413c"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413c"></script>
-<script src="07-post-load.js?v=20260413c" defer></script>
-<script src="08-post-actions.js?v=20260413c" defer></script>
-<script src="09-library.js?v=20260413c" defer></script>
-<script src="09-approval.js?v=20260413c" defer></script>
-<script src="04-router.js?v=20260413c" defer></script>
+<script src="06-post-create.js?v=20260413d" defer></script>
+<script defer src="render/dashboard.js?v=20260413d"></script>
+<script defer src="render/client.js?v=20260413d"></script>
+<script defer src="render/pipeline.js?v=20260413d"></script>
+<script defer src="render/brief.js?v=20260413d"></script>
+<script defer src="actions/pcs.js?v=20260413d"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413d"></script>
+<script src="07-post-load.js?v=20260413d" defer></script>
+<script src="08-post-actions.js?v=20260413d" defer></script>
+<script src="09-library.js?v=20260413d" defer></script>
+<script src="09-approval.js?v=20260413d" defer></script>
+<script src="04-router.js?v=20260413d" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/utils.js
+++ b/utils.js
@@ -92,12 +92,10 @@ function formatIST(ts) {
   });
 }
 
-// Resolve actor display name from effectiveRole
+// Resolve actor identifier — returns email (unique, immutable)
 function resolveActor() {
-  var role = window.AppState.user.effectiveRole || window.AppState.user.role || '';
-  if (role === 'Admin') return 'Shubham';
-  if (role === 'Servicing') return 'Chitra';
-  if (role === 'Creative') return 'Pranav';
-  if (role === 'Client') return 'Client';
-  return 'Shubham';
+  return window.AppState.user.email
+    || localStorage.getItem('hinglish_email')
+    || window.AppState.user.name
+    || 'unknown';
 }


### PR DESCRIPTION
## Summary

- **Replace `resolveActor()` hardcoded name mapping with email** — was returning hardcoded `'Shubham'`/`'Chitra'`/`'Pranav'` based on role. Now returns `AppState.user.email` with cascading fallbacks (`localStorage → name → 'unknown'`).
- **Add `displayNameSafe(nameOrEmail)`** to `12-profiles.js` — if input contains `@`, resolves via `getDisplayName()` from profiles cache; otherwise returns the input as-is. Safe for mixed old (name) and new (email) data.

## Files changed
| File | Change |
|------|--------|
| `utils.js` | `resolveActor()` → email-first, no hardcoded names |
| `12-profiles.js` | +5 lines — `displayNameSafe()` |
| `index.html` | 22 version bumps → `?v=20260413d` |
| `CLAUDE.md` | Version updated |

## Test plan
- [x] 508/508 unit tests passing
- [ ] After merge: Cloudflare → srtd.io → Caching → Purge Everything

https://claude.ai/code/session_01Dv2GxsRnzkhHXKaEFypA7i