### PR TITLE
fix: srtd-ai Worker R2 binding → AI_ASSETS / sorted-ai bucket

### DIFF
--- a/srtd-ai-worker/src/index.js
+++ b/srtd-ai-worker/src/index.js
@@ -115,7 +115,7 @@ async function checkWorkspaceEnabled(workspaceId, feature) {
 
 async function loadBrandGuide(env) {
   try {
-    const obj = await env.SORTED_IMAGES.get('ai/brand-guide.txt');
+    const obj = await env.AI_ASSETS.get('brand-guide.txt');
     if (!obj) return '';
     return await obj.text();
   } catch (e) {

--- a/srtd-ai-worker/wrangler.toml
+++ b/srtd-ai-worker/wrangler.toml
@@ -3,8 +3,8 @@ main = "src/index.js"
 compatibility_date = "2026-04-14"
 
 [[r2_buckets]]
-binding     = "SORTED_IMAGES"
-bucket_name = "sorted-images"
+binding     = "AI_ASSETS"
+bucket_name = "sorted-ai"
 
 # Secrets provisioned separately via `wrangler secret put`:
 # ANTHROPIC_API_KEY


### PR DESCRIPTION
The srtd-ai Worker was originally wired to the shared sorted-images R2 bucket with binding SORTED_IMAGES and key ai/brand-guide.txt. Move it to its own dedicated bucket so AI assets live separately from post images / profile pictures / click-log telemetry:

- wrangler.toml binding renamed SORTED_IMAGES → AI_ASSETS, bucket renamed sorted-images → sorted-ai.
- loadBrandGuide() in src/index.js now reads brand-guide.txt from the root of the AI_ASSETS bucket (previously ai/brand-guide.txt under the shared bucket — the ai/ path prefix is no longer needed once the bucket itself is AI-only).

Two file changes only. No version bumps. No CLAUDE.md updates.

https://claude.ai/code/session_01B7HckCiW6H5SJwMP8tWbSb