### PR TITLE
Stop 24-logouts/day: narrow 401 recovery, roll back intervals, collapse refresh timers

### DIFF
--- a/00-appstate.js
+++ b/00-appstate.js
@@ -57,7 +57,6 @@ window.AppState = window.AppState || {
   },
 
   timers: {
-    tokenRefresh: null,
     dashDatetime: null,
     renderTimer: null
   }

--- a/03-auth.js
+++ b/03-auth.js
@@ -53,7 +53,6 @@ function _clearSessionAndLogin() {
   localStorage.removeItem('hinglish_name');
   if (typeof stopRealtime === 'function') stopRealtime();
   if (typeof stopClientRealtime === 'function') stopClientRealtime();
-  if (typeof _teardownClientTokenTimer === 'function') _teardownClientTokenTimer();
   if (window._tokenRefreshTimer) {
     clearInterval(window._tokenRefreshTimer);
     window._tokenRefreshTimer = null;
@@ -105,9 +104,37 @@ async function _doRefresh(refreshToken) {
       headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_KEY },
       body: JSON.stringify({ refresh_token: refreshToken }),
     });
-    if (res.status === 400 || res.status === 401 || res.status === 403) {
+
+    // HTTP 400 from /auth/v1/token is almost always refresh-token REUSE
+    // (another tab already rotated this token). The previously-stored
+    // sb_access_token is still valid for its TTL window — return it
+    // instead of evicting the user. Only a missing access token falls
+    // through to auth_expired classification.
+    if (res.status === 400) {
+      var storedAccess = localStorage.getItem('sb_access_token');
+      if (storedAccess) {
+        console.warn('[auth] refresh returned 400 (token-reuse race), using stored sb_access_token');
+        return { token: storedAccess };
+      }
       return { error: 'auth_expired' };
     }
+
+    // 401/403: narrow auth_expired to bodies that carry a refresh_token_*
+    // error code. Any other 401/403 (unexpected server responses, edge
+    // function hiccups, CORS preflight oddities) are treated as transient
+    // server errors and will not evict the user.
+    if (res.status === 401 || res.status === 403) {
+      var body = await res.json().catch(function() { return {}; });
+      var code = ((body && (body.error || body.error_code || body.msg)) || '').toString().toLowerCase();
+      if (code.indexOf('refresh_token_not_found') !== -1 ||
+          code.indexOf('refresh_token_already_used') !== -1 ||
+          code.indexOf('invalid_grant') !== -1 ||
+          code.indexOf('refresh_token_expired') !== -1) {
+        return { error: 'auth_expired' };
+      }
+      return { error: 'server' };
+    }
+
     if (!res.ok) {
       return { error: 'server' };
     }
@@ -323,7 +350,6 @@ function logout() {
   localStorage.removeItem('hinglish_pending_email');
   stopRealtime();
   if (typeof stopClientRealtime === 'function') stopClientRealtime();
-  if (typeof _teardownClientTokenTimer === 'function') _teardownClientTokenTimer();
   if (window._tokenRefreshTimer) {
     clearInterval(window._tokenRefreshTimer);
     window._tokenRefreshTimer = null;
@@ -336,12 +362,12 @@ function logout() {
 function activateRole(role) {
   role = normalizeRole(role) || role;
 
-  // Proactive token refresh for all roles (50 min).
-  // Installed at the top so every branch (admin, client, agency, preview)
-  // gets the timer before any early return. Coexists with the legacy
-  // AppState.timers.tokenRefresh in startRealtime and the client branch
-  // timer below — refreshSession() is internally deduped so duplicates
-  // are safe.
+  // Proactive token refresh for all roles (50 min). Single canonical
+  // timer — the legacy AppState.timers.tokenRefresh (07-post-load.js)
+  // and window._clientTokenTimer (03-auth.js client branch) duplicates
+  // were removed. Installed at the top so every activateRole branch
+  // (admin, client, agency, preview) gets the timer before any early
+  // return. refreshSession() is internally deduped via _refreshInProgress.
   if (window._tokenRefreshTimer) clearInterval(window._tokenRefreshTimer);
   window._tokenRefreshTimer = setInterval(async function() {
     if (document.hidden) return;
@@ -396,21 +422,10 @@ function activateRole(role) {
       try { updateLastActive(); } catch(e) { console.warn('[auth] updateLastActive error:', e); }
     }
     if (typeof startClientRealtime === 'function') startClientRealtime();
-    if (!window._clientTokenTimer) {
-      window._clientTokenTimer = setInterval(async function() {
-        try {
-          var result = await refreshSession();
-          if (result && result.error === 'auth_expired') {
-            _clearSessionAndLogin();
-          } else if (result && result.error) {
-            console.warn('[auth] client token refresh: ' + result.error);
-          }
-        } catch(err) {
-          console.error('[auth] client token refresh threw', err);
-          window.logError && window.logError(err && err.message, err && err.stack, 'client-token-refresh');
-        }
-      }, 50 * 60 * 1000);
-    }
+    // Proactive token refresh is installed once at the top of
+    // activateRole() via window._tokenRefreshTimer — no client-specific
+    // timer needed here. The legacy window._clientTokenTimer duplicate
+    // was removed so every role goes through one refresh code path.
     return;
   }
 
@@ -465,17 +480,6 @@ window.resetRolePreview = function() {
   localStorage.removeItem('pcs_role_preview');
   location.reload();
 };
-
-// Tear down the client 50-min token refresh interval. Declared below
-// activateRole() so that the first textual occurrence of _clientTokenTimer
-// in this file remains the setInterval block above (keeps session-resilience
-// test 10 anchored to the right code path).
-function _teardownClientTokenTimer() {
-  if (window._clientTokenTimer) {
-    clearInterval(window._clientTokenTimer);
-    window._clientTokenTimer = null;
-  }
-}
 
 function _buildUserMenu() {
   const menu = document.getElementById('user-menu');

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -370,9 +370,6 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
   }
 }
 
-// Background token refresh interval handle (separate from data poll)
-window.AppState.timers.tokenRefresh = null;
-
 // Lightweight fingerprint: count + ids + stages (avoids full JSON.stringify)
 function _postsFingerprint(posts) {
   let s = '' + posts.length;
@@ -398,7 +395,7 @@ function _clientPostsFingerprint(posts) {
 function startRealtime() {
   if (window.AppState.timers.realtimeTimer) return;
 
-  // Data polling  -  every 5 seconds (tightened from 15s for responsiveness)
+  // Data polling  -  every 10 seconds (rolled back from 5s to halve API load)
   window.AppState.timers.realtimeTimer = setInterval(async () => {
     if (document.hidden) return;
     if (!localStorage.getItem('sb_access_token')) return;
@@ -430,33 +427,18 @@ function startRealtime() {
       console.warn('realtime poll failed:', e.message);
       window.logError && window.logError(e && e.message, e && e.stack, 'realtime-poll');
     }
-  }, 5000);
+  }, 10000);
 
-  // Proactive token refresh  -  every 50 minutes
-  // Keeps sessions alive indefinitely without user action
-  if (!window.AppState.timers.tokenRefresh) {
-    window.AppState.timers.tokenRefresh = setInterval(async () => {
-      if (!localStorage.getItem('sb_refresh_token')) return;
-      try {
-        var result = await refreshSession();
-        if (result && result.error === 'auth_expired') {
-          if (typeof _clearSessionAndLogin === 'function') _clearSessionAndLogin();
-        } else if (result && result.error) {
-          console.warn('Background token refresh: ' + result.error);
-        }
-      } catch (e) {
-        console.error('[post-load] token refresh failed', e);
-        window.logError && window.logError(e && e.message, e && e.stack, 'token-refresh');
-      }
-    }, 50 * 60 * 1000); // 50 minutes
-  }
+  // Proactive token refresh is handled by the single canonical
+  // window._tokenRefreshTimer installed in activateRole() (03-auth.js).
+  // The legacy AppState.timers.tokenRefresh duplicate was removed so
+  // refresh flow has one owner; refreshSession() dedupe kept this
+  // harmless for network load but obscured the mental model.
 }
 
 function stopRealtime() {
   clearInterval(window.AppState.timers.realtimeTimer);
   window.AppState.timers.realtimeTimer = null;
-  clearInterval(window.AppState.timers.tokenRefresh);
-  window.AppState.timers.tokenRefresh = null;
   // Tear down the client-side poll timer too, so both agency and client
   // sessions are fully cleaned up through a single entry point.
   if (typeof stopClientRealtime === 'function') stopClientRealtime();
@@ -477,7 +459,7 @@ function _drainPollStash() {
 }
 window._drainPollStash = _drainPollStash;
 
-// 5-second background data poll for the Client role. Mirrors the
+// 10-second background data poll for the Client role. Mirrors the
 // startRealtime() pattern but hits the client-scoped fetch (via
 // loadPostsForClient(true)) and gates re-renders on _clientPostsFingerprint
 // so typing and scroll position survive.
@@ -505,7 +487,7 @@ function startClientRealtime() {
     } finally {
       window._isLoadingClientPosts = false;
     }
-  }, 5000);
+  }, 10000);
 }
 
 function stopClientRealtime() {

--- a/10-ui.js
+++ b/10-ui.js
@@ -2356,7 +2356,7 @@ window.AppState.timers.notifBadgeTimer = setInterval(function() {
   if (document.hidden) return;
   if (!localStorage.getItem('sb_access_token') && !localStorage.getItem('sb_refresh_token')) return;
   if (typeof updateNotifBadge === 'function') updateNotifBadge();
-}, 10000);
+}, 20000);
 
 // ===============================================
 // GLOBAL ACTION ROUTER (Phase 4 — event delegation)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Sorted (srtd.io)
 
-Last updated: 2026-04-13 (session-resilience-401-fix). Full history: `CLAUDE-archive-20260411.md`.
+Last updated: 2026-04-13 (refresh-400-recovery + collapse-timers + interval-rollback). Full history: `CLAUDE-archive-20260411.md`.
 
 ## 1 — WHAT IS SORTED
 
@@ -65,7 +65,7 @@ Root:
 - `02-session.js` — session globals
 - `utils.js` — esc(), formatDate()
 - `12-profiles.js` — Profile data loader and helpers. Fetches `profiles` table on login, caches in `window._profilesCache` (keyed by email). Also fetches `user_roles` to build `window._nameToRoleCache` (maps names and emails to roles) and `window._nameToEmailCache` (maps short names to emails for avatar/display-name resolution). Exposes: `getDisplayName(email)`, `getAvatarUrl(email)`, `getProfileByEmail(email)`, `getRoleFor(nameOrEmail)`, `updateLastActive()`, `fetchProfiles()`, `enrichAppStateUser()`, `renderAvatar(emailOrName, role, size, opts)`, `_avatarColors(role)`, `openProfilePanel()`, `closeProfilePanel()`, `saveProfile()`, `handleAvatarUpload(file)`, `_renderProfileTrigger()`. All helpers return graceful fallbacks if cache not loaded or fetch failed. `enrichAppStateUser()` sets `AppState.user.displayName`, `.avatarUrl`, `.title`, `.username` from the cached profile after fetch, then calls `_renderProfileTrigger()` to populate the topbar avatar. `getRoleFor()` resolves any name or email to a canonical role string via `_nameToRoleCache`; returns `''` for unknown inputs. Profile panel: full-screen overlay (`#prof-overlay`, z-index 1300) for editing own display name, username, title, notification prefs, and uploading avatar photo. Opens via `openProfilePanel()` (topbar avatar trigger), closes via `closeProfilePanel()`. `saveProfile()` PATCHes `/profiles` and updates local caches + AppState. `handleAvatarUpload(file)` validates type/size (<5MB), compresses via `_compressAvatar` (max 400×400 JPEG q0.80), uploads to R2 `profile-pictures/{sanitizedEmail}.jpeg` (sanitize: @ → -at-, . → -), stores clean URL `https://images.srtd.io/` + key in DB, uses cache-busted `?t=` URL for immediate display, PATCHes avatar_url. Scratchpad: profile panel includes a textarea that auto-saves on blur to the `scratchpad` column; also included in `saveProfile()` PATCH payload.
-- `03-auth.js` — magic link, OTP, refreshSession (typed errors), cross-tab refresh lock, visibilitychange refresh, normalizeRole, `_teardownClientTokenTimer()` (cleans 50-min client token interval on logout)
+- `03-auth.js` — magic link, OTP, refreshSession (typed errors, 400-is-token-reuse recovery), cross-tab refresh lock, visibilitychange refresh, normalizeRole, single canonical `window._tokenRefreshTimer` (50-min proactive refresh, installed at top of activateRole, torn down in logout / _clearSessionAndLogin)
 - `04-router.js` — routing, deep-link handling (must be LAST script)
 - `05-api.js` — apiFetch (no-cache headers, 401 retry), uploadPostAsset, logActivity, normalise
 - `06-post-create.js` — new post form, asset input, WhatsApp KV preview seed
@@ -113,7 +113,7 @@ window.AppState = {
 - If a PATCH hangs > 10s (`_SAVE_TIMEOUT_MS`) the timer force-clears the flag, logs `[SAVE TIMEOUT]`, and calls `scheduleRender()`. Force-cleared posts can be saved again immediately. `apiFetch` has no timeout — this is the only indefinite-hang guard. Wired into `quickStage`, `clientApprove`, `_executeStageChange`/`Async`, `updatePost`.
 
 ### Client 30s polling (`startClientRealtime` in 07-post-load.js)
-- Singleton via `window._clientPollTimer`, installed from `activateRole()` (03-auth.js) and cleared by `stopClientRealtime()` (called by `stopRealtime()` → cascades on logout). `_teardownClientTokenTimer()` clears the 50-min token interval.
+- Singleton via `window._clientPollTimer`, installed from `activateRole()` (03-auth.js) and cleared by `stopClientRealtime()` (called by `stopRealtime()` → cascades on logout). The unified `window._tokenRefreshTimer` handles the 50-min proactive refresh for all roles.
 - Interval guards (in order): `document.hidden`, `sb_access_token`, `window._isLoadingClientPosts`, active-typing (input/textarea/contenteditable). Any hit → return.
 - Delegates to `loadPostsForClient(true)` with `skipRenderIfUnchanged` — re-renders only when `_clientPostsFingerprint(posts.all) !== window._lastClientFp`. Fingerprint extends `_postsFingerprint` with per-post `post_comments.length`.
 - `loadPostsForClient` skips overwriting `post.post_comments` when `_commentSaving === true` — object-level lock set by `_handleSubmitComment` (render/client.js) so in-flight optimistic rows aren't clobbered.
@@ -126,7 +126,7 @@ window.AppState = {
 - `_postsFingerprint()` is a cheap hash of `posts.all`. Renderers skip rebuild when unchanged — always mutate via `setAll`. `_renderBackgroundViews()` re-renders dashboard/pipeline/client feed without tearing down PCS. PCS render goes through `_renderPCS()`; `09-library.js` is the one exception.
 
 ### Agency poll fetch-and-stash (`startRealtime` in 07-post-load.js)
-- 5s agency poll fetches regardless of modal state. If fingerprint differs, stashes the array into `window._postsPollStash` (+ `_postsPollStashFp`). Latest-wins, no queue.
+- 10s agency poll fetches regardless of modal state. If fingerprint differs, stashes the array into `window._postsPollStash` (+ `_postsPollStashFp`). Latest-wins, no queue.
 - `_drainPollStash()` reads the stash, clears it, runs `mergePosts(stash)`, `scheduleRender()`, `updateNotifBadge()` — no-op when stash is null.
 - `_drainDeferredRender()` calls `_drainPollStash()` unconditionally after its safeRender debounce, so every modal-close drain site also flushes poll data. Drain sites: `forcePCSReset` (actions/pcs.js), `closeAdminEdit` / `closeNewPostModal`, `closeNotifications` / `closePipelineFilter` (10-ui.js), `_lbClose` and client post overlay close (render/client.js).
 - Client 30s poll has NO stash — active-typing guard + `_clientPostsFingerprint` are enough.
@@ -157,12 +157,13 @@ window.AppState = {
 - `apiFetch(path, options, meta)` — optional third `meta` arg. `meta.allowLogout === false` disables the `_clearSessionAndLogin()` call on the `auth_expired` branch so a transient 401 in a background poll CANNOT evict the user. Only user-initiated actions (comments, stage changes, approvals) get the default `allowLogout: true` behaviour.
 - Background pollers that pass `{ allowLogout: false }`: `updateNotifBadge` (10-ui.js, 10s interval), `_flushClickBuffer` (10-ui.js, 5s interval), `startRealtime` both 5s agency poll branches (07-post-load.js), and `loadPostsForClient(true, true)` called from `startClientRealtime` (5s client poll). `loadPostsForClient` accepts a new `fromPoll` boolean; when truthy it builds `_apiMeta = { allowLogout: false }` and threads it through every internal apiFetch call (posts, requests, post_comments). User-facing first-render calls leave `fromPoll` unset so the flag stays off.
 - `apiFetch` second-chance refresh: after the first `refreshSession()` returns `{error:'server'|'network'}`, apiFetch now waits 1500 ms and retries `refreshSession()` one more time. On success it replays the original request; on failure it falls through to the pre-existing soft-banner + throw. `auth_expired` classification from the retry is honoured.
-- `window._tokenRefreshTimer` — unified 50-minute proactive refresh installed at the TOP of `activateRole()` (03-auth.js) so every branch (admin, agency, admin-preview, client) gets it before any early return. Coexists safely with the legacy `AppState.timers.tokenRefresh` (startRealtime) and `window._clientTokenTimer` (client branch) because `refreshSession()` is internally deduped via `_refreshInProgress`. Torn down in `logout()` and `_clearSessionAndLogin()` alongside the legacy timers.
+- `window._tokenRefreshTimer` — SINGLE canonical 50-minute proactive refresh installed at the TOP of `activateRole()` (03-auth.js) so every branch (admin, agency, admin-preview, client) gets it before any early return. The prior duplicates (`AppState.timers.tokenRefresh` in startRealtime and `window._clientTokenTimer` in the client branch) were deleted — one owner, one mental model. Torn down in `logout()` and `_clearSessionAndLogin()`.
+- `_doRefresh` (03-auth.js) narrows the `auth_expired` classification: HTTP 400 from `/auth/v1/token` is treated as a refresh-token REUSE race (another tab rotated first) and is RECOVERED by returning the currently-stored `sb_access_token`. HTTP 401/403 only map to `auth_expired` when the response body carries a `refresh_token_not_found`, `refresh_token_already_used`, `refresh_token_expired`, or `invalid_grant` code. Any other 401/403 is returned as `{ error: 'server' }` so the second-chance refresh in apiFetch (Fix 5) gets a chance. This is the fix that stops multi-tab users from getting evicted during legit token rotations.
 - `sendMagicLink` catch branch now classifies `TypeError` as a network failure and shows "Unable to reach the server. Check your connection and try again." instead of Safari's raw "Load failed" string. Rate-limit errors containing "31 seconds" get a friendly "Please wait a moment before requesting another code." message.
 
 ### Misc gotchas
 - `_commentInputHtml()` only renders for `awaiting_approval`/`awaiting_brand_input` and MUST be called inside `_cardHtml()`. `apiFetch()` never calls `logout()` on 401 by design — refresh flow handles it. Silent `.catch(()=>{})` is a bug — always `window.logError`.
-- Polling: 5s agency (`startRealtime`), 5s client (`startClientRealtime`), 10s notif badge, 5s click-log flush, 50min token refresh. Client DB role takes priority over `pcs_role_preview`. Deep link `srtd.io/?open=POST_ID` → `window._pendingOpenPost` fired after loadPosts.
+- Polling: 10s agency (`startRealtime`), 10s client (`startClientRealtime`), 20s notif badge, 5s click-log flush, 50min token refresh. Client DB role takes priority over `pcs_role_preview`. Deep link `srtd.io/?open=POST_ID` → `window._pendingOpenPost` fired after loadPosts.
 - PCS document-click-close skips close when the active dropdown contains `input[type="date"]`. `_cardClickDelegate` (07-post-load.js) guards `input, textarea, button, [contenteditable="true"], a, [role="button"]` — don't narrow.
 - Image download: `_pcsLbDownload` + `_pcsSaveAllPhotos` must strip BOTH `https://images.srtd.io/` and legacy `pub-*.r2.dev` prefix before hitting the R2 worker `/download?key=`.
 
@@ -172,7 +173,7 @@ DB roles (canonical, Title Case): `Admin`, `Servicing`, `Creative`, `Client`. Pe
 
 - `effectiveRole` = the canonical DB role the app acts as, possibly overridden by admin preview.
 - `normalizeRole(x)` canonicalizes any person name / casing to a DB role.
-- Client activation: skips `startRealtime()` and instead calls `startClientRealtime()` (5-second client poll, see §4).
+- Client activation: skips `startRealtime()` and instead calls `startClientRealtime()` (10-second client poll, see §4).
 - Admin preview: set `AppState.user.previewRole` (stored as `pcs_role_preview` in localStorage) to render as another role without touching the DB. A real Client DB role ALWAYS wins.
 - `switchTab(tabOrEl)` accepts a string (`'dashboard'`, `'pipeline'`, `'tasks'`, `'client'`) OR a DOM element from click delegation. The `pipeline` branch triggers `loadPosts()` with a `_isFetchingPosts` guard to prevent double fetches on rapid tab spam.
 - Sessions: `refreshSession()` returns typed errors: `{token}` | `{error:'auth_expired'|'server'|'network'}`. Network errors KEEP tokens. Cross-tab refresh lock via `localStorage._srtd_refresh_lock` prevents Supabase token-reuse revocation. `visibilitychange` listener guarded by `window._authReady` refreshes on tab focus.
@@ -197,7 +198,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413q`.
+1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413r`.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413q">
+ <link rel="stylesheet" href="styles.css?v=20260413r">
 
 </head>
 <body>
@@ -1077,28 +1077,28 @@ window.setPcsVisibility = function(el, vis) {
 };
 </script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413q"></script>
-<script src="00-appstate-compat.js?v=20260413q"></script>
-<script src="01-config.js?v=20260413q" defer></script>
-<script src="02-session.js?v=20260413q" defer></script>
-<script src="utils.js?v=20260413q" defer></script>
-<script src="12-profiles.js?v=20260413q" defer></script>
-<script src="03-auth.js?v=20260413q" defer></script>
-<script src="05-api.js?v=20260413q" defer></script>
-<script src="10-ui.js?v=20260413q" defer></script>
+<script src="00-appstate.js?v=20260413r"></script>
+<script src="00-appstate-compat.js?v=20260413r"></script>
+<script src="01-config.js?v=20260413r" defer></script>
+<script src="02-session.js?v=20260413r" defer></script>
+<script src="utils.js?v=20260413r" defer></script>
+<script src="12-profiles.js?v=20260413r" defer></script>
+<script src="03-auth.js?v=20260413r" defer></script>
+<script src="05-api.js?v=20260413r" defer></script>
+<script src="10-ui.js?v=20260413r" defer></script>
 
-<script src="06-post-create.js?v=20260413q" defer></script>
-<script defer src="render/dashboard.js?v=20260413q"></script>
-<script defer src="render/client.js?v=20260413q"></script>
-<script defer src="render/pipeline.js?v=20260413q"></script>
-<script defer src="render/brief.js?v=20260413q"></script>
-<script defer src="actions/pcs.js?v=20260413q"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413q"></script>
-<script src="07-post-load.js?v=20260413q" defer></script>
-<script src="08-post-actions.js?v=20260413q" defer></script>
-<script src="09-library.js?v=20260413q" defer></script>
-<script src="09-approval.js?v=20260413q" defer></script>
-<script src="04-router.js?v=20260413q" defer></script>
+<script src="06-post-create.js?v=20260413r" defer></script>
+<script defer src="render/dashboard.js?v=20260413r"></script>
+<script defer src="render/client.js?v=20260413r"></script>
+<script defer src="render/pipeline.js?v=20260413r"></script>
+<script defer src="render/brief.js?v=20260413r"></script>
+<script defer src="actions/pcs.js?v=20260413r"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413r"></script>
+<script src="07-post-load.js?v=20260413r" defer></script>
+<script src="08-post-actions.js?v=20260413r" defer></script>
+<script src="09-library.js?v=20260413r" defer></script>
+<script src="09-approval.js?v=20260413r" defer></script>
+<script src="04-router.js?v=20260413r" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/tests/appstate-compat.test.js
+++ b/tests/appstate-compat.test.js
@@ -24,8 +24,7 @@ describe('AppState compat layer', function() {
         pipelineFilter: [], nrsUrgency: 'normal',
         retryCount: 0, retryTimer: null,
         realtimeTimer: null, unreadCount: 0 },
-      timers: { tokenRefresh: null,
-        dashDatetime: null, renderTimer: null }
+      timers: { dashDatetime: null, renderTimer: null }
     };
 
     delete window.currentRole;

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -116,10 +116,10 @@ describe('Notification badge', function() {
     expect(uiSrc).toMatch(/setInterval\(function\(\)\s*\{[\s\S]*?updateNotifBadge/);
   });
 
-  it('periodic badge refresh interval is 10 seconds', function() {
+  it('periodic badge refresh interval is 20 seconds', function() {
     var match = uiSrc.match(/AppState\.timers\.notifBadgeTimer\s*=\s*setInterval\([\s\S]*?,\s*(\d+)\)/);
     expect(match).not.toBeNull();
-    expect(parseInt(match[1])).toBe(10000);
+    expect(parseInt(match[1])).toBe(20000);
   });
 
 });

--- a/tests/session-resilience.test.js
+++ b/tests/session-resilience.test.js
@@ -67,18 +67,20 @@ describe('LAYER 1 — refreshSession typed error returns', function() {
     expect(routerSrc).toContain("result.error === 'auth_expired'");
   });
 
-  it('10. client 50-min timer handles auth_expired', function() {
-    var clientTimer = authSrc.match(/_clientTokenTimer[\s\S]{0,400}/);
-    expect(clientTimer).toBeTruthy();
-    expect(clientTimer[0]).toContain("result.error === 'auth_expired'");
-    expect(clientTimer[0]).toContain('_clearSessionAndLogin');
+  it('10. canonical _tokenRefreshTimer handles auth_expired', function() {
+    // Single unified timer (03-auth.js:activateRole) replaced the prior
+    // duplicates AppState.timers.tokenRefresh (07-post-load.js) and
+    // window._clientTokenTimer (03-auth.js client branch). This test
+    // asserts the remaining timer evicts on auth_expired.
+    var timer = authSrc.match(/_tokenRefreshTimer\s*=\s*setInterval[\s\S]{0,500}/);
+    expect(timer).toBeTruthy();
+    expect(timer[0]).toContain("r.error === 'auth_expired'");
+    expect(timer[0]).toContain('_clearSessionAndLogin');
   });
 
-  it('11. non-client 50-min timer handles auth_expired', function() {
-    var timer = postLoadSrc.match(/tokenRefresh[\s\S]{0,800}50 \* 60/);
-    expect(timer).toBeTruthy();
-    expect(timer[0]).toContain("result.error === 'auth_expired'");
-    expect(timer[0]).toContain('_clearSessionAndLogin');
+  it('11. _tokenRefreshTimer fires at 50-minute cadence', function() {
+    var match = authSrc.match(/_tokenRefreshTimer\s*=\s*setInterval\([\s\S]*?,\s*50\s*\*\s*60\s*\*\s*1000\s*\)/);
+    expect(match).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary

Three surgical fixes based on this morning's background-polling audit. Targets yesterday's 24 logouts caused by excessive background Supabase requests + aggressive 401 classification during multi-tab token rotation.

### Fix 1 — Narrow `auth_expired` + recover HTTP 400 in `_doRefresh`  (03-auth.js:100–147)

The root cause of most of yesterday's evictions. Previously `_doRefresh` mapped HTTP 400/401/403 to `auth_expired`, which triggered `_clearSessionAndLogin`. Supabase returns 400 for refresh-token **reuse** during multi-tab rotation races — that is recoverable because the currently-stored `sb_access_token` is still valid for its TTL window.

- **On 400:** read `sb_access_token` from localStorage and return `{ token: storedAccess }`. `apiFetch` replays the original request with the stored token instead of evicting the user.
- **On 401/403:** only classify as `auth_expired` when the response body carries a `refresh_token_not_found` / `refresh_token_already_used` / `refresh_token_expired` / `invalid_grant` code. Everything else returns `{ error: 'server' }` so the `apiFetch` second-chance refresh (Fix 5 from PR #823) can retry instead of failing open.

### Fix 2 — Roll back polling intervals to halve API load

| Timer | Before | After | Req/hr per user |
|---|---|---|---|
| `startRealtime` (agency) | 5000 | 10000 | 720 → 360 |
| `startClientRealtime` (client) | 5000 | 10000 | 2160 → 1080 |
| `notifBadgeTimer` | 10000 | 20000 | 360 → 180 |
| `_flushClickBuffer` | 5000 | 5000 (unchanged) | ~0 when idle |

Still 50% faster than the original pre-PR #823 values (15s/30s/60s), so responsiveness stays well above the old baseline.

### Fix 3 — Collapse the 3 duplicate 50-min refresh timers to 1

**Deleted:**
- `AppState.timers.tokenRefresh` (07-post-load.js `startRealtime`)
- `window._clientTokenTimer` (03-auth.js client branch)
- `_teardownClientTokenTimer` helper + its call sites in `logout` / `_clearSessionAndLogin`
- `AppState.timers.tokenRefresh` field from `00-appstate.js` initial state

**Kept:** `window._tokenRefreshTimer` (03-auth.js `activateRole`, installed at the top so every branch gets it). Plus the existing `visibilitychange` handler in 03-auth.js still refreshes on tab focus. `refreshSession()` remains internally deduped via `_refreshInProgress` so concurrent 401s coalesce into one refresh POST.

### Audit follow-up: `window.logError`

`window.logError` uses raw `fetch()` with the anon apikey, **not** `apiFetch` (see 00-appstate.js:82–92). It never enters the 401 refresh path, so no `allowLogout` meta arg is needed there.

## Files changed

| File | Change |
|---|---|
| `03-auth.js` | Fix 1 + Fix 3 (delete client timer + `_teardownClientTokenTimer`) |
| `07-post-load.js` | Fix 2 (interval rollback) + Fix 3 (delete `AppState.timers.tokenRefresh`) |
| `10-ui.js` | Fix 2 (badge interval 10→20s) |
| `00-appstate.js` | Fix 3 (remove `tokenRefresh` field from initial state) |
| `tests/session-resilience.test.js` | Rewrite tests #10/#11 to anchor on canonical `_tokenRefreshTimer` |
| `tests/appstate-compat.test.js` | Remove deleted `tokenRefresh` field from fixture |
| `tests/notifications.test.js` | Badge interval expectation 10000 → 20000 |
| `index.html` | 22× `?v=20260413q` → `?v=20260413r` |
| `CLAUDE.md` | §3/§4/§5/§7 updated — new polling cadences, single refresh timer owner, 400-recovery behavior, version string |

## Test plan

- [x] `TZ=Asia/Kolkata npx vitest run` — **508/508** unit tests pass
- [ ] Multi-tab test: open Sorted in two Chrome tabs, leave both for 55 min (past the first 50-min refresh window). Neither tab should evict.
- [ ] Manual 400 simulation in DevTools: override `/auth/v1/token` response to 400, confirm recovery uses stored `sb_access_token` and no login overlay appears
- [ ] Manual 401 simulation: override `/auth/v1/token` response to 401 with body `{"error":"refresh_token_not_found"}` → confirm eviction still fires for genuine expiry
- [ ] Manual 401 simulation: override `/auth/v1/token` response to 401 with an unrelated body → confirm NO eviction (falls through to `server`)
- [ ] Verify only ONE `window._tokenRefreshTimer` exists after login (DevTools → `window._tokenRefreshTimer` truthy, `window._clientTokenTimer` undefined, `window.AppState.timers.tokenRefresh` undefined)
- [ ] Check Supabase request rate in DevTools Network tab — should be roughly half of yesterday
- [ ] No new console errors during normal usage

## Deploy notes

1. Merge this PR
2. Cloudflare dash → srtd.io → Caching → **Purge Everything**
3. Hard refresh every device

https://claude.ai/code/session_012hTpxXZnUbVJKvpMdjCy5q