### PR TITLE
Scratchpad in dropdown + fix avatar hero re-render

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -354,8 +354,12 @@ function activateRole(role) {
     if (loginOv) loginOv.classList.add('hidden');
     document.getElementById('client-view')?.classList.add('active');
     if (typeof loadPostsForClient === 'function') loadPostsForClient();
-    if (typeof fetchProfiles === 'function') fetchProfiles();
-    if (typeof updateLastActive === 'function') updateLastActive();
+    if (typeof fetchProfiles === 'function') {
+      try { fetchProfiles(); } catch(e) { console.warn('[auth] fetchProfiles error:', e); }
+    }
+    if (typeof updateLastActive === 'function') {
+      try { updateLastActive(); } catch(e) { console.warn('[auth] updateLastActive error:', e); }
+    }
     if (typeof startClientRealtime === 'function') startClientRealtime();
     if (!window._clientTokenTimer) {
       window._clientTokenTimer = setInterval(async function() {
@@ -385,8 +389,12 @@ function activateRole(role) {
   const overlay = document.getElementById('login-overlay');
   if (overlay) overlay.classList.add('hidden');
   updateActionButton();
-  if (typeof fetchProfiles === 'function') fetchProfiles();
-  if (typeof updateLastActive === 'function') updateLastActive();
+  if (typeof fetchProfiles === 'function') {
+    try { fetchProfiles(); } catch(e) { console.warn('[auth] fetchProfiles error:', e); }
+  }
+  if (typeof updateLastActive === 'function') {
+    try { updateLastActive(); } catch(e) { console.warn('[auth] updateLastActive error:', e); }
+  }
   if (window.AppState.user.effectiveRole === 'Client') {
     document.getElementById('client-view')?.classList.add('active');
     loadPostsForClient();
@@ -443,6 +451,7 @@ function _buildUserMenu() {
   // My Profile item (all roles)
   var _profAv = (typeof renderAvatar === 'function') ? renderAvatar(window.AppState.user.email || '', _roleLower, 20) : '';
   html += '<button class="user-menu-item" onclick="openProfilePanel(); closeUserMenu()">' + _profAv + ' My Profile</button>';
+  html += '<button class="user-menu-item" onclick="openScratchpadPanel();closeUserMenu();"><span style="font-size:14px;margin-right:8px;">\uD83D\uDCDD</span> Scratchpad</button>';
   html += '<div class="um-divider"></div>';
 
   // Client gets a dedicated slim menu

--- a/04-router.js
+++ b/04-router.js
@@ -47,7 +47,9 @@ async function _startRouter() {
       const result = await refreshSession();
       if (result && result.token) {
         activateRole(savedRole);
-        if (typeof fetchProfiles === 'function') fetchProfiles();
+        if (typeof fetchProfiles === 'function') {
+          try { fetchProfiles(); } catch(e) { console.warn('[router] fetchProfiles error:', e); }
+        }
         window._authReady = true;
         return;
       }
@@ -60,7 +62,9 @@ async function _startRouter() {
       // Network/server error — keep tokens, try with stale token
       if (savedToken) {
         activateRole(savedRole);
-        if (typeof fetchProfiles === 'function') fetchProfiles();
+        if (typeof fetchProfiles === 'function') {
+          try { fetchProfiles(); } catch(e) { console.warn('[router] fetchProfiles error:', e); }
+        }
         window._authReady = true;
         return;
       }
@@ -72,7 +76,9 @@ async function _startRouter() {
     }
     if (savedToken) {
       activateRole(savedRole);
-      if (typeof fetchProfiles === 'function') fetchProfiles();
+      if (typeof fetchProfiles === 'function') {
+        try { fetchProfiles(); } catch(e) { console.warn('[router] fetchProfiles error:', e); }
+      }
       window._authReady = true;
       return;
     }

--- a/12-profiles.js
+++ b/12-profiles.js
@@ -648,30 +648,14 @@ async function handleAvatarUpload(file) {
     }
     AppState.user.avatarUrl = displayUrl;
 
-    // Replace progress ring with new photo (green border + glow)
-    var ringWrap = document.getElementById('upload-ring-wrap');
-    if (ringWrap) {
-      ringWrap.outerHTML =
-        '<div style="position:relative;display:inline-block;">' +
-          '<div style="width:88px;height:88px;border-radius:50%;overflow:hidden;border:3px solid #3ECF8E;box-shadow:0 0 24px #3ECF8E4D;">' +
-            '<img src="' + displayUrl + '" style="width:100%;height:100%;object-fit:cover;">' +
-          '</div>' +
-          '<button class="prof-photo-edit" id="prof-photo-edit-btn" title="Change photo">' +
-            '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 3a2.83 2.83 0 114 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>' +
-          '</button>' +
-        '</div>';
-      // Re-wire photo edit button
-      var editBtn = document.getElementById('prof-photo-edit-btn');
-      if (editBtn) {
-        editBtn.onclick = function() {
-          var inp = document.getElementById('prof-photo-input');
-          if (inp) inp.click();
-        };
-      }
-    }
+    // Wait 500ms for the ring animation to feel complete
+    await new Promise(function(r) { setTimeout(r, 500); });
 
-    // Update topbar avatar
-    _renderProfileTrigger();
+    // Re-render the ENTIRE profile hero (not just the ring)
+    if (typeof _profileRenderHero === 'function') _profileRenderHero();
+
+    // Re-render the topbar avatar trigger
+    if (typeof _renderProfileTrigger === 'function') _renderProfileTrigger();
 
     if (typeof showToast === 'function') showToast('Photo updated', 'success');
   } catch (err) {
@@ -684,37 +668,37 @@ async function handleAvatarUpload(file) {
 }
 
 /* ===============================================
-   Scratchpad strip — below topbar
+   Scratchpad — full-screen overlay opened from dropdown
 =============================================== */
 
-var _scratchTimer = null;
+function _scratchLoad() {
+  // No DOM updates needed - panel reads from cache when opened
+}
 
-function toggleScratchpad() {
-  var panel = document.getElementById('scratch-panel');
+function openScratchpadPanel() {
+  var panel = document.getElementById('scratchpad-panel');
   if (!panel) return;
-  var isOpen = panel.style.display !== 'none';
-  panel.style.display = isOpen ? 'none' : 'block';
-  if (!isOpen) {
-    var input = document.getElementById('scratch-input');
-    if (input) input.focus();
+  panel.style.display = 'flex';
+  var profile = getProfileByEmail(AppState.user.email);
+  var input = document.getElementById('scratchpad-textarea');
+  if (input) {
+    input.value = (profile && profile.scratchpad) || '';
+    input.focus();
   }
 }
 
-function _scratchChanged() {
-  clearTimeout(_scratchTimer);
-  var saved = document.getElementById('scratch-saved');
-  if (saved) saved.style.opacity = '0';
-  _scratchTimer = setTimeout(function() { _scratchSave(); }, 2000);
+function closeScratchpadPanel() {
+  _scratchSaveFromPanel();
+  var panel = document.getElementById('scratchpad-panel');
+  if (panel) panel.style.display = 'none';
 }
 
-function _scratchSave() {
-  clearTimeout(_scratchTimer);
-  var input = document.getElementById('scratch-input');
+function _scratchSaveFromPanel() {
+  var input = document.getElementById('scratchpad-textarea');
   if (!input) return;
   var val = input.value;
   var email = AppState.user.email;
   if (!email) return;
-
   apiFetch('/profiles?email=eq.' + encodeURIComponent(email), {
     method: 'PATCH',
     body: JSON.stringify({ scratchpad: val })
@@ -723,33 +707,11 @@ function _scratchSave() {
     if (window._profilesCache && window._profilesCache[cacheKey]) {
       window._profilesCache[cacheKey].scratchpad = val;
     }
-    var saved = document.getElementById('scratch-saved');
-    if (saved) { saved.style.opacity = '1'; setTimeout(function() { saved.style.opacity = '0'; }, 2000); }
+    if (typeof showToast === 'function') showToast('Notes saved', 'success');
   }).catch(function(err) {
     console.warn('[scratch] Save failed:', err);
-    if (typeof window.logError === 'function') window.logError(err, 'scratchpad-strip-save');
+    if (typeof showToast === 'function') showToast('Failed to save notes', 'error');
   });
-
-  // Update preview
-  var preview = document.getElementById('scratch-preview');
-  if (preview) {
-    var first = val.split('\n')[0].slice(0, 60);
-    preview.textContent = first ? first + (val.length > 60 ? '...' : '') : 'Quick notes, reminders, to-dos...';
-    preview.style.color = first ? 'var(--text2,#BCBCD0)' : 'var(--text3,#7a7a90)';
-  }
-}
-
-function _scratchLoad() {
-  var profile = getProfileByEmail(AppState.user.email);
-  var val = (profile && profile.scratchpad) || '';
-  var input = document.getElementById('scratch-input');
-  if (input) input.value = val;
-  var preview = document.getElementById('scratch-preview');
-  if (preview) {
-    var first = val.split('\n')[0].slice(0, 60);
-    preview.textContent = first ? first + (val.length > 60 ? '...' : '') : 'Quick notes, reminders, to-dos...';
-    preview.style.color = first ? 'var(--text2,#BCBCD0)' : 'var(--text3,#7a7a90)';
-  }
 }
 
 function _renderProfileTrigger() {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413n">
+ <link rel="stylesheet" href="styles.css?v=20260413o">
 
 </head>
 <body>
@@ -166,25 +166,6 @@
       <button class="app-icon-btn prof-trigger-btn" id="prof-trigger" onclick="toggleUserMenu()" title="Menu" style="width:36px;height:36px;padding:0;overflow:hidden;border-radius:50%"></button>
     </div>
   </header>
-
-  <!-- SCRATCHPAD STRIP -->
-  <div id="scratch-strip" style="padding:8px 20px 12px;background:var(--surface,#0e0e16);border-bottom:1px solid var(--border2,#2a2a3a);">
-    <div id="scratch-row" style="display:flex;align-items:center;gap:10px;cursor:pointer;padding:8px 12px;background:var(--surface2,#141420);border:1px solid var(--border,#1e1e2e);" onclick="toggleScratchpad()">
-      <span style="font-size:14px;flex-shrink:0;">&#x1F4DD;</span>
-      <span id="scratch-preview" style="flex:1;font-family:'IBM Plex Mono',monospace;font-size:11px;color:var(--text3,#7a7a90);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">Quick notes, reminders, to-dos...</span>
-      <span style="font-family:'IBM Plex Mono',monospace;font-size:8px;letter-spacing:.08em;text-transform:uppercase;color:var(--text4,#444458);flex-shrink:0;">Edit</span>
-    </div>
-  </div>
-
-  <div id="scratch-panel" style="display:none;background:var(--surface,#0e0e16);border-bottom:1px solid var(--border2,#2a2a3a);">
-    <div style="padding:10px 20px 4px;display:flex;align-items:center;justify-content:space-between;">
-      <span style="font-family:'IBM Plex Mono',monospace;font-size:10px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--gold-b,#e0c060);">&#x1F4DD; My Notes</span>
-      <span id="scratch-saved" style="font-family:'IBM Plex Mono',monospace;font-size:8px;color:var(--green,#3ECF8E);opacity:0;transition:opacity .2s;">Saved &#x2713;</span>
-    </div>
-    <div style="padding:0 20px 12px;">
-      <textarea id="scratch-input" style="width:100%;min-height:100px;max-height:250px;resize:vertical;background:var(--surface2,#141420);border:1px solid var(--border,#1e1e2e);padding:12px;font-family:'DM Sans',sans-serif;font-size:14px;color:var(--text,#F0F0F2);outline:none;line-height:1.6;" placeholder="Quick notes, reminders, to-dos..." oninput="_scratchChanged()" onblur="_scratchSave()"></textarea>
-    </div>
-  </div>
 
   <!-- ERROR BANNER -->
   <div id="error-banner">
@@ -1096,28 +1077,28 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413n"></script>
-<script src="00-appstate-compat.js?v=20260413n"></script>
-<script src="01-config.js?v=20260413n" defer></script>
-<script src="02-session.js?v=20260413n" defer></script>
-<script src="utils.js?v=20260413n" defer></script>
-<script src="12-profiles.js?v=20260413n" defer></script>
-<script src="03-auth.js?v=20260413n" defer></script>
-<script src="05-api.js?v=20260413n" defer></script>
-<script src="10-ui.js?v=20260413n" defer></script>
+<script src="00-appstate.js?v=20260413o"></script>
+<script src="00-appstate-compat.js?v=20260413o"></script>
+<script src="01-config.js?v=20260413o" defer></script>
+<script src="02-session.js?v=20260413o" defer></script>
+<script src="utils.js?v=20260413o" defer></script>
+<script src="12-profiles.js?v=20260413o" defer></script>
+<script src="03-auth.js?v=20260413o" defer></script>
+<script src="05-api.js?v=20260413o" defer></script>
+<script src="10-ui.js?v=20260413o" defer></script>
 
-<script src="06-post-create.js?v=20260413n" defer></script>
-<script defer src="render/dashboard.js?v=20260413n"></script>
-<script defer src="render/client.js?v=20260413n"></script>
-<script defer src="render/pipeline.js?v=20260413n"></script>
-<script defer src="render/brief.js?v=20260413n"></script>
-<script defer src="actions/pcs.js?v=20260413n"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413n"></script>
-<script src="07-post-load.js?v=20260413n" defer></script>
-<script src="08-post-actions.js?v=20260413n" defer></script>
-<script src="09-library.js?v=20260413n" defer></script>
-<script src="09-approval.js?v=20260413n" defer></script>
-<script src="04-router.js?v=20260413n" defer></script>
+<script src="06-post-create.js?v=20260413o" defer></script>
+<script defer src="render/dashboard.js?v=20260413o"></script>
+<script defer src="render/client.js?v=20260413o"></script>
+<script defer src="render/pipeline.js?v=20260413o"></script>
+<script defer src="render/brief.js?v=20260413o"></script>
+<script defer src="actions/pcs.js?v=20260413o"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413o"></script>
+<script src="07-post-load.js?v=20260413o" defer></script>
+<script src="08-post-actions.js?v=20260413o" defer></script>
+<script src="09-library.js?v=20260413o" defer></script>
+<script src="09-approval.js?v=20260413o" defer></script>
+<script src="04-router.js?v=20260413o" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 
@@ -1710,6 +1691,26 @@ window.setPcsVisibility = function(el, vis) {
 <!-- PROFILE PANEL OVERLAY -->
 <div id="prof-overlay" style="display:none;position:fixed;inset:0;z-index:1300;background:#0a0a0f;align-items:stretch;justify-content:center;">
   <div id="prof-panel" style="width:100%;max-width:480px;height:100%;overflow-y:auto;background:#0e0e16;-ms-overflow-style:none;scrollbar-width:none;"></div>
+</div>
+
+<!-- SCRATCHPAD PANEL OVERLAY -->
+<div id="scratchpad-panel" style="display:none;position:fixed;top:0;left:0;width:100%;height:100vh;background:var(--bg,#0a0a0f);z-index:3100;flex-direction:column;overflow-y:auto;">
+  <!-- Topbar -->
+  <div style="padding:14px 20px 12px;background:var(--surface,#0e0e16);border-bottom:1px solid var(--border2,#2a2a3a);display:flex;align-items:center;justify-content:space-between;flex-shrink:0;">
+    <div>
+      <div style="font-size:20px;font-weight:700;color:#fff;">Scratchpad</div>
+      <div style="font-family:'IBM Plex Mono',monospace;font-size:9px;color:var(--text2,#BCBCD0);letter-spacing:.06em;text-transform:uppercase;margin-top:2px;">Your private notes</div>
+    </div>
+    <button onclick="closeScratchpadPanel()" style="font-family:'IBM Plex Mono',monospace;font-size:8px;letter-spacing:.08em;color:var(--text3,#7a7a90);background:none;border:1px solid var(--border2,#2a2a3a);padding:5px 12px;cursor:pointer;">&#x2715; CLOSE</button>
+  </div>
+  <!-- Textarea -->
+  <div style="flex:1;padding:16px 20px;">
+    <textarea id="scratchpad-textarea" style="width:100%;min-height:300px;height:calc(100vh - 180px);resize:none;background:var(--surface2,#141420);border:1px solid var(--border,#1e1e2e);padding:16px;font-family:'DM Sans',sans-serif;font-size:15px;color:var(--text,#F0F0F2);outline:none;line-height:1.7;" placeholder="Quick notes, reminders, to-dos..."></textarea>
+  </div>
+  <!-- Save button -->
+  <div style="padding:12px 20px 24px;flex-shrink:0;">
+    <button onclick="_scratchSaveFromPanel()" style="width:100%;font-family:'IBM Plex Mono',monospace;font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:#000;background:var(--green,#3ECF8E);border:none;padding:14px;cursor:pointer;">Save Notes</button>
+  </div>
 </div>
 
 </body>


### PR DESCRIPTION
## Summary

Three focused fixes based on error-log audit.

### Fix 1 — Scratchpad moved from dashboard to dropdown overlay
- Removed `#scratch-strip` and `#scratch-panel` from dashboard (no more clutter above the greeting)
- Added `#scratchpad-panel` full-screen overlay (z-index 3100) beside `#prof-overlay`
- Added **Scratchpad** item to `_buildUserMenu` in `03-auth.js` (under "My Profile")
- Replaced `toggleScratchpad`/`_scratchChanged`/`_scratchSave` with `openScratchpadPanel`/`closeScratchpadPanel`/`_scratchSaveFromPanel` in `12-profiles.js`
- `_scratchLoad()` is now a no-op (panel reads from cache on open)

### Fix 2 — Avatar hero + topbar re-render after upload
- Removed custom ring-replacement HTML
- Added 500ms delay after cache update (ring animation feels complete)
- Calls `_profileRenderHero()` to rebuild full hero from cache (cache-busted URL ensures fresh img)
- Calls `_renderProfileTrigger()` to update topbar avatar

### Fix 3 — Profile calls never block login
- Wrapped `fetchProfiles()` / `updateLastActive()` in try/catch in `03-auth.js` `activateRole()` (client + agency paths)
- Wrapped `fetchProfiles()` in try/catch in `04-router.js` (all 3 sites)

## Test plan

- [x] 508/508 unit tests passing
- [ ] Dashboard loads with NO scratchpad strip at top (clean)
- [ ] Tap profile photo → dropdown shows "My Profile" and "Scratchpad"
- [ ] Tap "Scratchpad" → full-screen panel with textarea
- [ ] Type notes → "Save Notes" → toast "Notes saved"
- [ ] Close → reopen → notes persist
- [ ] Upload profile photo → ring fills → photo updates in hero
- [ ] Close profile panel → topbar shows new photo
- [ ] Reload page → login works with no visible errors

Files changed: `index.html`, `12-profiles.js`, `03-auth.js`, `04-router.js`
Version: `?v=20260413o`

https://claude.ai/code/session_01HbBp1UTSqNtejutayVCzK4