### PR TITLE
Title-case mention user_role on client comment notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414a">
+ <link rel="stylesheet" href="styles.css?v=20260414b">
 
 </head>
 <body>
@@ -1084,28 +1084,28 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414a"></script>
-<script src="00-appstate-compat.js?v=20260414a"></script>
-<script src="01-config.js?v=20260414a" defer></script>
-<script src="02-session.js?v=20260414a" defer></script>
-<script src="utils.js?v=20260414a" defer></script>
-<script src="12-profiles.js?v=20260414a" defer></script>
-<script src="03-auth.js?v=20260414a" defer></script>
-<script src="05-api.js?v=20260414a" defer></script>
-<script src="10-ui.js?v=20260414a" defer></script>
+<script src="00-appstate.js?v=20260414b"></script>
+<script src="00-appstate-compat.js?v=20260414b"></script>
+<script src="01-config.js?v=20260414b" defer></script>
+<script src="02-session.js?v=20260414b" defer></script>
+<script src="utils.js?v=20260414b" defer></script>
+<script src="12-profiles.js?v=20260414b" defer></script>
+<script src="03-auth.js?v=20260414b" defer></script>
+<script src="05-api.js?v=20260414b" defer></script>
+<script src="10-ui.js?v=20260414b" defer></script>
 
-<script src="06-post-create.js?v=20260414a" defer></script>
-<script defer src="render/dashboard.js?v=20260414a"></script>
-<script defer src="render/client.js?v=20260414a"></script>
-<script defer src="render/pipeline.js?v=20260414a"></script>
-<script defer src="render/brief.js?v=20260414a"></script>
-<script defer src="actions/pcs.js?v=20260414a"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414a"></script>
-<script src="07-post-load.js?v=20260414a" defer></script>
-<script src="08-post-actions.js?v=20260414a" defer></script>
-<script src="09-library.js?v=20260414a" defer></script>
-<script src="09-approval.js?v=20260414a" defer></script>
-<script src="04-router.js?v=20260414a" defer></script>
+<script src="06-post-create.js?v=20260414b" defer></script>
+<script defer src="render/dashboard.js?v=20260414b"></script>
+<script defer src="render/client.js?v=20260414b"></script>
+<script defer src="render/pipeline.js?v=20260414b"></script>
+<script defer src="render/brief.js?v=20260414b"></script>
+<script defer src="actions/pcs.js?v=20260414b"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414b"></script>
+<script src="07-post-load.js?v=20260414b" defer></script>
+<script src="08-post-actions.js?v=20260414b" defer></script>
+<script src="09-library.js?v=20260414b" defer></script>
+<script src="09-approval.js?v=20260414b" defer></script>
+<script src="04-router.js?v=20260414b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1780,10 +1780,12 @@ console.log('LOADED:', 'render/client.js');
           return m.name && m.name.toLowerCase() === name.toLowerCase();
         });
         if (!_member || !_member.role) return;
+        var safeRole = _member.role ? String(_member.role) : 'Client';
+        var titleCaseRole = safeRole.charAt(0).toUpperCase() + safeRole.slice(1).toLowerCase();
         window.apiFetch('/notifications', {
           method: 'POST',
           body: JSON.stringify({
-            user_role: _member.role,
+            user_role: titleCaseRole,
             post_id: realPostId,
             type: 'mention',
             message: displayName + ' mentioned you on "' + postTitle + '"',


### PR DESCRIPTION
## Summary

- Phase 1 of the mention/notification migration. Single-file fix.
- `render/client.js` `_handleSubmitComment` was writing `user_role: _member.role` verbatim from `window._clientMentionRoster` (fetched from `/user_roles`). Some user_roles rows store `role` in lowercase (`creative`, `client`), which violates the `notifications.valid_roles` CHECK constraint (`Admin | Creative | Servicing | Client`), so the mention notification was silently dropped and the mentioned user never got a bell update.
- Fix title-cases the value before the INSERT, with a `'Client'` fallback for any blank/null role so `charAt(0)` on an empty string can't crash the comment flow.

## What changed

**Before** (`render/client.js:1783-1793`)
```js
if (!_member || !_member.role) return;
window.apiFetch('/notifications', {
  method: 'POST',
  body: JSON.stringify({
    user_role: _member.role,
    post_id: realPostId,
    type: 'mention',
    message: displayName + ' mentioned you on "' + postTitle + '"',
    actor: displayName,
    read: false
  })
}).catch(function(err) { console.error('[mention notif]', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-mention-notif'); });
```

**After**
```js
if (!_member || !_member.role) return;
var safeRole = _member.role ? String(_member.role) : 'Client';
var titleCaseRole = safeRole.charAt(0).toUpperCase() + safeRole.slice(1).toLowerCase();
window.apiFetch('/notifications', {
  method: 'POST',
  body: JSON.stringify({
    user_role: titleCaseRole,
    post_id: realPostId,
    type: 'mention',
    message: displayName + ' mentioned you on "' + postTitle + '"',
    actor: displayName,
    read: false
  })
}).catch(function(err) { console.error('[mention notif]', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-mention-notif'); });
```

## Scope

- Only the `client-mention-notif` INSERT was touched.
- The three static fan-outs above it (`user_role:'Servicing'`, `'Admin'`, `'Creative'`) are already correct Title Case and were left alone.
- `_fetchClientMentionRoster`, `normalizeRole`, and every other file were left alone.
- All 22 `?v=` strings in `index.html` bumped from `20260414a` → `20260414b`.
- `CLAUDE.md` not updated — schema and architecture facts are unchanged.

## Test plan

- [ ] Deploy, hard refresh, Cloudflare cache purge.
- [ ] Agency user @-mentions a team member from a client post comment → verify a row lands in `notifications` with `user_role` in Title Case and no `valid_roles` violation in `error_log`.
- [ ] Recipient's bell badge increments via the agency Realtime listener (`_onAgencyNotificationInsert` → `updateNotifBadge`).
- [ ] Static Servicing/Admin/Creative fan-out still fires one row each as before.
- [ ] `error_log` has zero new `client-mention-notif` entries after a mention.

https://claude.ai/code/session_01RJsyyTRTjTBUWSiYXzcxDe