### PR TITLE
Client view: preserve comment expand + drive link card + notif name resolve

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -360,8 +360,17 @@ function _notifActionText(n) {
   var actor = n.actor || '';
   var msg = n.message || '';
   var actionText = msg;
+  // Strip the actor prefix in either raw form (email) or display-name
+  // form, so historical rows that embedded an email in the message
+  // ("manisha@srtd.io commented on ...") render cleanly after the
+  // _buildItem strong tag swaps in the resolved display name.
+  var displayActor = (typeof getDisplayName === 'function')
+    ? getDisplayName(actor)
+    : actor;
   if (actor && msg.toLowerCase().indexOf(actor.toLowerCase()) === 0) {
     actionText = msg.slice(actor.length).trim();
+  } else if (displayActor && msg.toLowerCase().indexOf(displayActor.toLowerCase()) === 0) {
+    actionText = msg.slice(displayActor.length).trim();
   }
   Object.keys(_NOTIF_STAGE_LABELS).forEach(function(key) {
     actionText = actionText.replace(new RegExp('\\b' + key + '\\b', 'gi'), _NOTIF_STAGE_LABELS[key]);
@@ -636,8 +645,16 @@ function renderNotifications(name, role) {
       }
     }
     var actor = n.actor || '';
+    // Resolve the raw actor field (which may be an email for older
+    // notification rows written before the displayName fix) to a clean
+    // display name so the card always shows a friendly name. The avatar
+    // + color class still key off the raw `actor` value because both
+    // `renderAvatar` and `getRoleFor` already accept either form.
+    var displayActor = (typeof getDisplayName === 'function')
+      ? getDisplayName(actor)
+      : actor;
     var avClass = _notifActorClass(actor);
-    var initial = actor ? actor.charAt(0).toUpperCase() : '?';
+    var initial = displayActor ? displayActor.charAt(0).toUpperCase() : '?';
     var ts = _notifRelTime(n.created_at);
 
     // Response time for approval-resolved notifications
@@ -776,7 +793,7 @@ function renderNotifications(name, role) {
           pubLabel +
           '<div class="notif-text">' +
             unreadDot +
-            '<strong>' + esc(actor) + '</strong> ' + esc(actionText) +
+            '<strong>' + esc(displayActor) + '</strong> ' + esc(actionText) +
             respTimeHtml +
           '</div>' +
           previewHtml +

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413w">
+ <link rel="stylesheet" href="styles.css?v=20260413x">
 
 </head>
 <body>
@@ -1080,28 +1080,28 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413w"></script>
-<script src="00-appstate-compat.js?v=20260413w"></script>
-<script src="01-config.js?v=20260413w" defer></script>
-<script src="02-session.js?v=20260413w" defer></script>
-<script src="utils.js?v=20260413w" defer></script>
-<script src="12-profiles.js?v=20260413w" defer></script>
-<script src="03-auth.js?v=20260413w" defer></script>
-<script src="05-api.js?v=20260413w" defer></script>
-<script src="10-ui.js?v=20260413w" defer></script>
+<script src="00-appstate.js?v=20260413x"></script>
+<script src="00-appstate-compat.js?v=20260413x"></script>
+<script src="01-config.js?v=20260413x" defer></script>
+<script src="02-session.js?v=20260413x" defer></script>
+<script src="utils.js?v=20260413x" defer></script>
+<script src="12-profiles.js?v=20260413x" defer></script>
+<script src="03-auth.js?v=20260413x" defer></script>
+<script src="05-api.js?v=20260413x" defer></script>
+<script src="10-ui.js?v=20260413x" defer></script>
 
-<script src="06-post-create.js?v=20260413w" defer></script>
-<script defer src="render/dashboard.js?v=20260413w"></script>
-<script defer src="render/client.js?v=20260413w"></script>
-<script defer src="render/pipeline.js?v=20260413w"></script>
-<script defer src="render/brief.js?v=20260413w"></script>
-<script defer src="actions/pcs.js?v=20260413w"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413w"></script>
-<script src="07-post-load.js?v=20260413w" defer></script>
-<script src="08-post-actions.js?v=20260413w" defer></script>
-<script src="09-library.js?v=20260413w" defer></script>
-<script src="09-approval.js?v=20260413w" defer></script>
-<script src="04-router.js?v=20260413w" defer></script>
+<script src="06-post-create.js?v=20260413x" defer></script>
+<script defer src="render/dashboard.js?v=20260413x"></script>
+<script defer src="render/client.js?v=20260413x"></script>
+<script defer src="render/pipeline.js?v=20260413x"></script>
+<script defer src="render/brief.js?v=20260413x"></script>
+<script defer src="actions/pcs.js?v=20260413x"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413x"></script>
+<script src="07-post-load.js?v=20260413x" defer></script>
+<script src="08-post-actions.js?v=20260413x" defer></script>
+<script src="09-library.js?v=20260413x" defer></script>
+<script src="09-approval.js?v=20260413x" defer></script>
+<script src="04-router.js?v=20260413x" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -829,6 +829,39 @@ console.log('LOADED:', 'render/client.js');
     '</div>';
   }
 
+  /* ---- drive link card ----
+     Read-only mirror of actions/pcs.js:_buildDriveLinkCard for the
+     client feed. No edit/remove buttons (clients can't manage drive
+     links), no add-link CTA when missing — empty driveLink yields an
+     empty string so the card disappears entirely. Visual styling
+     matches the PCS card byte-for-byte. */
+  function _driveLinkCardHtml(driveLink) {
+    if (!driveLink) return '';
+    return '<div class="drive-link-wrap" style="padding:10px 14px 0;">' +
+      '<div style="background:#0d1117;border:1px solid #1a1f27;border-radius:8px;overflow:hidden;">' +
+        '<a href="' + _esc(driveLink) + '" target="_blank" rel="noopener" ' +
+          'style="display:flex;align-items:center;gap:10px;padding:12px 14px;text-decoration:none;">' +
+          '<div style="width:40px;height:40px;border-radius:6px;background:#1a1a0a;border:1px solid #3d2e0a;' +
+            'display:flex;align-items:center;justify-content:center;flex-shrink:0;">' +
+            '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#F6A623" stroke-width="1.5">' +
+              '<path d="M15 10l4.553-2.069A1 1 0 0121 8.87V15.13a1 1 0 01-1.447.9L15 14M3 8a2 2 0 012-2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z"/>' +
+            '</svg>' +
+          '</div>' +
+          '<div style="flex:1;min-width:0;">' +
+            '<div style="font-size:12px;font-weight:600;color:#e8eaed;margin-bottom:2px;">View on Drive</div>' +
+            '<div style="font-size:10px;color:#556070;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' +
+              _esc(driveLink) +
+            '</div>' +
+          '</div>' +
+          '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#556070" stroke-width="2">' +
+            '<path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/>' +
+            '<polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>' +
+          '</svg>' +
+        '</a>' +
+      '</div>' +
+    '</div>';
+  }
+
   /* ---- single card ---- */
 
   function _cardHtml(post, isPublished) {
@@ -845,6 +878,8 @@ console.log('LOADED:', 'render/client.js');
       _captionHtml(post) +
       /* images */
       _imgGridHtml(post.images) +
+      /* drive link card (read-only; hidden when post has no drive_link) */
+      _driveLinkCardHtml(post.drive_link || post.driveLink || '') +
       /* stats bar (shows comment count even when collapsed) */
       _statsBarHtml(post, isPublished) +
       /* engagement bar (not on published) */
@@ -2159,6 +2194,23 @@ console.log('LOADED:', 'render/client.js');
     try {
     _ensurePulseStyle();
     _ensureReqOverlay();
+
+    // Capture which comment sections are currently expanded so we can
+    // restore them after innerHTML is rebuilt. Without this, a Realtime
+    // refresh (post_comments INSERT/UPDATE) collapses any thread the
+    // user had manually opened via the Comment toggle button.
+    var _expandedCommentPids = {};
+    try {
+      var _openSecs = cv.querySelectorAll('[data-comments-section]');
+      for (var _i = 0; _i < _openSecs.length; _i++) {
+        var _sec = _openSecs[_i];
+        if (_sec.style && _sec.style.display === 'block') {
+          var _spid = _sec.getAttribute('data-comments-section');
+          if (_spid) _expandedCommentPids[_spid] = 1;
+        }
+      }
+    } catch (_capErr) {}
+
     cv.style.display = 'block';
     cv.style.background = '#0D0D12';
 
@@ -2206,6 +2258,19 @@ console.log('LOADED:', 'render/client.js');
     html += _lightboxHtml();
 
     cv.innerHTML = html;
+
+    // Restore any comment sections that were expanded before the rebuild.
+    // The Comment toggle button writes display:block/none directly on the
+    // [data-comments-section] element, so we re-apply that flag here.
+    try {
+      var _restoreKeys = Object.keys(_expandedCommentPids);
+      for (var _r = 0; _r < _restoreKeys.length; _r++) {
+        var _rpid = _restoreKeys[_r];
+        var _restoreEl = document.getElementById('client-comments-section-' + _rpid);
+        if (_restoreEl) _restoreEl.style.display = 'block';
+      }
+    } catch (_restErr) {}
+
     _wireTopNavOnce();
     // cv is a persistent DOM element — only its innerHTML is replaced
     // by re-renders. Listeners attached to cv itself survive every
@@ -2262,8 +2327,25 @@ console.log('LOADED:', 'render/client.js');
       return;
     }
 
+    // Mirror the renderClientView preservation pattern: if the overlay
+    // is already open (e.g. a Realtime refresh re-mounts it), capture
+    // any comment sections that were expanded so we can re-apply that
+    // display state after the new HTML is mounted below.
+    var _overlayExpandedPids = {};
     var existing = document.getElementById('client-post-overlay');
-    if (existing) existing.remove();
+    if (existing) {
+      try {
+        var _exSecs = existing.querySelectorAll('[data-comments-section]');
+        for (var _ex = 0; _ex < _exSecs.length; _ex++) {
+          var _exSec = _exSecs[_ex];
+          if (_exSec.style && _exSec.style.display === 'block') {
+            var _expid = _exSec.getAttribute('data-comments-section');
+            if (_expid) _overlayExpandedPids[_expid] = 1;
+          }
+        }
+      } catch (_oexErr) {}
+      existing.remove();
+    }
 
     _ensurePulseStyle();
 
@@ -2286,6 +2368,7 @@ console.log('LOADED:', 'render/client.js');
       _cardHeaderHtml(post, pid) +
       _captionHtml(post) +
       _imgGridHtml(post.images) +
+      _driveLinkCardHtml(post.drive_link || post.driveLink || '') +
       _statsBarHtml(post, isPublished) +
       (isPublished ? '' : _engagementBarHtml(post)) +
       /* overlay shows comments expanded by default since the user
@@ -2308,6 +2391,18 @@ console.log('LOADED:', 'render/client.js');
     var _self_overlay = overlay;
     requestAnimationFrame(function() {
       document.body.appendChild(_self_overlay);
+      // Re-apply any comment sections that were expanded on the prior
+      // overlay before it got re-mounted (mirrors renderClientView).
+      try {
+        var _orestKeys = Object.keys(_overlayExpandedPids);
+        for (var _o = 0; _o < _orestKeys.length; _o++) {
+          var _opid = _orestKeys[_o];
+          var _orestEl = _self_overlay.querySelector(
+            '[data-comments-section="' + _opid + '"]'
+          );
+          if (_orestEl) _orestEl.style.display = 'block';
+        }
+      } catch (_orestErr) {}
       window.AppState.ui.modalOpen = true;
       document.body.style.overflow = 'hidden';
       _wireEvents(_self_overlay);


### PR DESCRIPTION
## Summary

Four client-side issues across `render/client.js`, `10-ui.js`, and `index.html`. Issue B was already fixed in commit 6dd7a22; the audit confirmed no further work was needed there.

### A) Comments collapse bug (render/client.js)
A Realtime refresh (post_comments INSERT/UPDATE) re-rendered the entire client feed, which collapsed any thread the user had manually expanded via the Comment toggle button. Fix:
- `renderClientView` now captures every `[data-comments-section]` whose `style.display === 'block'` *before* `cv.innerHTML = html`, then walks the captured set after the rebuild and re-applies `display:block` by id.
- `_openClientPostOverlay` mirrors the same capture-then-restore pattern around the `existing.remove()` + re-mount path so a Realtime-driven re-mount of the open overlay also preserves expanded state.

### B) Display name at write time (verified, already applied)
Confirmed `render/client.js:1525-1526` sets `authorName` (email) and resolves `displayName` via `getDisplayName(authorName)`. All four notification POST blocks (Servicing 1621, Admin 1632, Creative 1643, mention 1666) already use `displayName` for both `message` and `actor`. The `/post_comments` POST body still uses `authorName` (email) for DB tracking. `10-ui.js:_notifSubmitReply` does NOT post any notifications from JS (relies on the `notify-comment` edge function), so its `authorName=email` for the `/post_comments` POST body is correct as-is.

### C) Display name at render time (10-ui.js)
The notification card was rendering `n.actor` raw, so any historical row stored with an email in the actor field showed the raw mailbox in the strong tag. Fix:
- `_buildItem` resolves `actor` through `getDisplayName()` into `displayActor` and uses that value for the `<strong>` and the avatar initial. The avatar/role lookup still uses the raw actor (both `renderAvatar` and `getRoleFor` accept either form).
- `_notifActionText` strips the actor prefix in *either* raw email form *or* the resolved display name form, so historical messages like `"manisha@srtd.io commented on Post"` render cleanly.

### D) Drive link card in client view (render/client.js)
PCS posts already exposed drive links via `_buildDriveLinkCard`, but the client feed showed nothing. Fix:
- New `_driveLinkCardHtml(driveLink)` returns empty string when there's no link; otherwise emits a read-only mirror of the PCS card (amber video icon, "View on Drive" label, ellipsized URL, external-link arrow). No edit/remove buttons — clients cannot manage drive links. Anchor opens `target="_blank" rel="noopener"`.
- Inserted into `_cardHtml` between `_imgGridHtml` and `_statsBarHtml`, and into `_openClientPostOverlay` at the matching position. Reads `post.drive_link || post.driveLink || ''`. All styles inline (no `styles.css` changes).

### E) Versions
All 22 versioned resources bumped from `?v=20260413w` to `?v=20260413x`.

## Test plan
- [x] `npx vitest run` — 563/563 passing across 22 test files
- [ ] Verify on iPhone Safari that opening a comment thread on an awaiting_approval post survives a post_comments Realtime refresh
- [ ] Verify the drive link card renders on a client post that has `drive_link` set, and is hidden on posts without
- [ ] Verify the notification panel shows display names instead of raw emails on historical notification rows
- [ ] Cloudflare dash → srtd.io → Caching → Purge Everything after merge

https://claude.ai/code/session_01KsJEyT592vt36U8sdqp2zA