### PR TITLE
Brief campaign tracking — multiple posts per brief

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -612,6 +612,9 @@ stage: 'in_production',
 target_date: date || null,
 format: formatVal,
 drive_link: driveLinkVal,
+brief_id: (window._activeBriefPostId &&
+  window._activeBriefPostId.indexOf('REQ-') === 0)
+  ? window._activeBriefPostId : null,
 };
 if (captionVal) payload.caption = captionVal;
 // Defensive: remove any invalid field names that must never reach DB
@@ -706,43 +709,52 @@ if (window._activeBriefPostId) {
   }
 
   if (_bid && _bid.toString().indexOf('REQ-') === 0) {
-    // This brief came from a request row, not a posts row. The old
-    // /posts PATCH matched zero rows and left the request orphaned
-    // at status='assigned' forever. Close the request instead.
-    // NOTE: requests table has no updated_at or linked_post_id
-    // columns — only `status` is safe to PATCH here.
+    // This brief came from a request row, not a posts row. The brief
+    // is now a campaign container — increment completed_posts on each
+    // create and only flip status to 'closed' once completed_posts
+    // catches up to total_posts. first_post_created_at gets stamped
+    // on the first create only.
+    var _bsRows = await apiFetch(
+      '/requests?id=eq.' + encodeURIComponent(_bid) +
+      '&select=total_posts,completed_posts,' +
+      'first_post_created_at&limit=1',
+      {}, { allowLogout: false }
+    );
+    var _bs = (Array.isArray(_bsRows) && _bsRows[0])
+      ? _bsRows[0] : {};
+    var _newCompleted = (_bs.completed_posts || 0) + 1;
+    var _newTotal     = _bs.total_posts || 1;
+    var _isFullyDone  = _newCompleted >= _newTotal;
+    var _nowISO       = new Date().toISOString();
 
-    // Guard: check the request is not already closed before
-    // creating another post from it.
-    try {
-      var _guardRows = await apiFetch(
-        '/requests?id=eq.' + encodeURIComponent(_bid) +
-        '&select=status&limit=1',
-        {}, { allowLogout: false }
-      );
-      if (Array.isArray(_guardRows) && _guardRows[0] &&
-          _guardRows[0].status === 'closed') {
-        // Brief already has a post created from it.
-        // Do not create a duplicate. Show a warning and abort.
-        showToast && showToast(
-          'This brief already has a post created from it.',
-          'warning'
-        );
-        window._activeBriefPostId = null;
-        window._briefImportedImages = null;
-        return;
-      }
-    } catch (_guardErr) {}
+    var _briefPatch = {
+      completed_posts: _newCompleted,
+      status: _isFullyDone ? 'closed' : 'assigned'
+    };
+    if (!_bs.first_post_created_at) {
+      _briefPatch.first_post_created_at = _nowISO;
+    }
 
-    apiFetch('/requests?id=eq.' + encodeURIComponent(_bid), {
-      method: 'PATCH',
-      body: JSON.stringify({
-        status: 'closed'
-      })
-    }).catch(function(err) {
-      console.warn('[post-create] close request failed', err);
-      window.logError && window.logError(err && err.message, err && err.stack, 'close-request-on-convert');
-    });
+    await apiFetch(
+      '/requests?id=eq.' + encodeURIComponent(_bid),
+      {
+        method: 'PATCH',
+        body: JSON.stringify(_briefPatch)
+      },
+      { allowLogout: false }
+    );
+
+    if (_isFullyDone) {
+      showToast && showToast(
+        'Brief complete — all ' + _newTotal + ' posts created');
+    } else {
+      showToast && showToast(
+        _newCompleted + ' of ' + _newTotal +
+        ' posts created from this brief');
+    }
+
+    window._activeBriefPostId    = null;
+    window._briefImportedImages  = null;
   } else {
     // Legacy flow: brief was a posts row. Original PATCH unchanged.
     apiFetch('/posts?post_id=eq.' + encodeURIComponent(_bid), {

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -208,6 +208,10 @@ async function loadPosts(fromPoll) {
             created_at: r.created_at || '',
             updated_at: r.created_at || '',
             assigned_to: r.assigned_to || null,
+            total_posts:           r.total_posts || 1,
+            completed_posts:       r.completed_posts || 0,
+            first_post_created_at: r.first_post_created_at || null,
+            brief_id:              r.id || null,
             _requestStatus: r.status || 'pending',
             _isRequest: true
           };
@@ -306,6 +310,10 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
             created_at: r.created_at || '',
             updated_at: r.created_at || '',
             assigned_to: r.assigned_to || null,
+            total_posts:           r.total_posts || 1,
+            completed_posts:       r.completed_posts || 0,
+            first_post_created_at: r.first_post_created_at || null,
+            brief_id:              r.id || null,
             _requestStatus: r.status || 'pending',
             _isRequest: true
           });

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -534,6 +534,24 @@ function _confirmPublish(postId) {
       new_stage: 'published'
     });
     // Stage change notification is handled by the notify-stage edge function.
+    // Campaign tracking: stamp last_post_published_at on the parent
+    // brief request so the campaign card knows when the most recent
+    // post in the series went live. Fire-and-forget — never blocks.
+    var _pubPost = (window.AppState.posts.all || [])
+      .find(function(p) { return p.post_id === postId; });
+    if (_pubPost && _pubPost.brief_id) {
+      apiFetch(
+        '/requests?id=eq.' +
+          encodeURIComponent(_pubPost.brief_id),
+        {
+          method: 'PATCH',
+          body: JSON.stringify({
+            last_post_published_at: new Date().toISOString()
+          })
+        },
+        { allowLogout: false }
+      ).catch(function() {});
+    }
     showToast('Published', 'success');
     if (typeof _removePublishSheet === 'function') _removePublishSheet();
     if (typeof closePCS === 'function') closePCS();
@@ -608,6 +626,23 @@ async function _executeStageChangeAsync(post, postId, newStage, previousStage) {
     }
     _clearSaveTimeout(post);
     post._isSaving = false;
+
+    // Campaign tracking: when this stage change moved a post into
+    // 'published' and the post belongs to a brief campaign, stamp
+    // last_post_published_at on the parent request. Fire-and-forget.
+    if (newStage === 'published' && post && post.brief_id) {
+      apiFetch(
+        '/requests?id=eq.' +
+          encodeURIComponent(post.brief_id),
+        {
+          method: 'PATCH',
+          body: JSON.stringify({
+            last_post_published_at: new Date().toISOString()
+          })
+        },
+        { allowLogout: false }
+      ).catch(function() {});
+    }
 
     // FINAL TRUTH RENDER
     _renderPCS(postId);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414s">
+ <link rel="stylesheet" href="styles.css?v=20260414t">
 
 </head>
 <body>
@@ -1156,29 +1156,29 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414s"></script>
-<script src="00-appstate-compat.js?v=20260414s"></script>
-<script src="01-config.js?v=20260414s" defer></script>
-<script src="02-session.js?v=20260414s" defer></script>
-<script src="utils.js?v=20260414s" defer></script>
-<script src="12-profiles.js?v=20260414s" defer></script>
-<script src="03-auth.js?v=20260414s" defer></script>
-<script src="05-api.js?v=20260414s" defer></script>
-<script src="10-ui.js?v=20260414s" defer></script>
+<script src="00-appstate.js?v=20260414t"></script>
+<script src="00-appstate-compat.js?v=20260414t"></script>
+<script src="01-config.js?v=20260414t" defer></script>
+<script src="02-session.js?v=20260414t" defer></script>
+<script src="utils.js?v=20260414t" defer></script>
+<script src="12-profiles.js?v=20260414t" defer></script>
+<script src="03-auth.js?v=20260414t" defer></script>
+<script src="05-api.js?v=20260414t" defer></script>
+<script src="10-ui.js?v=20260414t" defer></script>
 
-<script src="06-post-create.js?v=20260414s" defer></script>
-<script defer src="render/dashboard.js?v=20260414s"></script>
-<script defer src="render/client.js?v=20260414s"></script>
-<script defer src="render/pipeline.js?v=20260414s"></script>
-<script defer src="render/brief.js?v=20260414s"></script>
-<script defer src="actions/pcs.js?v=20260414s"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414s"></script>
-<script src="ai-config.js?v=20260414s" defer></script>
-<script src="07-post-load.js?v=20260414s" defer></script>
-<script src="08-post-actions.js?v=20260414s" defer></script>
-<script src="09-library.js?v=20260414s" defer></script>
-<script src="09-approval.js?v=20260414s" defer></script>
-<script src="04-router.js?v=20260414s" defer></script>
+<script src="06-post-create.js?v=20260414t" defer></script>
+<script defer src="render/dashboard.js?v=20260414t"></script>
+<script defer src="render/client.js?v=20260414t"></script>
+<script defer src="render/pipeline.js?v=20260414t"></script>
+<script defer src="render/brief.js?v=20260414t"></script>
+<script defer src="actions/pcs.js?v=20260414t"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414t"></script>
+<script src="ai-config.js?v=20260414t" defer></script>
+<script src="07-post-load.js?v=20260414t" defer></script>
+<script src="08-post-actions.js?v=20260414t" defer></script>
+<script src="09-library.js?v=20260414t" defer></script>
+<script src="09-approval.js?v=20260414t" defer></script>
+<script src="04-router.js?v=20260414t" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -431,6 +431,27 @@ window._openBriefSheet = async function(postId) {
   overlay.style.cssText = 'position:fixed;inset:0;z-index:9500;' +
     'background:#0a0a0f;overflow-y:auto;font-family:\'DM Sans\',sans-serif;';
 
+  // Campaign progress (multi-post briefs). The progress block only
+  // renders when the brief has more than one slot or at least one
+  // post has been created from it; single-post briefs stay clean.
+  var _totalPosts = post.total_posts || 1;
+  var _donePosts  = post.completed_posts || 0;
+  var _progressHtml = '';
+  if (_totalPosts > 1 || _donePosts > 0) {
+    var _pct = Math.round((_donePosts / _totalPosts) * 100);
+    _progressHtml =
+      '<div class="brief-progress-wrap">' +
+        '<div class="brief-progress-bar">' +
+          '<div class="brief-progress-fill" style="width:' +
+            _pct + '%"></div>' +
+        '</div>' +
+        '<div class="brief-progress-label">' +
+          _donePosts + ' of ' + _totalPosts + ' posts created' +
+          (_pct === 100 ? ' &middot; Complete' : ' &middot; ' + _pct + '%') +
+        '</div>' +
+      '</div>';
+  }
+
   // --- Build action buttons for the sticky footer ---
   var _footerActions = (function() {
     var _viewPostBtn = (_hasLinkedPost && linkedPost) ?
@@ -483,10 +504,23 @@ window._openBriefSheet = async function(postId) {
       return _viewPostBtn +
         (_canAssign ? _reopenBtn : '');
     }
-    // STATE: has linked post (post already created)
+    // STATE: has linked post (post already created). For multi-post
+    // campaign briefs, expose a Create Another Post button until
+    // completed_posts catches up to total_posts.
     if (_hasLinkedPost && linkedPost) {
-      return _viewPostBtn +
-        (_canAssign ? _closeBtn : '');
+      var _remaining = Math.max(0,
+        (post.total_posts || 1) - (post.completed_posts || 0));
+      var _html = _viewPostBtn;
+      if (_remaining > 0 && _canAssign) {
+        _html +=
+          '<button class="brief-create-more-btn" ' +
+          'onclick="window._createPostFromBrief(\'' +
+          esc(postId) + '\')">' +
+          '+ Create Post (' + _remaining + ' remaining)' +
+          '</button>';
+      }
+      if (_canAssign) _html += _closeBtn;
+      return _html;
     }
     // STATE: assigned, no linked post yet
     // Create Post button visibility (Fix C):
@@ -544,6 +578,17 @@ window._openBriefSheet = async function(postId) {
         'padding:8px 0 10px;outline:none;resize:none;line-height:1.7;' +
         'caret-color:#C8A84B;"></textarea>' +
         '</div>' +
+        '<div class="brief-total-posts-wrap">' +
+          '<div class="brief-field-label">Posts in this brief</div>' +
+          '<div class="brief-total-posts-row">' +
+            '<button class="brief-count-btn" onclick="window.' +
+              '_briefAdjustTotal(\'' + esc(postId) + '\',-1)">&minus;</button>' +
+            '<span class="brief-count-val" id="brief-total-val-' +
+              esc(postId) + '">' + (post.total_posts || 1) + '</span>' +
+            '<button class="brief-count-btn" onclick="window.' +
+              '_briefAdjustTotal(\'' + esc(postId) + '\',1)">+</button>' +
+          '</div>' +
+        '</div>' +
         '<button id="brief-assign-trigger-' + postId + '" ' +
         'onclick="_briefShowAssignDropdown(\'' + postId + '\',false)" ' +
         'style="display:flex;align-items:center;justify-content:center;gap:6px;' +
@@ -596,6 +641,9 @@ window._openBriefSheet = async function(postId) {
     '</span>' +
     '</div>' +
     '</div>' +
+
+    // Campaign progress (only when total_posts > 1 or any completed)
+    _progressHtml +
 
     // Brief Done status banner
     (_isBriefDone ?
@@ -758,6 +806,16 @@ window._openBriefSheet = async function(postId) {
   });
 }
 
+// Adjust the in-DOM total_posts counter on the unassigned brief
+// footer. Only mutates the <span> text — the DB write happens later
+// in _assignBrief which reads the current span value at PATCH time.
+window._briefAdjustTotal = function(postId, delta) {
+  var el = document.getElementById('brief-total-val-' + postId);
+  if (!el) return;
+  var next = Math.max(1, (parseInt(el.textContent) || 1) + delta);
+  el.textContent = next;
+};
+
 // Fetch team members (non-client roles) from user_roles and show
 // assignment dropdown. Uses window._briefTeamMembersCache so the
 // result is re-used across renders and re-opens within a session.
@@ -888,17 +946,26 @@ window._assignBrief = function(postId, ownerRole, displayName, isReassign) {
     // posts row is created later when the creative (or admin) taps
     // Create Post and fills out the new post form.
     // NOTE: requests table has no updated_at column — do not include it.
+    // Read the in-DOM total_posts counter (set by _briefAdjustTotal
+    // before the user tapped Assign) and persist it on the request so
+    // the brief becomes a campaign container for N posts.
+    var _totalEl = document.getElementById('brief-total-val-' + postId);
+    var _totalPosts = _totalEl
+      ? (parseInt(_totalEl.textContent) || 1)
+      : (post.total_posts || 1);
     apiFetch('/requests?id=eq.' + encodeURIComponent(postId), {
       method: 'PATCH',
       body: JSON.stringify({
         assigned_to: displayName || ownerRole,
-        status: 'assigned'
+        status: 'assigned',
+        total_posts: _totalPosts
       })
     }).then(function() {
       // Mutate the in-memory request stub so the brief sheet reopen
       // reflects the new assignee without waiting for a poll.
       post.assigned_to = displayName || ownerRole;
       post._requestStatus = 'assigned';
+      post.total_posts = _totalPosts;
       logActivity({
         post_id: postId,
         actor: actorName,

--- a/styles.css
+++ b/styles.css
@@ -8249,3 +8249,80 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   color: #9b87f5; background: #1a1624;
   border: 1px solid #2a2244; padding: 2px 6px; margin-left: 6px;
 }
+
+/* Brief campaign tracking — multi-post brief container UI */
+.brief-total-posts-wrap {
+  padding: 10px 16px 6px;
+  border-top: 1px solid #323244;
+}
+.brief-field-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: #606078;
+  margin-bottom: 6px;
+  display: block;
+}
+.brief-total-posts-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.brief-count-btn {
+  width: 28px;
+  height: 28px;
+  background: none;
+  border: 1px solid #323244;
+  color: #B8B8C0;
+  font-size: 18px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'DM Sans', sans-serif;
+  line-height: 1;
+}
+.brief-count-val {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 18px;
+  font-weight: 600;
+  color: #F0F0F2;
+  min-width: 24px;
+  text-align: center;
+}
+.brief-progress-wrap {
+  padding: 6px 16px 4px;
+  border-bottom: 1px solid #323244;
+}
+.brief-progress-bar {
+  height: 2px;
+  background: #1a1a24;
+  margin-bottom: 5px;
+}
+.brief-progress-fill {
+  height: 100%;
+  background: #3ECF8E;
+  transition: width .3s ease;
+  min-width: 2px;
+}
+.brief-progress-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: #606078;
+}
+.brief-create-more-btn {
+  flex: 1;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: #9b87f5;
+  background: #0f0d1a;
+  border: 1px solid #2a2244;
+  padding: 13px 0;
+  cursor: pointer;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary

Wires up the existing `requests` campaign columns plus `posts.brief_id` so a brief becomes a campaign container that can spawn N posts before it auto-closes. No schema changes — all DB columns already exist.

- **render/brief.js**: total_posts +/- counter on the unassigned brief footer (`_briefAdjustTotal`), persisted on assign, plus a progress bar in the brief panel body when `total_posts > 1` or `completed_posts > 0`. The linked-post state now exposes a "Create Post (N remaining)" button until `completed_posts` catches up to `total_posts`.
- **06-post-create.js**: post payload carries `brief_id` when the active brief is a `REQ-*` request. The REQ- branch reads the request's campaign counters, increments `completed_posts`, stamps `first_post_created_at` on the first create, and only flips status to `closed` once the campaign is fully done.
- **07-post-load.js**: both stub builders (agency + client) carry `total_posts`, `completed_posts`, `first_post_created_at`, `brief_id`.
- **08-post-actions.js**: stage-to-`published` in both `_confirmPublish` and `_executeStageChangeAsync` stamps `last_post_published_at` on the parent brief, fire-and-forget.
- **styles.css**: `brief-total-posts-wrap`, `brief-progress-wrap`, `brief-create-more-btn` — hex-only, no `rgba()`.
- **index.html**: bump all 23 `?v=` strings `20260414s` → `20260414t`.

## Test plan

- [x] `npx vitest run` — 543/543 passing
- [ ] Open an unassigned REQ-* brief → counter renders before Assign, +/- adjusts (min 1)
- [ ] Assign with counter set to 3 → `requests.total_posts = 3`, brief stays visible after first post create with "2 remaining" CTA
- [ ] First post create stamps `first_post_created_at`, increments `completed_posts` to 1, status stays `assigned`
- [ ] Third post create flips status to `closed`, shows "Brief complete — all 3 posts created" toast
- [ ] Publishing a brief-linked post stamps `last_post_published_at` on the parent request
- [ ] Single-post briefs (`total_posts === 1`) skip the progress bar entirely

https://claude.ai/code/session_01EdLHWXyNDFPTPKKj9FxEeX