### PR TITLE
Caption hook preview in Gmail import options

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -311,9 +311,11 @@ window._npsSelectEmail = async function(messageId, subject) {
     var optsWrap = document.getElementById('nps-caption-opts');
     if (textarea) textarea.style.display = 'none';
     if (optsWrap) {
-      document.getElementById('nps-opt-txt-1').textContent = data.copy_option_1 || '';
-      document.getElementById('nps-opt-txt-2').textContent = data.copy_option_2 || '';
-      document.getElementById('nps-opt-txt-3').textContent = data.copy_option_3 || '';
+      window._npsRenderOptions([
+        data.copy_option_1 || '',
+        data.copy_option_2 || '',
+        data.copy_option_3 || ''
+      ]);
       optsWrap.style.display = 'flex';
       // Default pick: option 1.
       window._npsPickOpt(document.getElementById('nps-cap-opt-1'));
@@ -368,6 +370,60 @@ window._npsSelectEmail = async function(messageId, subject) {
   }
 };
 
+// Hook preview: show only the first 10 words of a caption option.
+// The rest is mounted in a sibling `.nps-opt-full` div (hidden by
+// default) which `_npsToggleExpand` flips on/off. `submitNewPost`
+// and `_npsRefine` always read the FULL caption from `.nps-opt-full`
+// so the hook truncation is purely a display concern.
+function _npsGetHook(text) {
+  if (!text) return '';
+  var words = String(text).trim().split(/\s+/);
+  if (words.length <= 10) return String(text);
+  return words.slice(0, 10).join(' ') + '...';
+}
+
+// Populate the 3 existing caption option cards with hook/full/expand
+// structure. `opts` is an array of up to 3 full caption strings.
+// Each `#nps-opt-txt-N` container is treated as a mount point; its
+// innerHTML is fully replaced on every render so repeat calls from
+// Gmail import and refine keep the DOM in sync with the latest text.
+window._npsRenderOptions = function(opts) {
+  var list = opts || [];
+  for (var i = 0; i < 3; i++) {
+    var slot = document.getElementById('nps-opt-txt-' + (i + 1));
+    if (!slot) continue;
+    var full = (list[i] || '') + '';
+    slot.innerHTML =
+      '<div class="nps-opt-hook">' + esc(_npsGetHook(full)) + '</div>' +
+      '<div class="nps-opt-full" style="display:none">' + esc(full) + '</div>' +
+      '<button class="nps-opt-expand" type="button"' +
+        ' onclick="event.stopPropagation(); window._npsToggleExpand(this)">' +
+        'Read more' +
+      '</button>';
+    var card = document.getElementById('nps-cap-opt-' + (i + 1));
+    if (card) card.setAttribute('data-expanded', 'false');
+  }
+};
+
+window._npsToggleExpand = function(btn) {
+  var card = btn.closest('.nps-opt-card');
+  if (!card) return;
+  var full = card.querySelector('.nps-opt-full');
+  var hook = card.querySelector('.nps-opt-hook');
+  var expanded = card.getAttribute('data-expanded') === 'true';
+  if (expanded) {
+    if (full) full.style.display = 'none';
+    if (hook) hook.style.display = 'block';
+    btn.textContent = 'Read more';
+    card.setAttribute('data-expanded', 'false');
+  } else {
+    if (full) full.style.display = 'block';
+    if (hook) hook.style.display = 'none';
+    btn.textContent = 'Show less';
+    card.setAttribute('data-expanded', 'true');
+  }
+};
+
 window._npsPickOpt = function(el) {
   if (!el) return;
   document.querySelectorAll('.nps-cap-opt').forEach(function(o) {
@@ -389,10 +445,21 @@ window._npsRefine = async function() {
 
   if (sendBtn) { sendBtn.textContent = '...'; sendBtn.disabled = true; }
 
+  // Read the FULL caption text from each `.nps-opt-full` sibling so
+  // the refine payload carries the complete caption, not the 10-word
+  // hook preview. Falls back to the container textContent if the
+  // options haven't been rendered through `_npsRenderOptions` yet.
+  function _npsReadFullOpt(idx) {
+    var slot = document.getElementById('nps-opt-txt-' + idx);
+    if (!slot) return '';
+    var fullEl = slot.querySelector('.nps-opt-full');
+    if (fullEl) return fullEl.textContent || '';
+    return slot.textContent || '';
+  }
   var currentOpts = [
-    document.getElementById('nps-opt-txt-1') ? (document.getElementById('nps-opt-txt-1').textContent || '') : '',
-    document.getElementById('nps-opt-txt-2') ? (document.getElementById('nps-opt-txt-2').textContent || '') : '',
-    document.getElementById('nps-opt-txt-3') ? (document.getElementById('nps-opt-txt-3').textContent || '') : ''
+    _npsReadFullOpt(1),
+    _npsReadFullOpt(2),
+    _npsReadFullOpt(3)
   ];
 
   try {
@@ -426,9 +493,14 @@ window._npsRefine = async function() {
       try {
         var clean = data.content.replace(/```json|```/g, '').trim();
         var parsed = JSON.parse(clean);
-        if (parsed.copy_option_1) document.getElementById('nps-opt-txt-1').textContent = parsed.copy_option_1;
-        if (parsed.copy_option_2) document.getElementById('nps-opt-txt-2').textContent = parsed.copy_option_2;
-        if (parsed.copy_option_3) document.getElementById('nps-opt-txt-3').textContent = parsed.copy_option_3;
+        // Re-render through `_npsRenderOptions` so the refined
+        // copies come back as hook previews instead of full text.
+        // Keep any option that the refine call didn't return.
+        window._npsRenderOptions([
+          parsed.copy_option_1 || currentOpts[0],
+          parsed.copy_option_2 || currentOpts[1],
+          parsed.copy_option_3 || currentOpts[2]
+        ]);
         // Re-select option 1 after replacement so the submit path
         // always points at a fresh option.
         window._npsPickOpt(document.getElementById('nps-cap-opt-1'));
@@ -610,8 +682,15 @@ const postLink = (_s('new-post-link')?.value || '').trim();
 // to manual entry.
 var captionVal = '';
 if (window._npsGmailImported && window._npsSelectedOptIdx > 0) {
-  var selectedOptEl = document.getElementById('nps-opt-txt-' + window._npsSelectedOptIdx);
-  captionVal = selectedOptEl ? (selectedOptEl.textContent || '').trim() : '';
+  // Read the FULL caption from the hidden `.nps-opt-full` sibling,
+  // NOT the visible hook preview. Falls back to the container text
+  // if the options haven't been rendered through `_npsRenderOptions`
+  // yet (defensive — shouldn't happen in the imported flow).
+  var selectedSlot = document.getElementById('nps-opt-txt-' + window._npsSelectedOptIdx);
+  if (selectedSlot) {
+    var selectedFull = selectedSlot.querySelector('.nps-opt-full');
+    captionVal = (selectedFull ? (selectedFull.textContent || '') : (selectedSlot.textContent || '')).trim();
+  }
 }
 if (!captionVal) {
   captionVal = (_s('new-post-caption')?.value || '').trim();

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260414u">
+ <link rel="stylesheet" href="styles.css?v=20260414v">
 
 </head>
 <body>
@@ -620,19 +620,22 @@
           rows="6"
           oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';"></textarea>
 
-        <!-- AI caption options — shown after Gmail import, hidden by default -->
+        <!-- AI caption options — shown after Gmail import, hidden by default.
+             Each card carries the `nps-opt-card` alias class so
+             `_npsToggleExpand` can walk up via `closest('.nps-opt-card')`
+             to flip the hook/full preview state. -->
         <div id="nps-caption-opts" style="display:none;flex-direction:column;gap:1px;margin-top:6px">
-          <div class="nps-cap-opt" id="nps-cap-opt-1" data-idx="1" onclick="window._npsPickOpt(this)">
+          <div class="nps-cap-opt nps-opt-card" id="nps-cap-opt-1" data-idx="1" data-expanded="false" onclick="window._npsPickOpt(this)">
             <div class="nps-cap-opt-n">Option 01 <span class="nps-cap-opt-tag">Tap to select</span></div>
             <div class="nps-cap-opt-txt" id="nps-opt-txt-1"></div>
             <div class="nps-cap-sel-dot"></div>
           </div>
-          <div class="nps-cap-opt" id="nps-cap-opt-2" data-idx="2" onclick="window._npsPickOpt(this)">
+          <div class="nps-cap-opt nps-opt-card" id="nps-cap-opt-2" data-idx="2" data-expanded="false" onclick="window._npsPickOpt(this)">
             <div class="nps-cap-opt-n">Option 02 <span class="nps-cap-opt-tag">Tap to select</span></div>
             <div class="nps-cap-opt-txt" id="nps-opt-txt-2"></div>
             <div class="nps-cap-sel-dot"></div>
           </div>
-          <div class="nps-cap-opt" id="nps-cap-opt-3" data-idx="3" onclick="window._npsPickOpt(this)">
+          <div class="nps-cap-opt nps-opt-card" id="nps-cap-opt-3" data-idx="3" data-expanded="false" onclick="window._npsPickOpt(this)">
             <div class="nps-cap-opt-n">Option 03 <span class="nps-cap-opt-tag">Tap to select</span></div>
             <div class="nps-cap-opt-txt" id="nps-opt-txt-3"></div>
             <div class="nps-cap-sel-dot"></div>
@@ -1156,29 +1159,29 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260414u"></script>
-<script src="00-appstate-compat.js?v=20260414u"></script>
-<script src="01-config.js?v=20260414u" defer></script>
-<script src="02-session.js?v=20260414u" defer></script>
-<script src="utils.js?v=20260414u" defer></script>
-<script src="12-profiles.js?v=20260414u" defer></script>
-<script src="03-auth.js?v=20260414u" defer></script>
-<script src="05-api.js?v=20260414u" defer></script>
-<script src="10-ui.js?v=20260414u" defer></script>
+<script src="00-appstate.js?v=20260414v"></script>
+<script src="00-appstate-compat.js?v=20260414v"></script>
+<script src="01-config.js?v=20260414v" defer></script>
+<script src="02-session.js?v=20260414v" defer></script>
+<script src="utils.js?v=20260414v" defer></script>
+<script src="12-profiles.js?v=20260414v" defer></script>
+<script src="03-auth.js?v=20260414v" defer></script>
+<script src="05-api.js?v=20260414v" defer></script>
+<script src="10-ui.js?v=20260414v" defer></script>
 
-<script src="06-post-create.js?v=20260414u" defer></script>
-<script defer src="render/dashboard.js?v=20260414u"></script>
-<script defer src="render/client.js?v=20260414u"></script>
-<script defer src="render/pipeline.js?v=20260414u"></script>
-<script defer src="render/brief.js?v=20260414u"></script>
-<script defer src="actions/pcs.js?v=20260414u"></script>
-<script defer src="actions/pcs-longpress.js?v=20260414u"></script>
-<script src="ai-config.js?v=20260414u" defer></script>
-<script src="07-post-load.js?v=20260414u" defer></script>
-<script src="08-post-actions.js?v=20260414u" defer></script>
-<script src="09-library.js?v=20260414u" defer></script>
-<script src="09-approval.js?v=20260414u" defer></script>
-<script src="04-router.js?v=20260414u" defer></script>
+<script src="06-post-create.js?v=20260414v" defer></script>
+<script defer src="render/dashboard.js?v=20260414v"></script>
+<script defer src="render/client.js?v=20260414v"></script>
+<script defer src="render/pipeline.js?v=20260414v"></script>
+<script defer src="render/brief.js?v=20260414v"></script>
+<script defer src="actions/pcs.js?v=20260414v"></script>
+<script defer src="actions/pcs-longpress.js?v=20260414v"></script>
+<script src="ai-config.js?v=20260414v" defer></script>
+<script src="07-post-load.js?v=20260414v" defer></script>
+<script src="08-post-actions.js?v=20260414v" defer></script>
+<script src="09-library.js?v=20260414v" defer></script>
+<script src="09-approval.js?v=20260414v" defer></script>
+<script src="04-router.js?v=20260414v" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -8250,6 +8250,38 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .nps-cap-opt--sel .nps-cap-sel-dot { background: #9b87f5; border-color: #9b87f5; }
 
+/* Caption hook preview — first 10 words shown initially, Read more
+   expands to the full `.nps-opt-full` sibling. See
+   `_npsRenderOptions` + `_npsToggleExpand` in 06-post-create.js. */
+.nps-opt-hook {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #F0F0F2;
+  line-height: 1.5;
+  margin-bottom: 6px;
+}
+.nps-opt-full {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  color: #B8B8C0;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  margin-bottom: 6px;
+}
+.nps-opt-expand {
+  background: none;
+  border: none;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: #9b87f5;
+  cursor: pointer;
+  padding: 0;
+  margin-top: 2px;
+}
+
 .nps-ai-tag {
   display: inline-flex; align-items: center; gap: 3px;
   font-family: 'IBM Plex Mono', monospace;


### PR DESCRIPTION
## Summary
- Show only the first 10 words of each AI caption option as a hook preview after Gmail import; user taps `Read more` / `Show less` to expand/collapse the full caption before selecting.
- New helpers `_npsGetHook`, `_npsRenderOptions`, `_npsToggleExpand` in `06-post-create.js`; Gmail import + `_npsRefine` now populate cards through `_npsRenderOptions`, and `submitNewPost` + `_npsRefine` read the FULL caption from `.nps-opt-full` (not the visible hook) so the submitted payload always carries the complete text.
- CSS for `.nps-opt-hook`, `.nps-opt-full`, `.nps-opt-expand` + a `nps-opt-card` alias class on the 3 existing `.nps-cap-opt` elements so `closest('.nps-opt-card')` resolves. Version bumped 23× from `20260414u` → `20260414v`.

## Test plan
- [x] `npx vitest run` — 22/22 files, 543/543 tests passing
- [ ] Manual: import a brief from Gmail, confirm each card shows only the first 10 words + `Read more`
- [ ] Manual: tap `Read more` → full caption shows and button flips to `Show less`; tap again → collapses
- [ ] Manual: tap card body (not the button) → card becomes selected without toggling expand
- [ ] Manual: run `Refine` with an instruction → all 3 cards re-render back into hook-preview state
- [ ] Manual: save post → captured caption in DB is the FULL option text, not the 10-word hook

https://claude.ai/code/session_01Q3VJQukgoro1xTmsr4Jzif