### PR TITLE
Fix 4 brief panel silent-fail bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413c">
+ <link rel="stylesheet" href="styles.css?v=20260413d">
 
 </head>
 <body>
@@ -1084,28 +1084,28 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413c"></script>
-<script src="00-appstate-compat.js?v=20260413c"></script>
-<script src="01-config.js?v=20260413c" defer></script>
-<script src="02-session.js?v=20260413c" defer></script>
-<script src="utils.js?v=20260413c" defer></script>
-<script src="12-profiles.js?v=20260413c" defer></script>
-<script src="03-auth.js?v=20260413c" defer></script>
-<script src="05-api.js?v=20260413c" defer></script>
-<script src="10-ui.js?v=20260413c" defer></script>
+<script src="00-appstate.js?v=20260413d"></script>
+<script src="00-appstate-compat.js?v=20260413d"></script>
+<script src="01-config.js?v=20260413d" defer></script>
+<script src="02-session.js?v=20260413d" defer></script>
+<script src="utils.js?v=20260413d" defer></script>
+<script src="12-profiles.js?v=20260413d" defer></script>
+<script src="03-auth.js?v=20260413d" defer></script>
+<script src="05-api.js?v=20260413d" defer></script>
+<script src="10-ui.js?v=20260413d" defer></script>
 
-<script src="06-post-create.js?v=20260413c" defer></script>
-<script defer src="render/dashboard.js?v=20260413c"></script>
-<script defer src="render/client.js?v=20260413c"></script>
-<script defer src="render/pipeline.js?v=20260413c"></script>
-<script defer src="render/brief.js?v=20260413c"></script>
-<script defer src="actions/pcs.js?v=20260413c"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413c"></script>
-<script src="07-post-load.js?v=20260413c" defer></script>
-<script src="08-post-actions.js?v=20260413c" defer></script>
-<script src="09-library.js?v=20260413c" defer></script>
-<script src="09-approval.js?v=20260413c" defer></script>
-<script src="04-router.js?v=20260413c" defer></script>
+<script src="06-post-create.js?v=20260413d" defer></script>
+<script defer src="render/dashboard.js?v=20260413d"></script>
+<script defer src="render/client.js?v=20260413d"></script>
+<script defer src="render/pipeline.js?v=20260413d"></script>
+<script defer src="render/brief.js?v=20260413d"></script>
+<script defer src="actions/pcs.js?v=20260413d"></script>
+<script defer src="actions/pcs-longpress.js?v=20260413d"></script>
+<script src="07-post-load.js?v=20260413d" defer></script>
+<script src="08-post-actions.js?v=20260413d" defer></script>
+<script src="09-library.js?v=20260413d" defer></script>
+<script src="09-approval.js?v=20260413d" defer></script>
+<script src="04-router.js?v=20260413d" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -361,7 +361,11 @@ window._openBriefSheet = async function(postId) {
         post._requestStatus = reqRows[0].status || '';
       }
     } catch (e) {
-      // Non-fatal — fall through with whatever is cached on the post.
+      // Non-fatal — fall through with whatever is cached on the post,
+      // but surface the failure so we can see when the refetch drops
+      // (otherwise a silent 4xx leaves a stale assigned_to in memory).
+      console.error('[brief] fetch assigned_to failed', e);
+      if (window.logError) window.logError(e && e.message, e && e.stack, 'brief-fetch-assigned');
     }
   }
 
@@ -369,6 +373,7 @@ window._openBriefSheet = async function(postId) {
   var _isClient = _role === 'client';
   var _isCreativeRole = _role === 'creative' || _role === 'pranav';
   var _canAssign = _role === 'admin' || _role === 'servicing' || _role === 'chitra' || _role === 'shubham';
+  var _isChitra = _canAssign;
   var _isBriefDone = (post.stage || '') === 'brief_done';
   var sentTime = '';
   if (post.status_changed_at && post.status_changed_at !== 'null') {
@@ -749,14 +754,6 @@ window._openBriefSheet = async function(postId) {
     '<div style="display:flex;flex-direction:column;gap:8px;">' +
     _footerActions +
     '</div>' +
-    '<button onclick="document.getElementById(\'brief-sheet-overlay\').remove();' +
-    'document.body.style.overflow=\'\';" ' +
-    'style="display:flex;align-items:center;justify-content:center;gap:6px;' +
-    'background:transparent;border:1px solid #252535;border-radius:10px;' +
-    'padding:11px 20px;cursor:pointer;width:100%;margin-top:8px;">' +
-    '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:500;' +
-    'letter-spacing:0.1em;text-transform:uppercase;color:#555566;">&#x2715;   CLOSE BRIEF</span>' +
-    '</button>' +
     '</div>';
 
   document.body.appendChild(overlay);
@@ -800,7 +797,7 @@ window._briefFetchTeamMembers = function() {
     return Promise.resolve(window._briefTeamMembersCache);
   }
   // SELECT name, role FROM user_roles WHERE role != 'client' ORDER BY name
-  return apiFetch('/user_roles?role=neq.client&select=name,role,email&order=name.asc', { method: 'GET' })
+  return apiFetch('/user_roles?role=neq.Client&select=name,role,email&order=name.asc', { method: 'GET' })
     .then(function(rows) {
       var list = Array.isArray(rows) ? rows.filter(function(r) { return r && r.name; }) : [];
       window._briefTeamMembersCache = list;


### PR DESCRIPTION
## Summary

Fixes 4 silent-fail bugs in the brief panel surfaced by the audit. All changes are in `render/brief.js` + the `index.html` version bump. No business logic changes beyond the 4 fixes.

## The 4 fixes

### FIX 1 — Delete the duplicate dismiss-only "CLOSE BRIEF" button
`render/brief.js:752-759` (removed). This button lived in the sticky footer BELOW `_footerActions` and was visually identical to the real close button at L493 (same icon, same IBM Plex Mono uppercase dim grey styling, same text). Its onclick only called `.remove()` on the overlay — no `_closeBriefConfirm`, no `_closeBrief`, no apiFetch, no state mutation. Tapping it made the sheet disappear but left the request row untouched; the brief reappeared on next poll. This was the root cause of "close button doesn't work, no error_log entry".

### FIX 2 — Declare `_isChitra`
`render/brief.js:376` (new line). The `_footerActions` IIFE referenced `_isChitra` on L509 and L514 for the brief_done reopen/close branches, but the variable was never declared. For a brief in stage `brief_done` (or a legacy post with a `linked_post_id`), the IIFE threw `ReferenceError`, `overlay.innerHTML = ...` aborted, and the user saw a blank black overlay. Declared as `var _isChitra = _canAssign;` next to the other role flags — `_canAssign` already covers Admin + Servicing + Chitra + Shubham, which matches the reopen/close audience.

### FIX 3 — Case-sensitive role filter in `_briefFetchTeamMembers`
`render/brief.js:800`: `role=neq.client` → `role=neq.Client`. Per CLAUDE.md §2, PostgREST `eq`/`neq` is case-sensitive and DB roles are Title Case. The lowercase filter was a no-op (no row has role literally equal to 'client'), so Manisha and Shivangini were showing up in the assign dropdown. An Admin who picked a client would end up writing a client name into `requests.assigned_to` and the brief would never be picked up by creative.

### FIX 4 — Surface the empty catch in `_openBriefSheet`
`render/brief.js:363-369`. The try/catch around the `/requests?select=assigned_to,status` refetch silently swallowed failures, so a 4xx on the refetch left a stale `post.assigned_to` in memory (the sheet would render as "assigned to X" even after SQL reset). Added `console.error` + `window.logError(..., 'brief-fetch-assigned')` inside the catch so the failure mode is visible in error_log.

### FIX 5 — Notification font sharpness (verified, no change needed)
Already landed in PR #836. Verified every spec target against the current CSS:
- `#notif-overlay #panel-updates`: `-webkit-font-smoothing: antialiased` + `-moz-osx-font-smoothing: grayscale` + `text-rendering: optimizeLegibility` at `styles.css:3836-3838` ✓
- `.notif-text` weight 500, color `#B2B2B7` at `styles.css:4019,4021` ✓
- `.notif-text strong` weight 700, color `#FFFFFF` at `styles.css:4024,4025` ✓
- `.notif-preview` weight 500, size 10px, color `#92929B` at `styles.css:4042,4043,4045` ✓
- `.notif-time` weight 500, color `#545460` at `styles.css:4075,4076` ✓
- Read-state: only `.notif-item.read { background: transparent; }` at L3977 (no dimming) ✓
- Zero `rgba()` in the entire notification CSS section (all translucencies are 8-digit hex) ✓

No `styles.css` change in this PR.

## Version

All 22 `?v=` strings in `index.html` bumped `20260413c` → `20260413d`.

## Tests

- `npx vitest run` — **563/563 passing** across 22 test files.

## Test plan

- [x] vitest suite passes
- [ ] Open a pending request in the brief sheet — only ONE "Close Brief" button visible in the footer; tapping it opens the confirm overlay and the request becomes `status='closed'` after confirm.
- [ ] Open a `brief_done` request — overlay renders (not blank). Reopen / Close buttons appear for Admin/Servicing.
- [ ] Open the assign dropdown — only Admin/Servicing/Creative team members appear (no Manisha/Shivangini).
- [ ] Force a 4xx on `/requests?id=eq.X&select=assigned_to,status` — error_log gets a row tagged `brief-fetch-assigned` instead of silently keeping stale state.

## Post-merge

Purge Cloudflare cache at dash.cloudflare.com → srtd.io → Caching → Purge Everything, then hard-refresh every device.

https://claude.ai/code/session_01ASviDZUDyu2b2u1HRZuyf2