### PR TITLE
Wire profile photos into all 9 avatar render sites

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -2065,7 +2065,7 @@ function _updateNextScheduled(allP) {
     if (metaParts.length) html += '<div style="font-family:var(--mono);font-size:8px;color:#444;letter-spacing:0.04em;text-transform:uppercase;">' + metaParts.join(' - ') + '</div>';
     html += '</div>';
     html += '<div style="padding:8px 14px 8px 8px;display:flex;align-items:center;flex-shrink:0;">';
-    html += '<div style="width:26px;height:26px;border-radius:50%;background:#FFFFFF0D;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:8px;letter-spacing:0.04em;color:' + _ownerColor(owner) + ';">' + esc(initials) + '</div>';
+    html += (typeof renderAvatar === 'function') ? renderAvatar(owner, getRoleFor(owner), 26, { fontSize: '8px', fontFamily: 'var(--mono)' }) : '<div style="width:26px;height:26px;border-radius:50%;background:#FFFFFF0D;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:8px;letter-spacing:0.04em;color:' + _ownerColor(owner) + ';">' + esc(initials) + '</div>';
     html += '</div></div>';
   }
   listEl.innerHTML = html;

--- a/10-ui.js
+++ b/10-ui.js
@@ -770,7 +770,7 @@ function renderNotifications(name, role) {
       expandableAttr +
       isBriefAttr + '>' +
       '<div class="notif-item-row">' +
-        '<div class="notif-av ' + avClass + '">' + esc(initial) + '</div>' +
+        (typeof renderAvatar === 'function' ? renderAvatar(actor, getRoleFor(actor), 32, { classes: 'notif-av' }) : '<div class="notif-av ' + avClass + '">' + esc(initial) + '</div>') +
         '<div class="notif-body">' +
           pubLabel +
           '<div class="notif-text">' +
@@ -940,7 +940,7 @@ function _notifThreadMsgHtml(c) {
     ? '<span class="thread-role">' + esc(authorRole) + '</span>'
     : '';
   return '<div class="thread-msg">' +
-      '<div class="thread-av ' + avClass + '">' + esc(initial) + '</div>' +
+      (typeof renderAvatar === 'function' ? renderAvatar(author, getRoleFor(authorRole || author), 18, { classes: 'thread-av', fontSize: '7px' }) : '<div class="thread-av ' + avClass + '">' + esc(initial) + '</div>') +
       '<div class="thread-content">' +
         '<div class="thread-header">' +
           '<span class="thread-author">' + esc(_authorDisplay) + '</span>' +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413e`.
+1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413f`.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1155,7 +1155,7 @@ window.loadPcsComments = async function(postId) {
         : '';
       var _resolveBtnLabel = c.resolved ? 'Unresolve' : 'Resolve';
       return '<div class="pcs-comment-item" data-comment-id="' + esc(c.id) + '" data-author="' + esc(c.author) + '">' +
-        '<div class="pcs-cmt-av"><div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div></div>' +
+        '<div class="pcs-cmt-av">' + ((typeof renderAvatar === 'function') ? renderAvatar(c.author, c.author_role, 28, { classes: 'pcs-avatar', fontSize: '9px', fontFamily: "'IBM Plex Mono', monospace" }) : '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>') + '</div>' +
         '<div class="pcs-cmt-mid">' +
           (c.reply_to && c.reply_to_author ?
             '<div class="pcs-cmt-reply-tag">&#8629; <span class="pcs-reply-name">' + esc(c.reply_to_author) + '</span></div>'
@@ -1298,7 +1298,7 @@ window.loadPcsComments = async function(postId) {
       var _resolveBtnLabel = c.resolved ? 'Unresolve' : 'Resolve';
       return '<div class="pcs-note-item' +
         (c.resolved ? ' pcs-resolved' : '') + '" data-comment-id="' + esc(c.id) + '" data-author="' + esc(c.author) + '">' +
-        '<div class="pcs-cmt-av"><div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div></div>' +
+        '<div class="pcs-cmt-av">' + ((typeof renderAvatar === 'function') ? renderAvatar(c.author, c.author_role, 28, { classes: 'pcs-avatar', fontSize: '9px', fontFamily: "'IBM Plex Mono', monospace" }) : '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>') + '</div>' +
         '<div class="pcs-cmt-mid">' +
           (c.reply_to && c.reply_to_author ?
             '<div class="pcs-cmt-reply-tag">&#8629; <span class="pcs-reply-name">' + esc(c.reply_to_author) + '</span></div>'

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413e">
+ <link rel="stylesheet" href="styles.css?v=20260413f">
 
 </head>
 <body>
@@ -1081,28 +1081,28 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413e"></script>
-<script src="00-appstate-compat.js?v=20260413e"></script>
-<script src="01-config.js?v=20260413e" defer></script>
-<script src="02-session.js?v=20260413e" defer></script>
-<script src="utils.js?v=20260413e" defer></script>
-<script src="12-profiles.js?v=20260413e" defer></script>
-<script src="03-auth.js?v=20260413e" defer></script>
-<script src="05-api.js?v=20260413e" defer></script>
-<script src="10-ui.js?v=20260413e" defer></script>
+<script src="00-appstate.js?v=20260413f"></script>
+<script src="00-appstate-compat.js?v=20260413f"></script>
+<script src="01-config.js?v=20260413f" defer></script>
+<script src="02-session.js?v=20260413f" defer></script>
+<script src="utils.js?v=20260413f" defer></script>
+<script src="12-profiles.js?v=20260413f" defer></script>
+<script src="03-auth.js?v=20260413f" defer></script>
+<script src="05-api.js?v=20260413f" defer></script>
+<script src="10-ui.js?v=20260413f" defer></script>
 
-<script src="06-post-create.js?v=20260413e" defer></script>
-<script defer src="render/dashboard.js?v=20260413e"></script>
-<script defer src="render/client.js?v=20260413e"></script>
-<script defer src="render/pipeline.js?v=20260413e"></script>
-<script defer src="render/brief.js?v=20260413e"></script>
-<script defer src="actions/pcs.js?v=20260413e"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413e"></script>
-<script src="07-post-load.js?v=20260413e" defer></script>
-<script src="08-post-actions.js?v=20260413e" defer></script>
-<script src="09-library.js?v=20260413e" defer></script>
-<script src="09-approval.js?v=20260413e" defer></script>
-<script src="04-router.js?v=20260413e" defer></script>
+<script src="06-post-create.js?v=20260413f" defer></script>
+<script defer src="render/dashboard.js?v=20260413f"></script>
+<script defer src="render/client.js?v=20260413f"></script>
+<script defer src="render/pipeline.js?v=20260413f"></script>
+<script defer src="render/brief.js?v=20260413f"></script>
+<script defer src="actions/pcs.js?v=20260413f"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413f"></script>
+<script src="07-post-load.js?v=20260413f" defer></script>
+<script src="08-post-actions.js?v=20260413f" defer></script>
+<script src="09-library.js?v=20260413f" defer></script>
+<script src="09-approval.js?v=20260413f" defer></script>
+<script src="04-router.js?v=20260413f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -356,10 +356,7 @@ window._openBriefSheet = function(postId) {
       'color:#E8E8E8;margin-bottom:10px;">Assigned To</div>' +
       '<div style="display:flex;align-items:center;gap:10px;background:#141420;' +
       'border:1px solid #252535;border-radius:8px;padding:11px 14px;">' +
-      '<div style="width:28px;height:28px;border-radius:50%;background:#9b87f526;' +
-      'border:1px solid #9b87f54d;display:flex;align-items:center;justify-content:center;' +
-      'font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:600;color:#9b87f5;">' +
-      esc((_assigneeName || '?').charAt(0).toUpperCase()) + '</div>' +
+      ((typeof renderAvatar === 'function') ? renderAvatar(_assigneeName, 'creative', 28) : '<div style="width:28px;height:28px;border-radius:50%;background:#9b87f526;border:1px solid #9b87f54d;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:600;color:#9b87f5;">' + esc((_assigneeName || '?').charAt(0).toUpperCase()) + '</div>') +
       '<div>' +
       '<div style="font-family:\'DM Sans\',sans-serif;font-size:14px;font-weight:600;color:#F0F0F2;">' +
       esc(_assigneeName) + '</div>' +
@@ -435,10 +432,7 @@ window._briefShowAssignDropdown = function(postId, isReassign) {
         html += '<button onclick="_assignBrief(\'' + esc(postId) + '\',\'' + esc(name) + '\',' + isReassign + ')" ' +
           'style="display:flex;align-items:center;gap:10px;width:100%;padding:12px 14px;' +
           'background:#0d0d12;border:none;border-bottom:1px solid #191924;cursor:pointer;">' +
-          '<div style="width:28px;height:28px;border-radius:50%;background:#9b87f526;' +
-          'border:1px solid #9b87f54d;display:flex;align-items:center;justify-content:center;' +
-          'font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:600;color:#9b87f5;">' +
-          esc(initial) + '</div>' +
+          ((typeof renderAvatar === 'function') ? renderAvatar(m.email || name, 'creative', 28) : '<div style="width:28px;height:28px;border-radius:50%;background:#9b87f526;border:1px solid #9b87f54d;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:600;color:#9b87f5;">' + esc(initial) + '</div>') +
           '<div style="font-family:\'DM Sans\',sans-serif;font-size:14px;font-weight:600;color:#F0F0F2;">' +
           esc(name) + '</div>' +
           '</button>';

--- a/render/client.js
+++ b/render/client.js
@@ -622,12 +622,12 @@ console.log('LOADED:', 'render/client.js');
         '<div class="client-comment-tombstone">This message was deleted.</div>' +
       '</div>';
     }
-    var palette = _clientAvatarColors(c.author_role);
     var _authorDisplay = (typeof getDisplayName === 'function') ? getDisplayName(c.author) : (c.author || '?');
-    var initial = _authorDisplay.charAt(0).toUpperCase();
     var roleLabel = _esc((c.author_role || '').toUpperCase());
     var ts = _relativeTime(c.created_at);
-    var avatarStyle = 'width:' + avSize + 'px;height:' + avSize + 'px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:' + avFontPx + 'px;font-weight:700;color:' + palette.fg + ';background:' + palette.bg + ';';
+    var avatarHtml = (typeof renderAvatar === 'function')
+      ? renderAvatar(c.author, c.author_role, avSize || 32)
+      : (function() { var palette = _clientAvatarColors(c.author_role); var initial = _authorDisplay.charAt(0).toUpperCase(); return '<div style="width:' + avSize + 'px;height:' + avSize + 'px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:' + avFontPx + 'px;font-weight:700;color:' + palette.fg + ';background:' + palette.bg + ';">' + _esc(initial) + '</div>'; })();
     var messageHtml = _highlightClientMentions(_esc(c.message || ''));
     var imgHtml = _commentImgHtml(c);
     var resolvedHtml = '';
@@ -663,7 +663,7 @@ console.log('LOADED:', 'render/client.js');
       '</span>';
     return '<div class="client-comment-wrap" data-comment-id="' + cid + '" style="display:flex;gap:10px;padding:' + wrapperPad + ';position:relative;">' +
       connectorHtml +
-      '<div style="' + avatarStyle + '">' + _esc(initial) + '</div>' +
+      avatarHtml +
       '<div style="flex:1;min-width:0;">' +
         replyTagHtml +
         '<div style="display:flex;align-items:center;flex-wrap:nowrap;gap:6px;">' +
@@ -785,7 +785,7 @@ console.log('LOADED:', 'render/client.js');
        pill anymore; the "Comment" button in Row 3 is the single
        submit trigger for this bar. */
     '<div style="display:flex;align-items:center;gap:8px;padding:10px 14px 6px;">' +
-      '<div style="width:32px;height:32px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;background:#2A2A34;border:1px solid #3A3A48;font-family:\'IBM Plex Mono\',monospace;font-size:12px;font-weight:700;color:#D0D0D8;">' + _esc(initial) + '</div>' +
+      ((typeof renderAvatar === 'function') ? renderAvatar(window.AppState.user.email || window.AppState.user.name, window.AppState.user.effectiveRole, 32) : '<div style="width:32px;height:32px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;background:#2A2A34;border:1px solid #3A3A48;font-family:\'IBM Plex Mono\',monospace;font-size:12px;font-weight:700;color:#D0D0D8;">' + _esc(initial) + '</div>') +
       '<div style="flex:1;min-width:0;">' +
         '<input id="comment-input-' + pid + '" type="text" placeholder="' + _esc(placeholder) + '" ' +
           'style="width:100%;height:38px;background:#111118;border:1px solid #505058;border-radius:24px;padding:10px 16px;color:#E8E8E8;font-family:\'DM Sans\',sans-serif;font-size:14px;outline:none;box-sizing:border-box;" data-post-id="' + pid + '">' +

--- a/render/dashboard.js
+++ b/render/dashboard.js
@@ -1098,7 +1098,7 @@ window._updateNextScheduled = function(allP) {
     if (metaParts.length) html += '<div style="font-family:var(--mono);font-size:8px;color:#444;letter-spacing:0.04em;text-transform:uppercase;">' + metaParts.join(' - ') + '</div>';
     html += '</div>';
     html += '<div style="padding:8px 14px 8px 8px;display:flex;align-items:center;flex-shrink:0;">';
-    html += '<div style="width:26px;height:26px;border-radius:50%;background:#FFFFFF0D;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:8px;letter-spacing:0.04em;color:' + _ownerColor(owner) + ';">' + esc(initials) + '</div>';
+    html += (typeof renderAvatar === 'function') ? renderAvatar(owner, getRoleFor(owner), 26, { fontSize: '8px', fontFamily: 'var(--mono)' }) : '<div style="width:26px;height:26px;border-radius:50%;background:#FFFFFF0D;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:8px;letter-spacing:0.04em;color:' + _ownerColor(owner) + ';">' + esc(initials) + '</div>';
     html += '</div></div>';
   }
   listEl.innerHTML = html;


### PR DESCRIPTION
## Summary

Wire profile photos into all 9 avatar render sites using `renderAvatar()`. When a user has `avatar_url` in their profile, their photo appears as a circular `<img>`. When they don't, the existing letter circle renders exactly as before.

**Users with photos:** Shubham, Chitra, Manisha, Shivangini
**Users with letter circles (no photo):** Pranav, Aishuwarya, Test Client

## Sites replaced

| # | File | Location | Size | Description |
|---|------|----------|------|-------------|
| 1 | `10-ui.js` | line 773 | 32px | Notification panel avatar |
| 2 | `10-ui.js` | line 943 | 18px | Notification thread avatar |
| 3 | `render/client.js` | comment render | variable | Client comment avatar |
| 4 | `render/client.js` | comment input | 32px | Current user avatar in input bar |
| 6 | `actions/pcs.js` | _renderSingleClient | 28px | PCS client comment avatar |
| 7 | `actions/pcs.js` | _renderSingleNote | 28px | PCS internal note avatar |
| 9 | `07-post-load.js` | line 2068 | 26px | Pipeline owner badge |
| 10 | `render/dashboard.js` | line 1101 | 26px | Dashboard owner badge |
| 11 | `render/brief.js` | lines 359+438 | 28px | Brief assign avatars (2 locations) |

**Skipped:** Site 5 (post title initial, not a person) and Site 8 (deleted message "?" placeholder).

Every site uses `typeof renderAvatar === 'function'` guard with full inline fallback, so the old letter circle still renders if `12-profiles.js` hasn't loaded.

## Test plan
- [x] 508/508 unit tests passing
- [x] 40/40 e2e-critical tests passing
- [ ] Open PCS → comment by Manisha/Shivangini shows photo
- [ ] Open PCS → comment by Pranav shows letter circle "P" in purple
- [ ] Notification panel → photos for Shubham/Chitra/Manisha/Shivangini
- [ ] Pipeline/Dashboard → owner badges show photos where available
- [ ] Client view → comment avatars show photos
- [ ] Brief panel → assign dropdown shows photos
- [ ] After merge: Cloudflare → srtd.io → Caching → Purge Everything

https://claude.ai/code/session_01Dv2GxsRnzkhHXKaEFypA7i