### PR TITLE
Brief images transfer + duplicate post guard

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -521,6 +521,8 @@ var _ownerSel = document.getElementById('new-post-owner');
 if (_ownerSel) _ownerSel.innerHTML =
   '<option value="">Assign to...</option>';
 
+window._briefImportedImages = null;
+
 document.getElementById('new-post-overlay').style.display = 'none';
 var nav = document.getElementById('bottom-nav');
 if (nav) nav.style.display = '';
@@ -640,6 +642,13 @@ if (_newPostAssetFiles.length && typeof uploadPostAsset === 'function') {
   }
 }
 
+// If no new files uploaded but brief images exist, use those
+if ((!payload.images || payload.images.length === 0) &&
+    Array.isArray(window._briefImportedImages) &&
+    window._briefImportedImages.length > 0) {
+  payload.images = window._briefImportedImages.slice();
+}
+
 console.log('[submitNewPost] VALIDATION PASSED');
 console.log('FINAL PAYLOAD:', JSON.stringify(payload, null, 2));
 
@@ -702,6 +711,29 @@ if (window._activeBriefPostId) {
     // at status='assigned' forever. Close the request instead.
     // NOTE: requests table has no updated_at or linked_post_id
     // columns — only `status` is safe to PATCH here.
+
+    // Guard: check the request is not already closed before
+    // creating another post from it.
+    try {
+      var _guardRows = await apiFetch(
+        '/requests?id=eq.' + encodeURIComponent(_bid) +
+        '&select=status&limit=1',
+        {}, { allowLogout: false }
+      );
+      if (Array.isArray(_guardRows) && _guardRows[0] &&
+          _guardRows[0].status === 'closed') {
+        // Brief already has a post created from it.
+        // Do not create a duplicate. Show a warning and abort.
+        showToast && showToast(
+          'This brief already has a post created from it.',
+          'warning'
+        );
+        window._activeBriefPostId = null;
+        window._briefImportedImages = null;
+        return;
+      }
+    } catch (_guardErr) {}
+
     apiFetch('/requests?id=eq.' + encodeURIComponent(_bid), {
       method: 'PATCH',
       body: JSON.stringify({

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414p">
+ <link rel="stylesheet" href="styles.css?v=20260414q">
 
 </head>
 <body>
@@ -1156,29 +1156,29 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414p"></script>
-<script src="00-appstate-compat.js?v=20260414p"></script>
-<script src="01-config.js?v=20260414p" defer></script>
-<script src="02-session.js?v=20260414p" defer></script>
-<script src="utils.js?v=20260414p" defer></script>
-<script src="12-profiles.js?v=20260414p" defer></script>
-<script src="03-auth.js?v=20260414p" defer></script>
-<script src="05-api.js?v=20260414p" defer></script>
-<script src="10-ui.js?v=20260414p" defer></script>
+<script src="00-appstate.js?v=20260414q"></script>
+<script src="00-appstate-compat.js?v=20260414q"></script>
+<script src="01-config.js?v=20260414q" defer></script>
+<script src="02-session.js?v=20260414q" defer></script>
+<script src="utils.js?v=20260414q" defer></script>
+<script src="12-profiles.js?v=20260414q" defer></script>
+<script src="03-auth.js?v=20260414q" defer></script>
+<script src="05-api.js?v=20260414q" defer></script>
+<script src="10-ui.js?v=20260414q" defer></script>
 
-<script src="06-post-create.js?v=20260414p" defer></script>
-<script defer src="render/dashboard.js?v=20260414p"></script>
-<script defer src="render/client.js?v=20260414p"></script>
-<script defer src="render/pipeline.js?v=20260414p"></script>
-<script defer src="render/brief.js?v=20260414p"></script>
-<script defer src="actions/pcs.js?v=20260414p"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414p"></script>
-<script src="ai-config.js?v=20260414p" defer></script>
-<script src="07-post-load.js?v=20260414p" defer></script>
-<script src="08-post-actions.js?v=20260414p" defer></script>
-<script src="09-library.js?v=20260414p" defer></script>
-<script src="09-approval.js?v=20260414p" defer></script>
-<script src="04-router.js?v=20260414p" defer></script>
+<script src="06-post-create.js?v=20260414q" defer></script>
+<script defer src="render/dashboard.js?v=20260414q"></script>
+<script defer src="render/client.js?v=20260414q"></script>
+<script defer src="render/pipeline.js?v=20260414q"></script>
+<script defer src="render/brief.js?v=20260414q"></script>
+<script defer src="actions/pcs.js?v=20260414q"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414q"></script>
+<script src="ai-config.js?v=20260414q" defer></script>
+<script src="07-post-load.js?v=20260414q" defer></script>
+<script src="08-post-actions.js?v=20260414q" defer></script>
+<script src="09-library.js?v=20260414q" defer></script>
+<script src="09-approval.js?v=20260414q" defer></script>
+<script src="04-router.js?v=20260414q" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -494,6 +494,7 @@ window._openBriefSheet = async function(postId) {
     //   • Other roles → hide (read-only)
     var _createPostBtn =
       '<button onclick="_createPostFromBrief(\'' + postId + '\')" ' +
+      'data-brief-id="' + esc(postId) + '" ' +
       'style="display:flex;align-items:center;justify-content:center;gap:6px;' +
       'background:#0e0e0e;border:1px solid #C8A84B;border-radius:10px;' +
       'padding:13px 20px;width:100%;font-family:\'IBM Plex Mono\',monospace;' +
@@ -1201,6 +1202,35 @@ window._createPostFromBrief = function(briefPostId) {
     if (ownerEl) {
       ownerEl.value = 'Creative';
       ownerEl.dispatchEvent(new Event('change'));
+    }
+
+    // Transfer brief reference images to the new post form
+    if (Array.isArray(brief.images) && brief.images.length > 0) {
+      try {
+        window._newPostAssetFiles = window._newPostAssetFiles || [];
+        // Store the existing image URLs so the submit handler
+        // can include them in payload.images without re-upload.
+        // We inject them as a special property the submit handler
+        // already reads.
+        window._briefImportedImages = brief.images.slice();
+
+        // Show a visual indicator in the form that images are
+        // pre-loaded from the brief.
+        var _previewWrap = document.getElementById('new-post-asset-preview');
+        if (_previewWrap) {
+          _previewWrap.innerHTML = '';
+          brief.images.forEach(function(url) {
+            if (!url) return;
+            var _thumb = document.createElement('div');
+            _thumb.style.cssText = 'position:relative;display:inline-block;margin:4px';
+            _thumb.innerHTML = '<img src="' + url + '" style="width:56px;height:56px;object-fit:cover;border:1px solid #323244">' +
+              '<span style="position:absolute;top:2px;left:2px;background:#1a1a24;font-family:IBM Plex Mono,monospace;font-size:6px;color:#9b87f5;padding:1px 3px;letter-spacing:.06em;text-transform:uppercase">brief</span>';
+            _previewWrap.appendChild(_thumb);
+          });
+        }
+      } catch (_imgErr) {}
+    } else {
+      window._briefImportedImages = null;
     }
 
     // Trigger validation so Create Post button enables


### PR DESCRIPTION
## Summary

Depends on #858 being merged first (now merged). Two non-blocking improvements identified in the brief-lifecycle audit:

1. **Brief reference images transfer into the new post on Create Post.** Previously the creative had to manually re-upload every reference photo the client attached to the request — `_createPostFromBrief` only pre-filled title, caption, and owner, so `brief.images` got orphaned on the closed request row. Now `_createPostFromBrief` stashes `brief.images` into `window._briefImportedImages`, and `submitNewPost` falls back to that stash for `payload.images` when no new files were uploaded. `closeNewPostModal` clears the stash so the next form open starts clean.

2. **Duplicate post guard.** If the old assign notification for a closed brief is tapped (the notification row still exists after close), the submit handler now reads the current status of the request before closing it a second time. If status is already `'closed'`, the submit aborts with a warning toast and the `_activeBriefPostId` / imported-images globals are cleared.

Change 5 (data-brief-id attribute on the Create Post button) adds a traceability hook only — no behavioral change.

## Changes

- `render/brief.js`: `_createPostFromBrief` transfers `brief.images` into `window._briefImportedImages` with a thumbnail-preview hook (gated on `#new-post-asset-preview`, see note below); Create Post button carries `data-brief-id="<postId>"`.
- `06-post-create.js`: `submitNewPost` uses `_briefImportedImages` as `payload.images` fallback when no new files uploaded; duplicate-status guard before `PATCH /requests` close; `closeNewPostModal` resets `_briefImportedImages`.
- `index.html`: 23 `?v=` strings bumped `20260414p` → `20260414q`.

No schema changes. No new files. CLAUDE.md left untouched per PR instructions.

## Notes on the spec

- **Thumbnail preview element.** The spec writes thumbnails into `document.getElementById('new-post-asset-preview')`. That element does not currently exist in `index.html` — the existing file-upload preview is `#new-post-asset-grid`. The `if (_previewWrap)` guard defensively skips, so the branch is a no-op until `#new-post-asset-preview` is added. The functional image transfer via `_briefImportedImages` → `payload.images` works regardless.
- **Duplicate guard placement.** The spec places the guard immediately before the `PATCH /requests?...` that closes the request. By that point in `submitNewPost`, the `POST /posts` at line 648 has already succeeded, so a duplicate post row IS briefly created before the guard catches the closed state. The guard still prevents the request from being re-closed and clears the stashed globals, but a truly-no-duplicate behavior would require the status check to run BEFORE the `POST /posts`. Flagging in case the placement needs to move earlier.

## Test plan

- [x] `npx vitest run` — 553/553 passing across 22 test files, no regressions
- [ ] Create a client request with 2-3 reference photos, assign it to Creative, tap Create Post from the brief overlay, submit the form without uploading any new files. Confirm the resulting `/posts` row has `images` populated with the brief's URLs.
- [ ] Tap an old assign notification for an already-closed brief and proceed to Create Post + submit. Confirm the warning toast fires and the flow aborts (observe the extra `/posts` row created pre-guard — see note above).
- [ ] Submit a new post with fresh user-uploaded files after a brief-originated open. Confirm the user-uploaded files win over the brief stash (existing behavior; `_briefImportedImages` is a fallback only).
- [ ] Open and close the new-post form twice in a row. Confirm `window._briefImportedImages` is cleared between opens.

https://claude.ai/code/session_017ugd2WJZtxesGrEAW4iZTX