### PR TITLE
fix: srtd-ai Worker R2 binding → AI_ASSETS / sorted-ai bucket

### DIFF
--- a/srtd-ai-worker/src/index.js
+++ b/srtd-ai-worker/src/index.js
@@ -115,7 +115,7 @@ async function checkWorkspaceEnabled(workspaceId, feature) {
 
 async function loadBrandGuide(env) {
   try {
-    const obj = await env.SORTED_IMAGES.get('ai/brand-guide.txt');
+    const obj = await env.AI_ASSETS.get('brand-guide.txt');
     if (!obj) return '';
     return await obj.text();
   } catch (e) {

--- a/srtd-ai-worker/wrangler.toml
+++ b/srtd-ai-worker/wrangler.toml
@@ -3,8 +3,8 @@ main = "src/index.js"
 compatibility_date = "2026-04-14"
 
 [[r2_buckets]]
-binding     = "SORTED_IMAGES"
-bucket_name = "sorted-images"
+binding     = "AI_ASSETS"
+bucket_name = "sorted-ai"
 
 # Secrets provisioned separately via `wrangler secret put`:
 # ANTHROPIC_API_KEY


### PR DESCRIPTION
## Summary

Two-line fix on top of guneygaar/guneygaar.github.io#850 (the AI foundation PR). Moves the `srtd-ai` Worker from the shared `sorted-images` R2 bucket to its own dedicated `sorted-ai` bucket so AI assets live separately from post images / profile pictures / click-log telemetry.

- `srtd-ai-worker/wrangler.toml` — binding `SORTED_IMAGES` → `AI_ASSETS`, bucket `sorted-images` → `sorted-ai`.
- `srtd-ai-worker/src/index.js` — `loadBrandGuide()` now reads `brand-guide.txt` from the root of the `AI_ASSETS` bucket (the `ai/` path prefix is no longer needed once the bucket itself is AI-only).

Base branch is `feature/ai-foundation-pr1` so the PR diff is ONLY the 2-file change, not the entire PR 1 stack. Retarget to `main-/-root` after PR 1 merges (or squash-merge into PR 1 first).

## Test plan

- [ ] Create R2 bucket `sorted-ai` in Cloudflare dashboard (one-time).
- [ ] Upload `brand-guide.txt` to the root of the `sorted-ai` bucket (optional — loader falls back to empty string if missing).
- [ ] `wrangler deploy` from `srtd-ai-worker/` — should pick up the new binding automatically.
- [ ] Probe `POST /ai/complete` with a valid payload; confirm the brand guide is loaded without errors.

https://claude.ai/code/session_01B7HckCiW6H5SJwMP8tWbSb