### PR TITLE
Surface pending request briefs in client feed

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -300,6 +300,7 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
             drive_link: r.drive_link || null,
             created_at: r.created_at || '',
             updated_at: r.created_at || '',
+            assigned_to: r.assigned_to || null,
             _isRequest: true
           });
         });

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413b">
+ <link rel="stylesheet" href="styles.css?v=20260413c">
 
 </head>
 <body>
@@ -1084,28 +1084,28 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413b"></script>
-<script src="00-appstate-compat.js?v=20260413b"></script>
-<script src="01-config.js?v=20260413b" defer></script>
-<script src="02-session.js?v=20260413b" defer></script>
-<script src="utils.js?v=20260413b" defer></script>
-<script src="12-profiles.js?v=20260413b" defer></script>
-<script src="03-auth.js?v=20260413b" defer></script>
-<script src="05-api.js?v=20260413b" defer></script>
-<script src="10-ui.js?v=20260413b" defer></script>
+<script src="00-appstate.js?v=20260413c"></script>
+<script src="00-appstate-compat.js?v=20260413c"></script>
+<script src="01-config.js?v=20260413c" defer></script>
+<script src="02-session.js?v=20260413c" defer></script>
+<script src="utils.js?v=20260413c" defer></script>
+<script src="12-profiles.js?v=20260413c" defer></script>
+<script src="03-auth.js?v=20260413c" defer></script>
+<script src="05-api.js?v=20260413c" defer></script>
+<script src="10-ui.js?v=20260413c" defer></script>
 
-<script src="06-post-create.js?v=20260413b" defer></script>
-<script defer src="render/dashboard.js?v=20260413b"></script>
-<script defer src="render/client.js?v=20260413b"></script>
-<script defer src="render/pipeline.js?v=20260413b"></script>
-<script defer src="render/brief.js?v=20260413b"></script>
-<script defer src="actions/pcs.js?v=20260413b"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413b"></script>
-<script src="07-post-load.js?v=20260413b" defer></script>
-<script src="08-post-actions.js?v=20260413b" defer></script>
-<script src="09-library.js?v=20260413b" defer></script>
-<script src="09-approval.js?v=20260413b" defer></script>
-<script src="04-router.js?v=20260413b" defer></script>
+<script src="06-post-create.js?v=20260413c" defer></script>
+<script defer src="render/dashboard.js?v=20260413c"></script>
+<script defer src="render/client.js?v=20260413c"></script>
+<script defer src="render/pipeline.js?v=20260413c"></script>
+<script defer src="render/brief.js?v=20260413c"></script>
+<script defer src="actions/pcs.js?v=20260413c"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413c"></script>
+<script src="07-post-load.js?v=20260413c" defer></script>
+<script src="08-post-actions.js?v=20260413c" defer></script>
+<script src="09-library.js?v=20260413c" defer></script>
+<script src="09-approval.js?v=20260413c" defer></script>
+<script src="04-router.js?v=20260413c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -244,6 +244,74 @@ window._briefSubmitComment = function(postId) {
       post_title: (post && post.title) || '',
       created_at: nowISO
     })
+  }).then(function() {
+    // Notification fan-out — route based on author role so the
+    // Client bell lights up when agency replies on a brief, and
+    // Servicing + Admin get notified when the client responds.
+    // notify-comment (edge) does NOT fire on brief comments today,
+    // so this JS fan-out is the only writer for these rows. Each
+    // POST is wrapped in its own catch so a failed insert cannot
+    // block the comment UI.
+    try {
+      var authorEmail = (window.AppState.user && window.AppState.user.email) || '';
+      var actor = authorEmail || authorName;
+      var briefTitle = (post && post.title) || 'your request';
+      var preview = text.length > 50 ? text.slice(0, 50) : text;
+      var roleLower = String(normRole || '').toLowerCase();
+      if (roleLower !== 'client') {
+        // Agency user commenting — notify the Client role
+        var agencyMsg = authorName + ' commented on your request: ' + preview;
+        try {
+          apiFetch('/notifications', {
+            method: 'POST',
+            body: JSON.stringify({
+              user_role: 'Client',
+              post_id: postId,
+              type: 'comment',
+              message: agencyMsg,
+              actor: actor,
+              read: false,
+              created_at: new Date().toISOString()
+            })
+          }).catch(function(e) {
+            console.warn('[brief] client notification POST failed', e);
+            window.logError && window.logError(e && e.message, e && e.stack, 'brief-notify-client');
+          });
+        } catch (e) {
+          console.warn('[brief] client notification threw', e);
+        }
+      } else {
+        // Client responding — notify Servicing AND Admin
+        var clientMsg = authorName + ' replied on ' + briefTitle + ': ' + preview;
+        var roles = ['Servicing', 'Admin'];
+        for (var ri = 0; ri < roles.length; ri++) {
+          (function(targetRole) {
+            try {
+              apiFetch('/notifications', {
+                method: 'POST',
+                body: JSON.stringify({
+                  user_role: targetRole,
+                  post_id: postId,
+                  type: 'comment',
+                  message: clientMsg,
+                  actor: actor,
+                  read: false,
+                  created_at: new Date().toISOString()
+                })
+              }).catch(function(e) {
+                console.warn('[brief] ' + targetRole + ' notification POST failed', e);
+                window.logError && window.logError(e && e.message, e && e.stack, 'brief-notify-' + targetRole.toLowerCase());
+              });
+            } catch (e) {
+              console.warn('[brief] ' + targetRole + ' notification threw', e);
+            }
+          })(roles[ri]);
+        }
+      }
+    } catch (fanErr) {
+      console.warn('[brief] notification fan-out threw', fanErr);
+      window.logError && window.logError(fanErr && fanErr.message, fanErr && fanErr.stack, 'brief-notify-fanout');
+    }
   }).catch(function(err) {
     console.error('[brief] submit comment failed', err);
     window.logError && window.logError(err && err.message, err && err.stack, 'brief-submit-comment');

--- a/render/client.js
+++ b/render/client.js
@@ -134,8 +134,27 @@ console.log('LOADED:', 'render/client.js');
     var approval = [];
     var input = [];
     var published = [];
+    var requests = [];
     for (var i = 0; i < posts.length; i++) {
       var p = posts[i];
+      if (p._isRequest) {
+        // Only surface requests that need client input: assigned_to is
+        // empty/null AND at least one agency comment exists. Briefs
+        // already picked up by creative (assigned_to set) or still
+        // waiting on agency to reply (no agency comment yet) stay
+        // hidden from the client feed.
+        var assigned = (p.assigned_to || '').trim();
+        if (assigned) continue;
+        var comments = p.post_comments || [];
+        var hasAgencyComment = false;
+        for (var ci = 0; ci < comments.length; ci++) {
+          var cRole = String(comments[ci].author_role || '').toLowerCase();
+          if (cRole && cRole !== 'client') { hasAgencyComment = true; break; }
+        }
+        if (!hasAgencyComment) continue;
+        requests.push(p);
+        continue;
+      }
       if (p.stage === 'awaiting_approval') approval.push(p);
       else if (p.stage === 'awaiting_brand_input') input.push(p);
       else if (p.stage === 'published') published.push(p);
@@ -143,7 +162,8 @@ console.log('LOADED:', 'render/client.js');
     _sortAsc(approval);
     _sortAsc(input);
     _sortDesc(published);
-    return { approval: approval, input: input, published: published };
+    _sortDesc(requests);
+    return { approval: approval, input: input, published: published, requests: requests };
   }
 
   /* ---- avatar ---- */
@@ -887,6 +907,74 @@ console.log('LOADED:', 'render/client.js');
       /* comments + input; collapsed only on the stages that have the
          Comment toggle button in the engagement bar */
       _commentsContainerHtml(post, !hasCommentBtn) +
+    '</div>';
+  }
+
+  /* ---- brief card (requests bucket) ---- */
+
+  function _briefRelTime(iso) {
+    if (typeof window._notifRelTime === 'function') {
+      return window._notifRelTime(iso);
+    }
+    return _relativeTime(iso);
+  }
+
+  function _briefCardHtml(post) {
+    var pid = post.post_id || post.id || '';
+    var title = post.title || 'Untitled request';
+    var tag = post.content_pillar || post.format || post.content_type || '';
+    var created = post.created_at || '';
+
+    // Latest agency comment (last non-client by created_at)
+    var comments = (post.post_comments || []).slice().sort(function(a, b) {
+      return new Date(a.created_at || 0).getTime() - new Date(b.created_at || 0).getTime();
+    });
+    var latestAgency = null;
+    for (var i = comments.length - 1; i >= 0; i--) {
+      var cRole = String(comments[i].author_role || '').toLowerCase();
+      if (cRole && cRole !== 'client') { latestAgency = comments[i]; break; }
+    }
+    var totalCount = comments.length;
+
+    var chipStyle = 'display:inline-flex;align-items:center;gap:5px;font-family:\'IBM Plex Mono\',monospace;font-size:8px;letter-spacing:.08em;text-transform:uppercase;font-weight:600;padding:3px 8px;border-radius:2px;background:#FBBF2410;color:#FBBF24;border:1px solid #FBBF2425;';
+    var chipDot = '<span style="width:5px;height:5px;border-radius:50%;background:#FBBF24;display:inline-block;"></span>';
+    var chipHtml = '<span style="' + chipStyle + '">' + chipDot + 'NEEDS YOUR INPUT</span>';
+
+    var timeStyle = 'font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#545460;font-weight:500;';
+    var timeHtml = '<span style="' + timeStyle + '">' + _esc(_briefRelTime(created)) + '</span>';
+
+    var topRow = '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">' + chipHtml + timeHtml + '</div>';
+
+    var titleHtml = '<div style="font-size:15px;font-weight:700;color:#FFFFFF;line-height:1.3;margin-bottom:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + _esc(title) + '</div>';
+
+    var tagHtml = '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;letter-spacing:.06em;color:#545460;text-transform:uppercase;font-weight:500;margin-bottom:10px;">' + _esc(tag || '') + '</div>';
+
+    var previewHtml = '';
+    if (latestAgency) {
+      var authorName = latestAgency.author || '';
+      var initial = (authorName.charAt(0) || '?').toUpperCase();
+      var msg = String(latestAgency.message || '').replace(/\s+/g, ' ').trim();
+      var avStyle = 'width:22px;height:22px;border-radius:50%;display:inline-flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:8px;font-weight:700;background:#22D3EE18;color:#22D3EE;border:1px solid #22D3EE30;flex-shrink:0;';
+      var nameStyle = 'font-size:10px;font-weight:600;color:#B2B2B7;';
+      var textStyle = 'font-size:11px;font-weight:500;color:#92929B;display:-webkit-box;-webkit-line-clamp:1;-webkit-box-orient:vertical;overflow:hidden;';
+      previewHtml = '<div style="padding:8px 10px;background:#15151F;border-radius:4px;border-left:2px solid #22D3EE;display:flex;align-items:flex-start;gap:8px;margin-bottom:10px;">' +
+        '<div style="' + avStyle + '">' + _esc(initial) + '</div>' +
+        '<div style="min-width:0;flex:1;">' +
+          '<div style="' + nameStyle + '">' + _esc(authorName) + '</div>' +
+          '<div style="' + textStyle + '">' + _esc(msg) + '</div>' +
+        '</div>' +
+      '</div>';
+    }
+
+    var countIcon = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#545460" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>';
+    var countHtml = '<div style="display:inline-flex;align-items:center;gap:5px;font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#545460;font-weight:500;">' + countIcon + '<span>' + totalCount + '</span></div>';
+
+    return '<div data-brief-card="' + _esc(pid) + '" onclick="window._openBriefSheet(\'' + _esc(pid) + '\')" style="background:#0D0D12;border-bottom:1px solid #2A2A34;padding:14px 16px;cursor:pointer;">' +
+      topRow +
+      titleHtml +
+      tagHtml +
+      previewHtml +
+      countHtml +
     '</div>';
   }
 
@@ -2226,13 +2314,19 @@ console.log('LOADED:', 'render/client.js');
 
     var html = _topBarHtml(buckets);
 
-    var hasContent = buckets.approval.length || buckets.input.length || buckets.published.length;
+    var hasContent = buckets.approval.length || buckets.input.length || buckets.published.length || (buckets.requests && buckets.requests.length);
 
     html += '<div style="padding-bottom:72px;max-width:560px;margin:0 auto;">';
 
     if (!hasContent) {
-      html += '<div style="padding:48px 16px;text-align:center;font-family:\'IBM Plex Mono\',monospace;font-size:11px;letter-spacing:0.06em;color:#FFFFFF59;">Nothing awaiting your review.</div>';
+      html += '<div style="padding:48px 16px;text-align:center;font-family:\'IBM Plex Mono\',monospace;font-size:11px;letter-spacing:0.06em;color:#FFFFFF59;">All caught up. Nothing pending.</div>';
     } else {
+      if (buckets.requests && buckets.requests.length) {
+        html += '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:#505058;font-weight:600;padding:18px 16px 8px;">YOUR REQUESTS <span style="color:#C8A84B;font-weight:700;">' + buckets.requests.length + '</span></div>';
+        for (var r = 0; r < buckets.requests.length; r++) {
+          html += _briefCardHtml(buckets.requests[r]);
+        }
+      }
       if (buckets.approval.length) {
         html += _sectionLabel('&#9670; Awaiting Your Approval');
         for (var a = 0; a < buckets.approval.length; a++) {


### PR DESCRIPTION
## Summary

Client feed now shows a "Your Requests" bucket at the top with any pending brief that needs client input (unassigned + at least one agency comment). Tap opens the existing brief sheet. Notifications fan out on every brief comment so the bell lights up on both sides.

### Changes

- **FIX A — `07-post-load.js`:** `loadPostsForClient` merges `assigned_to` on the request-stub so the client-side filter can skip briefs already picked up by creative. Single-field edit — no other changes in this file.
- **FIX B + C — `render/client.js`:**
  - New `_briefCardHtml(post)` brief card template (all inline styles, no CSS file changes). Status chip "NEEDS YOUR INPUT", relative timestamp, title, content type, latest agency comment preview (avatar + name + 1-line clamp), and a total comment count with chat bubble icon.
  - `_bucket` now returns a `requests` bucket that filters to `!assigned_to && hasAgencyComment && _isRequest`. Briefs with no agency reply or already-assigned briefs stay hidden.
  - `renderClientView` renders the `YOUR REQUESTS` section FIRST, above approvals/input/published. Section header in IBM Plex Mono + gold count badge. Cards route to `_openBriefSheet(postId)` via inline onclick (not `_openClientPostOverlay`).
- **FIX D — `render/brief.js`:** `_briefSubmitComment` now fans out notifications after the `/post_comments` POST succeeds. Agency commenter → `Client` bell. Client commenter → `Servicing` + `Admin` bells. Each POST is wrapped in its own try/catch so a notification failure can't block the comment.
- **FIX E — empty state:** When all buckets including requests are empty, the feed reads "All caught up. Nothing pending."
- **Version bump:** All 22 `?v=` strings → `20260413c`.

### Out of scope (intentionally untouched)
- No change to brief sheet visual design (already works for clients).
- No DB schema change.
- No new client bottom-nav tab.
- No Pipeline / Library / Insights edits.
- No `styles.css` edits — brief card styling is inline.

## Test plan

- [x] `npx vitest run` — 563/563 passing across 22 files
- [ ] Client role: YOUR REQUESTS section renders above approvals with correct count badge
- [ ] Brief card tap opens `_openBriefSheet` (not client overlay)
- [ ] Brief with `assigned_to` set does NOT appear in client feed
- [ ] Brief with zero agency comments does NOT appear in client feed
- [ ] Agency comment on brief → Client bell increments
- [ ] Client reply on brief → Servicing + Admin bells increment
- [ ] Empty state reads "All caught up. Nothing pending."

https://claude.ai/code/session_01ASviDZUDyu2b2u1HRZuyf2