### PR TITLE
feat: Sorted AI foundation — srtd-ai Worker + schema + plumbing

### DIFF
--- a/00-appstate.js
+++ b/00-appstate.js
@@ -59,7 +59,13 @@ window.AppState = window.AppState || {
   timers: {
     dashDatetime: null,
     renderTimer: null
-  }
+  },
+
+  // Workspace-level feature flags + metadata loaded once on login via
+  // loadWorkspaceSettings() (05-api.js). Initialised to an empty object
+  // so AI feature gates can safely read `AppState.workspace.ai_writer`
+  // even before the post-login fetch resolves.
+  workspace: {}
 
 };
 

--- a/03-auth.js
+++ b/03-auth.js
@@ -393,6 +393,14 @@ function activateRole(role) {
     } catch(e) { console.warn('[auth] Proactive refresh failed:', e); }
   }, 50 * 60 * 1000);
 
+  // Load workspace_settings once per session so every AI feature gate
+  // (writer / qc / chat / email_brief) can read window.AppState.workspace
+  // synchronously without a network call. Fire-and-forget: activateRole
+  // continues immediately so the render path is never blocked on it.
+  if (typeof loadWorkspaceSettings === 'function') {
+    loadWorkspaceSettings();
+  }
+
   // Clear stale preview role for non-admin users
   var _dbRole = (role || '').toLowerCase();
   if (_dbRole !== 'admin') {

--- a/05-api.js
+++ b/05-api.js
@@ -171,6 +171,27 @@ async function uploadPostAsset(file, postId) {
   return data.url;
 }
 
+// Fetches workspace_settings row for the active workspace and stashes
+// the result on window.AppState.workspace so every AI feature gate can
+// read it without making a network call. Called once from activateRole()
+// (03-auth.js) right after the post-login token refresh timer is wired,
+// BEFORE any render function runs. Fire-and-forget: never blocks login,
+// never shows a toast, and swallows errors into an empty object so the
+// app degrades gracefully if workspace_settings is unreachable.
+async function loadWorkspaceSettings() {
+  try {
+    const rows = await apiFetch(
+      '/workspace_settings?workspace_id=eq.default&select=*&limit=1',
+      {},
+      { allowLogout: false }
+    );
+    window.AppState.workspace = (Array.isArray(rows) && rows[0]) ? rows[0] : {};
+  } catch (err) {
+    window.AppState.workspace = window.AppState.workspace || {};
+    window.logError && window.logError(err && err.message, err && err.stack, 'load-workspace-settings');
+  }
+}
+
 async function logActivity({ post_id, actor, actor_role, action, old_stage, new_stage }) {
   console.log('[logActivity] called:', { post_id, actor, action, old_stage, new_stage });
   var token = localStorage.getItem('sb_access_token');

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -183,7 +183,10 @@ async function loadPosts(fromPoll) {
   const reqId = _newPostsRequest();
   var _apiMeta = fromPoll ? { allowLogout: false } : undefined;
   try {
-    const data = await apiFetch('/posts?select=*&order=id.desc', {}, _apiMeta);
+    const isDraftFilter = (window.AppState.user.effectiveRole === 'Admin')
+      ? ''
+      : '&is_draft=eq.false';
+    const data = await apiFetch('/posts?select=*' + isDraftFilter + '&order=id.desc', {}, _apiMeta);
     if (!_commitPostsResult(reqId, 'network')) return;
     // Fetch pending requests and merge as brief-stage entries
     var reqData = [];
@@ -276,7 +279,7 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
       'awaiting_approval,awaiting_brand_input,published,brief,brief_done,scheduled,in_production';
     var data  = await apiFetch(
       '/posts?stage=in.(' + allowedStages +
-      ')&select=*&order=created_at.desc',
+      ')&is_draft=eq.false&select=*&order=created_at.desc',
       {},
       _apiMeta
     );

--- a/ai-config.js
+++ b/ai-config.js
@@ -1,0 +1,14 @@
+/* ===============================================
+   ai-config.js — single source of truth for the
+   srtd-ai Worker URL + shared secret on the
+   frontend. Every future AI feature reads from
+   window.AI_CONFIG. Never hardcode the Worker
+   URL anywhere else.
+=============================================== */
+console.log("LOADED:", "ai-config.js");
+
+window.AI_CONFIG = {
+  workerUrl: 'https://srtd-ai.ksg-kumarshubhamgune.workers.dev',
+  secret:    'srtd-ai-2026xK9mN3pQ',
+  model:     'claude-sonnet-4-20250514'
+};

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414k">
+ <link rel="stylesheet" href="styles.css?v=20260414l">
 
 </head>
 <body>
@@ -1084,28 +1084,29 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414k"></script>
-<script src="00-appstate-compat.js?v=20260414k"></script>
-<script src="01-config.js?v=20260414k" defer></script>
-<script src="02-session.js?v=20260414k" defer></script>
-<script src="utils.js?v=20260414k" defer></script>
-<script src="12-profiles.js?v=20260414k" defer></script>
-<script src="03-auth.js?v=20260414k" defer></script>
-<script src="05-api.js?v=20260414k" defer></script>
-<script src="10-ui.js?v=20260414k" defer></script>
+<script src="00-appstate.js?v=20260414l"></script>
+<script src="00-appstate-compat.js?v=20260414l"></script>
+<script src="01-config.js?v=20260414l" defer></script>
+<script src="02-session.js?v=20260414l" defer></script>
+<script src="utils.js?v=20260414l" defer></script>
+<script src="12-profiles.js?v=20260414l" defer></script>
+<script src="03-auth.js?v=20260414l" defer></script>
+<script src="05-api.js?v=20260414l" defer></script>
+<script src="10-ui.js?v=20260414l" defer></script>
 
-<script src="06-post-create.js?v=20260414k" defer></script>
-<script defer src="render/dashboard.js?v=20260414k"></script>
-<script defer src="render/client.js?v=20260414k"></script>
-<script defer src="render/pipeline.js?v=20260414k"></script>
-<script defer src="render/brief.js?v=20260414k"></script>
-<script defer src="actions/pcs.js?v=20260414k"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414k"></script>
-<script src="07-post-load.js?v=20260414k" defer></script>
-<script src="08-post-actions.js?v=20260414k" defer></script>
-<script src="09-library.js?v=20260414k" defer></script>
-<script src="09-approval.js?v=20260414k" defer></script>
-<script src="04-router.js?v=20260414k" defer></script>
+<script src="06-post-create.js?v=20260414l" defer></script>
+<script defer src="render/dashboard.js?v=20260414l"></script>
+<script defer src="render/client.js?v=20260414l"></script>
+<script defer src="render/pipeline.js?v=20260414l"></script>
+<script defer src="render/brief.js?v=20260414l"></script>
+<script defer src="actions/pcs.js?v=20260414l"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414l"></script>
+<script src="ai-config.js?v=20260414l" defer></script>
+<script src="07-post-load.js?v=20260414l" defer></script>
+<script src="08-post-actions.js?v=20260414l" defer></script>
+<script src="09-library.js?v=20260414l" defer></script>
+<script src="09-approval.js?v=20260414l" defer></script>
+<script src="04-router.js?v=20260414l" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/sql/003-posts-ai-columns.sql
+++ b/sql/003-posts-ai-columns.sql
@@ -1,0 +1,52 @@
+-- ═══════════════════════════════════════════════════════════════
+-- PR 1 — Sorted AI Foundation
+-- Migration 003: add is_draft + ai_origin columns to posts
+-- ═══════════════════════════════════════════════════════════════
+--
+-- PURPOSE:
+--   is_draft  — true = AI-created draft, only visible to the admin
+--               who created it. false = live in the pipeline.
+--               Every non-Admin query in 07-post-load.js is scoped
+--               by `is_draft=eq.false` so Servicing / Creative /
+--               Client never see drafts. Admin sees everything.
+--
+--   ai_origin — permanent provenance flag. true = this post was
+--               ever AI-created. NEVER flipped back to false — it
+--               survives push-to-production and any future edit.
+--               Used for the ✦ symbol in future AI PRs.
+--
+-- SAFETY:
+--   Both columns ship with DEFAULT false so every existing row is
+--   backfilled as "not a draft, not AI-origin" with zero downtime.
+--   Adding a boolean column with a constant default is a metadata-
+--   only operation in Postgres 11+ — no table rewrite.
+--
+-- RUN ORDER:
+--   1. sql/003-posts-ai-columns.sql   (this file)
+--   2. sql/004-ai-usage-table.sql
+--
+-- DEPLOYMENT:
+--   Shubham runs this manually in the Supabase SQL editor before
+--   the corresponding web deploy goes live. Nothing in this file
+--   is auto-applied by the app.
+-- ═══════════════════════════════════════════════════════════════
+
+ALTER TABLE posts ADD COLUMN is_draft  boolean DEFAULT false;
+ALTER TABLE posts ADD COLUMN ai_origin boolean DEFAULT false;
+
+-- ─────────────────────────────────────────────────────────────
+-- VERIFICATION (run after applying):
+--
+--   SELECT column_name, data_type, column_default, is_nullable
+--   FROM   information_schema.columns
+--   WHERE  table_name = 'posts'
+--     AND  column_name IN ('is_draft', 'ai_origin')
+--   ORDER  BY column_name;
+--   -- Both rows should show data_type = 'boolean',
+--   --                    column_default = 'false',
+--   --                    is_nullable    = 'YES'.
+--
+--   -- Backfill sanity check:
+--   SELECT COUNT(*) FROM posts WHERE is_draft  IS NULL;  -- expect 0
+--   SELECT COUNT(*) FROM posts WHERE ai_origin IS NULL;  -- expect 0
+-- ─────────────────────────────────────────────────────────────

--- a/sql/004-ai-usage-table.sql
+++ b/sql/004-ai-usage-table.sql
@@ -1,0 +1,65 @@
+-- ═══════════════════════════════════════════════════════════════
+-- PR 1 — Sorted AI Foundation
+-- Migration 004: create ai_usage table
+-- ═══════════════════════════════════════════════════════════════
+--
+-- PURPOSE:
+--   Per-call telemetry sink for every Anthropic API invocation
+--   made by the srtd-ai Worker. Fed fire-and-forget from the
+--   Worker's POST /ai/complete path AND from the lightweight
+--   POST /ai/log path (used when the client needs to log usage
+--   without a completion).
+--
+--   Cost accounting uses Claude Sonnet 4 pricing:
+--     input  $3  per 1M tokens
+--     output $15 per 1M tokens
+--   cost_usd = ((input * 3) + (output * 15)) / 1000000
+--
+-- SCHEMA NOTES:
+--   - feature: 'writer' | 'qc' | 'chat' | 'email_brief'
+--   - post_id: NO foreign key to posts.post_id on purpose —
+--              email-brief flows create the post AFTER the AI
+--              call, so post_id may be null at log time. A hard
+--              FK would reject those rows.
+--   - workspace_id: text (not uuid) to match the already-created
+--                   workspace_settings.workspace_id column. The
+--                   single-tenant install uses 'default'.
+--
+-- RUN ORDER:
+--   Run AFTER sql/003-posts-ai-columns.sql.
+--
+-- RLS:
+--   Not enabled. Consistent with error_log / notifications /
+--   activity_log in the existing schema. The Worker uses the
+--   service-role key to INSERT; the frontend never reads this
+--   table directly.
+-- ═══════════════════════════════════════════════════════════════
+
+CREATE TABLE ai_usage (
+  id            uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  workspace_id  text DEFAULT 'default',
+  post_id       text,
+  feature       text,
+  tokens_input  integer,
+  tokens_output integer,
+  cost_usd      numeric(10,6),
+  created_by    text,
+  created_at    timestamptz DEFAULT now()
+);
+
+-- ─────────────────────────────────────────────────────────────
+-- VERIFICATION (run after applying):
+--
+--   SELECT column_name, data_type
+--   FROM   information_schema.columns
+--   WHERE  table_name = 'ai_usage'
+--   ORDER  BY ordinal_position;
+--
+--   -- Insert a probe row to confirm writes work:
+--   INSERT INTO ai_usage (feature, tokens_input, tokens_output, cost_usd, created_by)
+--   VALUES ('writer', 100, 200, 0.003300, 'test@example.com');
+--
+--   SELECT * FROM ai_usage ORDER BY created_at DESC LIMIT 1;
+--   -- Clean up:
+--   DELETE FROM ai_usage WHERE created_by = 'test@example.com';
+-- ─────────────────────────────────────────────────────────────

--- a/srtd-ai-worker/README.md
+++ b/srtd-ai-worker/README.md
@@ -1,0 +1,69 @@
+# srtd-ai Worker — Deployment
+
+Single Cloudflare Worker that fronts the Anthropic API for every AI
+feature in Sorted. Gated per-workspace via `workspace_settings.ai_*`
+flags, logs every call to the `ai_usage` table.
+
+## First-time setup
+
+```
+cd srtd-ai-worker
+npm install    # if wrangler is not already installed globally
+```
+
+## Set secrets (run once)
+
+```
+wrangler secret put ANTHROPIC_API_KEY
+wrangler secret put AI_SECRET
+```
+
+Use value `srtd-ai-2026xK9mN3pQ` for `AI_SECRET` (must match
+`window.AI_CONFIG.secret` in `ai-config.js`).
+
+## Deploy
+
+```
+wrangler deploy
+```
+
+## After deploy
+
+Upload the brand guide to R2:
+
+- Key: `ai/brand-guide.txt`
+- Content: paste the GBL brand guide text
+- Bucket: `sorted-images`
+
+This file is optional. If it is missing, the Worker falls back to the
+approved-posts context only and still works.
+
+## SQL migrations to run in Supabase before using AI features
+
+Run in order in the Supabase SQL editor:
+
+1. `sql/003-posts-ai-columns.sql`
+2. `sql/004-ai-usage-table.sql`
+
+The `workspace_settings` table already exists and has been created
+manually — do NOT create it again.
+
+## Routes
+
+- `OPTIONS *`          → CORS preflight (204)
+- `POST /ai/complete`  → main AI completion endpoint
+- `POST /ai/log`       → lightweight standalone usage logger
+- anything else        → 404
+
+Every POST must include the header `X-AI-Secret: <AI_SECRET>`.
+
+## Secrets / bindings summary
+
+| Name                | Type   | Where set                       |
+|---------------------|--------|---------------------------------|
+| `ANTHROPIC_API_KEY` | secret | `wrangler secret put`           |
+| `AI_SECRET`         | secret | `wrangler secret put`           |
+| `SORTED_IMAGES`     | R2     | `wrangler.toml` (`sorted-images`) |
+
+Supabase URL + service-role key are hardcoded in `src/index.js`,
+matching the pattern already used by `sorted-preview-worker`.

--- a/srtd-ai-worker/src/index.js
+++ b/srtd-ai-worker/src/index.js
@@ -1,0 +1,334 @@
+// ═══════════════════════════════════════════════════════════════
+// srtd-ai Worker
+//
+// Single entry point for every AI feature in Sorted. Fronts the
+// Anthropic API, loads brand context from R2 + Supabase, gates on
+// workspace_settings.ai_* flags, and logs every call to ai_usage.
+//
+// Routes:
+//   OPTIONS *          → CORS preflight (204)
+//   POST    /ai/complete → main AI completion endpoint
+//   POST    /ai/log      → lightweight standalone usage logger
+//   *                  → 404
+// ═══════════════════════════════════════════════════════════════
+
+const SUPABASE_URL = 'https://vxokfscjzytpgdrmertk.supabase.co';
+// Service-role key — required for workspace_settings reads + ai_usage
+// writes with the current (loose) table permissions. Consistent with
+// the hardcoded-Supabase-creds pattern used by sorted-preview-worker.
+const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ4b2tmc2Nqenl0cGdkcm1lcnRrIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0MzA2NjkxNCwiZXhwIjoyMDU4NjQyOTE0fQ.mhMGDExFm3pVFmB24gzBGwIuXHHBB2B88FVqnmM5JQkw';
+
+const ANTHROPIC_MODEL = 'claude-sonnet-4-20250514';
+const ANTHROPIC_MAX_TOKENS = 1500;
+
+// Sonnet 4 pricing (per 1M tokens): input $3, output $15.
+const PRICE_INPUT_PER_MTOK = 3;
+const PRICE_OUTPUT_PER_MTOK = 15;
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, X-AI-Secret'
+};
+
+const FEATURE_FLAGS = {
+  writer:      'ai_writer',
+  qc:          'ai_qc',
+  chat:        'ai_chat',
+  email_brief: 'ai_email_briefs'
+};
+
+// ─── helpers ─────────────────────────────────────────────────
+
+function jsonResponse(body, status) {
+  return new Response(JSON.stringify(body), {
+    status: status || 200,
+    headers: {
+      'Content-Type': 'application/json',
+      ...CORS_HEADERS
+    }
+  });
+}
+
+function errorResponse(message, status) {
+  return jsonResponse({ success: false, error: message }, status || 500);
+}
+
+async function supabaseGet(path) {
+  const res = await fetch(SUPABASE_URL + '/rest/v1' + path, {
+    headers: {
+      'apikey': SUPABASE_KEY,
+      'Authorization': 'Bearer ' + SUPABASE_KEY,
+      'Accept': 'application/json'
+    }
+  });
+  if (!res.ok) {
+    throw new Error('supabase GET ' + res.status + ' ' + path);
+  }
+  return res.json();
+}
+
+async function supabasePost(path, body) {
+  return fetch(SUPABASE_URL + '/rest/v1' + path, {
+    method: 'POST',
+    headers: {
+      'apikey': SUPABASE_KEY,
+      'Authorization': 'Bearer ' + SUPABASE_KEY,
+      'Content-Type': 'application/json',
+      'Prefer': 'return=minimal'
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+function calcCostUsd(inputTokens, outputTokens) {
+  const n = (Number(inputTokens) || 0) * PRICE_INPUT_PER_MTOK
+          + (Number(outputTokens) || 0) * PRICE_OUTPUT_PER_MTOK;
+  return n / 1000000;
+}
+
+// ─── workspace-settings gate ─────────────────────────────────
+
+async function checkWorkspaceEnabled(workspaceId, feature) {
+  const rows = await supabaseGet(
+    '/workspace_settings?workspace_id=eq.' + encodeURIComponent(workspaceId)
+    + '&select=ai_enabled,ai_writer,ai_qc,ai_chat,ai_email_briefs&limit=1'
+  );
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return { ok: false, reason: 'AI not enabled for this workspace' };
+  }
+  const row = rows[0];
+  if (row.ai_enabled !== true) {
+    return { ok: false, reason: 'AI not enabled for this workspace' };
+  }
+  const flagKey = FEATURE_FLAGS[feature];
+  if (!flagKey) {
+    return { ok: false, reason: 'Unknown feature' };
+  }
+  if (row[flagKey] !== true) {
+    return { ok: false, reason: 'Feature not enabled for this workspace' };
+  }
+  return { ok: true };
+}
+
+// ─── system-prompt builder ───────────────────────────────────
+
+async function loadBrandGuide(env) {
+  try {
+    const obj = await env.SORTED_IMAGES.get('ai/brand-guide.txt');
+    if (!obj) return '';
+    return await obj.text();
+  } catch (e) {
+    return '';
+  }
+}
+
+async function loadApprovedContext() {
+  try {
+    const rows = await supabaseGet(
+      '/posts?stage=eq.approved&select=title,caption,content_pillar,format'
+      + '&order=updated_at.desc&limit=20'
+    );
+    if (!Array.isArray(rows) || rows.length === 0) return '';
+    return rows.map(function(p) {
+      return 'Title: ' + (p.title || '') + '\nCaption: ' + (p.caption || '');
+    }).join('\n---\n');
+  } catch (e) {
+    return '';
+  }
+}
+
+function buildSystemPrompt(feature, approvedContext, brandGuide) {
+  const ctx = approvedContext || '';
+  const bg  = brandGuide || '';
+  if (feature === 'writer') {
+    return 'You are a LinkedIn content writer for Godavari Biorefineries Limited (GBL), a sugarcane biorefinery. '
+      + 'Write in their established voice. Here are 20 approved posts for reference:\n\n'
+      + ctx
+      + '\n\nBrand guide:\n'
+      + bg
+      + '\n\nReturn exactly 3 numbered copy options. Each option on its own. No preamble.';
+  }
+  if (feature === 'qc') {
+    return 'You are a brand quality controller for GBL. Check the provided copy against the brand voice and approved posts. '
+      + 'Here are 20 approved posts:\n\n'
+      + ctx
+      + '\n\nBrand guide:\n'
+      + bg
+      + '\n\nReturn a structured verdict: PASS or FLAG for each item checked. Be specific. Be brief.';
+  }
+  if (feature === 'chat') {
+    return 'You are a copy editor helping refine LinkedIn content for GBL. Here are 20 approved posts for reference:\n\n'
+      + ctx
+      + '\n\nBrand guide:\n'
+      + bg
+      + '\n\nHelp the user improve the copy. Be direct and brief.';
+  }
+  if (feature === 'email_brief') {
+    return 'You are a content strategist. Read the email below and identify every distinct post brief it contains. '
+      + 'Return a JSON array only — no preamble, no markdown, no backticks. '
+      + 'Each object must have: title (string), brief (string), content_pillar (string), '
+      + 'format (string, one of: Photo/Carousel/Video/Creative), '
+      + 'copy_options (array of exactly 3 strings), visual_direction (string). '
+      + 'If brief count is unclear, return 1 object and set title to include [REVIEW: may contain multiple briefs].';
+  }
+  return '';
+}
+
+// ─── Anthropic call ──────────────────────────────────────────
+
+async function callAnthropic(env, systemPrompt, messages) {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'x-api-key': env.ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: ANTHROPIC_MAX_TOKENS,
+      system: systemPrompt,
+      messages: messages
+    })
+  });
+  if (!res.ok) {
+    const txt = await res.text().catch(function() { return ''; });
+    // Never echo the API key: only the status + sanitised body.
+    throw new Error('anthropic ' + res.status + ': ' + txt.slice(0, 500));
+  }
+  return res.json();
+}
+
+// ─── fire-and-forget usage logger ────────────────────────────
+
+function logUsage(payload) {
+  supabasePost('/ai_usage', payload).catch(function(err) {
+    console.error('[srtd-ai] ai_usage log failed:', err && err.message);
+  });
+}
+
+// ─── route handlers ──────────────────────────────────────────
+
+async function handleComplete(request, env) {
+  try {
+    if (request.headers.get('X-AI-Secret') !== env.AI_SECRET) {
+      return errorResponse('Unauthorized', 401);
+    }
+
+    let body;
+    try {
+      body = await request.json();
+    } catch (e) {
+      return errorResponse('Invalid JSON', 400);
+    }
+
+    const feature     = body && body.feature;
+    const messages    = body && body.messages;
+    const postId      = (body && body.post_id) || null;
+    const workspaceId = (body && body.workspace_id) || 'default';
+    const createdBy   = (body && body.created_by) || '';
+
+    if (!feature || !FEATURE_FLAGS[feature]) {
+      return errorResponse('Invalid or missing feature', 400);
+    }
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return errorResponse('Invalid or missing messages', 400);
+    }
+
+    const gate = await checkWorkspaceEnabled(workspaceId, feature);
+    if (!gate.ok) {
+      return jsonResponse({ success: false, error: gate.reason }, 403);
+    }
+
+    const brandGuide      = await loadBrandGuide(env);
+    const approvedContext = await loadApprovedContext();
+    const systemPrompt    = buildSystemPrompt(feature, approvedContext, brandGuide);
+
+    const anthropicRes = await callAnthropic(env, systemPrompt, messages);
+
+    const contentBlocks = anthropicRes && anthropicRes.content;
+    const responseText  = (Array.isArray(contentBlocks) && contentBlocks[0] && contentBlocks[0].text)
+      ? contentBlocks[0].text
+      : '';
+    const usage         = (anthropicRes && anthropicRes.usage) || {};
+    const inputTokens   = Number(usage.input_tokens)  || 0;
+    const outputTokens  = Number(usage.output_tokens) || 0;
+
+    // Fire-and-forget: never block the response on the log write.
+    logUsage({
+      workspace_id:  workspaceId,
+      post_id:       postId,
+      feature:       feature,
+      tokens_input:  inputTokens,
+      tokens_output: outputTokens,
+      cost_usd:      calcCostUsd(inputTokens, outputTokens),
+      created_by:    createdBy
+    });
+
+    return jsonResponse({
+      success: true,
+      content: responseText,
+      usage: { input: inputTokens, output: outputTokens }
+    });
+  } catch (err) {
+    const msg = (err && err.message) || 'unknown error';
+    return errorResponse(msg, 500);
+  }
+}
+
+async function handleLog(request, env) {
+  try {
+    if (request.headers.get('X-AI-Secret') !== env.AI_SECRET) {
+      return errorResponse('Unauthorized', 401);
+    }
+
+    let body;
+    try {
+      body = await request.json();
+    } catch (e) {
+      return errorResponse('Invalid JSON', 400);
+    }
+
+    const payload = {
+      workspace_id:  (body && body.workspace_id) || 'default',
+      post_id:       (body && body.post_id) || null,
+      feature:       body && body.feature,
+      tokens_input:  Number(body && body.tokens_input)  || 0,
+      tokens_output: Number(body && body.tokens_output) || 0,
+      cost_usd:      Number(body && body.cost_usd)      || 0,
+      created_by:    (body && body.created_by) || ''
+    };
+
+    const res = await supabasePost('/ai_usage', payload);
+    if (!res.ok) {
+      const txt = await res.text().catch(function() { return ''; });
+      return errorResponse('ai_usage insert ' + res.status + ': ' + txt.slice(0, 300), 500);
+    }
+    return jsonResponse({ success: true });
+  } catch (err) {
+    const msg = (err && err.message) || 'unknown error';
+    return errorResponse(msg, 500);
+  }
+}
+
+// ─── entry point ─────────────────────────────────────────────
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
+    if (request.method === 'POST' && url.pathname === '/ai/complete') {
+      return handleComplete(request, env);
+    }
+    if (request.method === 'POST' && url.pathname === '/ai/log') {
+      return handleLog(request, env);
+    }
+
+    return new Response('Not Found', { status: 404, headers: CORS_HEADERS });
+  }
+};

--- a/srtd-ai-worker/wrangler.toml
+++ b/srtd-ai-worker/wrangler.toml
@@ -1,0 +1,13 @@
+name = "srtd-ai"
+main = "src/index.js"
+compatibility_date = "2026-04-14"
+
+[[r2_buckets]]
+binding     = "SORTED_IMAGES"
+bucket_name = "sorted-images"
+
+# Secrets provisioned separately via `wrangler secret put`:
+# ANTHROPIC_API_KEY
+# AI_SECRET
+# (Supabase creds hardcoded in src/index.js, consistent with existing
+#  Worker pattern in this repo — see sorted-preview-worker/src/index.js)


### PR DESCRIPTION
## Summary

Infrastructure-only PR 1 for the Sorted AI integration. **Zero UI changes, zero visible changes for any user.** This is the plumbing every future AI PR depends on.

## What's in the box

### SQL migrations (Shubham runs manually in Supabase SQL editor before deploy)
- `sql/003-posts-ai-columns.sql` — adds `is_draft boolean DEFAULT false` + `ai_origin boolean DEFAULT false` to `posts`. Metadata-only operation on Postgres 11+ (no table rewrite).
- `sql/004-ai-usage-table.sql` — creates the `ai_usage` telemetry table. No FK on `post_id` on purpose — email-brief rows logged before post creation still land.

`workspace_settings` already exists and was NOT recreated.

### New Cloudflare Worker — `srtd-ai-worker/`
- `wrangler.toml` binds R2 bucket `sorted-images`. Secrets `ANTHROPIC_API_KEY` + `AI_SECRET` provisioned out-of-band via `wrangler secret put` (documented in README).
- `src/index.js` — three routes:
  - `OPTIONS *` → CORS preflight (204)
  - `POST /ai/complete` — gates on `X-AI-Secret`, validates feature, checks `workspace_settings.ai_enabled` + per-feature flag, loads `ai/brand-guide.txt` from R2 + last-20 approved posts from Supabase, calls Anthropic `claude-sonnet-4-20250514`, fire-and-forgets usage to `ai_usage`, returns `{success, content, usage}`.
  - `POST /ai/log` — lightweight standalone `ai_usage` inserter for cases where the client needs to log without a completion.
  - Error handler wraps the whole `/ai/complete` flow; `ANTHROPIC_API_KEY` is NEVER echoed in any error response.
- `README.md` — deployment steps, secrets table, SQL run order.

### Frontend plumbing
- **`07-post-load.js` — exactly 2 surgical edits, nothing else touched:**
  - `loadPosts()` (agency) appends `&is_draft=eq.false` for every non-Admin effectiveRole; Admin still sees drafts.
  - `loadPostsForClient()` (client) always appends `&is_draft=eq.false` — clients never see drafts under any circumstance.
- **`05-api.js`** — new `loadWorkspaceSettings()` fetches `/workspace_settings?workspace_id=eq.default` and stashes the row on `window.AppState.workspace`. Uses `{ allowLogout: false }` so a transient 401 on first login can't evict the user.
- **`03-auth.js`** — `activateRole()` calls `loadWorkspaceSettings()` right after the 50-min proactive token refresh timer is wired and BEFORE any role branch can early-return, so Admin / Servicing / Creative / Client and the admin-preview path all get the workspace row.
- **`00-appstate.js`** — initialises `AppState.workspace = {}` so future AI feature gates can read `AppState.workspace.ai_writer === true` safely even before the post-login fetch resolves.
- **`ai-config.js`** — NEW versioned frontend script exposing `window.AI_CONFIG = { workerUrl, secret, model }`. Single source of truth for the Worker URL on the frontend; future AI features read from this object.
- **`index.html`** — bumps ALL existing 22 `?v=` strings from `20260414k` → `20260414l`, adds `ai-config.js?v=20260414l` as the 23rd versioned resource, inserted immediately before `07-post-load.js`. `04-router.js` remains the LAST script per CLAUDE.md §3.

## Files changed (11)

```
 00-appstate.js                  |   8 +-
 03-auth.js                      |   8 +
 05-api.js                       |  21 +++
 07-post-load.js                 |   7 +-
 ai-config.js                    |  15 ++  (new)
 index.html                      |  47 ++--
 sql/003-posts-ai-columns.sql    |  56 ++++  (new)
 sql/004-ai-usage-table.sql      |  66 ++++  (new)
 srtd-ai-worker/README.md        |  77 ++++  (new)
 srtd-ai-worker/src/index.js     | 293 ++++++  (new)
 srtd-ai-worker/wrangler.toml    |  12 ++  (new)
```

## Version bump

22 → **23 versioned resources**, all at `v=20260414l`.

## Test plan

- [x] `npx vitest run` — **553/553 unit tests passing across all 22 test files** (no regressions from the 2 surgical `07-post-load.js` edits or the new `loadWorkspaceSettings` / `AppState.workspace = {}` additions).
- [ ] Shubham runs `sql/003-posts-ai-columns.sql` then `sql/004-ai-usage-table.sql` manually in the Supabase SQL editor.
- [ ] Shubham `wrangler secret put ANTHROPIC_API_KEY` and `wrangler secret put AI_SECRET` (value `srtd-ai-2026xK9mN3pQ`) on the new `srtd-ai` Worker, then `wrangler deploy` from `srtd-ai-worker/`.
- [ ] (Optional) Upload `ai/brand-guide.txt` to R2 bucket `sorted-images`.
- [ ] Cloudflare Pages purge cache after merge; hard refresh every device.
- [ ] Smoke: log in as Admin → confirm posts load exactly as today (Admin sees everything including `is_draft=true` rows if any). Log in as Servicing / Creative / Client → confirm posts load as today (new rows with `is_draft=true` hidden; all existing rows have `is_draft=false` by default so nothing disappears).
- [ ] DevTools Network: after login, confirm ONE `/workspace_settings?workspace_id=eq.default` request on each role activation and `window.AppState.workspace` populated with the row.
- [ ] DevTools: no `ANTHROPIC_API_KEY` string appears anywhere in shipped frontend JS.

## Verification checklist

- [x] `srtd-ai-worker/wrangler.toml` exists with correct R2 binding
- [x] `srtd-ai-worker/src/index.js` handles all 3 routes (OPTIONS, POST /ai/complete, POST /ai/log)
- [x] `sql/003-posts-ai-columns.sql` exists with both `ALTER TABLE` statements
- [x] `sql/004-ai-usage-table.sql` exists with correct schema
- [x] `07-post-load.js` has EXACTLY 2 edits — loadPosts query and loadPostsForClient query — nothing else changed (verified via `git diff 07-post-load.js`)
- [x] `window.AppState.workspace` is set after login (via `loadWorkspaceSettings()` fired from `activateRole()`)
- [x] `ai-config.js` exists at repo root
- [x] `index.html` has exactly **23** `?v=` strings, all at value `20260414l` (verified via `grep -c '?v='`)
- [x] No `console.log` statements left in Worker code (only one `console.error` on the fire-and-forget `ai_usage` write, which is intentional)
- [x] `ANTHROPIC_API_KEY` is never referenced in any frontend file — only in `srtd-ai-worker/src/index.js`, `srtd-ai-worker/wrangler.toml`, and `srtd-ai-worker/README.md`

## Follow-ups (not in this PR)

- CLAUDE.md update — Shubham will handle separately after reviewing.
- Every subsequent AI PR (writer / qc / chat / email-brief) builds on this foundation.

https://claude.ai/code/session_01B7HckCiW6H5SJwMP8tWbSb