### PR TITLE
Fix brief disappearing after assignment

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -191,7 +191,7 @@ async function loadPosts(fromPoll) {
     // Fetch pending requests and merge as brief-stage entries
     var reqData = [];
     try {
-      var rawReqs = await apiFetch('/requests?status=eq.pending&order=created_at.desc', {}, _apiMeta);
+      var rawReqs = await apiFetch('/requests?status=in.(pending,assigned)&order=created_at.desc', {}, _apiMeta);
       if (Array.isArray(rawReqs)) {
         reqData = rawReqs.map(function(r) {
           return {
@@ -199,7 +199,7 @@ async function loadPosts(fromPoll) {
             id: r.id,
             title: r.title || '',
             stage: 'brief',
-            owner: 'Servicing',
+            owner: r.assigned_to ? 'Creative' : 'Servicing',
             client_feedback: r.description || '',
             content_type: r.content_type || '',
             target_date: r.target_date || '',
@@ -207,6 +207,8 @@ async function loadPosts(fromPoll) {
             drive_link: r.drive_link || null,
             created_at: r.created_at || '',
             updated_at: r.created_at || '',
+            assigned_to: r.assigned_to || null,
+            _requestStatus: r.status || 'pending',
             _isRequest: true
           };
         });
@@ -287,7 +289,7 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
 
     // Fetch pending requests for client view (shows as brief cards)
     try {
-      var clientReqs = await apiFetch('/requests?status=eq.pending&order=created_at.desc', {}, _apiMeta);
+      var clientReqs = await apiFetch('/requests?status=in.(pending,assigned)&order=created_at.desc', {}, _apiMeta);
       if (Array.isArray(clientReqs)) {
         clientReqs.forEach(function(r) {
           data.push({
@@ -295,7 +297,7 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
             id: r.id,
             title: r.title || '',
             stage: 'brief',
-            owner: 'Servicing',
+            owner: r.assigned_to ? 'Creative' : 'Servicing',
             client_feedback: r.description || '',
             content_type: r.content_type || '',
             target_date: r.target_date || '',
@@ -304,6 +306,7 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
             created_at: r.created_at || '',
             updated_at: r.created_at || '',
             assigned_to: r.assigned_to || null,
+            _requestStatus: r.status || 'pending',
             _isRequest: true
           });
         });

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414o">
+ <link rel="stylesheet" href="styles.css?v=20260414p">
 
 </head>
 <body>
@@ -1159,29 +1159,29 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414o"></script>
-<script src="00-appstate-compat.js?v=20260414o"></script>
-<script src="01-config.js?v=20260414o" defer></script>
-<script src="02-session.js?v=20260414o" defer></script>
-<script src="utils.js?v=20260414o" defer></script>
-<script src="12-profiles.js?v=20260414o" defer></script>
-<script src="03-auth.js?v=20260414o" defer></script>
-<script src="05-api.js?v=20260414o" defer></script>
-<script src="10-ui.js?v=20260414o" defer></script>
+<script src="00-appstate.js?v=20260414p"></script>
+<script src="00-appstate-compat.js?v=20260414p"></script>
+<script src="01-config.js?v=20260414p" defer></script>
+<script src="02-session.js?v=20260414p" defer></script>
+<script src="utils.js?v=20260414p" defer></script>
+<script src="12-profiles.js?v=20260414p" defer></script>
+<script src="03-auth.js?v=20260414p" defer></script>
+<script src="05-api.js?v=20260414p" defer></script>
+<script src="10-ui.js?v=20260414p" defer></script>
 
-<script src="06-post-create.js?v=20260414o" defer></script>
-<script defer src="render/dashboard.js?v=20260414o"></script>
-<script defer src="render/client.js?v=20260414o"></script>
-<script defer src="render/pipeline.js?v=20260414o"></script>
-<script defer src="render/brief.js?v=20260414o"></script>
-<script defer src="actions/pcs.js?v=20260414o"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414o"></script>
-<script src="ai-config.js?v=20260414o" defer></script>
-<script src="07-post-load.js?v=20260414o" defer></script>
-<script src="08-post-actions.js?v=20260414o" defer></script>
-<script src="09-library.js?v=20260414o" defer></script>
-<script src="09-approval.js?v=20260414o" defer></script>
-<script src="04-router.js?v=20260414o" defer></script>
+<script src="06-post-create.js?v=20260414p" defer></script>
+<script defer src="render/dashboard.js?v=20260414p"></script>
+<script defer src="render/client.js?v=20260414p"></script>
+<script defer src="render/pipeline.js?v=20260414p"></script>
+<script defer src="render/brief.js?v=20260414p"></script>
+<script defer src="actions/pcs.js?v=20260414p"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414p"></script>
+<script src="ai-config.js?v=20260414p" defer></script>
+<script src="07-post-load.js?v=20260414p" defer></script>
+<script src="08-post-actions.js?v=20260414p" defer></script>
+<script src="09-library.js?v=20260414p" defer></script>
+<script src="09-approval.js?v=20260414p" defer></script>
+<script src="04-router.js?v=20260414p" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -267,7 +267,34 @@ window._briefSubmitComment = function(postId) {
 // ===============================================
 window._openBriefSheet = async function(postId) {
   var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
-  if (!post) return;
+  if (!post) {
+    try {
+      var fallback = await apiFetch(
+        '/requests?id=eq.' + encodeURIComponent(postId) +
+        '&select=*&limit=1', {}, { allowLogout: false }
+      );
+      if (Array.isArray(fallback) && fallback[0]) {
+        var r = fallback[0];
+        post = {
+          post_id: r.id,
+          title: r.title,
+          stage: 'brief',
+          owner: r.assigned_to ? 'Creative' : 'Servicing',
+          assigned_to: r.assigned_to || null,
+          _isRequest: true,
+          _requestStatus: r.status,
+          description: r.description,
+          content_type: r.content_type,
+          target_date: r.target_date,
+          images: r.images || [],
+          drive_link: r.drive_link || null,
+          created_by: r.created_by,
+          created_at: r.created_at
+        };
+      }
+    } catch (e) {}
+    if (!post) return;
+  }
 
   var existing = document.getElementById('brief-sheet-overlay');
   if (existing) existing.remove();


### PR DESCRIPTION
## Summary

When Admin/Servicing assigned a client-request brief to Creative, the brief vanished from every view and could not be reopened. Root cause was three compounding lines in `07-post-load.js`:

- Both loaders fetched `/requests?status=eq.pending` only. `_assignBrief` flips status to `'assigned'`, so the next Realtime refresh omitted the row and `mergePosts` (lines 138-140) evicted it from `AppState.posts.all`.
- The stub builder set `owner:'Servicing'` unconditionally and never carried `assigned_to`, so even if the row had survived, the Pranav pipeline filter (`owner === 'creative'`) would still have rejected it.
- `_openBriefSheet` early-returned when `getPostById` was null, with no by-id fallback, so deep links and notification taps could not recover an evicted brief.

## Changes

**`07-post-load.js`**
- Agency loader (line 194): `status=in.(pending,assigned)`.
- Client loader (line 290): `status=in.(pending,assigned)`.
- Stub builder (both loaders): `owner: r.assigned_to ? 'Creative' : 'Servicing'`, and now carries `assigned_to` + `_requestStatus` so the brief panel opens without a secondary `/requests` refetch.

**`render/brief.js`**
- `_openBriefSheet` (line 268): when `getPostById` returns null, fall back to `apiFetch('/requests?id=eq.<id>&select=*&limit=1', {}, { allowLogout: false })` and synthesize the stub in-place before giving up. Safety net for any future eviction.

**`index.html`**
- Bumped all 23 `?v=` strings from `20260414o` to `20260414p`.

No schema changes. No new files. No CLAUDE.md update in this PR.

## Test plan

- [x] `npx vitest run` — 553/553 passing across 22 test files, no regressions
- [ ] Manually assign a client request as Admin/Servicing and confirm:
  - Brief card stays visible in pipeline after the assign PATCH
  - Brief card appears under Pranav's pipeline view (owner flips to 'Creative')
  - Tapping the brief card reopens the overlay with "Assigned to <name>"
  - Reassign, Create Post, and Close Brief all still work from the reopened overlay
- [ ] Deep-link `srtd.io/?open=REQ-XXXX` for an assigned request opens the brief sheet via the new fallback path
- [ ] Client feed still hides assigned requests (unchanged — `render/client.js:147` still skips `if (assigned)`)

https://claude.ai/code/session_017ugd2WJZtxesGrEAW4iZTX