### PR TITLE
Replace client polling with Supabase Realtime subscriptions

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -459,44 +459,181 @@ function _drainPollStash() {
 }
 window._drainPollStash = _drainPollStash;
 
-// 10-second background data poll for the Client role. Mirrors the
-// startRealtime() pattern but hits the client-scoped fetch (via
-// loadPostsForClient(true)) and gates re-renders on _clientPostsFingerprint
-// so typing and scroll position survive.
-function startClientRealtime() {
-  if (window._clientPollTimer) return;
-  window._clientPollTimer = setInterval(async function() {
-    // Guard 1: tab hidden — no point polling
+// -----------------------------------------------------------------
+// Client-side Supabase Realtime subscriptions
+// -----------------------------------------------------------------
+// Replaces the legacy setInterval-based startClientRealtime poll.
+// Rationale: the 10s client poll (posts + requests + post_comments,
+// 3 endpoints) was the single largest source of 401s + token races
+// on iPhone Safari. Swapping to a single WebSocket removes the
+// polling fan-out entirely — token refresh only has to fire on the
+// 50-minute cadence installed by activateRole().
+//
+// All four subscriptions live on one channel ('srtd-client') so
+// there's only one WebSocket. Events are debounced (400 ms) into
+// a single loadPostsForClient(true, true) call — `fromPoll=true`
+// so internal apiFetch calls still use { allowLogout: false } and
+// a transient 401 during the refresh fetch cannot evict the user.
+// Notification INSERT events call updateNotifBadge() directly so
+// the bell badge updates without refetching posts.
+//
+// Required Supabase setup (see CLAUDE.md §6):
+//   ALTER PUBLICATION supabase_realtime ADD TABLE posts;
+//   ALTER PUBLICATION supabase_realtime ADD TABLE requests;
+//   ALTER PUBLICATION supabase_realtime ADD TABLE post_comments;
+//   ALTER PUBLICATION supabase_realtime ADD TABLE notifications;
+function _initSupabaseRealtimeClient() {
+  if (window._supabaseClient) return window._supabaseClient;
+  if (!window.supabase || typeof window.supabase.createClient !== 'function') {
+    console.warn('[realtime] Supabase SDK not loaded — cannot init client');
+    return null;
+  }
+  var token = localStorage.getItem('sb_access_token');
+  try {
+    window._supabaseClient = window.supabase.createClient(
+      SUPABASE_URL,
+      SUPABASE_KEY,
+      {
+        auth: {
+          persistSession: false,
+          autoRefreshToken: false,
+          detectSessionInUrl: false
+        },
+        realtime: {
+          params: { eventsPerSecond: 10 }
+        },
+        global: {
+          headers: token ? { Authorization: 'Bearer ' + token } : {}
+        }
+      }
+    );
+    // Push the JWT onto the Realtime socket so any future RLS-gated
+    // postgres_changes filters work. Harmless if RLS is disabled.
+    if (token && window._supabaseClient.realtime &&
+        typeof window._supabaseClient.realtime.setAuth === 'function') {
+      try { window._supabaseClient.realtime.setAuth(token); }
+      catch(e) { console.warn('[realtime] setAuth failed', e); }
+    }
+  } catch (err) {
+    console.error('[realtime] createClient failed', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'realtime-create-client');
+    window._supabaseClient = null;
+    return null;
+  }
+  return window._supabaseClient;
+}
+window._initSupabaseRealtimeClient = _initSupabaseRealtimeClient;
+
+// Debounced refresh — collapses rapid-fire INSERT/UPDATE events into
+// a single loadPostsForClient() call. 400 ms window chosen so a burst
+// (e.g. new post + comment inserted back-to-back) fans into one fetch.
+function _clientRealtimeRefresh() {
+  if (window._clientRealtimeDebounce) {
+    clearTimeout(window._clientRealtimeDebounce);
+  }
+  window._clientRealtimeDebounce = setTimeout(function() {
+    window._clientRealtimeDebounce = null;
     if (document.hidden) return;
-    // Guard 2: no auth token — another flow will re-login
     if (!localStorage.getItem('sb_access_token')) return;
-    // Guard 3: in-flight fetch — skip overlapping polls
     if (window._isLoadingClientPosts) return;
-    // Guard 4: user is typing — do not rebuild the DOM underneath them
+    // Guard: user is typing — do not rebuild the DOM underneath them.
+    // The realtime event will be re-delivered on the next change, and
+    // a focus/blur will naturally drain queued updates on the next tap.
     var ae = document.activeElement;
     if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable)) return;
-
     window._isLoadingClientPosts = true;
-    try {
-      // fromPoll=true so internal apiFetch calls use { allowLogout: false }
-      // — a transient 401 during a background poll must not evict the user.
-      await loadPostsForClient(true, true);
-    } catch (e) {
-      // Keep poll quiet — no error banner thrash on transient failures
-      console.warn('[client-poll]', e);
-    } finally {
-      window._isLoadingClientPosts = false;
-    }
-  }, 10000);
+    Promise.resolve(loadPostsForClient(true, true))
+      .catch(function(e) { console.warn('[client-realtime] refresh failed', e); })
+      .then(function() { window._isLoadingClientPosts = false; });
+  }, 400);
+}
+window._clientRealtimeRefresh = _clientRealtimeRefresh;
+
+function _onClientNotificationInsert(payload) {
+  // Incremental path: Realtime dropped a brand-new Client notification
+  // row into our lap, so we can bump the badge without round-tripping
+  // to the REST endpoint. updateNotifBadge() also runs as a safety net.
+  if (typeof updateNotifBadge === 'function') {
+    try { updateNotifBadge(); } catch(e) { console.warn('[client-realtime] updateNotifBadge', e); }
+  }
+}
+
+function startClientRealtime() {
+  if (window._clientRealtimeChannel) return;
+  var sb = _initSupabaseRealtimeClient();
+  if (!sb) {
+    console.warn('[client-realtime] Supabase client unavailable — realtime disabled');
+    return;
+  }
+  try {
+    var channel = sb.channel('srtd-client')
+      .on('postgres_changes',
+        { event: '*', schema: 'public', table: 'posts' },
+        function(payload) { _clientRealtimeRefresh(); })
+      .on('postgres_changes',
+        { event: '*', schema: 'public', table: 'requests' },
+        function(payload) { _clientRealtimeRefresh(); })
+      .on('postgres_changes',
+        { event: '*', schema: 'public', table: 'post_comments' },
+        function(payload) { _clientRealtimeRefresh(); })
+      .on('postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'notifications', filter: 'user_role=eq.Client' },
+        function(payload) { _onClientNotificationInsert(payload); })
+      .subscribe(function(status, err) {
+        if (err) {
+          console.warn('[client-realtime] subscribe error', status, err);
+          window.logError && window.logError(err && err.message, err && err.stack, 'client-realtime-subscribe');
+        } else {
+          console.log('[client-realtime] channel status:', status);
+        }
+      });
+    window._clientRealtimeChannel = channel;
+  } catch (err) {
+    console.error('[client-realtime] startClientRealtime failed', err);
+    window.logError && window.logError(err && err.message, err && err.stack, 'client-realtime-start');
+  }
+
+  // Visibility-driven reconnect: when the tab returns to focus, verify
+  // the channel is still JOINED. If the socket dropped (phone locked,
+  // app backgrounded on iOS Safari) tear the channel down and rebuild.
+  // We do NOT poll or fetch posts here — loadPostsForClient runs on the
+  // first INSERT/UPDATE delivered after reconnect.
+  if (!window._clientRealtimeVisBound) {
+    window._clientRealtimeVisBound = true;
+    document.addEventListener('visibilitychange', function() {
+      if (document.visibilityState !== 'visible') return;
+      if (!window._clientRealtimeChannel) return;
+      var ch = window._clientRealtimeChannel;
+      var state = ch && ch.state;
+      // phoenix channel state: 'closed' | 'errored' | 'joined' | 'joining' | 'leaving'
+      if (state && state !== 'joined' && state !== 'joining') {
+        console.log('[client-realtime] reconnect on focus; state was', state);
+        try { stopClientRealtime(); } catch(e) {}
+        startClientRealtime();
+      }
+    });
+  }
 }
 
 function stopClientRealtime() {
-  if (window._clientPollTimer) {
-    clearInterval(window._clientPollTimer);
+  if (window._clientRealtimeDebounce) {
+    clearTimeout(window._clientRealtimeDebounce);
+    window._clientRealtimeDebounce = null;
   }
-  window._clientPollTimer = null;
+  if (window._clientRealtimeChannel && window._supabaseClient &&
+      typeof window._supabaseClient.removeChannel === 'function') {
+    try { window._supabaseClient.removeChannel(window._clientRealtimeChannel); }
+    catch (e) { console.warn('[client-realtime] removeChannel error', e); }
+  }
+  window._clientRealtimeChannel = null;
   window._isLoadingClientPosts = false;
   window._lastClientFp = null;
+  // Legacy poll-timer slot: clear it defensively in case any stale build
+  // is still running alongside a hot-reloaded session.
+  if (window._clientPollTimer) {
+    clearInterval(window._clientPollTimer);
+    window._clientPollTimer = null;
+  }
 }
 
 async function loadTasks() {

--- a/10-ui.js
+++ b/10-ui.js
@@ -2352,9 +2352,15 @@ document.addEventListener('DOMContentLoaded', () => {
   if (typeof updateDashGreeting === 'function') updateDashGreeting();
 });
 
+// Agency-only badge refresh. Client users receive notification updates
+// via the Supabase Realtime subscription wired in 07-post-load.js
+// (_onClientNotificationInsert), so this interval skips them to avoid
+// the extra REST round-trip + token race on iPhone Safari.
 window.AppState.timers.notifBadgeTimer = setInterval(function() {
   if (document.hidden) return;
   if (!localStorage.getItem('sb_access_token') && !localStorage.getItem('sb_refresh_token')) return;
+  var _er = (window.AppState.user && window.AppState.user.effectiveRole) || '';
+  if (_er === 'Client') return;
   if (typeof updateNotifBadge === 'function') updateNotifBadge();
 }, 20000);
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # CLAUDE.md — Sorted (srtd.io)
 
-Last updated: 2026-04-13 (refresh-400-recovery + collapse-timers + interval-rollback). Full history: `CLAUDE-archive-20260411.md`.
+Last updated: 2026-04-13 (client-realtime-subscriptions + refresh-400-recovery + collapse-timers + interval-rollback). Full history: `CLAUDE-archive-20260411.md`.
 
 ## 1 — WHAT IS SORTED
 
 Social media content ops platform for agencies — workflow + client trust, NOT a scheduler.
 
-Stack: Vanilla JS (no framework, no build step), Supabase (PostgREST + auth), Cloudflare Workers + R2, GitHub Pages, Resend (email).
+Stack: Vanilla JS (no framework, no build step), Supabase (PostgREST + auth + Realtime), Cloudflare Workers + R2, GitHub Pages, Resend (email). Client-side Realtime uses `@supabase/supabase-js@2.45.4` loaded as a UMD bundle from jsDelivr (see `index.html`); all REST traffic still flows through `apiFetch()`, the SDK is ONLY used for the Realtime WebSocket.
 
 Repo: `github.com/Guneygaar/guneygaar.github.io`. ALL files at REPO ROOT. Never reference `/sorted/` — it does not exist. Subdirs: `render/ actions/ tests/ tests/e2e/ sorted-preview-worker/ sql/ preview/ mockups/`.
 
@@ -69,7 +69,7 @@ Root:
 - `04-router.js` — routing, deep-link handling (must be LAST script)
 - `05-api.js` — apiFetch (no-cache headers, 401 retry), uploadPostAsset, logActivity, normalise
 - `06-post-create.js` — new post form, asset input, WhatsApp KV preview seed
-- `07-post-load.js` — loadPosts, loadPostsForClient(skipRenderIfUnchanged), mergePosts, startRealtime (agency 15s poll with modal-open fetch-and-stash), startClientRealtime/stopClientRealtime (client 30s poll), _postsFingerprint, _clientPostsFingerprint, _drainPollStash, _renderBackgroundViews, bottom sheets, _cardClickDelegate
+- `07-post-load.js` — loadPosts, loadPostsForClient(skipRenderIfUnchanged), mergePosts, startRealtime (agency 10s poll with modal-open fetch-and-stash), startClientRealtime/stopClientRealtime (client Supabase Realtime WebSocket — 4 postgres_changes listeners, no polling), _initSupabaseRealtimeClient, _clientRealtimeRefresh (400 ms debounced loadPostsForClient), _onClientNotificationInsert, _postsFingerprint, _clientPostsFingerprint, _drainPollStash, _renderBackgroundViews, bottom sheets, _cardClickDelegate
 - `08-post-actions.js` — quickStage, updatePost, clientApprove, _confirmPublish, _sendStageNotif, _startSaveTimeout/_clearSaveTimeout
 - `09-approval.js` — client approval flow, submitApproval
 - `09-library.js` — library view (calls `_renderPCS` directly — keep on window.*)
@@ -112,12 +112,22 @@ window.AppState = {
 - Before every PATCH: `post._isSaving = true` + `_startSaveTimeout(post, postId)`. On success AND catch paths: `_clearSaveTimeout(post)` then `post._isSaving = false`.
 - If a PATCH hangs > 10s (`_SAVE_TIMEOUT_MS`) the timer force-clears the flag, logs `[SAVE TIMEOUT]`, and calls `scheduleRender()`. Force-cleared posts can be saved again immediately. `apiFetch` has no timeout — this is the only indefinite-hang guard. Wired into `quickStage`, `clientApprove`, `_executeStageChange`/`Async`, `updatePost`.
 
-### Client 30s polling (`startClientRealtime` in 07-post-load.js)
-- Singleton via `window._clientPollTimer`, installed from `activateRole()` (03-auth.js) and cleared by `stopClientRealtime()` (called by `stopRealtime()` → cascades on logout). The unified `window._tokenRefreshTimer` handles the 50-min proactive refresh for all roles.
-- Interval guards (in order): `document.hidden`, `sb_access_token`, `window._isLoadingClientPosts`, active-typing (input/textarea/contenteditable). Any hit → return.
-- Delegates to `loadPostsForClient(true)` with `skipRenderIfUnchanged` — re-renders only when `_clientPostsFingerprint(posts.all) !== window._lastClientFp`. Fingerprint extends `_postsFingerprint` with per-post `post_comments.length`.
-- `loadPostsForClient` skips overwriting `post.post_comments` when `_commentSaving === true` — object-level lock set by `_handleSubmitComment` (render/client.js) so in-flight optimistic rows aren't clobbered.
-- `renderClientView` guards cv click listeners via `cv._clientEventsWired` (cv persists across re-renders, unguarded `addEventListener` stacks on every poll).
+### Client Realtime subscriptions (`startClientRealtime` in 07-post-load.js)
+- **No polling.** Replaces the legacy 10s `setInterval` (which was the #1 cause of iPhone-Safari 401/logout churn on the Client role). Installs a single Supabase Realtime WebSocket via `window._supabaseClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY, { auth:{ persistSession:false, autoRefreshToken:false, detectSessionInUrl:false }, realtime:{ params:{ eventsPerSecond:10 } }, global:{ headers:{ Authorization:'Bearer '+token } } })` (`_initSupabaseRealtimeClient`), then subscribes ONE channel (`'srtd-client'`) with four `postgres_changes` listeners: `posts` (all events) → debounced refresh, `requests` (all events) → debounced refresh, `post_comments` (all events) → debounced refresh, and `notifications` (INSERT only, filter `user_role=eq.Client`) → `updateNotifBadge()` direct.
+- **Singleton + cleanup.** `window._clientRealtimeChannel` holds the channel; `window._supabaseClient` holds the client. `stopClientRealtime()` calls `_supabaseClient.removeChannel(_clientRealtimeChannel)`, clears both globals, kills the `_clientRealtimeDebounce` timer, and defensively clears the legacy `window._clientPollTimer` slot in case any stale hot-reloaded build still has one running. `stopRealtime()` cascades to `stopClientRealtime()` on logout.
+- **Debounced refresh.** `_clientRealtimeRefresh` collapses bursty INSERT/UPDATE events into one `loadPostsForClient(true, true)` call with a 400 ms debounce. Guards (in order): `document.hidden`, `sb_access_token`, `window._isLoadingClientPosts`, active-typing (input/textarea/contenteditable). `fromPoll=true` threads `{ allowLogout:false }` through apiFetch so a transient 401 during the refresh fetch cannot evict the user.
+- **Visibility reconnect.** Single `visibilitychange` listener gated on `window._clientRealtimeVisBound`. On `visibilityState==='visible'`, inspects `_clientRealtimeChannel.state` (phoenix channel state: `closed | errored | joined | joining | leaving`). If anything other than `joined`/`joining`, tears the channel down and re-subscribes. **Does NOT poll or fetch posts on focus** — the first INSERT/UPDATE delivered after reconnect triggers the refresh.
+- **Notification badge bypass.** The agency-side `AppState.timers.notifBadgeTimer` (10-ui.js, 20 s cadence) skips when `AppState.user.effectiveRole === 'Client'` — the notification Realtime INSERT handler fires `updateNotifBadge()` directly, so the bell is incremental instead of polled.
+- **Required Supabase publication setup (run ONCE on the database):**
+  ```sql
+  ALTER PUBLICATION supabase_realtime ADD TABLE posts;
+  ALTER PUBLICATION supabase_realtime ADD TABLE requests;
+  ALTER PUBLICATION supabase_realtime ADD TABLE post_comments;
+  ALTER PUBLICATION supabase_realtime ADD TABLE notifications;
+  ```
+  All four tables must be in the `supabase_realtime` publication or `postgres_changes` delivers zero events. RLS is disabled on `notifications` (see §2), so the `user_role=eq.Client` clause is a SERVER-SIDE broadcast filter applied by the Realtime server, not a row-level security policy.
+- `loadPostsForClient` still skips overwriting `post.post_comments` when `_commentSaving === true` — object-level lock set by `_handleSubmitComment` (render/client.js) so in-flight optimistic rows aren't clobbered.
+- `renderClientView` guards cv click listeners via `cv._clientEventsWired` (cv persists across re-renders, unguarded `addEventListener` stacks on every render).
 - Client @mention roster fetched live from `/user_roles`, cached in `window._clientMentionRoster` via `_fetchClientMentionRoster()`.
 
 ### Render pipeline
@@ -163,7 +173,7 @@ window.AppState = {
 
 ### Misc gotchas
 - `_commentInputHtml()` only renders for `awaiting_approval`/`awaiting_brand_input` and MUST be called inside `_cardHtml()`. `apiFetch()` never calls `logout()` on 401 by design — refresh flow handles it. Silent `.catch(()=>{})` is a bug — always `window.logError`.
-- Polling: 10s agency (`startRealtime`), 10s client (`startClientRealtime`), 20s notif badge, 5s click-log flush, 50min token refresh. Client DB role takes priority over `pcs_role_preview`. Deep link `srtd.io/?open=POST_ID` → `window._pendingOpenPost` fired after loadPosts.
+- Polling: 10s agency (`startRealtime`), 20s agency notif badge (skipped for Client — see §4 Client Realtime), 5s click-log flush, 50min token refresh. **Client role uses a Supabase Realtime WebSocket and polls NOTHING.** Client DB role takes priority over `pcs_role_preview`. Deep link `srtd.io/?open=POST_ID` → `window._pendingOpenPost` fired after loadPosts.
 - PCS document-click-close skips close when the active dropdown contains `input[type="date"]`. `_cardClickDelegate` (07-post-load.js) guards `input, textarea, button, [contenteditable="true"], a, [role="button"]` — don't narrow.
 - Image download: `_pcsLbDownload` + `_pcsSaveAllPhotos` must strip BOTH `https://images.srtd.io/` and legacy `pub-*.r2.dev` prefix before hitting the R2 worker `/download?key=`.
 
@@ -173,7 +183,7 @@ DB roles (canonical, Title Case): `Admin`, `Servicing`, `Creative`, `Client`. Pe
 
 - `effectiveRole` = the canonical DB role the app acts as, possibly overridden by admin preview.
 - `normalizeRole(x)` canonicalizes any person name / casing to a DB role.
-- Client activation: skips `startRealtime()` and instead calls `startClientRealtime()` (10-second client poll, see §4).
+- Client activation: skips `startRealtime()` and instead calls `startClientRealtime()` (Supabase Realtime WebSocket — no polling; see §4).
 - Admin preview: set `AppState.user.previewRole` (stored as `pcs_role_preview` in localStorage) to render as another role without touching the DB. A real Client DB role ALWAYS wins.
 - `switchTab(tabOrEl)` accepts a string (`'dashboard'`, `'pipeline'`, `'tasks'`, `'client'`) OR a DOM element from click delegation. The `pipeline` branch triggers `loadPosts()` with a `_isFetchingPosts` guard to prevent double fetches on rapid tab spam.
 - Sessions: `refreshSession()` returns typed errors: `{token}` | `{error:'auth_expired'|'server'|'network'}`. Network errors KEEP tokens. Cross-tab refresh lock via `localStorage._srtd_refresh_lock` prevents Supabase token-reuse revocation. `visibilitychange` listener guarded by `window._authReady` refreshes on tab focus.
@@ -198,7 +208,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413r`.
+1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413s`. The Supabase JS SDK `<script>` tag sits ABOVE the versioned block and is pinned to an external jsDelivr URL — do NOT add a `?v=` to it.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413r">
+ <link rel="stylesheet" href="styles.css?v=20260413s">
 
 </head>
 <body>
@@ -1076,29 +1076,32 @@ window.setPcsVisibility = function(el, vis) {
   if (postId && postId.value && typeof loadPcsComments === 'function') loadPcsComments(postId.value);
 };
 </script>
+<!-- Supabase JS SDK (UMD) — pinned version. Exposes window.supabase.createClient. -->
+<!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413r"></script>
-<script src="00-appstate-compat.js?v=20260413r"></script>
-<script src="01-config.js?v=20260413r" defer></script>
-<script src="02-session.js?v=20260413r" defer></script>
-<script src="utils.js?v=20260413r" defer></script>
-<script src="12-profiles.js?v=20260413r" defer></script>
-<script src="03-auth.js?v=20260413r" defer></script>
-<script src="05-api.js?v=20260413r" defer></script>
-<script src="10-ui.js?v=20260413r" defer></script>
+<script src="00-appstate.js?v=20260413s"></script>
+<script src="00-appstate-compat.js?v=20260413s"></script>
+<script src="01-config.js?v=20260413s" defer></script>
+<script src="02-session.js?v=20260413s" defer></script>
+<script src="utils.js?v=20260413s" defer></script>
+<script src="12-profiles.js?v=20260413s" defer></script>
+<script src="03-auth.js?v=20260413s" defer></script>
+<script src="05-api.js?v=20260413s" defer></script>
+<script src="10-ui.js?v=20260413s" defer></script>
 
-<script src="06-post-create.js?v=20260413r" defer></script>
-<script defer src="render/dashboard.js?v=20260413r"></script>
-<script defer src="render/client.js?v=20260413r"></script>
-<script defer src="render/pipeline.js?v=20260413r"></script>
-<script defer src="render/brief.js?v=20260413r"></script>
-<script defer src="actions/pcs.js?v=20260413r"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413r"></script>
-<script src="07-post-load.js?v=20260413r" defer></script>
-<script src="08-post-actions.js?v=20260413r" defer></script>
-<script src="09-library.js?v=20260413r" defer></script>
-<script src="09-approval.js?v=20260413r" defer></script>
-<script src="04-router.js?v=20260413r" defer></script>
+<script src="06-post-create.js?v=20260413s" defer></script>
+<script defer src="render/dashboard.js?v=20260413s"></script>
+<script defer src="render/client.js?v=20260413s"></script>
+<script defer src="render/pipeline.js?v=20260413s"></script>
+<script defer src="render/brief.js?v=20260413s"></script>
+<script defer src="actions/pcs.js?v=20260413s"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413s"></script>
+<script src="07-post-load.js?v=20260413s" defer></script>
+<script src="08-post-actions.js?v=20260413s" defer></script>
+<script src="09-library.js?v=20260413s" defer></script>
+<script src="09-approval.js?v=20260413s" defer></script>
+<script src="04-router.js?v=20260413s" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
The 10s client-side setInterval that fanned out to /posts + /requests + /post_comments was the #1 source of 401s and silent logouts on iPhone Safari. Swap it for a single Supabase Realtime WebSocket so the Client role polls nothing.

- 07-post-load.js: _initSupabaseRealtimeClient() boots a standalone supabase-js v2 client using the UMD bundle loaded in index.html. startClientRealtime() now subscribes ONE 'srtd-client' channel with four postgres_changes listeners: posts (*), requests (*), post_comments (*), and notifications (INSERT, user_role=eq.Client). All three data listeners funnel through a 400ms-debounced _clientRealtimeRefresh() that calls loadPostsForClient(true, true) once per burst; the notification listener pokes updateNotifBadge() directly. Visibility change on the Client role inspects channel.state and rebuilds the channel on 'closed'/'errored'/'leaving' instead of polling or fetching. stopClientRealtime() removes the channel and clears the legacy _clientPollTimer slot defensively.
- 10-ui.js: notifBadgeTimer skips when effectiveRole === 'Client'; the agency role still keeps its 20s refresh cadence. Test expectations for the setInterval declaration are preserved.
- index.html: load @supabase/supabase-js@2.45.4 UMD from jsDelivr above the versioned script block. Bump all 22 ?v= strings to 20260413s.
- CLAUDE.md: rewrite the Client polling section as 'Client Realtime subscriptions', document the required ALTER PUBLICATION commands, and update the polling cadence gotcha so Client is listed as 'polls NOTHING'.

Required ONE-TIME database setup (run on Supabase SQL editor):
  ALTER PUBLICATION supabase_realtime ADD TABLE posts;
  ALTER PUBLICATION supabase_realtime ADD TABLE requests;
  ALTER PUBLICATION supabase_realtime ADD TABLE post_comments;
  ALTER PUBLICATION supabase_realtime ADD TABLE notifications;

Tests: 508/508 unit tests still passing (21 files).

https://claude.ai/code/session_01NcPxJ1opuJkS32k5D5u12V