### PR TITLE
Gmail caption options: show 10-word hook, tap to expand

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -311,9 +311,13 @@ window._npsSelectEmail = async function(messageId, subject) {
     var optsWrap = document.getElementById('nps-caption-opts');
     if (textarea) textarea.style.display = 'none';
     if (optsWrap) {
-      document.getElementById('nps-opt-txt-1').textContent = data.copy_option_1 || '';
-      document.getElementById('nps-opt-txt-2').textContent = data.copy_option_2 || '';
-      document.getElementById('nps-opt-txt-3').textContent = data.copy_option_3 || '';
+      // Seed each card with full text + 10-word hook preview.
+      // _npsSetCaptionOption resets the card to the collapsed
+      // "Read more" state and hides the expand button on short
+      // captions.
+      _npsSetCaptionOption(1, data.copy_option_1 || '');
+      _npsSetCaptionOption(2, data.copy_option_2 || '');
+      _npsSetCaptionOption(3, data.copy_option_3 || '');
       optsWrap.style.display = 'flex';
       // Default pick: option 1.
       window._npsPickOpt(document.getElementById('nps-cap-opt-1'));
@@ -365,6 +369,71 @@ window._npsSelectEmail = async function(messageId, subject) {
     if (typeof showToast === 'function') {
       showToast('Error reading brief. Try again.', 'error');
     }
+  }
+};
+
+// Extract the first 10 words of a caption as a "hook" preview.
+// Ten-word cap matches the opening of a LinkedIn carousel where
+// anything past the first ~12 words is truncated by the platform,
+// so the hook is exactly the text the user needs to judge a
+// caption on before tapping Read more.
+function _npsGetHook(text) {
+  if (!text) return '';
+  var words = text.trim().split(/\s+/);
+  if (words.length <= 10) return text;
+  return words.slice(0, 10).join(' ') + '...';
+}
+
+// Seed one option card with a fresh caption: full text into the
+// hidden .nps-opt-full div (which still carries the legacy
+// #nps-opt-txt-N id so submitNewPost can keep reading it), hook
+// into .nps-opt-hook, reset expanded state to collapsed, and
+// hide the expand button when the caption is 10 words or fewer
+// (nothing to reveal).
+function _npsSetCaptionOption(idx, text) {
+  var fullEl = document.getElementById('nps-opt-txt-' + idx);
+  var hookEl = document.getElementById('nps-opt-hook-' + idx);
+  var cardEl = document.getElementById('nps-cap-opt-' + idx);
+  var safeText = text || '';
+  if (fullEl) {
+    fullEl.textContent = safeText;
+    fullEl.style.display = 'none';
+  }
+  if (hookEl) {
+    hookEl.textContent = _npsGetHook(safeText);
+    hookEl.style.display = 'block';
+  }
+  if (cardEl) {
+    cardEl.setAttribute('data-expanded', 'false');
+    var btn = cardEl.querySelector('.nps-opt-expand');
+    if (btn) {
+      btn.textContent = 'Read more';
+      var wordCount = safeText.trim() ? safeText.trim().split(/\s+/).length : 0;
+      btn.style.display = (wordCount > 10) ? '' : 'none';
+    }
+  }
+}
+
+// Toggle hook / full text on one option card. Wired from the
+// inline onclick on each .nps-opt-expand button; the inline
+// handler also runs event.stopPropagation() so the card's own
+// onclick (which calls _npsPickOpt) does not fire as well.
+window._npsToggleExpand = function(btn) {
+  var card = btn.closest('.nps-cap-opt');
+  if (!card) return;
+  var full = card.querySelector('.nps-opt-full');
+  var hook = card.querySelector('.nps-opt-hook');
+  var expanded = card.getAttribute('data-expanded') === 'true';
+  if (expanded) {
+    if (full) full.style.display = 'none';
+    if (hook) hook.style.display = 'block';
+    btn.textContent = 'Read more';
+    card.setAttribute('data-expanded', 'false');
+  } else {
+    if (full) full.style.display = 'block';
+    if (hook) hook.style.display = 'none';
+    btn.textContent = 'Show less';
+    card.setAttribute('data-expanded', 'true');
   }
 };
 
@@ -426,9 +495,12 @@ window._npsRefine = async function() {
       try {
         var clean = data.content.replace(/```json|```/g, '').trim();
         var parsed = JSON.parse(clean);
-        if (parsed.copy_option_1) document.getElementById('nps-opt-txt-1').textContent = parsed.copy_option_1;
-        if (parsed.copy_option_2) document.getElementById('nps-opt-txt-2').textContent = parsed.copy_option_2;
-        if (parsed.copy_option_3) document.getElementById('nps-opt-txt-3').textContent = parsed.copy_option_3;
+        // Re-seed each card through the hook+full helper so the
+        // refined captions start collapsed to the 10-word preview
+        // and the expand state is reset across all three.
+        if (parsed.copy_option_1) _npsSetCaptionOption(1, parsed.copy_option_1);
+        if (parsed.copy_option_2) _npsSetCaptionOption(2, parsed.copy_option_2);
+        if (parsed.copy_option_3) _npsSetCaptionOption(3, parsed.copy_option_3);
         // Re-select option 1 after replacement so the submit path
         // always points at a fresh option.
         window._npsPickOpt(document.getElementById('nps-cap-opt-1'));

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414u">
+ <link rel="stylesheet" href="styles.css?v=20260414v">
 
 </head>
 <body>
@@ -622,19 +622,25 @@
 
         <!-- AI caption options — shown after Gmail import, hidden by default -->
         <div id="nps-caption-opts" style="display:none;flex-direction:column;gap:1px;margin-top:6px">
-          <div class="nps-cap-opt" id="nps-cap-opt-1" data-idx="1" onclick="window._npsPickOpt(this)">
+          <div class="nps-cap-opt" id="nps-cap-opt-1" data-idx="1" data-expanded="false" onclick="window._npsPickOpt(this)">
             <div class="nps-cap-opt-n">Option 01 <span class="nps-cap-opt-tag">Tap to select</span></div>
-            <div class="nps-cap-opt-txt" id="nps-opt-txt-1"></div>
+            <div class="nps-opt-hook" id="nps-opt-hook-1"></div>
+            <div class="nps-opt-full" id="nps-opt-txt-1" style="display:none"></div>
+            <button class="nps-opt-expand" type="button" onclick="event.stopPropagation(); window._npsToggleExpand(this)">Read more</button>
             <div class="nps-cap-sel-dot"></div>
           </div>
-          <div class="nps-cap-opt" id="nps-cap-opt-2" data-idx="2" onclick="window._npsPickOpt(this)">
+          <div class="nps-cap-opt" id="nps-cap-opt-2" data-idx="2" data-expanded="false" onclick="window._npsPickOpt(this)">
             <div class="nps-cap-opt-n">Option 02 <span class="nps-cap-opt-tag">Tap to select</span></div>
-            <div class="nps-cap-opt-txt" id="nps-opt-txt-2"></div>
+            <div class="nps-opt-hook" id="nps-opt-hook-2"></div>
+            <div class="nps-opt-full" id="nps-opt-txt-2" style="display:none"></div>
+            <button class="nps-opt-expand" type="button" onclick="event.stopPropagation(); window._npsToggleExpand(this)">Read more</button>
             <div class="nps-cap-sel-dot"></div>
           </div>
-          <div class="nps-cap-opt" id="nps-cap-opt-3" data-idx="3" onclick="window._npsPickOpt(this)">
+          <div class="nps-cap-opt" id="nps-cap-opt-3" data-idx="3" data-expanded="false" onclick="window._npsPickOpt(this)">
             <div class="nps-cap-opt-n">Option 03 <span class="nps-cap-opt-tag">Tap to select</span></div>
-            <div class="nps-cap-opt-txt" id="nps-opt-txt-3"></div>
+            <div class="nps-opt-hook" id="nps-opt-hook-3"></div>
+            <div class="nps-opt-full" id="nps-opt-txt-3" style="display:none"></div>
+            <button class="nps-opt-expand" type="button" onclick="event.stopPropagation(); window._npsToggleExpand(this)">Read more</button>
             <div class="nps-cap-sel-dot"></div>
           </div>
           <!-- Refine bar -->
@@ -1156,29 +1162,29 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414u"></script>
-<script src="00-appstate-compat.js?v=20260414u"></script>
-<script src="01-config.js?v=20260414u" defer></script>
-<script src="02-session.js?v=20260414u" defer></script>
-<script src="utils.js?v=20260414u" defer></script>
-<script src="12-profiles.js?v=20260414u" defer></script>
-<script src="03-auth.js?v=20260414u" defer></script>
-<script src="05-api.js?v=20260414u" defer></script>
-<script src="10-ui.js?v=20260414u" defer></script>
+<script src="00-appstate.js?v=20260414v"></script>
+<script src="00-appstate-compat.js?v=20260414v"></script>
+<script src="01-config.js?v=20260414v" defer></script>
+<script src="02-session.js?v=20260414v" defer></script>
+<script src="utils.js?v=20260414v" defer></script>
+<script src="12-profiles.js?v=20260414v" defer></script>
+<script src="03-auth.js?v=20260414v" defer></script>
+<script src="05-api.js?v=20260414v" defer></script>
+<script src="10-ui.js?v=20260414v" defer></script>
 
-<script src="06-post-create.js?v=20260414u" defer></script>
-<script defer src="render/dashboard.js?v=20260414u"></script>
-<script defer src="render/client.js?v=20260414u"></script>
-<script defer src="render/pipeline.js?v=20260414u"></script>
-<script defer src="render/brief.js?v=20260414u"></script>
-<script defer src="actions/pcs.js?v=20260414u"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414u"></script>
-<script src="ai-config.js?v=20260414u" defer></script>
-<script src="07-post-load.js?v=20260414u" defer></script>
-<script src="08-post-actions.js?v=20260414u" defer></script>
-<script src="09-library.js?v=20260414u" defer></script>
-<script src="09-approval.js?v=20260414u" defer></script>
-<script src="04-router.js?v=20260414u" defer></script>
+<script src="06-post-create.js?v=20260414v" defer></script>
+<script defer src="render/dashboard.js?v=20260414v"></script>
+<script defer src="render/client.js?v=20260414v"></script>
+<script defer src="render/pipeline.js?v=20260414v"></script>
+<script defer src="render/brief.js?v=20260414v"></script>
+<script defer src="actions/pcs.js?v=20260414v"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414v"></script>
+<script src="ai-config.js?v=20260414v" defer></script>
+<script src="07-post-load.js?v=20260414v" defer></script>
+<script src="08-post-actions.js?v=20260414v" defer></script>
+<script src="09-library.js?v=20260414v" defer></script>
+<script src="09-approval.js?v=20260414v" defer></script>
+<script src="04-router.js?v=20260414v" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -8243,6 +8243,34 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .nps-cap-opt-tag { color: #333; }
 .nps-cap-opt--sel .nps-cap-opt-tag { color: #9b87f5; }
 .nps-cap-opt-txt { font-size: 13px; color: #B8B8C0; line-height: 1.5; }
+.nps-opt-hook {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #F0F0F2;
+  line-height: 1.5;
+  margin-bottom: 6px;
+}
+.nps-opt-full {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  color: #B8B8C0;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  margin-bottom: 6px;
+}
+.nps-opt-expand {
+  background: none;
+  border: none;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: #9b87f5;
+  cursor: pointer;
+  padding: 0;
+  margin-top: 2px;
+}
 .nps-cap-sel-dot {
   width: 7px; height: 7px; border-radius: 50%;
   border: 1px solid #333;


### PR DESCRIPTION
## Summary

Show only the first **10 words** of each AI caption option after a Gmail import. Tapping "Read more" reveals the full caption; tapping "Show less" collapses back to the hook. Picks + submit still carry the full caption.

### Why

The Gmail import flow returns three full LinkedIn captions and stacks all three on screen. On a phone that's three walls of text to skim. A 10-word preview matches the LinkedIn carousel cutoff — exactly the span of text the user needs to pick between hooks before committing to a full read.

### Architecture note

The task spec assumed a dynamic `_npsRenderOptions()` render path. The real codebase has three static cards in `index.html` (class `.nps-cap-opt`, not `.nps-opt-card`) whose inner text is filled via `.textContent` on `#nps-opt-txt-N` from `_npsSelectEmail` and `_npsRefine`. This PR keeps that architecture and layers the hook/full/expand elements onto the existing static cards. `#nps-opt-txt-N` is preserved as the full-text holder (now also classed `.nps-opt-full`, `display:none`) so `submitNewPost` at line 685 reads full captions unchanged.

## Changes

### index.html — caption option markup (lines 624-645)
Each of the three `.nps-cap-opt` cards now carries:
- `data-expanded="false"` on the card
- `.nps-opt-hook` + `#nps-opt-hook-N` div (visible by default, gets the 10-word preview)
- `.nps-opt-full` + `#nps-opt-txt-N` div (`display:none`, gets the full caption — same id as before so `submitNewPost` unchanged)
- `<button class="nps-opt-expand" onclick="event.stopPropagation(); window._npsToggleExpand(this)">Read more</button>`
- `.nps-cap-sel-dot` kept

### 06-post-create.js
- New module-scope `_npsGetHook(text)` — trims, splits on whitespace, returns first 10 words + `...` (or full text if `<= 10` words).
- New module-scope `_npsSetCaptionOption(idx, text)` — seeds one card: full into `#nps-opt-txt-N`, hook into `#nps-opt-hook-N`, resets `data-expanded="false"`, resets button label to "Read more", hides the expand button entirely when `wordCount <= 10` (nothing to reveal).
- New `window._npsToggleExpand(btn)` — closes over `.nps-cap-opt` via `btn.closest`, flips `.nps-opt-hook` / `.nps-opt-full` display, flips button label, flips `data-expanded`. Inline handler runs `event.stopPropagation()` before calling this so the card's `_npsPickOpt` click does not also fire.
- `_npsSelectEmail`: replaced the three raw `.textContent` writes with `_npsSetCaptionOption(n, data.copy_option_n)` calls.
- `_npsRefine`: replaced the three raw `.textContent` writes inside the refine-success branch with `_npsSetCaptionOption(n, parsed.copy_option_n)` calls so refined captions always start collapsed.
- `_npsPickOpt`, `submitNewPost`, and `_npsRefine`'s *input* reads (which collect current option text to send to the refine worker) are **unchanged** — they all read `#nps-opt-txt-N`, which still holds the full caption.

### styles.css — three new classes
```css
.nps-opt-hook { DM Sans 14px/500, #F0F0F2, line-height 1.5, margin-bottom 6px; }
.nps-opt-full { DM Sans 13px, #B8B8C0, line-height 1.6, white-space: pre-wrap, margin-bottom 6px; }
.nps-opt-expand { IBM Plex Mono 8px/.06em uppercase #9b87f5, cursor pointer, no background/border/padding, margin-top 2px; }
```

### index.html — version bump
All 23 `?v=` strings bumped `20260414u` → `20260414v`.

## Verification checklist

- [x] Each caption card shows only the first 10 words initially (via `_npsGetHook` in `_npsSetCaptionOption`)
- [x] Tapping "Read more" expands to full caption (`_npsToggleExpand`)
- [x] Tapping "Show less" collapses back to hook (same handler)
- [x] `_npsPickOpt` / `submitNewPost` read **full** caption from `#nps-opt-txt-N` (the now-hidden `.nps-opt-full` div)
- [x] Onclick on the card still selects (stopPropagation on the button prevents double-fire)
- [x] `npx vitest run` → 543/543 passing
- [x] 23 `?v=` strings bumped to `20260414v`, 0 remaining on earlier
- [x] CLAUDE.md not touched per task instructions

## Test plan

- [ ] Admin on cold load → New Post → Import from Gmail → pick any thread. Each of the 3 cards renders as 10 words + `...`. Expand button reads "Read more".
- [ ] Tap "Read more" on Option 2. Card 2 expands, button reads "Show less", cards 1 and 3 remain collapsed.
- [ ] Tap "Show less" on Option 2. Card 2 collapses again.
- [ ] Tap anywhere on Card 3's body (not the button). Card 3 becomes `--sel` and `_npsSelectedOptIdx = 3`. Card 3 stays collapsed; selecting does not auto-expand.
- [ ] Tap "Read more" on Card 3. Card 3 expands; selection is preserved; no duplicate selection event.
- [ ] Submit with Card 3 expanded. Final post caption is the **full** Card 3 text, not the truncated hook.
- [ ] Pick an option that's actually 10 words or fewer (rare but possible). "Read more" button is hidden on that card.
- [ ] Hit "Refine" with instructions. All three cards re-seed and start collapsed again; default pick goes back to Option 1.

https://claude.ai/code/session_011kpnUcz6EMQPoNvRowt2Ko