### PR TITLE
Fix profilesCache null after page refresh

### DIFF
--- a/04-router.js
+++ b/04-router.js
@@ -47,6 +47,7 @@ async function _startRouter() {
       const result = await refreshSession();
       if (result && result.token) {
         activateRole(savedRole);
+        if (typeof fetchProfiles === 'function') fetchProfiles();
         window._authReady = true;
         return;
       }
@@ -59,6 +60,7 @@ async function _startRouter() {
       // Network/server error — keep tokens, try with stale token
       if (savedToken) {
         activateRole(savedRole);
+        if (typeof fetchProfiles === 'function') fetchProfiles();
         window._authReady = true;
         return;
       }
@@ -70,6 +72,7 @@ async function _startRouter() {
     }
     if (savedToken) {
       activateRole(savedRole);
+      if (typeof fetchProfiles === 'function') fetchProfiles();
       window._authReady = true;
       return;
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413d`.
+1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413e`.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413d">
+ <link rel="stylesheet" href="styles.css?v=20260413e">
 
 </head>
 <body>
@@ -1081,28 +1081,28 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413d"></script>
-<script src="00-appstate-compat.js?v=20260413d"></script>
-<script src="01-config.js?v=20260413d" defer></script>
-<script src="02-session.js?v=20260413d" defer></script>
-<script src="utils.js?v=20260413d" defer></script>
-<script src="12-profiles.js?v=20260413d" defer></script>
-<script src="03-auth.js?v=20260413d" defer></script>
-<script src="05-api.js?v=20260413d" defer></script>
-<script src="10-ui.js?v=20260413d" defer></script>
+<script src="00-appstate.js?v=20260413e"></script>
+<script src="00-appstate-compat.js?v=20260413e"></script>
+<script src="01-config.js?v=20260413e" defer></script>
+<script src="02-session.js?v=20260413e" defer></script>
+<script src="utils.js?v=20260413e" defer></script>
+<script src="12-profiles.js?v=20260413e" defer></script>
+<script src="03-auth.js?v=20260413e" defer></script>
+<script src="05-api.js?v=20260413e" defer></script>
+<script src="10-ui.js?v=20260413e" defer></script>
 
-<script src="06-post-create.js?v=20260413d" defer></script>
-<script defer src="render/dashboard.js?v=20260413d"></script>
-<script defer src="render/client.js?v=20260413d"></script>
-<script defer src="render/pipeline.js?v=20260413d"></script>
-<script defer src="render/brief.js?v=20260413d"></script>
-<script defer src="actions/pcs.js?v=20260413d"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413d"></script>
-<script src="07-post-load.js?v=20260413d" defer></script>
-<script src="08-post-actions.js?v=20260413d" defer></script>
-<script src="09-library.js?v=20260413d" defer></script>
-<script src="09-approval.js?v=20260413d" defer></script>
-<script src="04-router.js?v=20260413d" defer></script>
+<script src="06-post-create.js?v=20260413e" defer></script>
+<script defer src="render/dashboard.js?v=20260413e"></script>
+<script defer src="render/client.js?v=20260413e"></script>
+<script defer src="render/pipeline.js?v=20260413e"></script>
+<script defer src="render/brief.js?v=20260413e"></script>
+<script defer src="actions/pcs.js?v=20260413e"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413e"></script>
+<script src="07-post-load.js?v=20260413e" defer></script>
+<script src="08-post-actions.js?v=20260413e" defer></script>
+<script src="09-library.js?v=20260413e" defer></script>
+<script src="09-approval.js?v=20260413e" defer></script>
+<script src="04-router.js?v=20260413e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- **Fix `_profilesCache` staying null after page refresh** — `activateRole()` has an early-return path (admin role preview, `03-auth.js:329-336`) that skips `fetchProfiles()`. Added standalone `fetchProfiles()` calls after all 3 `activateRole(savedRole)` calls in `04-router.js` session restore paths, guaranteeing profiles load regardless of which `activateRole` branch executes.

## Files changed
| File | Change |
|------|--------|
| `04-router.js` | +3 lines — `fetchProfiles()` after each `activateRole()` |
| `index.html` | 22 version bumps → `?v=20260413e` |
| `CLAUDE.md` | Version updated |

## Test plan
- [x] 508/508 unit tests passing
- [ ] Refresh page while in admin preview → verify `_profilesCache` is populated
- [ ] After merge: Cloudflare → srtd.io → Caching → Purge Everything

https://claude.ai/code/session_01Dv2GxsRnzkhHXKaEFypA7i