### PR TITLE
feat: remove JS notification fan-out (Phase 5)

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -3,44 +3,10 @@
 =============================================== */
 console.log("LOADED:", "08-post-actions.js");
 
-// -- Stage change notification helper --
-// recipients: array of names e.g. ['Admin', 'Chitra', 'Pranav', 'Client']
-// Maps names to DB user_role values before inserting.
-window._sendStageNotif = function(postId, postTitle, stage, recipients, actorName) {
-  var roleMap = {
-    'Admin': 'Admin',
-    'Chitra': 'Servicing',
-    'Pranav': 'Creative',
-    'Client': 'Client'
-  };
-  var label = (typeof _stageLabel === 'function' && _stageLabel(stage)) || stage;
-  // Guard against double-fire (same post + stage within 5 seconds = blocked)
-  var _notifKey = postId + '|' + stage;
-  if (window._lastNotifKey === _notifKey) return;
-  window._lastNotifKey = _notifKey;
-  setTimeout(function() {
-    if (window._lastNotifKey === _notifKey) {
-      window._lastNotifKey = null;
-    }
-  }, 5000);
-  recipients.forEach(function(name) {
-    var userRole = roleMap[name] || name;
-    apiFetch('/notifications', {
-      method: 'POST',
-      body: JSON.stringify({
-        user_role: userRole,
-        post_id: postId,
-        type: stage,
-        message: actorName + ' moved ' + postTitle + ' to ' + label,
-        actor: actorName,
-        read: false
-      })
-    }).catch(function(err) {
-      console.error('[stage-notif] failed for ' + userRole, err);
-      window.logError && window.logError(err && err.message, err && err.stack, 'stage-notif-' + stage);
-    });
-  });
-};
+// -- Stage change notifications are handled entirely by the
+// notify-stage edge function (writes notification rows AND sends
+// emails). The JS fan-out helper _sendStageNotif was removed to
+// eliminate duplicate notification rows.
 
 // -- Save timeout safety net --
 // If a PATCH hangs (no resolve, no reject — e.g. iOS background-tab
@@ -145,8 +111,7 @@ async function quickStage(postId, newStage) {
     post._isSaving = false;
     scheduleRender();
     await logActivity({ post_id: postId, actor: window.AppState.user.email || actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}`, old_stage: oldStage, new_stage: newStage });
-    var _qsRecipients = _stageRecipients(newStage);
-    if (_qsRecipients.length) window._sendStageNotif(postId, getTitle(post), newStage, _qsRecipients, actor);
+    // Stage change notification is handled by the notify-stage edge function.
     showUndoToast('Moved to ' + _stageLabel(newStage), function() { quickStage(postId, oldStage); });
   } catch (err) {
     _clearSaveTimeout(post);
@@ -302,7 +267,7 @@ async function clientApprove(postId, btn) {
       _renderBackgroundViews();
       // Non-critical side effects
       await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled', old_stage: oldStage, new_stage: 'scheduled' });
-      window._sendStageNotif(postId, getTitle(post), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || 'Client');
+      // Stage change notification is handled by the notify-stage edge function.
     } catch (err) {
       _clearSaveTimeout(post);
       post._isSaving = false;
@@ -323,8 +288,7 @@ async function clientAcknowledge(postId) {
         body: JSON.stringify({ stage: 'in_production', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: resolveActor() }),
       });
       await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Client', actor_role: 'Client', action: 'Acknowledged  -  sending via WhatsApp' });
-      var _ackPost = getPostById(postId);
-      window._sendStageNotif(postId, (_ackPost ? getTitle(_ackPost) : postId), 'in_production', ['Creative'], window.AppState.user.name || 'Client');
+      // Stage change notification is handled by the notify-stage edge function.
       showToast('Got it! The team has been notified.', 'success');
       setTimeout(() => loadPostsForClient(), 800);
     } catch (err) {
@@ -567,8 +531,7 @@ function _confirmPublish(postId) {
       old_stage: _pubOldStage,
       new_stage: 'published'
     });
-    var _pubPost = getPostById(postId);
-    window._sendStageNotif(postId, (_pubPost ? getTitle(_pubPost) : postId), 'published', ['Admin', 'Servicing', 'Creative', 'Client'], window.AppState.user.name || 'Shubham');
+    // Stage change notification is handled by the notify-stage edge function.
     showToast('Published', 'success');
     if (typeof _removePublishSheet === 'function') _removePublishSheet();
     if (typeof closePCS === 'function') closePCS();
@@ -665,7 +628,7 @@ async function _executeStageChangeAsync(post, postId, newStage, previousStage) {
 
   // -- NON-CRITICAL  -  completely outside DB try/catch --
   try { await logActivity({ post_id: postId, actor: window.AppState.user.email || actor, actor_role: window.AppState.user.role, action: `Stage -> ${newStage}`, old_stage: previousStage, new_stage: newStage }); } catch(e) { console.warn('[PCS] logActivity failed:', e); }
-  try { var _esRecipients = _stageRecipients(newStage); if (_esRecipients.length) window._sendStageNotif(postId, getTitle(post), newStage, _esRecipients, actor); } catch(e) { console.warn('[PCS] stage notif failed:', e); }
+  // Stage change notification is handled by the notify-stage edge function.
   try { showUndoToast(`Moved to ${newStage}`, () => _executeStageChange(postId, previousStage)); } catch(e) { console.warn('[PCS] showUndoToast failed:', e); }
 }
 

--- a/09-approval.js
+++ b/09-approval.js
@@ -146,7 +146,7 @@ async function submitApproval(type, postId, btn) {
           body: JSON.stringify({ stage: 'in_production', client_feedback: text, updated_at: new Date().toISOString(), updated_by: resolveActor() }),
         });
         await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Client', actor_role: 'Client', action: `Changes requested: ${text.substring(0,80)}` });
-        if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, postId, 'in_production', ['Admin', 'Creative'], window.AppState.user.name || window.currentUserName || 'Client');
+        // Stage change notification is handled by the notify-stage edge function.
         const c = document.getElementById('approval-confirmation');
         if (c) { c.style.display = ''; c.textContent = 'Changes sent  -  the team will review it.'; }
         document.querySelector('.approval-actions')?.remove();
@@ -167,7 +167,7 @@ async function submitApproval(type, postId, btn) {
           body: JSON.stringify({ stage: 'scheduled', updated_at: new Date().toISOString(), status_changed_at: new Date().toISOString(), updated_by: resolveActor() }),
         });
         await logActivity({ post_id: postId, actor: window.AppState.user.email || 'Client', actor_role: 'Client', action: 'Approved  -  moved to Scheduled' });
-        if (typeof window._sendStageNotif === 'function') window._sendStageNotif(postId, esc(title), 'scheduled', ['Admin', 'Servicing', 'Creative'], window.AppState.user.name || window.currentUserName || 'Client');
+        // Stage change notification is handled by the notify-stage edge function.
         const c = document.getElementById('approval-confirmation');
         if (c) { c.style.display = ''; c.textContent = 'ok Approved! The team has been notified.'; }
         document.querySelector('.approval-actions')?.remove();

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -2441,58 +2441,9 @@ window._doSubmitComment = async function(opts) {
       action: 'Commented: ' + opts.message
     });
 
-    var _targets = [];
-    if (opts.visibility === 'all') {
-      if (_roleLower === 'client') {
-        _targets = ['Servicing', 'Admin', 'Creative'];
-      } else {
-        _targets = ['Client'];
-      }
-    } else if (opts.visibility === 'admin') {
-      _targets = ['Admin'];
-    } else if (opts.visibility === 'servicing') {
-      _targets = ['Servicing'];
-    } else if (opts.visibility === 'creative') {
-      _targets = ['Creative'];
-    }
-
-    _targets.forEach(function(role) {
-      apiFetch('/notifications', {
-        method: 'POST',
-        body: JSON.stringify({
-          user_role: role,
-          post_id: opts.postId,
-          type: 'comment',
-          message: opts.author + ' commented on ' + opts.title,
-          actor: (window.AppState.user.name || window.currentUserName || 'Unknown'),
-          read: false
-        })
-      }).catch(function(err){ console.error('[pcs] notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'pcs-notification-2'); });
-    });
-
-    if (opts.mentioned && opts.mentioned.length > 0) {
-      opts.mentioned.forEach(function(name) {
-        var _member = _AGENCY_MEMBERS.find(function(m) {
-          return m.name.toLowerCase() === name.toLowerCase();
-        });
-        if (!_member) return;
-        if (_targets.indexOf(_member.role) !== -1) return;
-        var _mentionMsg = opts.isInternal
-          ? opts.author + ' mentioned you in a note on "' + opts.title + '"'
-          : opts.author + ' mentioned you on "' + opts.title + '"';
-        apiFetch('/notifications', {
-          method: 'POST',
-          body: JSON.stringify({
-            user_role: _member.role,
-            post_id: opts.postId,
-            type: 'mention',
-            message: _mentionMsg,
-            actor: (window.AppState.user.name || window.currentUserName || 'Unknown'),
-            read: false
-          })
-        }).catch(function(err){ console.error('[pcs] mention notification failed', err); window.logError && window.logError(err && err.message, err && err.stack, 'mention-notification'); });
-      });
-    }
+    // Notification fan-out removed — notify-comment edge function now
+    // writes all comment + mention notification rows and sends emails.
+    // JS-side fan-out caused duplicate notifications.
 
     var _mentionContacts = await _lookupMentionEmails(opts.mentioned);
     window._lastMentionContacts = _mentionContacts;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414e">
+ <link rel="stylesheet" href="styles.css?v=20260414f">
 
 </head>
 <body>
@@ -1084,28 +1084,28 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414e"></script>
-<script src="00-appstate-compat.js?v=20260414e"></script>
-<script src="01-config.js?v=20260414e" defer></script>
-<script src="02-session.js?v=20260414e" defer></script>
-<script src="utils.js?v=20260414e" defer></script>
-<script src="12-profiles.js?v=20260414e" defer></script>
-<script src="03-auth.js?v=20260414e" defer></script>
-<script src="05-api.js?v=20260414e" defer></script>
-<script src="10-ui.js?v=20260414e" defer></script>
+<script src="00-appstate.js?v=20260414f"></script>
+<script src="00-appstate-compat.js?v=20260414f"></script>
+<script src="01-config.js?v=20260414f" defer></script>
+<script src="02-session.js?v=20260414f" defer></script>
+<script src="utils.js?v=20260414f" defer></script>
+<script src="12-profiles.js?v=20260414f" defer></script>
+<script src="03-auth.js?v=20260414f" defer></script>
+<script src="05-api.js?v=20260414f" defer></script>
+<script src="10-ui.js?v=20260414f" defer></script>
 
-<script src="06-post-create.js?v=20260414e" defer></script>
-<script defer src="render/dashboard.js?v=20260414e"></script>
-<script defer src="render/client.js?v=20260414e"></script>
-<script defer src="render/pipeline.js?v=20260414e"></script>
-<script defer src="render/brief.js?v=20260414e"></script>
-<script defer src="actions/pcs.js?v=20260414e"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414e"></script>
-<script src="07-post-load.js?v=20260414e" defer></script>
-<script src="08-post-actions.js?v=20260414e" defer></script>
-<script src="09-library.js?v=20260414e" defer></script>
-<script src="09-approval.js?v=20260414e" defer></script>
-<script src="04-router.js?v=20260414e" defer></script>
+<script src="06-post-create.js?v=20260414f" defer></script>
+<script defer src="render/dashboard.js?v=20260414f"></script>
+<script defer src="render/client.js?v=20260414f"></script>
+<script defer src="render/pipeline.js?v=20260414f"></script>
+<script defer src="render/brief.js?v=20260414f"></script>
+<script defer src="actions/pcs.js?v=20260414f"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414f"></script>
+<script src="07-post-load.js?v=20260414f" defer></script>
+<script src="08-post-actions.js?v=20260414f" defer></script>
+<script src="09-library.js?v=20260414f" defer></script>
+<script src="09-approval.js?v=20260414f" defer></script>
+<script src="04-router.js?v=20260414f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -245,73 +245,8 @@ window._briefSubmitComment = function(postId) {
       created_at: nowISO
     })
   }).then(function() {
-    // Notification fan-out — route based on author role so the
-    // Client bell lights up when agency replies on a brief, and
-    // Servicing + Admin get notified when the client responds.
-    // notify-comment (edge) does NOT fire on brief comments today,
-    // so this JS fan-out is the only writer for these rows. Each
-    // POST is wrapped in its own catch so a failed insert cannot
-    // block the comment UI.
-    try {
-      var authorEmail = (window.AppState.user && window.AppState.user.email) || '';
-      var actor = authorEmail || authorName;
-      var briefTitle = (post && post.title) || 'your request';
-      var preview = text.length > 50 ? text.slice(0, 50) : text;
-      var roleLower = String(normRole || '').toLowerCase();
-      if (roleLower !== 'client') {
-        // Agency user commenting — notify the Client role
-        var agencyMsg = authorName + ' commented on your request: ' + preview;
-        try {
-          apiFetch('/notifications', {
-            method: 'POST',
-            body: JSON.stringify({
-              user_role: 'Client',
-              post_id: postId,
-              type: 'comment',
-              message: agencyMsg,
-              actor: actor,
-              read: false,
-              created_at: new Date().toISOString()
-            })
-          }).catch(function(e) {
-            console.warn('[brief] client notification POST failed', e);
-            window.logError && window.logError(e && e.message, e && e.stack, 'brief-notify-client');
-          });
-        } catch (e) {
-          console.warn('[brief] client notification threw', e);
-        }
-      } else {
-        // Client responding — notify Servicing AND Admin
-        var clientMsg = authorName + ' replied on ' + briefTitle + ': ' + preview;
-        var roles = ['Servicing', 'Admin'];
-        for (var ri = 0; ri < roles.length; ri++) {
-          (function(targetRole) {
-            try {
-              apiFetch('/notifications', {
-                method: 'POST',
-                body: JSON.stringify({
-                  user_role: targetRole,
-                  post_id: postId,
-                  type: 'comment',
-                  message: clientMsg,
-                  actor: actor,
-                  read: false,
-                  created_at: new Date().toISOString()
-                })
-              }).catch(function(e) {
-                console.warn('[brief] ' + targetRole + ' notification POST failed', e);
-                window.logError && window.logError(e && e.message, e && e.stack, 'brief-notify-' + targetRole.toLowerCase());
-              });
-            } catch (e) {
-              console.warn('[brief] ' + targetRole + ' notification threw', e);
-            }
-          })(roles[ri]);
-        }
-      }
-    } catch (fanErr) {
-      console.warn('[brief] notification fan-out threw', fanErr);
-      window.logError && window.logError(fanErr && fanErr.message, fanErr && fanErr.stack, 'brief-notify-fanout');
-    }
+    // Notification fan-out removed — notify-comment edge function
+    // now writes all brief-comment notification rows and sends emails.
   }).catch(function(err) {
     console.error('[brief] submit comment failed', err);
     window.logError && window.logError(err && err.message, err && err.stack, 'brief-submit-comment');
@@ -870,27 +805,9 @@ window._assignBrief = function(postId, ownerName, isReassign) {
   var toastMsg = (isReassign ? 'Reassigned to ' : 'Assigned to ') + ownerName;
   var nowISO = new Date().toISOString();
 
-  function _postAssignNotification(targetPostId, postTitle) {
-    // Notify creatives that a brief has been assigned. user_role is
-    // ALWAYS the role string 'Creative' — the person's name belongs
-    // in the message body, never in user_role.
-    return apiFetch('/notifications', {
-      method: 'POST',
-      body: JSON.stringify({
-        user_role: 'Creative',
-        post_id: targetPostId,
-        type: 'brief',
-        message: actionLabel,
-        actor: actorName,
-        read: false,
-        created_at: nowISO
-      })
-    }).catch(function(err) {
-      // Non-fatal — the assign itself already succeeded.
-      console.warn('[brief] assign notification failed', err);
-      window.logError && window.logError(err && err.message, err && err.stack, 'assign-brief-notif');
-    });
-  }
+  // Assign notification is handled by the notify-stage edge function
+  // (brief stage writes trigger it). The JS-side _postAssignNotification
+  // helper was removed to eliminate duplicate notification rows.
 
   function _reopenBriefAfterAssign() {
     document.body.style.overflow = '';
@@ -926,8 +843,6 @@ window._assignBrief = function(postId, ownerName, isReassign) {
         actor_role: actorRole,
         action: actionLabel + (direction.trim() ? ' with direction' : '')
       });
-      return _postAssignNotification(postId, post.title || '');
-    }).then(function() {
       _reopenBriefAfterAssign();
     }).catch(function(err) {
       console.error('[brief] assign request failed', err);
@@ -975,8 +890,6 @@ window._assignBrief = function(postId, ownerName, isReassign) {
       actor_role: actorRole,
       action: actionLabel + (direction.trim() ? ' with direction' : '')
     });
-    return _postAssignNotification(postId, post.title || '');
-  }).then(function() {
     _reopenBriefAfterAssign();
   }).catch(function(err) {
     console.error('[brief] assign brief failed', err);

--- a/render/client.js
+++ b/render/client.js
@@ -1735,65 +1735,9 @@ console.log('LOADED:', 'render/client.js');
         }
         return;
       }
-      window.apiFetch('/notifications', {
-        method: 'POST',
-        body: JSON.stringify({
-          user_role: 'Servicing',
-          type: 'comment',
-          post_id: realPostId,
-          message: displayName + ' commented on ' + postTitle,
-          actor: displayName,
-          read: false
-        })
-      }).catch(function(err){ console.error('[client] comment patch', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'comment-patch'); });
-      window.apiFetch('/notifications', {
-        method: 'POST',
-        body: JSON.stringify({
-          user_role: 'Admin',
-          type: 'comment',
-          post_id: realPostId,
-          message: displayName + ' commented on ' + postTitle,
-          actor: displayName,
-          read: false
-        })
-      }).catch(function(err){ console.error('[client] notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-notification'); });
-      window.apiFetch('/notifications', {
-        method: 'POST',
-        body: JSON.stringify({
-          user_role: 'Creative',
-          type: 'comment',
-          post_id: realPostId,
-          message: displayName + ' commented on ' + postTitle,
-          actor: displayName,
-          read: false
-        })
-      }).catch(function(err){ console.error('[client] creative notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-creative-notification'); });
-      // Use the live @mention roster cached from user_roles.
-      // Falls back to [] if the fetch never ran — in that case
-      // unresolved names are skipped, matching the pre-dynamic
-      // roster behavior for unknown @names.
-      var _ROSTER = (window._clientMentionRoster || []).map(function(row) {
-        return { name: _displayNameForRow(row), role: row.role || '' };
-      });
-      _mentioned.forEach(function(name) {
-        var _member = _ROSTER.find(function(m) {
-          return m.name && m.name.toLowerCase() === name.toLowerCase();
-        });
-        if (!_member || !_member.role) return;
-        var safeRole = _member.role ? String(_member.role) : 'Client';
-        var titleCaseRole = safeRole.charAt(0).toUpperCase() + safeRole.slice(1).toLowerCase();
-        window.apiFetch('/notifications', {
-          method: 'POST',
-          body: JSON.stringify({
-            user_role: titleCaseRole,
-            post_id: realPostId,
-            type: 'mention',
-            message: displayName + ' mentioned you on "' + postTitle + '"',
-            actor: displayName,
-            read: false
-          })
-        }).catch(function(err) { console.error('[mention notif]', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'client-mention-notif'); });
-      });
+      // Notification fan-out removed — notify-comment edge function now
+      // writes all comment + mention notification rows and sends emails.
+      // JS-side fan-out caused duplicate notifications.
     }).catch(function (err) {
       if (typeof window.showToast === 'function') {
         window.showToast('Failed to send comment', 'error');

--- a/render/pipeline.js
+++ b/render/pipeline.js
@@ -629,30 +629,9 @@ window.executeBatchAction = async function(targetStage) {
       }),
     });
 
-    var notifActor = resolveActor() || 'Chitra';
-    var count = ids.length;
-    var stageLabel = targetStage === 'awaiting_approval'
-      ? 'for approval' : 'for brand input';
-    var batchMsg = notifActor + ' sent ' + count + ' posts ' + stageLabel;
-    var batchRecipients = targetStage === 'awaiting_approval'
-      ? ['Client', 'Admin'] : ['Client', 'Admin'];
-    batchRecipients.forEach(function(name) {
-      var roleMap = { 'Admin': 'Admin', 'Chitra': 'Servicing', 'Pranav': 'Creative', 'Client': 'Client' };
-      apiFetch('/notifications', {
-        method: 'POST',
-        body: JSON.stringify({
-          user_role: roleMap[name] || name,
-          post_id: null,
-          type: targetStage,
-          message: batchMsg,
-          actor: notifActor,
-          read: false
-        })
-      }).catch(function(err) {
-        console.error('[batch-notif]', err);
-        window.logError && window.logError(err && err.message, err && err.stack, 'batch-stage-notif');
-      });
-    });
+    // Batch stage change notifications are handled by the notify-stage
+    // edge function (fires per-row on the posts PATCH). The JS fan-out
+    // was removed to eliminate duplicate notification rows.
 
     toggleBatchMode();
     loadPosts();

--- a/tests/client-comment.test.js
+++ b/tests/client-comment.test.js
@@ -414,50 +414,47 @@ describe('@mention parsing', function() {
 
 
 // =========================================================
-// GROUP 6 — Notification firing
+// GROUP 6 — Notification firing (post js-notif-fanout removal)
 // =========================================================
+// The JS comment/mention notification fan-out was removed entirely —
+// notify-comment edge function is now the single writer for comment
+// and mention notification rows. These tests guard that the removal
+// stays removed.
 describe('comment notifications', function() {
 
   var fnMatch = clientSrc.match(/function _handleSubmitComment[\s\S]*?\n  \}/);
   var fnBody = fnMatch ? fnMatch[0] : '';
 
-  it('41. On submit -> fires notification to user_role:\'Servicing\'', function() {
-    expect(fnBody).toMatch(/user_role:\s*['"]Servicing['"]/);
+  it('41. _handleSubmitComment has no /notifications POST', function() {
+    var matches = fnBody.match(/apiFetch\(['"]\/notifications['"],\s*\{[\s\S]*?method:\s*['"]POST['"]/g);
+    expect(matches).toBeNull();
   });
 
-  it('42. On submit -> fires notification to user_role:\'Admin\'', function() {
-    expect(fnBody).toMatch(/user_role:\s*['"]Admin['"]/);
+  it('42. _handleSubmitComment has no user_role fan-out', function() {
+    expect(fnBody).not.toMatch(/user_role:\s*['"]Servicing['"]/);
+    expect(fnBody).not.toMatch(/user_role:\s*['"]Admin['"]/);
+    expect(fnBody).not.toMatch(/user_role:\s*['"]Creative['"]/);
   });
 
-  it('43. @Pranav -> fires additional mention notification type:\'mention\'', function() {
-    // After standard comment notifications, should fire mention-specific ones
-    expect(fnBody).toMatch(/type:\s*['"]mention['"]/);
+  it('43. _handleSubmitComment has no type:\'mention\' POST', function() {
+    expect(fnBody).not.toMatch(/type:\s*['"]mention['"]/);
   });
 
-  it('44. @Pranav -> mention notification has user_role:\'Creative\'', function() {
-    // Pranav is Creative in _AGENCY_MEMBERS
-    // The mention notification loop should resolve name -> role
-    expect(fnBody).toMatch(/mention|_AGENCY_MEMBERS|Creative/);
+  it('44. _handleSubmitComment still POSTs the comment itself', function() {
+    // Comment row still gets written to /post_comments — only the
+    // /notifications fan-out is removed.
+    expect(fnBody).toMatch(/apiFetch\(['"]\/post_comments['"]/);
   });
 
-  it('45. @Shubham -> mention notification has user_role:\'Admin\'', function() {
-    // Shubham is Admin — should resolve mention to Admin role notification
-    expect(fnBody).toMatch(/mention|_AGENCY_MEMBERS|_lookupMention/);
-  });
-
-  it('46. Unknown @name -> no mention notification fired', function() {
-    // Mention loop should skip unresolved names
-    expect(fnBody).toMatch(/if\s*\(!|filter|find/);
-  });
-
-  it('47. Failed POST -> no notifications fired', function() {
-    // Notifications are chained in .then() — if POST fails, .catch runs instead
+  it('45. _handleSubmitComment still has the .then / .catch chain', function() {
     expect(fnBody).toMatch(/\.then\(function/);
     expect(fnBody).toMatch(/\.catch\(function/);
-    // Notification calls must be inside .then(), not before it
-    var thenIdx = fnBody.indexOf('.then(function');
-    var notifIdx = fnBody.indexOf("'/notifications'");
-    expect(thenIdx).toBeLessThan(notifIdx);
+  });
+
+  it('46. client mention roster helpers are preserved for display', function() {
+    // window._clientMentionRoster and _displayNameForRow are used by
+    // the autocomplete UI and are kept intact after the fan-out removal.
+    expect(clientSrc).toContain('_clientMentionRoster');
   });
 });
 

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -128,32 +128,33 @@ describe('Notification badge', function() {
 // =========================================================
 // GROUP 3: Comment notifications (source analysis)
 // =========================================================
+// Comment notification fan-out now lives entirely in the notify-comment
+// edge function. The JS-side POST to /notifications for comments was
+// removed in the js-notif-fanout PR. These tests verify the removal
+// and preserve the pure routing-logic assertions.
 describe('Comment notifications', function() {
 
-  // Check actions/pcs.js (main moved submitPcsComment there)
-  var commentSrc = pcsSrc || actionsSrc;
-
-  it('comment notification uses type:comment', function() {
-    expect(commentSrc).toMatch(/type:\s*['"]comment['"]/);
+  it('pcs.js has zero comment notification POSTs', function() {
+    var matches = pcsSrc.match(/type:\s*['"]comment['"]/g);
+    expect(matches).toBeNull();
   });
 
-  it('comment notification includes actor field', function() {
-    // Find the notification insert block in comment handler
-    var match = commentSrc.match(/type:\s*['"]comment['"][\s\S]{0,200}/);
-    expect(match).not.toBeNull();
-    // Look nearby for actor field
-    var nearbyBlock = commentSrc.substring(
-      commentSrc.indexOf("type: 'comment'") - 200,
-      commentSrc.indexOf("type: 'comment'") + 300
-    );
-    expect(nearbyBlock).toContain('actor:');
+  it('render/client.js has zero notification POSTs', function() {
+    var clientSrc = readFileSync(resolve(__dirname, '..', 'render', 'client.js'), 'utf8');
+    var matches = clientSrc.match(/apiFetch\(['"]\/notifications['"],\s*\{[\s\S]*?method:\s*['"]POST['"]/g);
+    expect(matches).toBeNull();
   });
 
-  it('comment notification actor uses AppState.user.name', function() {
-    var idx = commentSrc.indexOf("type: 'comment'");
-    if (idx === -1) idx = commentSrc.indexOf('type: "comment"');
-    var nearbyBlock = commentSrc.substring(idx - 200, idx + 300);
-    expect(nearbyBlock).toContain('AppState.user.name');
+  it('render/brief.js has zero notification POSTs', function() {
+    var briefSrc = readFileSync(resolve(__dirname, '..', 'render', 'brief.js'), 'utf8');
+    var matches = briefSrc.match(/apiFetch\(['"]\/notifications['"],\s*\{[\s\S]*?method:\s*['"]POST['"]/g);
+    expect(matches).toBeNull();
+  });
+
+  it('render/pipeline.js has zero notification POSTs', function() {
+    var pipelineSrc = readFileSync(resolve(__dirname, '..', 'render', 'pipeline.js'), 'utf8');
+    var matches = pipelineSrc.match(/apiFetch\(['"]\/notifications['"],\s*\{[\s\S]*?method:\s*['"]POST['"]/g);
+    expect(matches).toBeNull();
   });
 
   it('Client comments notify Servicing and Admin', function() {
@@ -345,11 +346,24 @@ describe('No duplicate stage-change notifications from JS', function() {
     expect(hasNotifPost).toBe(false);
   });
 
-  it('08-post-actions.js has exactly 3 notification POSTs (2x new_request + _sendStageNotif helper)', function() {
+  it('08-post-actions.js has exactly 2 notification POSTs (2x new_request only)', function() {
     var matches = actionsSrc.match(/apiFetch\('\/notifications',\s*\{[\s\S]*?method:\s*'POST'/g);
-    // 1 = submitClientRequest Servicing, 2 = submitClientRequest Admin, 3 = _sendStageNotif helper
+    // 1 = submitClientRequest Servicing, 2 = submitClientRequest Admin.
+    // _sendStageNotif helper was removed — notify-stage edge function
+    // now writes all stage change notification rows.
     expect(matches).not.toBeNull();
-    expect(matches.length).toBe(3);
+    expect(matches.length).toBe(2);
+  });
+
+  it('_sendStageNotif helper has been removed from 08-post-actions.js', function() {
+    // The helper and all its call sites were removed in the js-notif-fanout PR.
+    expect(actionsSrc).not.toMatch(/window\._sendStageNotif\s*=\s*function/);
+    expect(actionsSrc).not.toMatch(/window\._sendStageNotif\s*\(/);
+  });
+
+  it('09-approval.js has no _sendStageNotif call sites', function() {
+    var approvalSrc = readFileSync(resolve(__dirname, '..', '09-approval.js'), 'utf8');
+    expect(approvalSrc).not.toMatch(/_sendStageNotif\s*\(/);
   });
 
   it('07-post-load.js has zero notification POSTs', function() {
@@ -582,56 +596,26 @@ describe('@mention notification routing', function() {
 
 });
 
-describe('@mention notifications in _doSubmitComment (source analysis)', function() {
+// @mention notification fan-out was moved into the notify-comment
+// edge function. The JS-side POST to /notifications with type:'mention'
+// was removed in the js-notif-fanout PR. These tests verify the removal
+// and preserve the pure name→role resolution checks in the block above.
+describe('@mention notifications removed from JS fan-out', function() {
 
-  it('pcs.js contains a mention notification loop after comment notifications', function() {
-    expect(pcsSrc).toContain("type: 'mention'");
+  it('pcs.js has no type:mention notification POST', function() {
+    expect(pcsSrc).not.toContain("type: 'mention'");
   });
 
-  it('mention notification maps name to role via _AGENCY_MEMBERS', function() {
-    var idx = pcsSrc.indexOf("type: 'mention'");
-    var mentionBlock = pcsSrc.substring(Math.max(0, idx - 800), idx + 200);
-    expect(mentionBlock).toContain('_AGENCY_MEMBERS');
+  it('render/client.js has no type:mention notification POST', function() {
+    var clientSrc = readFileSync(resolve(__dirname, '..', 'render', 'client.js'), 'utf8');
+    expect(clientSrc).not.toContain("type: 'mention'");
   });
 
-  it('mention notification skips names not in _AGENCY_MEMBERS', function() {
-    var mentionBlock = pcsSrc.substring(
-      pcsSrc.indexOf("type: 'mention'") - 500,
-      pcsSrc.indexOf("type: 'mention'") + 200
-    );
-    expect(mentionBlock).toMatch(/if\s*\(\s*!|continue/);
-  });
-
-  it('mention notification skips roles already in _targets to avoid doubles', function() {
-    var mentionBlock = pcsSrc.substring(
-      pcsSrc.indexOf("type: 'mention'") - 500,
-      pcsSrc.indexOf("type: 'mention'") + 200
-    );
-    expect(mentionBlock).toContain('_targets');
-    expect(mentionBlock).toMatch(/indexOf|includes/);
-  });
-
-  it('mention notification only runs when opts.mentioned has entries', function() {
-    var idx = pcsSrc.indexOf("type: 'mention'");
-    var mentionBlock = pcsSrc.substring(Math.max(0, idx - 800), idx + 200);
-    expect(mentionBlock).toMatch(/opts\.mentioned[\s\S]*?length/);
-  });
-
-  it('the old buggy fallback (targets = opts.mentioned) is removed', function() {
-    var targetBlock = pcsSrc.match(
-      /var _targets = \[\];[\s\S]*?_targets\.forEach/
-    );
-    expect(targetBlock).not.toBeNull();
-    var body = targetBlock[0];
-    expect(body).not.toContain('_targets = opts.mentioned');
-  });
-
-  it('mention message differs for internal notes vs client comments', function() {
-    var mentionBlock = pcsSrc.substring(
-      pcsSrc.indexOf("type: 'mention'") - 500,
-      pcsSrc.indexOf("type: 'mention'") + 300
-    );
-    expect(mentionBlock).toMatch(/isInternal|internal/i);
+  it('_lookupMentionEmails is preserved for display purposes', function() {
+    // Used to build window._lastMentionContacts for the UI, not for
+    // notification writes. Must stay after the fan-out removal.
+    expect(pcsSrc).toContain('_lookupMentionEmails');
+    expect(pcsSrc).toContain('window._lastMentionContacts');
   });
 
 });


### PR DESCRIPTION
## Summary

Phase 5 of the Mention & Notification migration. Edge functions `notify-comment`, `notify-stage`, and `notify-request` now write all notification rows AND send all emails. The JS-side fan-out is redundant and was causing **duplicate notifications**.

## What was removed

| File | Removed |
|---|---|
| `render/client.js` (`_handleSubmitComment`) | 3 comment fan-out POSTs (Servicing/Admin/Creative) + 1 `type:'mention'` POST |
| `actions/pcs.js` (`_doSubmitComment`) | visibility-based `_targets.forEach` broadcast loop + `type:'mention'` POST |
| `08-post-actions.js` | entire `_sendStageNotif` helper + 5 call sites (quickStage, clientApprove, clientAcknowledge, _confirmPublish, _executeStageChangeAsync) |
| `09-approval.js` | 2 `_sendStageNotif` call sites (changes_submit, approved) |
| `render/pipeline.js` (`executeBatchAction`) | batch-recipients fan-out loop |
| `render/brief.js` (`_briefSubmitComment`) | both client-branch and agency-branch comment fan-out |
| `render/brief.js` (`_assignBrief`) | `_postAssignNotification` helper + both call sites |

## What was NOT touched

- All `/post_comments` and `/internal_notes` POSTs — comments still write to the DB
- All `/notifications` GET / PATCH / DELETE calls — reads, mark-as-read, delete
- `updateNotifBadge`, `loadNotifications`, `_onAgencyNotificationInsert`, `_onClientNotificationInsert`, Realtime channel subscriptions
- `window._lastMentionContacts` and `_lookupMentionEmails` in pcs.js (display only)
- `_briefFetchTeamMembers` and the assign-brief owner fix from PR #843
- `03-auth.js`, `10-ui.js` notification reads, edge functions

## Out-of-scope (flagged)

The 2x `new_request` POSTs in `08-post-actions.js` `submitClientRequest` (lines 391 + 402) were NOT removed. They were NOT listed in the user's SURFACE 3 directive (which said only `_sendStageNotif`), and the existing `notifications.test.js` GROUP 4 tests explicitly enforce their existence. These may be candidates for a follow-up cleanup since `notify-request` edge fn now handles them.

## Test plan

- [x] Audited every `apiFetch('/notifications', { method:'POST' ... })` call before making changes
- [x] Removed only POST calls; no other logic changed
- [x] Updated `tests/notifications.test.js` GROUPs 3, 7, 12 to assert removal instead of existence
- [x] Updated `tests/client-comment.test.js` GROUP 6 to assert removal
- [x] `npx vitest run` → 553/553 pass across 22 test files
- [x] Bumped all 22 `?v=` strings in `index.html` from `20260414e` → `20260414f`
- [ ] Smoke test in production after Cloudflare purge

https://claude.ai/code/session_01UoHCkpquyonkREsosB4qjj