### PR TITLE
Pass role (not person name) to _assignBrief

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414b">
+ <link rel="stylesheet" href="styles.css?v=20260414d">
 
 </head>
 <body>
@@ -1084,28 +1084,28 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414b"></script>
-<script src="00-appstate-compat.js?v=20260414b"></script>
-<script src="01-config.js?v=20260414b" defer></script>
-<script src="02-session.js?v=20260414b" defer></script>
-<script src="utils.js?v=20260414b" defer></script>
-<script src="12-profiles.js?v=20260414b" defer></script>
-<script src="03-auth.js?v=20260414b" defer></script>
-<script src="05-api.js?v=20260414b" defer></script>
-<script src="10-ui.js?v=20260414b" defer></script>
+<script src="00-appstate.js?v=20260414d"></script>
+<script src="00-appstate-compat.js?v=20260414d"></script>
+<script src="01-config.js?v=20260414d" defer></script>
+<script src="02-session.js?v=20260414d" defer></script>
+<script src="utils.js?v=20260414d" defer></script>
+<script src="12-profiles.js?v=20260414d" defer></script>
+<script src="03-auth.js?v=20260414d" defer></script>
+<script src="05-api.js?v=20260414d" defer></script>
+<script src="10-ui.js?v=20260414d" defer></script>
 
-<script src="06-post-create.js?v=20260414b" defer></script>
-<script defer src="render/dashboard.js?v=20260414b"></script>
-<script defer src="render/client.js?v=20260414b"></script>
-<script defer src="render/pipeline.js?v=20260414b"></script>
-<script defer src="render/brief.js?v=20260414b"></script>
-<script defer src="actions/pcs.js?v=20260414b"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414b"></script>
-<script src="07-post-load.js?v=20260414b" defer></script>
-<script src="08-post-actions.js?v=20260414b" defer></script>
-<script src="09-library.js?v=20260414b" defer></script>
-<script src="09-approval.js?v=20260414b" defer></script>
-<script src="04-router.js?v=20260414b" defer></script>
+<script src="06-post-create.js?v=20260414d" defer></script>
+<script defer src="render/dashboard.js?v=20260414d"></script>
+<script defer src="render/client.js?v=20260414d"></script>
+<script defer src="render/pipeline.js?v=20260414d"></script>
+<script defer src="render/brief.js?v=20260414d"></script>
+<script defer src="actions/pcs.js?v=20260414d"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414d"></script>
+<script src="07-post-load.js?v=20260414d" defer></script>
+<script src="08-post-actions.js?v=20260414d" defer></script>
+<script src="09-library.js?v=20260414d" defer></script>
+<script src="09-approval.js?v=20260414d" defer></script>
+<script src="04-router.js?v=20260414d" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -827,7 +827,7 @@ window._briefShowAssignDropdown = function(postId, isReassign) {
         var name = m.name || m.email || '';
         var memberRole = (m.role || '').toLowerCase();
         var initial = (name.charAt(0) || '?').toUpperCase();
-        html += '<button onclick="_assignBrief(\'' + esc(postId) + '\',\'' + esc(name) + '\',' + isReassign + ')" ' +
+        html += '<button onclick="_assignBrief(\'' + esc(postId) + '\',\'' + esc(m.role || '') + '\',' + isReassign + ')" ' +
           'style="display:flex;align-items:center;gap:10px;width:100%;padding:12px 14px;' +
           'background:#0d0d12;border:none;border-bottom:1px solid #191924;cursor:pointer;">' +
           ((typeof renderAvatar === 'function') ? renderAvatar(m.email || name, memberRole || 'creative', 28) : '<div style="width:28px;height:28px;border-radius:50%;background:#9b87f526;border:1px solid #9b87f54d;display:flex;align-items:center;justify-content:center;font-family:\'IBM Plex Mono\',monospace;font-size:10px;font-weight:600;color:#9b87f5;">' + esc(initial) + '</div>') +
@@ -941,6 +941,14 @@ window._assignBrief = function(postId, ownerName, isReassign) {
   // (posts_owner_check only allows Creative/Servicing/Client/Admin).
   // The person's name is preserved only for display + notification.
   var dbOwner = (typeof normalizeRole === 'function') ? (normalizeRole(ownerName) || 'Creative') : 'Creative';
+  var _validOwners = ['Creative','Servicing','Admin','Client'];
+  if (_validOwners.indexOf(dbOwner) === -1) {
+    window.logError && window.logError(
+      'assign-brief: invalid dbOwner: ' + dbOwner,
+      null, 'assign-brief-owner-guard'
+    );
+    return;
+  }
   var updatedFeedback = (post.client_feedback || '');
   if (direction.trim()) {
     updatedFeedback += '\n\n[CHITRA NOTE] ' + direction.trim();


### PR DESCRIPTION
## Summary

- Root-cause fix for AUDIT 3 (`posts_owner_check` violation on `assign-brief`).
- The assign-brief dropdown at `render/brief.js:830` was building an `onclick` that passed `m.name || m.email` as the owner argument. `_assignBrief` then relied on `normalizeRole()` mapping that name back to a role (`'pranav' → 'Creative'`) before writing `posts.owner`. Two failure modes:
  1. Any `user_roles` row with a NULL `name` fell through to the `email` (e.g. `pranav@hinglish.agency`), which `normalizeRole()` does not know. `dbOwner = 'pranav@hinglish.agency'`. PATCH hits `posts_owner_check`. Nine confirmed errors in the error log.
  2. Once PR #842 drops person-name entries from `normalizeRole()`, the name path stops resolving entirely and every assign-brief PATCH fails.
- The dropdown already has `m.role` available in the same `/user_roles` row, so there is no reason to route a name through a name-to-role mapper. Pass the role directly.
- **This PR must merge before PR #842.** Once this is live, #842 is safe to merge and the production assign-brief flow no longer depends on the person-name map that #842 is removing.

## MUST-READ merge order

1. Merge this PR first (20260414d)
2. Rebase PR #842 (normalize-role-cleanup), bump its version strings from `20260414c` → `20260414e`, then merge it
3. Rebase PR #841 (mention-role-casing) as needed (already on `20260414b`, will just need a version bump to whatever the final sequential value is at that point)

## FIX 1 — pass m.role, not m.name

**Before** (`render/brief.js:830`)
```js
html += '<button onclick="_assignBrief(\'' + esc(postId) + '\',\'' + esc(name) + '\',' + isReassign + ')" ' +
```

**After**
```js
html += '<button onclick="_assignBrief(\'' + esc(postId) + '\',\'' + esc(m.role || '') + '\',' + isReassign + ')" ' +
```

`m.role` is the raw `role` column from `/user_roles?role=neq.Client&select=name,role,email` (fetched by `_briefFetchTeamMembers` at brief.js:800) — e.g. `'Creative'`, `'Servicing'`, `'Admin'`, or their lowercase variants. `normalizeRole()` canonicalises any of those to Title Case, so `dbOwner` ends up as a valid `posts_owner_check` value.

The **visible label** on the dropdown button (`esc(name)` at line 836 + `esc(m.role)` subtitle at line 838) is unchanged — the user still sees "Pranav / Creative", not "creative / creative".

## FIX 2 — _validOwners safety guard

**Before** (`render/brief.js:943-944`)
```js
var dbOwner = (typeof normalizeRole === 'function') ? (normalizeRole(ownerName) || 'Creative') : 'Creative';
var updatedFeedback = (post.client_feedback || '');
```

**After**
```js
var dbOwner = (typeof normalizeRole === 'function') ? (normalizeRole(ownerName) || 'Creative') : 'Creative';
var _validOwners = ['Creative','Servicing','Admin','Client'];
if (_validOwners.indexOf(dbOwner) === -1) {
  window.logError && window.logError(
    'assign-brief: invalid dbOwner: ' + dbOwner,
    null, 'assign-brief-owner-guard'
  );
  return;
}
var updatedFeedback = (post.client_feedback || '');
```

Defence-in-depth: if any future regression lets a non-canonical value through, we log `assign-brief-owner-guard` and bail out instead of sending a doomed PATCH to `/posts`.

## Scope

- Only `render/brief.js` and `index.html` touched.
- Dropdown button builder: onclick argument only. Visible label untouched.
- `_assignBrief`: guard added after `dbOwner` is computed. `normalizeRole` call itself untouched.
- `_briefFetchTeamMembers`: untouched.
- `normalizeRole` in `03-auth.js`: untouched.
- All 22 `?v=` strings in `index.html` bumped `20260414a` → `20260414d`.
- `CLAUDE.md` not updated — schema and architecture unchanged.

## Known scope trade-offs (explicit, not bugs)

After this change, the `ownerName` argument inside `_assignBrief` is a role string (`'creative'`, `'Admin'`, etc.) rather than a person name. That flows into a few display sites the task scope told me NOT to touch:

- `post.assigned_to = ownerName` (brief.js:921 and 962) — in-memory stub now stores the role, not the name. The brief sheet reopen will display the role until the next `loadPosts()` drain replaces the stub from the server.
- `actionLabel` and `toastMsg` (brief.js:869-870) — the assign toast will say "Assigned to creative" instead of "Assigned to Pranav" until the display wiring is refactored.
- `logActivity` action string (brief.js:927/968) — same.

These are display-only regressions that follow-up phases should fix by threading the display name through as a separate argument. **The DB write is now correct and stable**, which is the blocking issue.

## Test plan

- [ ] Deploy, hard refresh, Cloudflare cache purge.
- [ ] Admin + Servicing click Assign on a brief-stage post → dropdown shows team members with correct name/role labels.
- [ ] Assign to each of Pranav / Chitra / Shubham → `PATCH /posts` succeeds, `posts.owner` lands as `'Creative'`/`'Servicing'`/`'Admin'` respectively, zero `posts_owner_check` entries in error_log.
- [ ] Assign on a `_isRequest` row → request path at brief.js:905 still works (the request PATCH writes `assigned_to: ownerName` to the requests table — after this fix that is now a role string; confirm this is acceptable or plan a follow-up).
- [ ] Verify `assign-brief-owner-guard` never fires under normal operation.

https://claude.ai/code/session_01RJsyyTRTjTBUWSiYXzcxDe