### PR TITLE
Gmail import: fix click handler via cache bump + read full thread + total_posts

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -232,7 +232,15 @@ window._npsShowEmailList = async function() {
           '<span class="nps-email-time">' + dateStr + '</span>' +
         '</div>' +
         '<div class="nps-email-subject">' + ((email.subject || '') + '').replace(/</g, '&lt;') + '</div>' +
-        '<div class="nps-email-preview">' + ((email.snippet || '') + '').replace(/</g, '&lt;') + '</div>';
+        '<div class="nps-email-preview">' + ((email.snippet || '') + '').replace(/</g, '&lt;') + '</div>' +
+        (email.message_count && email.message_count > 1 ?
+          '<div class="nps-email-thread-count">' +
+            email.message_count + ' messages in thread</div>'
+          : '');
+      // Closure captures `email` per iteration. email.id holds the
+      // gmail thread id (handleGmailList now returns one row per
+      // thread, keyed by thread.id), so `window._npsSelectEmail`
+      // ships it as thread_id on the Worker call.
       div.onclick = function() { window._npsSelectEmail(email.id, email.subject); };
       items.appendChild(div);
     });
@@ -262,12 +270,30 @@ window._npsSelectEmail = async function(messageId, subject) {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-AI-Secret': cfg.secret },
       body: JSON.stringify({
-        message_id:   messageId,
+        // messageId is now a thread id — see closure note in
+        // _npsShowEmailList. The Worker accepts thread_id and
+        // still falls back to message_id for any stale cache.
+        thread_id:    messageId,
         workspace_id: 'default',
         created_by:   (window.AppState.user && window.AppState.user.email) || ''
       })
     });
     var data = await res.json();
+
+    // Stash total_posts for campaign tracking before any early
+    // return. Cleared in closeNewPostModal.
+    window._npsGmailTotalPosts = (data && data.total_posts) || 1;
+
+    // Show total posts indicator if > 1 (replaces the "reading
+    // brief" copy). Done before we hide the processing row.
+    if (data && data.total_posts && data.total_posts > 1) {
+      var _procTxt = document.getElementById('nps-proc-txt');
+      if (_procTxt) {
+        _procTxt.textContent = data.total_posts +
+          ' posts identified in this brief';
+        _procTxt.style.color = '#9b87f5';
+      }
+    }
 
     if (proc) proc.style.display = 'none';
 
@@ -332,7 +358,13 @@ window._npsSelectEmail = async function(messageId, subject) {
     _npsCheckValid();
   } catch (e) {
     if (proc) proc.style.display = 'none';
-    if (typeof showToast === 'function') showToast('Error reading brief', 'error');
+    // Never silently swallow — always log to error_log.
+    window.logError && window.logError(
+      e && e.message, e && e.stack, 'gmail-brief-import'
+    );
+    if (typeof showToast === 'function') {
+      showToast('Error reading brief. Try again.', 'error');
+    }
   }
 };
 
@@ -532,8 +564,9 @@ window.AppState.ui.modalOpen = false;
 // PR 4 — Gmail import: tear down every per-open UI shim so the
 // next open starts clean (button label, option wrap, processing
 // row, email list, AI tags).
-window._npsGmailImported  = false;
-window._npsSelectedOptIdx = 0;
+window._npsGmailImported   = false;
+window._npsSelectedOptIdx  = 0;
+window._npsGmailTotalPosts = null;
 var captionOpts = document.getElementById('nps-caption-opts');
 if (captionOpts) captionOpts.style.display = 'none';
 var captionTextarea = document.getElementById('new-post-caption');
@@ -734,11 +767,17 @@ if (window._activeBriefPostId) {
       }
     } catch (_guardErr) {}
 
+    // Gmail multi-post briefs: ship total_posts to the request row
+    // so campaign tracking knows how many posts make up the brief.
+    // Only injected when set by _npsSelectEmail — regular requests
+    // close with the same {status:'closed'} body as before.
+    var _briefPatch = { status: 'closed' };
+    if (window._npsGmailTotalPosts && window._npsGmailTotalPosts > 1) {
+      _briefPatch.total_posts = window._npsGmailTotalPosts;
+    }
     apiFetch('/requests?id=eq.' + encodeURIComponent(_bid), {
       method: 'PATCH',
-      body: JSON.stringify({
-        status: 'closed'
-      })
+      body: JSON.stringify(_briefPatch)
     }).catch(function(err) {
       console.warn('[post-create] close request failed', err);
       window.logError && window.logError(err && err.message, err && err.stack, 'close-request-on-convert');

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414q">
+ <link rel="stylesheet" href="styles.css?v=20260414r">
 
 </head>
 <body>
@@ -1156,29 +1156,29 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414q"></script>
-<script src="00-appstate-compat.js?v=20260414q"></script>
-<script src="01-config.js?v=20260414q" defer></script>
-<script src="02-session.js?v=20260414q" defer></script>
-<script src="utils.js?v=20260414q" defer></script>
-<script src="12-profiles.js?v=20260414q" defer></script>
-<script src="03-auth.js?v=20260414q" defer></script>
-<script src="05-api.js?v=20260414q" defer></script>
-<script src="10-ui.js?v=20260414q" defer></script>
+<script src="00-appstate.js?v=20260414r"></script>
+<script src="00-appstate-compat.js?v=20260414r"></script>
+<script src="01-config.js?v=20260414r" defer></script>
+<script src="02-session.js?v=20260414r" defer></script>
+<script src="utils.js?v=20260414r" defer></script>
+<script src="12-profiles.js?v=20260414r" defer></script>
+<script src="03-auth.js?v=20260414r" defer></script>
+<script src="05-api.js?v=20260414r" defer></script>
+<script src="10-ui.js?v=20260414r" defer></script>
 
-<script src="06-post-create.js?v=20260414q" defer></script>
-<script defer src="render/dashboard.js?v=20260414q"></script>
-<script defer src="render/client.js?v=20260414q"></script>
-<script defer src="render/pipeline.js?v=20260414q"></script>
-<script defer src="render/brief.js?v=20260414q"></script>
-<script defer src="actions/pcs.js?v=20260414q"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414q"></script>
-<script src="ai-config.js?v=20260414q" defer></script>
-<script src="07-post-load.js?v=20260414q" defer></script>
-<script src="08-post-actions.js?v=20260414q" defer></script>
-<script src="09-library.js?v=20260414q" defer></script>
-<script src="09-approval.js?v=20260414q" defer></script>
-<script src="04-router.js?v=20260414q" defer></script>
+<script src="06-post-create.js?v=20260414r" defer></script>
+<script defer src="render/dashboard.js?v=20260414r"></script>
+<script defer src="render/client.js?v=20260414r"></script>
+<script defer src="render/pipeline.js?v=20260414r"></script>
+<script defer src="render/brief.js?v=20260414r"></script>
+<script defer src="actions/pcs.js?v=20260414r"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414r"></script>
+<script src="ai-config.js?v=20260414r" defer></script>
+<script src="07-post-load.js?v=20260414r" defer></script>
+<script src="08-post-actions.js?v=20260414r" defer></script>
+<script src="09-library.js?v=20260414r" defer></script>
+<script src="09-approval.js?v=20260414r" defer></script>
+<script src="04-router.js?v=20260414r" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/srtd-ai-worker/src/index.js
+++ b/srtd-ai-worker/src/index.js
@@ -312,13 +312,17 @@ async function handleLog(request, env) {
   }
 }
 
-// ─── Gmail import (PR 4) ─────────────────────────────────────
+// ─── Gmail import (PR 4, thread rewrite) ─────────────────────
 //
 // Two routes that front the Gmail REST API on behalf of the
-// srtd-ai worker. handleGmailList fetches recent messages from a
-// fixed allowlist of client addresses. handleGmailBrief fetches a
-// single message body, then asks Claude to extract a title + 3
-// LinkedIn caption options + internal notes as strict JSON.
+// srtd-ai worker. handleGmailList fetches recent THREADS from a
+// fixed allowlist of client addresses (one list row per thread,
+// not one row per message). handleGmailBrief pulls the full
+// thread, concatenates every message body in chronological
+// order, and asks Claude to read the whole conversation and
+// extract the FINAL agreed brief — because the last reply
+// often redefines the scope (e.g. "make 2 carousels" narrowing
+// a 10-post wishlist).
 //
 // Secrets provisioned separately via `wrangler secret put`:
 //   GMAIL_CLIENT_ID
@@ -326,6 +330,26 @@ async function handleLog(request, env) {
 //   GMAIL_REFRESH_TOKEN
 // OAuth flow: refresh_token grant against oauth2.googleapis.com,
 // then Bearer token against gmail.googleapis.com/gmail/v1.
+
+// Pull a header value by name from a gmail message payload.
+function getHeaderFromMsg(msg, name) {
+  if (!msg || !msg.payload || !msg.payload.headers) return '';
+  var h = msg.payload.headers.find(function(h) {
+    return h.name === name;
+  });
+  return h ? h.value : '';
+}
+
+// Normalise the "From" header into a short sender label.
+// Hardcoded detection for the two known client names so the
+// list chip reads cleanly; otherwise take whatever sits before
+// the `<email>` bracket.
+function normaliseSender(fromRaw) {
+  if (!fromRaw) return 'Client';
+  if (fromRaw.indexOf('Manisha') !== -1) return 'Manisha';
+  if (fromRaw.indexOf('Shivangini') !== -1) return 'Shivangini';
+  return (fromRaw.split('<')[0].trim() || fromRaw);
+}
 
 async function getGmailAccessToken(env) {
   const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
@@ -356,46 +380,52 @@ async function handleGmailList(request, env) {
     // Allowlist: only pull from known client addresses. Hardcoded
     // so a compromised client cannot ask the worker to read arbitrary
     // senders. Window: last 7 days, cap 10 results.
+    //
+    // Query THREADS, not messages, so a five-reply conversation
+    // collapses to a single list row keyed by thread.id.
     const query = 'from:thakur.manisha@somaiya.com OR from:shivangini.j@somaiya.com newer_than:7d';
     const listRes = await fetch(
-      'https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=10&q=' + encodeURIComponent(query),
+      'https://gmail.googleapis.com/gmail/v1/users/me/threads?maxResults=10&q=' + encodeURIComponent(query),
       { headers: { 'Authorization': 'Bearer ' + accessToken } }
     );
     const listData = await listRes.json();
-    const messages = listData.messages || [];
+    const threads = listData.threads || [];
 
-    if (messages.length === 0) {
+    if (threads.length === 0) {
       return jsonResponse({ success: true, emails: [] });
     }
 
-    // Hydrate each message with subject + snippet + sender + date.
-    const emails = await Promise.all(messages.map(async function(msg) {
+    // Hydrate each thread: pull metadata for every message in the
+    // thread so we can show sender (first message), latest subject,
+    // latest snippet, and the message count.
+    const emails = await Promise.all(threads.map(async function(thread) {
       try {
-        const msgRes = await fetch(
-          'https://gmail.googleapis.com/gmail/v1/users/me/messages/' + msg.id +
-            '?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date',
+        const threadMeta = await fetch(
+          'https://gmail.googleapis.com/gmail/v1/users/me/threads/' +
+            thread.id +
+            '?format=metadata&metadataHeaders=Subject' +
+            '&metadataHeaders=From&metadataHeaders=Date',
           { headers: { 'Authorization': 'Bearer ' + accessToken } }
         );
-        const msgData = await msgRes.json();
-        const headers = (msgData.payload && msgData.payload.headers) || [];
-        const getHeader = function(name) {
-          const h = headers.find(function(h) { return h.name === name; });
-          return h ? h.value : '';
-        };
-        const fromRaw = getHeader('From');
-        const senderName = fromRaw.indexOf('Manisha') !== -1 ? 'Manisha' :
-                           fromRaw.indexOf('Shivangini') !== -1 ? 'Shivangini' :
-                           (fromRaw.split('<')[0].trim() || fromRaw);
+        const threadData = await threadMeta.json();
+        const messages = threadData.messages || [];
+        if (messages.length === 0) return null;
+
+        const firstMsg = messages[0];
+        const lastMsg  = messages[messages.length - 1];
+
         return {
-          id: msg.id,
-          subject: getHeader('Subject') || '(no subject)',
-          snippet: (msgData.snippet || '')
+          id: thread.id,
+          thread_id: thread.id,
+          subject: getHeaderFromMsg(firstMsg, 'Subject') || '(no subject)',
+          snippet: ((lastMsg && lastMsg.snippet) || '')
             .replace(/&#39;/g, "'")
             .replace(/&amp;/g, '&')
             .replace(/&quot;/g, '"')
             .slice(0, 120),
-          sender: senderName,
-          date: getHeader('Date')
+          sender: normaliseSender(getHeaderFromMsg(firstMsg, 'From')),
+          date: getHeaderFromMsg(lastMsg, 'Date'),
+          message_count: messages.length
         };
       } catch (e) {
         return null;
@@ -424,11 +454,13 @@ async function handleGmailBrief(request, env) {
       return errorResponse('Invalid JSON', 400);
     }
 
-    const messageId   = body && body.message_id;
+    // Accept thread_id going forward; fall back to message_id for
+    // any stale frontend cache still POSTing the old field name.
+    const threadId    = body && (body.thread_id || body.message_id);
     const workspaceId = (body && body.workspace_id) || 'default';
     const createdBy   = (body && body.created_by) || '';
 
-    if (!messageId) return errorResponse('message_id required', 400);
+    if (!threadId) return errorResponse('thread_id required', 400);
 
     // Workspace-level feature gate. Uses the 'email_brief' key in
     // FEATURE_FLAGS → 'ai_email_briefs' in workspace_settings.
@@ -438,15 +470,22 @@ async function handleGmailBrief(request, env) {
     const accessToken = await getGmailAccessToken(env);
     if (!accessToken) return errorResponse('Failed to get Gmail access token', 500);
 
-    // Pull the full message so we can walk the MIME tree and lift
-    // out the text/plain part.
-    const msgRes = await fetch(
-      'https://gmail.googleapis.com/gmail/v1/users/me/messages/' + messageId + '?format=full',
+    // Pull the full thread so we can walk every message's MIME tree
+    // and give Claude the complete conversation in order. The last
+    // reply often narrows/overrides the original scope, so reading
+    // only the first message loses the final agreed brief.
+    const threadRes = await fetch(
+      'https://gmail.googleapis.com/gmail/v1/users/me/threads/' + threadId + '?format=full',
       { headers: { 'Authorization': 'Bearer ' + accessToken } }
     );
-    const msgData = await msgRes.json();
+    const threadData = await threadRes.json();
+    const threadMessages = (threadData.messages || []);
 
-    function extractBody(payload) {
+    if (threadMessages.length === 0) {
+      return errorResponse('Thread is empty or not found', 404);
+    }
+
+    function extractBodyFromMsg(payload) {
       if (!payload) return '';
       if (payload.mimeType === 'text/plain' && payload.body && payload.body.data) {
         try {
@@ -457,18 +496,31 @@ async function handleGmailBrief(request, env) {
       }
       if (payload.parts) {
         for (var i = 0; i < payload.parts.length; i++) {
-          var result = extractBody(payload.parts[i]);
-          if (result) return result;
+          var r = extractBodyFromMsg(payload.parts[i]);
+          if (r) return r;
         }
       }
       return '';
     }
 
-    // 3000-char cap — keeps the prompt inside a sane token budget
-    // even on a forwarded-thread-of-doom email.
-    const emailBody = extractBody(msgData.payload).slice(0, 3000);
-    const headers = (msgData.payload && msgData.payload.headers) || [];
-    const subject = (headers.find(function(h) { return h.name === 'Subject'; }) || {}).value || '';
+    // Concatenate every message in chronological order. Cap each
+    // message at 1500 chars so a 10-reply thread still fits inside
+    // a sane token budget even on a forwarded-thread-of-doom email.
+    var threadContext = threadMessages.map(function(msg, idx) {
+      var hdrs = (msg.payload && msg.payload.headers) || [];
+      var from = (hdrs.find(function(h) { return h.name === 'From'; }) || {}).value || '';
+      var date = (hdrs.find(function(h) { return h.name === 'Date'; }) || {}).value || '';
+      var msgBody = extractBodyFromMsg(msg.payload).slice(0, 1500);
+      return 'MESSAGE ' + (idx + 1) + ' (' + date + ')\n' +
+             'From: ' + from + '\n' +
+             msgBody;
+    }).join('\n\n---\n\n');
+
+    var subject = (function() {
+      var firstHdrs = (threadMessages[0] && threadMessages[0].payload && threadMessages[0].payload.headers) || [];
+      var s = firstHdrs.find(function(h) { return h.name === 'Subject'; });
+      return s ? s.value : '';
+    })();
 
     // Load GBL brand context — shared with the writer / qc flows.
     const brandGuide      = await loadBrandGuide(env);
@@ -476,22 +528,29 @@ async function handleGmailBrief(request, env) {
 
     // System prompt pins Claude to a strict JSON schema so the
     // frontend can JSON.parse() the result without a regex dance.
+    // Critical: tell the model the thread can evolve and the LAST
+    // message defines the final scope.
     const systemPrompt =
-      'You are a LinkedIn content writer for Godavari Biorefineries Limited (GBL). ' +
-      'Read the email below and extract the content brief. ' +
-      'Return a JSON object only — no preamble, no markdown, no backticks — with these exact keys: ' +
-      'title (string, 5-8 words, the post title), ' +
-      'copy_option_1 (string, full LinkedIn caption option 1), ' +
-      'copy_option_2 (string, full LinkedIn caption option 2), ' +
-      'copy_option_3 (string, full LinkedIn caption option 3), ' +
-      'internal_notes (string, 1-2 lines: source of brief + key instructions from client). ' +
-      'Write 3 distinct caption options in GBL voice. Each should be complete and post-ready. ' +
-      'Here are approved posts for reference:\n\n' + approvedContext +
+      'You are a LinkedIn content strategist for Godavari Biorefineries Limited (GBL). ' +
+      'You will receive a full email thread. Read it carefully from start to finish. ' +
+      'The brief may evolve across messages — the LAST message defines the final agreed scope. ' +
+      'Return a JSON object only — no preamble, no markdown, no backticks — with these exact keys:\n' +
+      '  title (string, 5-8 words, the post or campaign title)\n' +
+      '  total_posts (integer, how many posts were finally agreed — read the last message carefully, e.g. "make 2 carousels" = 2)\n' +
+      '  copy_option_1 (string, full LinkedIn caption option 1)\n' +
+      '  copy_option_2 (string, full LinkedIn caption option 2)\n' +
+      '  copy_option_3 (string, full LinkedIn caption option 3)\n' +
+      '  internal_notes (string, 1-2 lines: source + final agreed scope from thread, e.g. "Chemexpo brief. Final: 2 carousels of 5 products each (per Shivangini 14 Apr).")\n' +
+      '  visual_direction (string, 1 line on visual style)\n' +
+      'Write 3 caption options in GBL voice. Base them on the FINAL agreed brief, not the original request.\n\n' +
+      'Approved posts for voice reference:\n\n' + approvedContext +
       '\n\nBrand guide:\n' + brandGuide;
 
     const messages = [{
       role: 'user',
-      content: 'Email subject: ' + subject + '\n\nEmail body:\n' + emailBody
+      content: 'Email thread subject: ' + subject +
+               '\n\nFull thread (' + threadMessages.length + ' messages):\n\n' +
+               threadContext
     }];
 
     const anthropicRes = await callAnthropic(env, systemPrompt, messages);
@@ -520,12 +579,14 @@ async function handleGmailBrief(request, env) {
     });
 
     return jsonResponse({
-      success:        true,
-      title:          parsed.title          || subject,
-      copy_option_1:  parsed.copy_option_1  || '',
-      copy_option_2:  parsed.copy_option_2  || '',
-      copy_option_3:  parsed.copy_option_3  || '',
-      internal_notes: parsed.internal_notes || ''
+      success:          true,
+      title:            parsed.title            || subject,
+      total_posts:      parsed.total_posts      || 1,
+      copy_option_1:    parsed.copy_option_1    || '',
+      copy_option_2:    parsed.copy_option_2    || '',
+      copy_option_3:    parsed.copy_option_3    || '',
+      internal_notes:   parsed.internal_notes   || '',
+      visual_direction: parsed.visual_direction || ''
     });
   } catch (err) {
     return errorResponse((err && err.message) || 'unknown error', 500);

--- a/styles.css
+++ b/styles.css
@@ -8210,6 +8210,14 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .nps-email-subject { font-size: 13px; font-weight: 600; color: #E8E8E8; margin-bottom: 2px; }
 .nps-email-preview { font-size: 12px; color: #555; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.nps-email-thread-count {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: #9b87f5;
+  margin-top: 3px;
+}
 
 .nps-cap-opt {
   background: #0c0c11;


### PR DESCRIPTION
## Summary

Three confirmed problems in the New Post → Import from Gmail flow, one PR.

1. **Click handler "does nothing"** — the `div.onclick` wiring in `_npsShowEmailList` is correct in tree; root cause is a stale CDN cache. This PR bumps the asset version `20260414q` → `20260414r` across all 23 strings in `index.html`, which forces a purge-eligible refetch after deploy.
2. **Worker only reads the first message** — `handleGmailBrief` now accepts `thread_id`, fetches `/threads/{id}?format=full`, walks every message's MIME tree, and sends the full chronological conversation to Claude. The system prompt tells Claude the brief can evolve and the **last** message defines the final agreed scope (e.g. Shivangini's "make 2 carousels" reply narrowing Manisha's 10-post wishlist for Chemexpo).
3. **List showed one row per message in a thread** — `handleGmailList` now queries `/threads` (not `/messages`), returns one list row per thread keyed by `thread.id`, plus `message_count` so the UI can render a `N messages in thread` indicator.

## Changes

### srtd-ai-worker/src/index.js
- `handleGmailList`: swaps `/messages` → `/threads`, hydrates each thread via `/threads/{id}?format=metadata`, returns `{id: thread.id, thread_id, subject, snippet, sender, date, message_count}`.
- `handleGmailBrief`: accepts `thread_id` (falls back to `message_id` for stale callers), fetches `/threads/{id}?format=full`, concatenates each message body (1500 char cap/message) in chronological order with `MESSAGE N (date) / From: …` separators, and ships the full thread to Claude.
- Updated system prompt instructs Claude to read the last message for the final scope and return `total_posts` + `visual_direction` in the JSON schema.
- Added `getHeaderFromMsg()` and `normaliseSender()` helpers at the top of the Gmail section.
- Response now returns `total_posts` (default 1) + `visual_direction`.

### 06-post-create.js
- `_npsShowEmailList`: email row renders a `.nps-email-thread-count` badge when `message_count > 1`. Closure comment clarifies that `email.id` now carries a thread id.
- `_npsSelectEmail`: Worker body uses `thread_id: messageId` (variable name preserved). Response is read into `window._npsGmailTotalPosts`. When `> 1`, the processing row copy swaps to "N posts identified in this brief" before it's hidden. Catch block now calls `window.logError(e.message, e.stack, 'gmail-brief-import')` in addition to the toast.
- `submitNewPost` REQ- close branch: only injects `total_posts` into the PATCH when `window._npsGmailTotalPosts > 1`, so the existing `{status:'closed'}` body is byte-identical for every non-Gmail close.
- `closeNewPostModal` clears `window._npsGmailTotalPosts = null`.

### styles.css
- New `.nps-email-thread-count` — IBM Plex Mono 7px, `.06em` tracking, uppercase, `#9b87f5`, 3px top margin.

### index.html
- Version bump `?v=20260414q` → `?v=20260414r` on all 23 asset URLs (1 stylesheet + 22 scripts). Exact count preserved.

## Test plan

- [x] `npx vitest run` → 553/553 passing (no regressions)
- [x] `node --check` on `06-post-create.js` and `srtd-ai-worker/src/index.js`
- [x] Every `?v=` string in `index.html` counted — 23 on `20260414r`, 0 on `20260414q`
- [ ] After merge + Cloudflare "Purge Everything": reopen New Post on an Admin account, tap "Import from Gmail", tap any email → processing row flashes "N posts identified" → form prefills
- [ ] Open the Chemexpo thread (threadId `19d87d8cd8f9d3ab`): verify `internal_notes` references Shivangini's "2 carousels" reply, not Manisha's 10-post list
- [ ] Verify the REQ- close PATCH stays at `{status:'closed'}` for manual (non-Gmail) briefs, and adds `total_posts` only when a Gmail multi-post import drove the form

## Deploy notes for Shubham

After merging, the `srtd-ai` Cloudflare Worker must be manually re-deployed from `srtd-ai-worker/src/index.js` via the Cloudflare dashboard — the Worker now expects `thread_id` on `/gmail/brief` and returns thread-keyed rows from `/gmail/list`. The frontend and worker stay backward-compatible during the transition window because `handleGmailBrief` still accepts `message_id` as a fallback, but the list endpoint switch is hard — rows from pre-deploy `/gmail/list` will still work because `thread.id` and `message.id` are both opaque to the frontend.

CLAUDE.md not touched per task instructions.

https://claude.ai/code/session_011kpnUcz6EMQPoNvRowt2Ko