### PR TITLE
Preserve client comment collapse state + resolve notif actor to display name

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -636,8 +636,13 @@ function renderNotifications(name, role) {
       }
     }
     var actor = n.actor || '';
+    // Resolve raw actor (which may be an email for older notifications
+    // written before the display-name fix) to a clean display name via
+    // the profiles cache. Falls back to the raw string when the helper
+    // is unavailable or the cache hasn't loaded yet.
+    var actorDisplay = (typeof getDisplayName === 'function' && actor) ? getDisplayName(actor) : actor;
     var avClass = _notifActorClass(actor);
-    var initial = actor ? actor.charAt(0).toUpperCase() : '?';
+    var initial = actorDisplay ? actorDisplay.charAt(0).toUpperCase() : '?';
     var ts = _notifRelTime(n.created_at);
 
     // Response time for approval-resolved notifications
@@ -776,7 +781,7 @@ function renderNotifications(name, role) {
           pubLabel +
           '<div class="notif-text">' +
             unreadDot +
-            '<strong>' + esc(actor) + '</strong> ' + esc(actionText) +
+            '<strong>' + esc(actorDisplay) + '</strong> ' + esc(actionText) +
             respTimeHtml +
           '</div>' +
           previewHtml +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Sorted (srtd.io)
 
-Last updated: 2026-04-13 (agency-realtime-subscriptions + client-realtime-subscriptions + refresh-400-recovery + collapse-timers + interval-rollback + scratchpad-auto-save). Full history: `CLAUDE-archive-20260411.md`.
+Last updated: 2026-04-13 (agency-realtime-subscriptions + client-realtime-subscriptions + refresh-400-recovery + collapse-timers + interval-rollback + scratchpad-auto-save + comment-collapse-preservation + notif-actor-display-name). Full history: `CLAUDE-archive-20260411.md`.
 
 ## 1 — WHAT IS SORTED
 
@@ -218,7 +218,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413v`. The Supabase JS SDK `<script>` tag sits ABOVE the versioned block and is pinned to an external jsDelivr URL — do NOT add a `?v=` to it.
+1. Bump ALL 22 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 21 scripts). Current: `?v=20260413x`. The Supabase JS SDK `<script>` tag sits ABOVE the versioned block and is pinned to an external jsDelivr URL — do NOT add a `?v=` to it.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413w">
+ <link rel="stylesheet" href="styles.css?v=20260413x">
 
 </head>
 <body>
@@ -1080,28 +1080,28 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413w"></script>
-<script src="00-appstate-compat.js?v=20260413w"></script>
-<script src="01-config.js?v=20260413w" defer></script>
-<script src="02-session.js?v=20260413w" defer></script>
-<script src="utils.js?v=20260413w" defer></script>
-<script src="12-profiles.js?v=20260413w" defer></script>
-<script src="03-auth.js?v=20260413w" defer></script>
-<script src="05-api.js?v=20260413w" defer></script>
-<script src="10-ui.js?v=20260413w" defer></script>
+<script src="00-appstate.js?v=20260413x"></script>
+<script src="00-appstate-compat.js?v=20260413x"></script>
+<script src="01-config.js?v=20260413x" defer></script>
+<script src="02-session.js?v=20260413x" defer></script>
+<script src="utils.js?v=20260413x" defer></script>
+<script src="12-profiles.js?v=20260413x" defer></script>
+<script src="03-auth.js?v=20260413x" defer></script>
+<script src="05-api.js?v=20260413x" defer></script>
+<script src="10-ui.js?v=20260413x" defer></script>
 
-<script src="06-post-create.js?v=20260413w" defer></script>
-<script defer src="render/dashboard.js?v=20260413w"></script>
-<script defer src="render/client.js?v=20260413w"></script>
-<script defer src="render/pipeline.js?v=20260413w"></script>
-<script defer src="render/brief.js?v=20260413w"></script>
-<script defer src="actions/pcs.js?v=20260413w"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413w"></script>
-<script src="07-post-load.js?v=20260413w" defer></script>
-<script src="08-post-actions.js?v=20260413w" defer></script>
-<script src="09-library.js?v=20260413w" defer></script>
-<script src="09-approval.js?v=20260413w" defer></script>
-<script src="04-router.js?v=20260413w" defer></script>
+<script src="06-post-create.js?v=20260413x" defer></script>
+<script defer src="render/dashboard.js?v=20260413x"></script>
+<script defer src="render/client.js?v=20260413x"></script>
+<script defer src="render/pipeline.js?v=20260413x"></script>
+<script defer src="render/brief.js?v=20260413x"></script>
+<script defer src="actions/pcs.js?v=20260413x"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413x"></script>
+<script src="07-post-load.js?v=20260413x" defer></script>
+<script src="08-post-actions.js?v=20260413x" defer></script>
+<script src="09-library.js?v=20260413x" defer></script>
+<script src="09-approval.js?v=20260413x" defer></script>
+<script src="04-router.js?v=20260413x" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -2205,7 +2205,29 @@ console.log('LOADED:', 'render/client.js');
     html += _approvePopupHtml();
     html += _lightboxHtml();
 
+    // Capture which comment sections are currently expanded BEFORE we
+    // rebuild innerHTML. The client realtime refresh and any other
+    // renderClientView() call would otherwise reset every awaiting_*
+    // card back to collapsed state, wiping the user's explicit toggle.
+    var _expandedCommentIds = [];
+    var _prevSections = cv.querySelectorAll('.client-comments-section');
+    for (var _psi = 0; _psi < _prevSections.length; _psi++) {
+      if (_prevSections[_psi].style.display === 'block') {
+        var _pid = _prevSections[_psi].getAttribute('data-comments-section');
+        if (_pid) _expandedCommentIds.push(_pid);
+      }
+    }
+
     cv.innerHTML = html;
+
+    // Restore the expanded comment sections captured above. Safe no-op
+    // when the post is gone from the new render or the section defaults
+    // to expanded already (non-awaiting stages).
+    for (var _rsi = 0; _rsi < _expandedCommentIds.length; _rsi++) {
+      var _restoreEl = cv.querySelector('[data-comments-section="' + _expandedCommentIds[_rsi] + '"]');
+      if (_restoreEl) _restoreEl.style.display = 'block';
+    }
+
     _wireTopNavOnce();
     // cv is a persistent DOM element — only its innerHTML is replaced
     // by re-renders. Listeners attached to cv itself survive every
@@ -2262,8 +2284,21 @@ console.log('LOADED:', 'render/client.js');
       return;
     }
 
+    // Capture expanded comment sections from an existing overlay before
+    // we tear it down, so a re-open of the same post (or any re-render
+    // while already open) preserves the user's explicit toggle state.
     var existing = document.getElementById('client-post-overlay');
-    if (existing) existing.remove();
+    var _overlayExpandedIds = [];
+    if (existing) {
+      var _exSecs = existing.querySelectorAll('.client-comments-section');
+      for (var _esi = 0; _esi < _exSecs.length; _esi++) {
+        if (_exSecs[_esi].style.display === 'block') {
+          var _esId = _exSecs[_esi].getAttribute('data-comments-section');
+          if (_esId) _overlayExpandedIds.push(_esId);
+        }
+      }
+      existing.remove();
+    }
 
     _ensurePulseStyle();
 
@@ -2308,6 +2343,15 @@ console.log('LOADED:', 'render/client.js');
     var _self_overlay = overlay;
     requestAnimationFrame(function() {
       document.body.appendChild(_self_overlay);
+      // Restore any expanded comment sections captured from the prior
+      // overlay. _commentsContainerHtml(post, true) already defaults the
+      // overlay card's section to display:block, so this is a no-op for
+      // the common case and only matters if the prior overlay had a
+      // different post open or had more than one section rendered.
+      for (var _orsi = 0; _orsi < _overlayExpandedIds.length; _orsi++) {
+        var _orEl = _self_overlay.querySelector('[data-comments-section="' + _overlayExpandedIds[_orsi] + '"]');
+        if (_orEl) _orEl.style.display = 'block';
+      }
       window.AppState.ui.modalOpen = true;
       document.body.style.overflow = 'hidden';
       _wireEvents(_self_overlay);


### PR DESCRIPTION
## Summary

Two surgical fixes that kept sliding past the previous display-name + realtime passes:

**1. Comment sections kept collapsing on every Realtime refresh (render/client.js)**
Any `posts` / `post_comments` / `requests` INSERT/UPDATE routed through `_clientRealtimeRefresh()` -> `loadPostsForClient(true, true)` -> `renderClientView()`, which calls `cv.innerHTML = html` and rebuilds every card from scratch. `_cardHtml()` hard-codes `awaiting_approval` / `awaiting_brand_input` cards to render with comments collapsed (`_commentsContainerHtml(post, !hasCommentBtn)` at client.js:854), so every Realtime tick slammed the section back to `display:none` even when the user had just tapped Comment to open it.

Fix: capture every `.client-comments-section` with `style.display === 'block'` BEFORE `cv.innerHTML = html`, then restore those IDs to `display:block` after the rebuild. Same capture/restore pattern mirrored across `_openClientPostOverlay()`'s `existing.remove()` teardown so a rebuild of an already-open overlay also preserves the user's toggle state.

**2. Notification cards rendered raw emails in the `<strong>` tag (10-ui.js)**
PR #831 fixed the write path (`_handleSubmitComment` now stores `displayName` in `actor` + `message`), but notifications inserted BEFORE that ship still have `actor = "someone@example.com"` in the DB. `_buildItem` rendered `esc(actor)` directly -> old cards showed a raw email address while new cards showed a clean name.

Fix: resolve `n.actor` through `getDisplayName()` into `actorDisplay` and render that in the `<strong>` tag + initial. `_notifActionText` still slices by raw `n.actor` so the prefix-strip logic continues to work correctly for both old (email prefix) and new (display-name prefix) rows - both cases are internally consistent within a single notification, so no messages double-up.

**Audit D — _notifSubmitReply:** checked, no fix needed. It only POSTs to `/post_comments` (the `notify-comment` edge function handles the fan-out per CLAUDE.md §6), so there is no JS-side notification message to sanitize. `author: authorName` is intentionally the email for the `post_comments.author` column, and the optimistic thread row goes through `_notifThreadMsgHtml` which already resolves via `getDisplayName` at 10-ui.js:937.

## Files changed
- `render/client.js` — capture + restore collapse state in `renderClientView` and `_openClientPostOverlay`
- `10-ui.js` — resolve `n.actor` to `actorDisplay` via `getDisplayName` in `_buildItem`
- `index.html` — bump all 22 `?v=` strings `20260413w` -> `20260413x`
- `CLAUDE.md` — add fix note to the last-updated line + bump current version marker

## Tests
- `npx vitest run` — **563/563 passing** across 22 test files (no regressions on `notif-render`, `client-comment`, `comments-separation`, `notifications`, or `defensive-guards`).
- Structural test patterns preserved: `notif-item`, `notif-live-card`, `nchip-count-*`, `(n.post_id||'') + '|' + (n.actor||'')` grouping key, `notif-resp-time`, day labels, `"left " + n + " comments on "`, and the `notifBadgeTimer` 20 s regex all still match.

## Test plan
- [ ] Load the Client feed as Manisha -> tap Comment on an awaiting post -> watch another device fire a comment on a different post -> confirm the first section stays expanded through the Realtime refresh
- [ ] Open the notification panel as Servicing -> confirm an old comment notification from Manisha renders `Manisha` in the `<strong>` tag (not `manisha@…`)
- [ ] Open the notification panel as Servicing -> confirm a new comment notification written after this ship still renders `Manisha` (displayName path unchanged)
- [ ] Run `npx vitest run` on a fresh clone -> 563/563 green

https://claude.ai/code/session_01C5KcE9jKnvU7aPUgC6wNZy