### PR TITLE
Fix client comment notifications showing raw email instead of display name

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413v">
+ <link rel="stylesheet" href="styles.css?v=20260413w">
 
 </head>
 <body>
@@ -1080,28 +1080,28 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413v"></script>
-<script src="00-appstate-compat.js?v=20260413v"></script>
-<script src="01-config.js?v=20260413v" defer></script>
-<script src="02-session.js?v=20260413v" defer></script>
-<script src="utils.js?v=20260413v" defer></script>
-<script src="12-profiles.js?v=20260413v" defer></script>
-<script src="03-auth.js?v=20260413v" defer></script>
-<script src="05-api.js?v=20260413v" defer></script>
-<script src="10-ui.js?v=20260413v" defer></script>
+<script src="00-appstate.js?v=20260413w"></script>
+<script src="00-appstate-compat.js?v=20260413w"></script>
+<script src="01-config.js?v=20260413w" defer></script>
+<script src="02-session.js?v=20260413w" defer></script>
+<script src="utils.js?v=20260413w" defer></script>
+<script src="12-profiles.js?v=20260413w" defer></script>
+<script src="03-auth.js?v=20260413w" defer></script>
+<script src="05-api.js?v=20260413w" defer></script>
+<script src="10-ui.js?v=20260413w" defer></script>
 
-<script src="06-post-create.js?v=20260413v" defer></script>
-<script defer src="render/dashboard.js?v=20260413v"></script>
-<script defer src="render/client.js?v=20260413v"></script>
-<script defer src="render/pipeline.js?v=20260413v"></script>
-<script defer src="render/brief.js?v=20260413v"></script>
-<script defer src="actions/pcs.js?v=20260413v"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413v"></script>
-<script src="07-post-load.js?v=20260413v" defer></script>
-<script src="08-post-actions.js?v=20260413v" defer></script>
-<script src="09-library.js?v=20260413v" defer></script>
-<script src="09-approval.js?v=20260413v" defer></script>
-<script src="04-router.js?v=20260413v" defer></script>
+<script src="06-post-create.js?v=20260413w" defer></script>
+<script defer src="render/dashboard.js?v=20260413w"></script>
+<script defer src="render/client.js?v=20260413w"></script>
+<script defer src="render/pipeline.js?v=20260413w"></script>
+<script defer src="render/brief.js?v=20260413w"></script>
+<script defer src="actions/pcs.js?v=20260413w"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413w"></script>
+<script src="07-post-load.js?v=20260413w" defer></script>
+<script src="08-post-actions.js?v=20260413w" defer></script>
+<script src="09-library.js?v=20260413w" defer></script>
+<script src="09-approval.js?v=20260413w" defer></script>
+<script src="04-router.js?v=20260413w" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1523,6 +1523,7 @@ console.log('LOADED:', 'render/client.js');
     input.value = '';
 
     var authorName = window.AppState.user.email || window.AppState.user.name || 'Client';
+    var displayName = (typeof getDisplayName === 'function') ? getDisplayName(authorName) : (window.AppState.user.displayName || window.AppState.user.name || 'Client');
     var _mentioned = _parseMentions(message);
     var post = (window.AppState.posts.all || []).find(function (p) {
       return p.post_id === postId || p.id === postId;
@@ -1617,8 +1618,8 @@ console.log('LOADED:', 'render/client.js');
           user_role: 'Servicing',
           type: 'comment',
           post_id: realPostId,
-          message: authorName + ' commented on ' + postTitle,
-          actor: window.AppState.user.name || 'Client',
+          message: displayName + ' commented on ' + postTitle,
+          actor: displayName,
           read: false
         })
       }).catch(function(err){ console.error('[client] comment patch', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'comment-patch'); });
@@ -1628,8 +1629,8 @@ console.log('LOADED:', 'render/client.js');
           user_role: 'Admin',
           type: 'comment',
           post_id: realPostId,
-          message: authorName + ' commented on ' + postTitle,
-          actor: window.AppState.user.name || 'Client',
+          message: displayName + ' commented on ' + postTitle,
+          actor: displayName,
           read: false
         })
       }).catch(function(err){ console.error('[client] notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-notification'); });
@@ -1639,8 +1640,8 @@ console.log('LOADED:', 'render/client.js');
           user_role: 'Creative',
           type: 'comment',
           post_id: realPostId,
-          message: authorName + ' commented on ' + postTitle,
-          actor: window.AppState.user.name || 'Client',
+          message: displayName + ' commented on ' + postTitle,
+          actor: displayName,
           read: false
         })
       }).catch(function(err){ console.error('[client] creative notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-creative-notification'); });
@@ -1662,8 +1663,8 @@ console.log('LOADED:', 'render/client.js');
             user_role: _member.role,
             post_id: realPostId,
             type: 'mention',
-            message: authorName + ' mentioned you on "' + postTitle + '"',
-            actor: window.AppState.user.name || 'Client',
+            message: displayName + ' mentioned you on "' + postTitle + '"',
+            actor: displayName,
             read: false
           })
         }).catch(function(err) { console.error('[mention notif]', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-mention-notif'); });


### PR DESCRIPTION
## Summary
- `render/client.js` `_handleSubmitComment` was reusing `authorName` (the user's email — required for `post_comments.author` DB tracking) for all four `/notifications` POST payloads, so client comment + mention notifications surfaced the raw email in the message text and actor field instead of the profile display name.
- Resolve the email to a display name once via `getDisplayName(authorName)` (with safe fallbacks to `AppState.user.displayName` / `.name` / `'Client'`) and use that `displayName` for the message + actor in all four notification POSTs (Servicing, Admin, Creative, mention fan-out). The `post_comments` POST body is unchanged — `author` stays as the email so DB identity / RLS / activity logs continue to key off email.
- `10-ui.js` `_notifSubmitReply` only writes to `/post_comments` (the `notify-comment` edge function handles the fan-out so there are no duplicate notification rows). It does not POST to `/notifications` directly, so no change is needed there.
- Bumped all 22 `?v=` cache strings in `index.html` from `20260413v` → `20260413w`.

## Test plan
- [x] `npx vitest run` → 563/563 passing across 22 test files
- [ ] Smoke: log in as Manisha (Client), comment on a post, confirm the resulting Servicing/Admin/Creative notification cards show "Manisha commented on …" instead of the raw email
- [ ] Smoke: @mention an agency user from the client feed, confirm the mention notification card uses the display name in both the message body and the avatar/actor row
- [ ] Verify `post_comments.author` row still contains the email (DB identity unchanged)
- [ ] Cloudflare → srtd.io → Caching → Purge Everything, hard refresh, verify on iPhone Safari

https://claude.ai/code/session_01P3vV3kdSpfAVLnVPHv1fLn