### PR TITLE
Wire resolveActor() into updated_by on all 23 PATCH /posts sites

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -366,7 +366,8 @@ if (window._activeBriefPostId) {
     body: JSON.stringify({
       stage: 'brief_done',
       linked_post_id: _newPostId || null,
-      updated_at: new Date().toISOString()
+      updated_at: new Date().toISOString(),
+      updated_by: resolveActor()
     })
   }).catch(function(err) {
     console.warn('[post-create] brief close failed', err);

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -132,7 +132,7 @@ async function quickStage(postId, newStage) {
     const actor = resolveActor();
     const rows = await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
       method: 'PATCH',
-      body: JSON.stringify({ stage: toDbStage(newStage), updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: window.AppState.user.email || actor }),
+      body: JSON.stringify({ stage: toDbStage(newStage), updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: resolveActor() }),
     });
     console.log('[PCS] DB WRITE SUCCESS:', postId, newStage, Date.now());
     // Apply server response
@@ -219,7 +219,7 @@ async function saveAdminEdit() {
   }
   const btn = _ae('ae-save-btn');
   if (btn) btn.disabled = true;
-  const _payload = { title, owner: owner||null, content_pillar: sanitizePillar(pillar)||null, location: location||null, stage: toDbStage(stage)||null, target_date: date||null, updated_at: new Date().toISOString() };
+  const _payload = { title, owner: owner||null, content_pillar: sanitizePillar(pillar)||null, location: location||null, stage: toDbStage(stage)||null, target_date: date||null, updated_at: new Date().toISOString(), updated_by: resolveActor() };
   // Defensive: remove any invalid field names that must never reach DB
   delete _payload.post_link;
   delete _payload.linkedin_url;
@@ -268,7 +268,7 @@ async function clientApprove(postId, btn) {
       // scheduled -> owner remains unchanged (per ownership rules)
       var rows = await apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
         method: 'PATCH',
-        body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: 'Client' }),
+        body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: resolveActor() }),
       });
       // Apply server response - same pattern as quickStage
       if (Array.isArray(rows) && rows[0]) {
@@ -320,7 +320,7 @@ async function clientAcknowledge(postId) {
     try {
       await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
         method: 'PATCH',
-        body: JSON.stringify({ stage: 'in_production', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString() }),
+        body: JSON.stringify({ stage: 'in_production', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: resolveActor() }),
       });
       await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Client', actor_role: 'Client', action: 'Acknowledged  -  sending via WhatsApp' });
       var _ackPost = getPostById(postId);
@@ -476,7 +476,7 @@ async function flagIssue(postId) {
   try {
     await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
       method: 'PATCH',
-      body: JSON.stringify({ client_feedback: `! ${msg}`, updated_at: new Date().toISOString() }),
+      body: JSON.stringify({ client_feedback: `! ${msg}`, updated_at: new Date().toISOString(), updated_by: resolveActor() }),
     });
     await logActivity({ post_id: postId, actor: window.AppState.user.email || window.AppState.user.role, actor_role: window.AppState.user.role, action: `Issue flagged: ${msg.substring(0,80)}` });
     showToast('Issue flagged  -  team has been notified', 'success');
@@ -533,7 +533,8 @@ function _confirmPublish(postId) {
   var payload = {
     stage: 'published',
     status_changed_at: new Date().toISOString(),
-    updated_at: new Date().toISOString()
+    updated_at: new Date().toISOString(),
+    updated_by: resolveActor()
   };
   if (url) payload.linkedin_link = url;
 
@@ -629,7 +630,7 @@ async function _executeStageChangeAsync(post, postId, newStage, previousStage) {
 
     const rows = await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
       method: 'PATCH',
-      body: JSON.stringify({ stage: toDbStage(newStage), updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: window.AppState.user.email || actor }),
+      body: JSON.stringify({ stage: toDbStage(newStage), updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: resolveActor() }),
     });
 
     console.log('[PCS] DB WRITE SUCCESS:', postId, newStage, Date.now());
@@ -737,7 +738,7 @@ async function updatePost(postId, field, value) {
 
   // Convert stage value to DB format before sending
   const wireValue = (dbField === 'stage') ? toDbStage(value) : (value || null);
-  const _writePayload = { [dbField]: wireValue, updated_at: new Date().toISOString() };
+  const _writePayload = { [dbField]: wireValue, updated_at: new Date().toISOString(), updated_by: resolveActor() };
   console.log('FINAL PAYLOAD:', JSON.stringify(_writePayload, null, 2));
 
   try {

--- a/09-approval.js
+++ b/09-approval.js
@@ -143,7 +143,7 @@ async function submitApproval(type, postId, btn) {
       try {
         await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
           method: 'PATCH',
-          body: JSON.stringify({ stage: 'in_production', client_feedback: text, updated_at: new Date().toISOString() }),
+          body: JSON.stringify({ stage: 'in_production', client_feedback: text, updated_at: new Date().toISOString(), updated_by: resolveActor() }),
         });
         await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Client', actor_role: 'Client', action: `Changes requested: ${text.substring(0,80)}` });
         if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, postId, 'in_production', ['Admin', 'Creative'], window.AppState.user.name || window.currentUserName || 'Client');
@@ -164,7 +164,7 @@ async function submitApproval(type, postId, btn) {
       try {
         await apiFetch(`/posts?post_id=eq.${encodeURIComponent(postId)}`, {
           method: 'PATCH',
-          body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: window.AppState.user.email || 'Client' }),
+          body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: resolveActor() }),
         });
         await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
         if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, esc(title), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || window.currentUserName || 'Client');

--- a/10-ui.js
+++ b/10-ui.js
@@ -2464,7 +2464,7 @@ if (!window._routerBound) {
           _dlNew = _dlNew.trim();
           apiFetch('/posts?post_id=eq.' + encodeURIComponent(_dlPostId), {
             method: 'PATCH',
-            body: JSON.stringify({ drive_link: _dlNew || null })
+            body: JSON.stringify({ drive_link: _dlNew || null, updated_by: resolveActor() })
           }).then(function() {
             if (window.AppState && window.AppState.pcs && window.AppState.pcs.post) {
               window.AppState.pcs.post.drive_link = _dlNew || null;
@@ -2477,7 +2477,7 @@ if (!window._routerBound) {
           var _clPostId = actionEl.dataset.id;
           apiFetch('/posts?post_id=eq.' + encodeURIComponent(_clPostId), {
             method: 'PATCH',
-            body: JSON.stringify({ drive_link: null })
+            body: JSON.stringify({ drive_link: null, updated_by: resolveActor() })
           }).then(function() {
             if (window.AppState && window.AppState.pcs && window.AppState.pcs.post) {
               window.AppState.pcs.post.drive_link = null;

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -936,7 +936,7 @@ window._saveLiUrlInline = function(postId) {
 
   apiFetch('/posts?post_id=eq.' + encodeURIComponent(_liPostId), {
     method: 'PATCH',
-    body: JSON.stringify({ linkedin_link: url })
+    body: JSON.stringify({ linkedin_link: url, updated_by: resolveActor() })
   }).then(function() {
     var _found_615 = false;
     var _next_615 = window.AppState.posts.all.map(function(p) {
@@ -1592,7 +1592,7 @@ window._pcsHandlePhotoInput = async function(postId, input) {
   try {
     await apiFetch('/posts?post_id=eq.' + postId, {
       method: 'PATCH',
-      body: JSON.stringify({ images: newImages })
+      body: JSON.stringify({ images: newImages, updated_by: resolveActor() })
     });
     var _found_1379 = false;
     var _next_1379 = window.AppState.posts.all.map(function(p) {
@@ -1640,7 +1640,7 @@ window._pcsRemovePhoto = async function(postId, idx) {
   try {
     await apiFetch('/posts?post_id=eq.' + postId, {
       method: 'PATCH',
-      body: JSON.stringify({ images: imgs })
+      body: JSON.stringify({ images: imgs, updated_by: resolveActor() })
     });
     var _found_1407 = false;
     var _next_1407 = window.AppState.posts.all.map(function(p) {
@@ -1755,7 +1755,7 @@ window._pcsDoRemovePhotoEdit = async function(postId, idx) {
   try {
     await apiFetch('/posts?post_id=eq.' + postId, {
       method: 'PATCH',
-      body: JSON.stringify({ images: imgs })
+      body: JSON.stringify({ images: imgs, updated_by: resolveActor() })
     });
     var _next = window.AppState.posts.all.map(function(p) {
       if (getPostId(p) === postId) {
@@ -1826,7 +1826,7 @@ window._pcsDoClearing = async function(postId) {
   try {
     await apiFetch('/posts?post_id=eq.' + postId, {
       method: 'PATCH',
-      body: JSON.stringify({ caption: '' })
+      body: JSON.stringify({ caption: '', updated_by: resolveActor() })
     });
     var _next = window.AppState.posts.all.map(function(p) {
       if (getPostId(p) === postId) {
@@ -2191,7 +2191,7 @@ window._saveCaptionEdit = async function(postId) {
   try {
     await apiFetch('/posts?post_id=eq.' + postId, {
       method: 'PATCH',
-      body: JSON.stringify({ caption: newCaption })
+      body: JSON.stringify({ caption: newCaption, updated_by: resolveActor() })
     });
   } catch (err) {
     console.error('[pcs] save caption failed', err);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260413d">
+ <link rel="stylesheet" href="styles.css?v=20260414a">
 
 </head>
 <body>
@@ -1084,28 +1084,28 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260413d"></script>
-<script src="00-appstate-compat.js?v=20260413d"></script>
-<script src="01-config.js?v=20260413d" defer></script>
-<script src="02-session.js?v=20260413d" defer></script>
-<script src="utils.js?v=20260413d" defer></script>
-<script src="12-profiles.js?v=20260413d" defer></script>
-<script src="03-auth.js?v=20260413d" defer></script>
-<script src="05-api.js?v=20260413d" defer></script>
-<script src="10-ui.js?v=20260413d" defer></script>
+<script src="00-appstate.js?v=20260414a"></script>
+<script src="00-appstate-compat.js?v=20260414a"></script>
+<script src="01-config.js?v=20260414a" defer></script>
+<script src="02-session.js?v=20260414a" defer></script>
+<script src="utils.js?v=20260414a" defer></script>
+<script src="12-profiles.js?v=20260414a" defer></script>
+<script src="03-auth.js?v=20260414a" defer></script>
+<script src="05-api.js?v=20260414a" defer></script>
+<script src="10-ui.js?v=20260414a" defer></script>
 
-<script src="06-post-create.js?v=20260413d" defer></script>
-<script defer src="render/dashboard.js?v=20260413d"></script>
-<script defer src="render/client.js?v=20260413d"></script>
-<script defer src="render/pipeline.js?v=20260413d"></script>
-<script defer src="render/brief.js?v=20260413d"></script>
-<script defer src="actions/pcs.js?v=20260413d"></script>
-<script defer src="actions/pcs-longpress.js?v=20260413d"></script>
-<script src="07-post-load.js?v=20260413d" defer></script>
-<script src="08-post-actions.js?v=20260413d" defer></script>
-<script src="09-library.js?v=20260413d" defer></script>
-<script src="09-approval.js?v=20260413d" defer></script>
-<script src="04-router.js?v=20260413d" defer></script>
+<script src="06-post-create.js?v=20260414a" defer></script>
+<script defer src="render/dashboard.js?v=20260414a"></script>
+<script defer src="render/client.js?v=20260414a"></script>
+<script defer src="render/pipeline.js?v=20260414a"></script>
+<script defer src="render/brief.js?v=20260414a"></script>
+<script defer src="actions/pcs.js?v=20260414a"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414a"></script>
+<script src="07-post-load.js?v=20260414a" defer></script>
+<script src="08-post-actions.js?v=20260414a" defer></script>
+<script src="09-library.js?v=20260414a" defer></script>
+<script src="09-approval.js?v=20260414a" defer></script>
+<script src="04-router.js?v=20260414a" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -952,7 +952,8 @@ window._assignBrief = function(postId, ownerName, isReassign) {
       owner: dbOwner,
       client_feedback: updatedFeedback,
       status_changed_at: nowISO,
-      updated_at: nowISO
+      updated_at: nowISO,
+      updated_by: resolveActor()
     })
   }).then(function() {
     // Persist the display name on the in-memory row so the reopen
@@ -1060,7 +1061,8 @@ window._closeBrief = function(postId) {
     method: 'PATCH',
     body: JSON.stringify({
       stage: 'brief_done',
-      updated_at: new Date().toISOString()
+      updated_at: new Date().toISOString(),
+      updated_by: resolveActor()
     })
   }).then(function() {
     var overlay = document.getElementById('brief-sheet-overlay');
@@ -1114,7 +1116,8 @@ window._reopenBrief = function(postId) {
     body: JSON.stringify({
       stage: 'brief',
       owner: 'Servicing',
-      updated_at: new Date().toISOString()
+      updated_at: new Date().toISOString(),
+      updated_by: resolveActor()
     })
   }).then(function() {
     var overlay = document.getElementById('brief-sheet-overlay');

--- a/render/pipeline.js
+++ b/render/pipeline.js
@@ -625,7 +625,7 @@ window.executeBatchAction = async function(targetStage) {
         stage: dbStage,
         status_changed_at: now,
         updated_at: now,
-        updated_by: window.AppState.user.email || actor
+        updated_by: resolveActor()
       }),
     });
 

--- a/tests/session-resilience.test.js
+++ b/tests/session-resilience.test.js
@@ -177,10 +177,10 @@ describe('BONUS — clientApprove guardAction + approval payload', function() {
     expect(approvedMatch[0]).toContain('status_changed_at');
   });
 
-  it('24. submitApproval approved PATCH includes updated_by Client', function() {
+  it('24. submitApproval approved PATCH includes updated_by resolveActor()', function() {
     var approvedMatch = approvalSrc.match(/type === 'approved'[\s\S]{0,400}/);
     expect(approvedMatch).toBeTruthy();
-    expect(approvedMatch[0]).toContain("updated_by: window.AppState.user.email || 'Client'");
+    expect(approvedMatch[0]).toContain("updated_by: resolveActor()");
   });
 
   it('25. _clearSessionAndLogin is exported to window', function() {

--- a/utils.js
+++ b/utils.js
@@ -92,10 +92,12 @@ function formatIST(ts) {
   });
 }
 
-// Resolve actor identifier — returns email (unique, immutable)
+// Resolve actor identifier — returns human-readable name first
+// so notifications/updated_by columns render nicely; falls back
+// to email if the user_roles row has no name.
 function resolveActor() {
-  return window.AppState.user.email
+  return window.AppState.user.name
+    || window.AppState.user.email
     || localStorage.getItem('hinglish_email')
-    || window.AppState.user.name
     || 'unknown';
 }


### PR DESCRIPTION
## Summary

- Flip `resolveActor()` in `utils.js` from email-first to **name-first** so `updated_by` + notifications render the human-readable short name (Shubham/Chitra/Pranav/Manisha) instead of the raw email. Fallback chain: `AppState.user.name || AppState.user.email || localStorage.hinglish_email || 'unknown'`.
- Audit every `apiFetch` PATCH `/posts` call (23 sites) and add `updated_by: resolveActor()` as the last field on every payload. 17 sites were missing it entirely; 6 had it but used inconsistent sources (email chain, hardcoded `'Client'`). Now all 23 pass the same value through to the DB trigger `generate_notifications`, which reads `COALESCE(NEW.updated_by, 'System')`.
- Bump all 22 `?v=` version strings in `index.html` from `20260413d` → `20260414a`.

## Files changed (10)

| File | Sites touched |
|---|---|
| `utils.js` | `resolveActor()` body (name-first) |
| `06-post-create.js` | brief-close block |
| `08-post-actions.js` | `quickStage`, `saveAdminEdit`, `clientApprove`, `clientAcknowledge`, `flagIssue`, `_confirmPublish`, `_executeStageChangeAsync`, `updatePost` |
| `09-approval.js` | `submitApproval` (changes_submit + approved branches) |
| `10-ui.js` | `pcs-edit-drive-link`, `pcs-clear-drive-link` |
| `actions/pcs.js` | `_saveLiUrlInline`, `_pcsHandlePhotoInput`, `_pcsDoRemovePhoto` (×2), `_pcsDoClearing`, `_saveCaptionEdit` |
| `render/brief.js` | `_assignBrief`, `_closeBrief`, `_reopenBrief` |
| `render/pipeline.js` | `executeBatchAction` |
| `tests/session-resilience.test.js` | test #24 assertion updated to match new value |
| `index.html` | 22 `?v=` strings → `20260414a` |

## Scope discipline

- Did NOT delete `resolveActor` or any other function
- Did NOT rename/rescope `resolveActor` — only replaced the body
- Did NOT touch any `logActivity` actor values (separate future PR)
- Did NOT touch any notification POST `actor` values (separate future PR)
- Did NOT touch `_sendStageNotif` (separate future PR)
- Did NOT touch `03-auth.js`, DB schema, or triggers

## Test plan

- [x] `npx vitest run` → 563/563 passing (22 test files, 13.91s)
- [x] Test #24 in `tests/session-resilience.test.js` updated to assert `updated_by: resolveActor()` in `submitApproval` approved branch
- [x] Every PATCH `/posts` payload in the codebase grepped and confirmed to carry `updated_by: resolveActor()`
- [ ] After merge: purge Cloudflare cache (dash.cloudflare.com → srtd.io → Caching → Purge Everything) + hard refresh devices
- [ ] Post-deploy smoke: move a post through stages, confirm `notifications.message` shows the short name (e.g. "Chitra moved X to In Production") instead of an email