### PR TITLE
Fix brief assigned visibility + notif routing + owner dropdown

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -472,6 +472,31 @@ _npsCheckValid();
 startDraftAutosave();
 if (typeof _initPostAssetInput === 'function') _initPostAssetInput();
 
+// Populate owner dropdown dynamically from user_roles
+(async function() {
+  try {
+    var _ownerSel = document.getElementById('new-post-owner');
+    if (!_ownerSel) return;
+    var _members = await apiFetch(
+      '/user_roles?role=neq.client&select=name,role,email' +
+      '&order=name.asc',
+      {}, { allowLogout: false }
+    );
+    if (!Array.isArray(_members)) return;
+    _ownerSel.innerHTML = '<option value="">Assign to...</option>';
+    _members.forEach(function(m) {
+      if (!m || !m.name || !m.role) return;
+      var _canonRole = m.role.charAt(0).toUpperCase() +
+                       m.role.slice(1).toLowerCase();
+      if (_canonRole === 'Client') return;
+      var opt = document.createElement('option');
+      opt.value = _canonRole;
+      opt.textContent = m.name;
+      _ownerSel.appendChild(opt);
+    });
+  } catch (_e) {}
+})();
+
 var captionEl = document.getElementById('new-post-caption');
 if (captionEl) {
   captionEl.style.height = 'auto';
@@ -491,6 +516,10 @@ var captionEl = document.getElementById('new-post-caption');
 if (captionEl) captionEl.value = '';
 _newPostAssetFiles = [];
 if (typeof clearPostAsset === 'function') clearPostAsset();
+
+var _ownerSel = document.getElementById('new-post-owner');
+if (_ownerSel) _ownerSel.innerHTML =
+  '<option value="">Assign to...</option>';
 
 document.getElementById('new-post-overlay').style.display = 'none';
 var nav = document.getElementById('bottom-nav');

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -191,7 +191,7 @@ async function loadPosts(fromPoll) {
     // Fetch pending requests and merge as brief-stage entries
     var reqData = [];
     try {
-      var rawReqs = await apiFetch('/requests?status=eq.pending&order=created_at.desc', {}, _apiMeta);
+      var rawReqs = await apiFetch('/requests?status=in.(pending,assigned)&order=created_at.desc', {}, _apiMeta);
       if (Array.isArray(rawReqs)) {
         reqData = rawReqs.map(function(r) {
           return {
@@ -199,7 +199,7 @@ async function loadPosts(fromPoll) {
             id: r.id,
             title: r.title || '',
             stage: 'brief',
-            owner: 'Servicing',
+            owner: r.assigned_to ? 'Creative' : 'Servicing',
             client_feedback: r.description || '',
             content_type: r.content_type || '',
             target_date: r.target_date || '',
@@ -207,6 +207,8 @@ async function loadPosts(fromPoll) {
             drive_link: r.drive_link || null,
             created_at: r.created_at || '',
             updated_at: r.created_at || '',
+            assigned_to: r.assigned_to || null,
+            _requestStatus: r.status || 'pending',
             _isRequest: true
           };
         });
@@ -287,7 +289,7 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
 
     // Fetch pending requests for client view (shows as brief cards)
     try {
-      var clientReqs = await apiFetch('/requests?status=eq.pending&order=created_at.desc', {}, _apiMeta);
+      var clientReqs = await apiFetch('/requests?status=in.(pending,assigned)&order=created_at.desc', {}, _apiMeta);
       if (Array.isArray(clientReqs)) {
         clientReqs.forEach(function(r) {
           data.push({
@@ -295,7 +297,7 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
             id: r.id,
             title: r.title || '',
             stage: 'brief',
-            owner: 'Servicing',
+            owner: r.assigned_to ? 'Creative' : 'Servicing',
             client_feedback: r.description || '',
             content_type: r.content_type || '',
             target_date: r.target_date || '',
@@ -304,6 +306,7 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
             created_at: r.created_at || '',
             updated_at: r.created_at || '',
             assigned_to: r.assigned_to || null,
+            _requestStatus: r.status || 'pending',
             _isRequest: true
           });
         });

--- a/10-ui.js
+++ b/10-ui.js
@@ -761,7 +761,7 @@ function renderNotifications(name, role) {
       ? '<div class="notif-thumb-wrap"><img class="notif-thumb" src="' + esc(postThumb) + '" onerror="this.style.display=\'none\'"></div>'
       : '';
 
-    var isBriefAttr = (n.type === 'new_request' || n.type === 'brief' || n.type === 'brief_done') ? ' data-is-brief="1"' : '';
+    var isBriefAttr = (n.type === 'new_request' || n.type === 'brief' || n.type === 'brief_done' || n.type === 'assign') ? ' data-is-brief="1"' : '';
     // notif-live-card retained as a marker class on published rows so the
     // tap delegate still finds them via closest('.notif-item, .notif-live-card').
     var liveMarker = isPublished ? ' notif-live-card' : '';

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414o">
+ <link rel="stylesheet" href="styles.css?v=20260414p">
 
 </head>
 <body>
@@ -554,9 +554,6 @@
           <span class="nps-label">Owner <span class="nps-req">*</span></span>
           <select class="nps-select" id="new-post-owner">
             <option value="">Assign to...</option>
-            <option value="Creative">Pranav</option>
-            <option value="Servicing">Chitra</option>
-            <option value="Client">Client</option>
           </select>
         </div>
 
@@ -1159,29 +1156,29 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414o"></script>
-<script src="00-appstate-compat.js?v=20260414o"></script>
-<script src="01-config.js?v=20260414o" defer></script>
-<script src="02-session.js?v=20260414o" defer></script>
-<script src="utils.js?v=20260414o" defer></script>
-<script src="12-profiles.js?v=20260414o" defer></script>
-<script src="03-auth.js?v=20260414o" defer></script>
-<script src="05-api.js?v=20260414o" defer></script>
-<script src="10-ui.js?v=20260414o" defer></script>
+<script src="00-appstate.js?v=20260414p"></script>
+<script src="00-appstate-compat.js?v=20260414p"></script>
+<script src="01-config.js?v=20260414p" defer></script>
+<script src="02-session.js?v=20260414p" defer></script>
+<script src="utils.js?v=20260414p" defer></script>
+<script src="12-profiles.js?v=20260414p" defer></script>
+<script src="03-auth.js?v=20260414p" defer></script>
+<script src="05-api.js?v=20260414p" defer></script>
+<script src="10-ui.js?v=20260414p" defer></script>
 
-<script src="06-post-create.js?v=20260414o" defer></script>
-<script defer src="render/dashboard.js?v=20260414o"></script>
-<script defer src="render/client.js?v=20260414o"></script>
-<script defer src="render/pipeline.js?v=20260414o"></script>
-<script defer src="render/brief.js?v=20260414o"></script>
-<script defer src="actions/pcs.js?v=20260414o"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414o"></script>
-<script src="ai-config.js?v=20260414o" defer></script>
-<script src="07-post-load.js?v=20260414o" defer></script>
-<script src="08-post-actions.js?v=20260414o" defer></script>
-<script src="09-library.js?v=20260414o" defer></script>
-<script src="09-approval.js?v=20260414o" defer></script>
-<script src="04-router.js?v=20260414o" defer></script>
+<script src="06-post-create.js?v=20260414p" defer></script>
+<script defer src="render/dashboard.js?v=20260414p"></script>
+<script defer src="render/client.js?v=20260414p"></script>
+<script defer src="render/pipeline.js?v=20260414p"></script>
+<script defer src="render/brief.js?v=20260414p"></script>
+<script defer src="actions/pcs.js?v=20260414p"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414p"></script>
+<script src="ai-config.js?v=20260414p" defer></script>
+<script src="07-post-load.js?v=20260414p" defer></script>
+<script src="08-post-actions.js?v=20260414p" defer></script>
+<script src="09-library.js?v=20260414p" defer></script>
+<script src="09-approval.js?v=20260414p" defer></script>
+<script src="04-router.js?v=20260414p" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -267,7 +267,36 @@ window._briefSubmitComment = function(postId) {
 // ===============================================
 window._openBriefSheet = async function(postId) {
   var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
-  if (!post) return;
+  if (!post) {
+    try {
+      var _fbRows = await apiFetch(
+        '/requests?id=eq.' + encodeURIComponent(postId) +
+        '&select=*&limit=1',
+        {}, { allowLogout: false }
+      );
+      if (Array.isArray(_fbRows) && _fbRows[0]) {
+        var _r = _fbRows[0];
+        post = {
+          post_id: _r.id,
+          title: _r.title || '',
+          stage: 'brief',
+          owner: _r.assigned_to ? 'Creative' : 'Servicing',
+          assigned_to: _r.assigned_to || null,
+          _isRequest: true,
+          _requestStatus: _r.status || 'pending',
+          description: _r.description || '',
+          client_feedback: _r.description || '',
+          content_type: _r.content_type || '',
+          target_date: _r.target_date || null,
+          images: Array.isArray(_r.images) ? _r.images : [],
+          drive_link: _r.drive_link || null,
+          created_by: _r.created_by || '',
+          created_at: _r.created_at || ''
+        };
+      }
+    } catch (_fbErr) {}
+    if (!post) return;
+  }
 
   var existing = document.getElementById('brief-sheet-overlay');
   if (existing) existing.remove();
@@ -883,7 +912,9 @@ window._assignBrief = function(postId, ownerRole, displayName, isReassign) {
           user_role: _assigneeRole,
           post_id:   postId,
           type:      'assign',
-          message:   (displayName || 'Someone') +
+          message:   (window.AppState.user.name ||
+                      window.AppState.user.email ||
+                      'Someone') +
                      ' assigned you a brief: "' +
                      (post.title || 'Untitled') + '"',
           actor:     (window.AppState.user.name ||
@@ -954,7 +985,9 @@ window._assignBrief = function(postId, ownerRole, displayName, isReassign) {
         user_role: _assigneeRole,
         post_id:   postId,
         type:      'assign',
-        message:   (displayName || 'Someone') +
+        message:   (window.AppState.user.name ||
+                    window.AppState.user.email ||
+                    'Someone') +
                    ' assigned you a brief: "' +
                    (post.title || 'Untitled') + '"',
         actor:     (window.AppState.user.name ||


### PR DESCRIPTION
## Summary

Supersedes and replaces #857 with the complete fix for the end-to-end brief flow. Close #857 before merging this one — they touch the same files and this covers everything #857 did plus four additional bugs identified in the follow-up audit.

Five bugs, five surgical changes:

1. **Disappearing-brief root cause** — both loaders fetched `/requests?status=eq.pending` only. `_assignBrief` flips status to `'assigned'`, so the next Realtime refresh dropped the row and `mergePosts` (07-post-load.js:138-140) evicted it from `AppState`. Switched to `status=in.(pending,assigned)` and gave the stub an `owner: r.assigned_to ? 'Creative' : 'Servicing'` mapping plus `assigned_to` + `_requestStatus` fields so the Pranav pipeline filter (`owner === 'creative'`, pipeline.js:895-907 + 952-962) matches assigned briefs.
2. **`_openBriefSheet` safety net** — early-returned on null `getPostById` with no fallback. Deep links and notification taps for any briefly-evicted row could not recover. Added a by-id `/requests` fetch that rebuilds the stub in-place before giving up.
3. **Wrong notification message prefix** — the assign notification said *"Pranav assigned you a brief"* because both write sites in `_assignBrief` templated on `displayName` (the assignee) instead of the actor. Both now use `AppState.user.name` as the prefix.
4. **Notification tap routing** — tapping an `'assign'` notification routed to `openPCS` instead of `_openBriefSheet` because `10-ui.js:764` only flagged `new_request` / `brief` / `brief_done` as `data-is-brief="1"`. Added `'assign'` to that list so the creative's assign-notification tap lands in the brief overlay.
5. **Hardcoded owner dropdown** — `index.html:557-559` hardcoded *Pranav* and *Chitra* as owner select labels. Stripped the static options and added a dynamic populate from `/user_roles?role=neq.client` in `openNewPostModal`, with a matching reset in `closeNewPostModal`.

## Changes

- `07-post-load.js`: both loaders switch to `status=in.(pending,assigned)`; both stubs carry `assigned_to`, `_requestStatus`, owner toggled to `'Creative'` when `assigned_to` is set.
- `render/brief.js`: `_openBriefSheet` `/requests` by-id fallback; both `_assignBrief` notification messages use `AppState.user.name || AppState.user.email || 'Someone'`.
- `10-ui.js`: `isBriefAttr` in `renderNotifications` includes `n.type === 'assign'`.
- `index.html`: hardcoded owner options removed; 23 `?v=` strings bumped `20260414o` → `20260414p`.
- `06-post-create.js`: dynamic `/user_roles` populate of `#new-post-owner` inside `openNewPostModal`; dropdown reset to `<option value="">Assign to...</option>` inside `closeNewPostModal`.

No schema changes. No new files. CLAUDE.md left untouched per PR instructions.

## Test plan

- [x] `npx vitest run` — 553/553 passing across 22 test files, no regressions
- [ ] As Admin/Servicing: assign a client request to Creative and confirm brief card stays visible in pipeline through the Realtime refresh
- [ ] As Creative: after assignment, confirm the brief appears in Pranav's pipeline brief group and the assign notification tap opens the brief sheet overlay (not the PCS card)
- [ ] Confirm the notification message reads *"<Admin/Servicing name> assigned you a brief: …"* (not *"<assignee name> assigned you a brief"*)
- [ ] Deep-link `srtd.io/?open=REQ-XXXX` opens the brief sheet via either AppState or the new `/requests` fallback
- [ ] Open the new-post form and verify owner dropdown is populated from `user_roles` with real team names (not hardcoded Pranav/Chitra)
- [ ] Close and reopen the new-post form to confirm the dropdown repopulates cleanly
- [ ] Client feed still hides assigned requests (unchanged behavior at `render/client.js:147`)

https://claude.ai/code/session_017ugd2WJZtxesGrEAW4iZTX