### PR TITLE
Replace three-dot menu trigger with profile avatar

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -440,6 +440,11 @@ function _buildUserMenu() {
   var _roleLower = (window.AppState.user.effectiveRole || window.AppState.user.role || '').toLowerCase();
   let html = '';
 
+  // My Profile item (all roles)
+  var _profAv = (typeof renderAvatar === 'function') ? renderAvatar(window.AppState.user.email || '', _roleLower, 20) : '';
+  html += '<button class="user-menu-item" onclick="openProfilePanel(); closeUserMenu()">' + _profAv + ' My Profile</button>';
+  html += '<div class="um-divider"></div>';
+
   // Client gets a dedicated slim menu
   if (_roleLower === 'client') {
     html += '<button class="user-menu-item" onclick="openClientRequestForm(); closeUserMenu()" style="color:#C8A84B;">+ New Request</button>';

--- a/10-ui.js
+++ b/10-ui.js
@@ -191,7 +191,8 @@ function toggleUserMenu() {
   m.style.display = 'block';
   setTimeout(function() {
     document.addEventListener('click', function _close(e) {
-      if (!m.contains(e.target)) {
+      var trigger = document.getElementById('prof-trigger');
+      if (!m.contains(e.target) && !(trigger && trigger.contains(e.target))) {
         m.style.display = 'none';
         document.removeEventListener('click', _close);
       }

--- a/12-profiles.js
+++ b/12-profiles.js
@@ -559,5 +559,7 @@ function _renderProfileTrigger() {
   if (!wrap) return;
   var email = (window.AppState && window.AppState.user && window.AppState.user.email) || '';
   var role = (window.AppState && window.AppState.user && (window.AppState.user.effectiveRole || window.AppState.user.role)) || '';
-  wrap.innerHTML = renderAvatar(email, role, 28);
+  var colors = _avatarColors(role);
+  wrap.style.border = '2px solid ' + colors.bg;
+  wrap.innerHTML = renderAvatar(email, role, 32);
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413i`.
+1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413j`.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413i">
+ <link rel="stylesheet" href="styles.css?v=20260413j">
 
 </head>
 <body>
@@ -157,19 +157,13 @@
       Good morning, <span id="dash-greeting-name" style="color:#C8A84B;font-weight:500;">Shubham</span>
     </div>
     <div class="app-header-right">
-      <!-- Profile trigger -->
-      <button class="app-icon-btn prof-trigger-btn" id="prof-trigger" onclick="openProfilePanel()" title="My Profile" style="width:28px;height:28px;padding:0;overflow:hidden;border-radius:50%"></button>
+      <!-- Profile avatar / menu trigger -->
+      <button class="app-icon-btn prof-trigger-btn" id="prof-trigger" onclick="toggleUserMenu()" title="Menu" style="width:36px;height:36px;padding:0;overflow:hidden;border-radius:50%"></button>
       <!-- Bell icon -->
       <button class="app-icon-btn" id="notif-bell" onclick="openNotifications()" title="Notifications" style="position:relative">
         <svg width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0"/></svg>
         <span class="nav-badge" id="notif-bell-badge" style="display:none"></span>
       </button>
-      <!-- Three-dot menu -->
-      <div class="user-menu-wrap" id="user-menu-wrap">
-        <button class="app-icon-btn" onclick="toggleUserMenu()" title="Menu">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><circle cx="12" cy="5" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="19" r="1.5" fill="currentColor" stroke="none"/></svg>
-        </button>
-      </div>
     </div>
   </header>
 
@@ -1083,28 +1077,28 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413i"></script>
-<script src="00-appstate-compat.js?v=20260413i"></script>
-<script src="01-config.js?v=20260413i" defer></script>
-<script src="02-session.js?v=20260413i" defer></script>
-<script src="utils.js?v=20260413i" defer></script>
-<script src="12-profiles.js?v=20260413i" defer></script>
-<script src="03-auth.js?v=20260413i" defer></script>
-<script src="05-api.js?v=20260413i" defer></script>
-<script src="10-ui.js?v=20260413i" defer></script>
+<script src="00-appstate.js?v=20260413j"></script>
+<script src="00-appstate-compat.js?v=20260413j"></script>
+<script src="01-config.js?v=20260413j" defer></script>
+<script src="02-session.js?v=20260413j" defer></script>
+<script src="utils.js?v=20260413j" defer></script>
+<script src="12-profiles.js?v=20260413j" defer></script>
+<script src="03-auth.js?v=20260413j" defer></script>
+<script src="05-api.js?v=20260413j" defer></script>
+<script src="10-ui.js?v=20260413j" defer></script>
 
-<script src="06-post-create.js?v=20260413i" defer></script>
-<script defer src="render/dashboard.js?v=20260413i"></script>
-<script defer src="render/client.js?v=20260413i"></script>
-<script defer src="render/pipeline.js?v=20260413i"></script>
-<script defer src="render/brief.js?v=20260413i"></script>
-<script defer src="actions/pcs.js?v=20260413i"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413i"></script>
-<script src="07-post-load.js?v=20260413i" defer></script>
-<script src="08-post-actions.js?v=20260413i" defer></script>
-<script src="09-library.js?v=20260413i" defer></script>
-<script src="09-approval.js?v=20260413i" defer></script>
-<script src="04-router.js?v=20260413i" defer></script>
+<script src="06-post-create.js?v=20260413j" defer></script>
+<script defer src="render/dashboard.js?v=20260413j"></script>
+<script defer src="render/client.js?v=20260413j"></script>
+<script defer src="render/pipeline.js?v=20260413j"></script>
+<script defer src="render/brief.js?v=20260413j"></script>
+<script defer src="actions/pcs.js?v=20260413j"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413j"></script>
+<script src="07-post-load.js?v=20260413j" defer></script>
+<script src="08-post-actions.js?v=20260413j" defer></script>
+<script src="09-library.js?v=20260413j" defer></script>
+<script src="09-approval.js?v=20260413j" defer></script>
+<script src="04-router.js?v=20260413j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- **Removed** standalone three-dot icon button from topbar
- **Profile avatar** (36px, 2px role-colored border: admin=gold, servicing=cyan, creative=purple, client=red) is now the menu trigger — single tap opens the existing dropdown
- **"My Profile"** added as the first item in the dropdown (above VIEW section) with a 20px inline avatar; tapping it calls `openProfilePanel()` and closes the menu — works for both agency and client roles
- **Click-outside handler** updated to exclude the trigger button so toggle open/close works correctly

## Files changed

| File | Change |
|---|---|
| `index.html` | Replaced three-dot `<div class="user-menu-wrap">` with avatar trigger; version bump `?v=20260413i` → `?v=20260413j` (22 resources) |
| `12-profiles.js` | `_renderProfileTrigger()` now renders 32px avatar inside 36px button with 2px role-colored border |
| `03-auth.js` | `_buildUserMenu()` prepends "My Profile" item with 20px avatar for all roles |
| `10-ui.js` | `toggleUserMenu()` click-outside handler excludes `#prof-trigger` |
| `CLAUDE.md` | Version string updated |

## Test plan

- [x] 508/508 unit tests pass (`npx vitest run`)
- [ ] Profile avatar visible in topbar (replaces three-dot icon)
- [ ] Avatar shows role-colored border (gold for admin)
- [ ] Tapping avatar opens dropdown menu
- [ ] "My Profile" is the first item with inline avatar
- [ ] Tapping "My Profile" opens profile panel + closes dropdown
- [ ] VIEW, PREFERENCES, Sign Out still present and functional
- [ ] Tapping avatar again closes the dropdown (toggle works)
- [ ] Clicking outside closes the dropdown
- [ ] Client role also sees "My Profile" in their menu
- [ ] Purge Cloudflare cache after merge

https://claude.ai/code/session_01RTC9F8MrNMedoZAsKQZ7xG