### PR TITLE
Fix short-name profile lookups via _nameToEmailCache

### DIFF
--- a/12-profiles.js
+++ b/12-profiles.js
@@ -32,6 +32,14 @@ async function fetchProfiles() {
           if (u.email) nrc[u.email.toLowerCase()] = uRole;
         }
         window._nameToRoleCache = nrc;
+        var nec = {};
+        for (var k = 0; k < rolesRes.length; k++) {
+          var ur = rolesRes[k];
+          if (ur.name && ur.email) {
+            nec[ur.name.toLowerCase()] = ur.email.toLowerCase();
+          }
+        }
+        window._nameToEmailCache = nec;
       }
     } catch (roleErr) {
       console.warn('[profiles] user_roles fetch failed:', roleErr);
@@ -60,6 +68,13 @@ function getDisplayName(emailOrName) {
       }
     }
   }
+  // Short name lookup via user_roles.name
+  if (window._nameToEmailCache && window._nameToEmailCache[key]) {
+    var resolvedEmail = window._nameToEmailCache[key];
+    if (cache && cache[resolvedEmail] && cache[resolvedEmail].display_name) {
+      return cache[resolvedEmail].display_name;
+    }
+  }
   if (key.indexOf('@') >= 0) {
     var local = key.split('@')[0];
     return local.charAt(0).toUpperCase() + local.slice(1);
@@ -84,6 +99,13 @@ function getAvatarUrl(nameOrEmail) {
       }
     }
   }
+  // Short name lookup via user_roles.name
+  if (window._nameToEmailCache && window._nameToEmailCache[key]) {
+    var resolvedEmail = window._nameToEmailCache[key];
+    if (cache && cache[resolvedEmail]) {
+      return cache[resolvedEmail].avatar_url || null;
+    }
+  }
   return null;
 }
 
@@ -99,6 +121,11 @@ function getProfileByEmail(nameOrEmail) {
     if (p.display_name && p.display_name.toLowerCase() === key) {
       return p;
     }
+  }
+  // Short name lookup via user_roles.name
+  if (window._nameToEmailCache && window._nameToEmailCache[key]) {
+    var resolvedEmail = window._nameToEmailCache[key];
+    if (cache[resolvedEmail]) return cache[resolvedEmail];
   }
   return null;
 }

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413g">
+ <link rel="stylesheet" href="styles.css?v=20260413h">
 
 </head>
 <body>
@@ -1081,28 +1081,28 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413g"></script>
-<script src="00-appstate-compat.js?v=20260413g"></script>
-<script src="01-config.js?v=20260413g" defer></script>
-<script src="02-session.js?v=20260413g" defer></script>
-<script src="utils.js?v=20260413g" defer></script>
-<script src="12-profiles.js?v=20260413g" defer></script>
-<script src="03-auth.js?v=20260413g" defer></script>
-<script src="05-api.js?v=20260413g" defer></script>
-<script src="10-ui.js?v=20260413g" defer></script>
+<script src="00-appstate.js?v=20260413h"></script>
+<script src="00-appstate-compat.js?v=20260413h"></script>
+<script src="01-config.js?v=20260413h" defer></script>
+<script src="02-session.js?v=20260413h" defer></script>
+<script src="utils.js?v=20260413h" defer></script>
+<script src="12-profiles.js?v=20260413h" defer></script>
+<script src="03-auth.js?v=20260413h" defer></script>
+<script src="05-api.js?v=20260413h" defer></script>
+<script src="10-ui.js?v=20260413h" defer></script>
 
-<script src="06-post-create.js?v=20260413g" defer></script>
-<script defer src="render/dashboard.js?v=20260413g"></script>
-<script defer src="render/client.js?v=20260413g"></script>
-<script defer src="render/pipeline.js?v=20260413g"></script>
-<script defer src="render/brief.js?v=20260413g"></script>
-<script defer src="actions/pcs.js?v=20260413g"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413g"></script>
-<script src="07-post-load.js?v=20260413g" defer></script>
-<script src="08-post-actions.js?v=20260413g" defer></script>
-<script src="09-library.js?v=20260413g" defer></script>
-<script src="09-approval.js?v=20260413g" defer></script>
-<script src="04-router.js?v=20260413g" defer></script>
+<script src="06-post-create.js?v=20260413h" defer></script>
+<script defer src="render/dashboard.js?v=20260413h"></script>
+<script defer src="render/client.js?v=20260413h"></script>
+<script defer src="render/pipeline.js?v=20260413h"></script>
+<script defer src="render/brief.js?v=20260413h"></script>
+<script defer src="actions/pcs.js?v=20260413h"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413h"></script>
+<script src="07-post-load.js?v=20260413h" defer></script>
+<script src="08-post-actions.js?v=20260413h" defer></script>
+<script src="09-library.js?v=20260413h" defer></script>
+<script src="09-approval.js?v=20260413h" defer></script>
+<script src="04-router.js?v=20260413h" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- **Problem:** `getAvatarUrl("Shubham")` returned `null` because `_profilesCache` is keyed by email and the display_name loop matches full names only ("Shubham Gune"), not short names from `user_roles.name` ("Shubham"). Old actor values like "Client" also matched no profile.
- **Fix:** Build `window._nameToEmailCache` (short name → email) from `user_roles` during `fetchProfiles()`. Add a fallback lookup in `getDisplayName()`, `getAvatarUrl()`, and `getProfileByEmail()` that resolves short names to emails via this cache before giving up.
- Unknown actors like "Client" still gracefully fall back to a letter circle — no cache entry, no crash.

## Files changed

| File | Change |
|---|---|
| `12-profiles.js` | Build `_nameToEmailCache` in `fetchProfiles()`; add short-name fallback in 3 getter functions |
| `index.html` | Version bump `?v=20260413g` → `?v=20260413h` (22 resources) |

## Test plan

- [x] 508/508 unit tests pass (`npx vitest run`)
- [ ] Verify `getAvatarUrl("Shubham")` returns the correct avatar URL after login
- [ ] Verify `getDisplayName("Shubham")` returns "Shubham Gune"
- [ ] Verify `getProfileByEmail("Shubham")` returns the full profile object
- [ ] Verify `getAvatarUrl("Client")` still returns `null` (letter circle fallback)
- [ ] Purge Cloudflare cache after merge

https://claude.ai/code/session_01RTC9F8MrNMedoZAsKQZ7xG