### PR TITLE
Gmail import button: role-only gate, drop workspace race

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -486,16 +486,19 @@ var nav = document.getElementById('bottom-nav');
 if (nav) nav.style.display = 'none';
 document.body.style.overflow = 'hidden';
 
-// PR 4 — Gmail import: show only for Admin when ai_email_briefs
-// is enabled in workspace_settings. Initial state on every open
-// is "button visible, list/processing hidden, no option picked".
+// PR 4 — Gmail import: show for Admin + Servicing. The Worker
+// (srtd-ai-worker, checkWorkspaceEnabled) enforces the
+// workspace_settings.ai_email_briefs flag server-side with a 403,
+// so the frontend gate is role-only — any workspace-level check
+// here would race loadWorkspaceSettings() and flicker on cold
+// loads (see PR #864). Initial state on every open is "button
+// visible if role allows, list/processing hidden, no option picked".
 var gmailWrap = document.getElementById('nps-gmail-wrap');
 var orDivider = document.getElementById('nps-or-divider');
 var _npsRole = ((window.AppState && window.AppState.user && window.AppState.user.effectiveRole) || '').toLowerCase();
-var _npsIsAdmin = _npsRole === 'admin';
-var _npsAiEnabled = !!(window.AppState && window.AppState.workspace && window.AppState.workspace.ai_email_briefs);
-if (gmailWrap) gmailWrap.style.display = (_npsIsAdmin && _npsAiEnabled) ? 'block' : 'none';
-if (orDivider) orDivider.style.display = (_npsIsAdmin && _npsAiEnabled) ? 'flex' : 'none';
+var _npsCanImport = _npsRole === 'admin' || _npsRole === 'servicing';
+if (gmailWrap) gmailWrap.style.display = _npsCanImport ? 'block' : 'none';
+if (orDivider) orDivider.style.display = _npsCanImport ? 'flex' : 'none';
 window._npsGmailImported  = false;
 window._npsSelectedOptIdx = 0;
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414t">
+ <link rel="stylesheet" href="styles.css?v=20260414u">
 
 </head>
 <body>
@@ -1156,29 +1156,29 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414t"></script>
-<script src="00-appstate-compat.js?v=20260414t"></script>
-<script src="01-config.js?v=20260414t" defer></script>
-<script src="02-session.js?v=20260414t" defer></script>
-<script src="utils.js?v=20260414t" defer></script>
-<script src="12-profiles.js?v=20260414t" defer></script>
-<script src="03-auth.js?v=20260414t" defer></script>
-<script src="05-api.js?v=20260414t" defer></script>
-<script src="10-ui.js?v=20260414t" defer></script>
+<script src="00-appstate.js?v=20260414u"></script>
+<script src="00-appstate-compat.js?v=20260414u"></script>
+<script src="01-config.js?v=20260414u" defer></script>
+<script src="02-session.js?v=20260414u" defer></script>
+<script src="utils.js?v=20260414u" defer></script>
+<script src="12-profiles.js?v=20260414u" defer></script>
+<script src="03-auth.js?v=20260414u" defer></script>
+<script src="05-api.js?v=20260414u" defer></script>
+<script src="10-ui.js?v=20260414u" defer></script>
 
-<script src="06-post-create.js?v=20260414t" defer></script>
-<script defer src="render/dashboard.js?v=20260414t"></script>
-<script defer src="render/client.js?v=20260414t"></script>
-<script defer src="render/pipeline.js?v=20260414t"></script>
-<script defer src="render/brief.js?v=20260414t"></script>
-<script defer src="actions/pcs.js?v=20260414t"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414t"></script>
-<script src="ai-config.js?v=20260414t" defer></script>
-<script src="07-post-load.js?v=20260414t" defer></script>
-<script src="08-post-actions.js?v=20260414t" defer></script>
-<script src="09-library.js?v=20260414t" defer></script>
-<script src="09-approval.js?v=20260414t" defer></script>
-<script src="04-router.js?v=20260414t" defer></script>
+<script src="06-post-create.js?v=20260414u" defer></script>
+<script defer src="render/dashboard.js?v=20260414u"></script>
+<script defer src="render/client.js?v=20260414u"></script>
+<script defer src="render/pipeline.js?v=20260414u"></script>
+<script defer src="render/brief.js?v=20260414u"></script>
+<script defer src="actions/pcs.js?v=20260414u"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414u"></script>
+<script src="ai-config.js?v=20260414u" defer></script>
+<script src="07-post-load.js?v=20260414u" defer></script>
+<script src="08-post-actions.js?v=20260414u" defer></script>
+<script src="09-library.js?v=20260414u" defer></script>
+<script src="09-approval.js?v=20260414u" defer></script>
+<script src="04-router.js?v=20260414u" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

Fixes the "Import from Gmail button sometimes shows, sometimes doesn't, refresh sometimes fixes it" bug in the New Post modal.

**Root cause.** `openNewPostModal()` gated the wrap on `AppState.workspace.ai_email_briefs`, which is populated by `loadWorkspaceSettings()` called fire-and-forget from `activateRole()` (03-auth.js:388). On cold loads, users opened New Post before the Supabase round-trip finished, so `AppState.workspace` was still the `{}` initial value from 00-appstate.js:68 and the `_npsAiEnabled` short-circuit returned false → wrap hidden. Warm browser cache (refresh) sometimes won the race, which matches the "refresh fixes it" behaviour.

**Fix.** Drop the client-side workspace check entirely. The srtd-ai Worker already enforces `ai_email_briefs` server-side via `checkWorkspaceEnabled()` — both `/gmail/list` and `/gmail/brief` return 403 with a feature-gate reason when the flag is off (srtd-ai-worker/src/index.js:94-95, referenced from handleGmailList and handleGmailBrief). Frontend gating was redundant and was the only source of the race.

Button visibility is now role-only:

| Role | Can see button |
|---|---|
| Admin | yes |
| Servicing | yes |
| Creative | no |
| Client | no |

## Diff

Before (06-post-create.js:489-500):

```js
// PR 4 — Gmail import: show only for Admin when ai_email_briefs
// is enabled in workspace_settings. Initial state on every open
// is "button visible, list/processing hidden, no option picked".
var gmailWrap = document.getElementById('nps-gmail-wrap');
var orDivider = document.getElementById('nps-or-divider');
var _npsRole = ((window.AppState && window.AppState.user && window.AppState.user.effectiveRole) || '').toLowerCase();
var _npsIsAdmin = _npsRole === 'admin';
var _npsAiEnabled = !!(window.AppState && window.AppState.workspace && window.AppState.workspace.ai_email_briefs);
if (gmailWrap) gmailWrap.style.display = (_npsIsAdmin && _npsAiEnabled) ? 'block' : 'none';
if (orDivider) orDivider.style.display = (_npsIsAdmin && _npsAiEnabled) ? 'flex' : 'none';
```

After:

```js
// PR 4 — Gmail import: show for Admin + Servicing. The Worker
// (srtd-ai-worker, checkWorkspaceEnabled) enforces the
// workspace_settings.ai_email_briefs flag server-side with a 403,
// so the frontend gate is role-only — any workspace-level check
// here would race loadWorkspaceSettings() and flicker on cold
// loads (see PR #864). Initial state on every open is "button
// visible if role allows, list/processing hidden, no option picked".
var gmailWrap = document.getElementById('nps-gmail-wrap');
var orDivider = document.getElementById('nps-or-divider');
var _npsRole = ((window.AppState && window.AppState.user && window.AppState.user.effectiveRole) || '').toLowerCase();
var _npsCanImport = _npsRole === 'admin' || _npsRole === 'servicing';
if (gmailWrap) gmailWrap.style.display = _npsCanImport ? 'block' : 'none';
if (orDivider) orDivider.style.display = _npsCanImport ? 'flex' : 'none';
```

Surgical surface area: only the gate inside `openNewPostModal`. No other logic changed anywhere in `openNewPostModal`. No changes to click handlers, `_npsShowEmailList`, `_npsSelectEmail`, or the Worker.

Version bump `20260414t` → `20260414u` across all 23 asset URLs in `index.html` (1 stylesheet + 22 scripts).

## Verification checklist

- [x] `_npsAiEnabled` variable completely removed
- [x] `_npsIsAdmin` variable completely removed
- [x] New `_npsCanImport = admin OR servicing`
- [x] `gmailWrap` / `orDivider` display depends only on `_npsCanImport`
- [x] No other logic changed inside `openNewPostModal`
- [x] `npx vitest run` → 543/543 passing
- [x] 23 `?v=` strings bumped to `20260414u`, zero remaining on `20260414t`
- [x] CLAUDE.md not touched per task instructions

## Test plan

- [ ] Log in as Admin on a cold tab (hard refresh + clear Supabase cache), tap FAB → Create Post immediately. Gmail wrap should be visible on first paint, every time, no race.
- [ ] Log in as Servicing. Gmail wrap should be visible.
- [ ] Log in as Creative. Gmail wrap should be hidden.
- [ ] Log in as Client. Gmail wrap should be hidden (client role never reaches New Post anyway).
- [ ] In admin preview mode, set `pcs_role_preview=Creative`. Wrap should be hidden (the gate reads `effectiveRole`, which preview overrides).
- [ ] With `ai_email_briefs=false` in `workspace_settings`, tap the button. The Worker should 403 and the existing `showToast('Could not read brief - try again', 'error')` path should fire cleanly with a `logError` row in `error_log`.

https://claude.ai/code/session_011kpnUcz6EMQPoNvRowt2Ko