### PR TITLE
Audit + fix: kill 6 redundant /notifications GETs + slow click_log cadence

### DIFF
--- a/07-post-load.js
+++ b/07-post-load.js
@@ -600,9 +600,33 @@ window._clientRealtimeRefresh = _clientRealtimeRefresh;
 function _onClientNotificationInsert(payload) {
   // Incremental path: Realtime dropped a brand-new Client notification
   // row into our lap, so we can bump the badge without round-tripping
-  // to the REST endpoint. updateNotifBadge() also runs as a safety net.
-  if (typeof updateNotifBadge === 'function') {
-    try { updateNotifBadge(); } catch(e) { console.warn('[client-realtime] updateNotifBadge', e); }
+  // to the REST endpoint. Push payload.new into _notifData (so the
+  // next loadNotifications() render picks it up) and then recompute
+  // the badge locally from the updated array. Previously this handler
+  // called updateNotifBadge() which fired a full GET /notifications
+  // on every incoming realtime event — under active comment volume
+  // that was the single biggest source of unnecessary REST traffic
+  // for Client users.
+  try {
+    if (payload && payload.new) {
+      if (!Array.isArray(window._notifData)) window._notifData = [];
+      // Dedupe by id — the REST poll fallback + realtime could both
+      // deliver the same row on rare reconnect windows.
+      var _pid = payload.new.id;
+      var _exists = false;
+      for (var i = 0; i < window._notifData.length; i++) {
+        if (window._notifData[i] && window._notifData[i].id === _pid) {
+          _exists = true;
+          break;
+        }
+      }
+      if (!_exists) window._notifData.unshift(payload.new);
+    }
+    if (typeof _recomputeBadgeLocal === 'function') {
+      _recomputeBadgeLocal();
+    }
+  } catch (e) {
+    console.warn('[client-realtime] notification insert', e);
   }
 }
 
@@ -760,12 +784,30 @@ window._agencyRealtimeRefresh = _agencyRealtimeRefresh;
 
 function _onAgencyNotificationInsert(payload) {
   // Incremental notification badge: a brand-new row landed for this
-  // agency user, so bump the badge without a /notifications GET. The
-  // REST-backed updateNotifBadge() call also acts as a safety net in
-  // case the Realtime payload arrives out of order with the read flag.
-  if (typeof updateNotifBadge === 'function') {
-    try { updateNotifBadge(); }
-    catch(e) { console.warn('[agency-realtime] updateNotifBadge', e); }
+  // agency user, so bump the badge without a /notifications GET.
+  // Push payload.new into _notifData (so a subsequent bell-open
+  // render picks it up) and then recompute the badge locally. The
+  // previous implementation called updateNotifBadge() which fired
+  // a full GET /notifications per event — the biggest single source
+  // of redundant REST traffic under active comment volume.
+  try {
+    if (payload && payload.new) {
+      if (!Array.isArray(window._notifData)) window._notifData = [];
+      var _pid = payload.new.id;
+      var _exists = false;
+      for (var i = 0; i < window._notifData.length; i++) {
+        if (window._notifData[i] && window._notifData[i].id === _pid) {
+          _exists = true;
+          break;
+        }
+      }
+      if (!_exists) window._notifData.unshift(payload.new);
+    }
+    if (typeof _recomputeBadgeLocal === 'function') {
+      _recomputeBadgeLocal();
+    }
+  } catch (e) {
+    console.warn('[agency-realtime] notification insert', e);
   }
 }
 

--- a/10-ui.js
+++ b/10-ui.js
@@ -54,7 +54,13 @@ function _flushClickBuffer() {
   }
 }
 
-setInterval(_flushClickBuffer, 5000);
+// Click-log flush interval bumped 5 000 → 30 000 ms as part of the
+// redundant-API-calls audit. The 5 s cadence was originally chosen
+// when click_log was hosted in a separate worker; now that it's a
+// PostgREST round trip we want far fewer POSTs during active use.
+// The beforeunload keepalive below guarantees no data loss on tab
+// close, so extending the idle cadence is safe.
+setInterval(_flushClickBuffer, 30000);
 
 window.addEventListener('beforeunload', function() {
   if (!window._clickBuffer.length) return;
@@ -457,7 +463,10 @@ async function loadNotifications() {
     }
 
     renderNotifications(currentName, _notifRole);
-    updateNotifBadge();
+    // Badge count is already in _notifData (the `read` field comes
+    // back in the SELECT above), so recompute locally instead of
+    // firing a second GET /notifications?read=eq.false round trip.
+    _recomputeBadgeLocal();
   } catch(e) {
     console.error('loadNotifications error:', e);
     window.logError && window.logError(e && e.message, e && e.stack, 'load-notifications');
@@ -1127,7 +1136,9 @@ async function _notifSubmitReply(sendBtn) {
 async function markNotifRead(id) {
   try {
     _notifData = _notifData.map(function(n) { return n.id === id ? Object.assign({}, n, { read: true }) : n; });
-    updateNotifBadge();
+    // _notifData was updated on the line above; recompute the badge
+    // locally instead of round-tripping GET /notifications.
+    _recomputeBadgeLocal();
     await apiFetch('/notifications?id=eq.' + id, {
       method: 'PATCH',
       body: JSON.stringify({ read: true }),
@@ -1153,7 +1164,9 @@ async function deleteNotification(id) {
         if (el.parentNode) el.parentNode.removeChild(el);
       }, 320);
     }
-    updateNotifBadge();
+    // _notifData was filtered above, so recompute the badge locally
+    // instead of a redundant GET /notifications round trip.
+    _recomputeBadgeLocal();
     await apiFetch('/notifications?id=eq.' + encodeURIComponent(id), {
       method: 'DELETE'
     });
@@ -1171,7 +1184,12 @@ async function markAllNotificationsRead() {
     _notifRole = _notifRole.charAt(0).toUpperCase() + _notifRole.slice(1).toLowerCase();
     var currentName = resolveActor() || 'there';
     renderNotifications(currentName, _notifRole);
-    updateNotifBadge();
+    // _notifData is now all-read, so _recomputeBadgeLocal will write
+    // count=0 to the four badge spans via _setBadgeCount. This
+    // replaces both the old updateNotifBadge() GET round trip AND
+    // the manual "hide all four" forEach that was running
+    // immediately after it.
+    _recomputeBadgeLocal();
     var readEls = document.querySelectorAll(
       '#panel-updates .notif-item:not(.read)');
     readEls.forEach(function(el) {
@@ -1184,11 +1202,6 @@ async function markAllNotificationsRead() {
     liveEls.forEach(function(el) {
       var dot = el.querySelector('.notif-unread-dot');
       if (dot) dot.style.display = 'none';
-    });
-    ['notif-bell-badge','notif-pipeline-badge',
-     'notif-lib-badge','notif-ins-badge'].forEach(function(id) {
-      var el = document.getElementById(id);
-      if (el) el.style.display = 'none';
     });
     // Chip counts are rebuilt by renderNotifications above;
     // belt-and-braces hide every count span in case render was skipped.
@@ -1207,6 +1220,37 @@ async function markAllNotificationsRead() {
   }
 }
 
+// Writes the unread count to all four notification badge spans.
+// Extracted from updateNotifBadge so both the REST-backed fallback
+// path and the local-recompute fast path share one DOM writer.
+function _setBadgeCount(count) {
+  var show = count > 0;
+  var countStr = count > 9 ? '9+' : String(count);
+  [
+    'notif-bell-badge',
+    'notif-pipeline-badge',
+    'notif-lib-badge',
+    'notif-ins-badge'
+  ].forEach(function(id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    el.textContent = countStr;
+    el.style.display = show ? 'flex' : 'none';
+  });
+}
+
+// Local badge recompute. Every caller of updateNotifBadge that already
+// has _notifData in memory should use this helper instead — it avoids
+// a redundant GET /notifications?read=eq.false round trip because the
+// source of truth (the read flag) is already sitting on the client.
+function _recomputeBadgeLocal() {
+  if (!Array.isArray(window._notifData)) return;
+  var count = window._notifData.filter(function(n) {
+    return !n.read;
+  }).length;
+  _setBadgeCount(count);
+}
+
 function updateNotifBadge() {
   if (!localStorage.getItem('sb_access_token')) return;
   var role = (window.AppState.user.effectiveRole || 'Admin');
@@ -1220,20 +1264,7 @@ function updateNotifBadge() {
   apiFetch(_badgeUrl, {}, { allowLogout: false })
   .then(function(rows) {
     var count = Array.isArray(rows) ? rows.length : 0;
-    var show = count > 0;
-    var countStr = count > 9 ? '9+' : String(count);
-
-    [
-      'notif-bell-badge',
-      'notif-pipeline-badge',
-      'notif-lib-badge',
-      'notif-ins-badge'
-    ].forEach(function(id) {
-      var el = document.getElementById(id);
-      if (!el) return;
-      el.textContent = countStr;
-      el.style.display = show ? 'flex' : 'none';
-    });
+    _setBadgeCount(count);
   }).catch(function(err){ console.error('[10-ui] updateNotifBadge', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'update-notif-badge'); });
 }
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260415c">
+ <link rel="stylesheet" href="styles.css?v=20260415d">
 
 </head>
 <body>
@@ -1166,29 +1166,29 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260415c"></script>
-<script src="00-appstate-compat.js?v=20260415c"></script>
-<script src="01-config.js?v=20260415c" defer></script>
-<script src="02-session.js?v=20260415c" defer></script>
-<script src="utils.js?v=20260415c" defer></script>
-<script src="12-profiles.js?v=20260415c" defer></script>
-<script src="03-auth.js?v=20260415c" defer></script>
-<script src="05-api.js?v=20260415c" defer></script>
-<script src="10-ui.js?v=20260415c" defer></script>
+<script src="00-appstate.js?v=20260415d"></script>
+<script src="00-appstate-compat.js?v=20260415d"></script>
+<script src="01-config.js?v=20260415d" defer></script>
+<script src="02-session.js?v=20260415d" defer></script>
+<script src="utils.js?v=20260415d" defer></script>
+<script src="12-profiles.js?v=20260415d" defer></script>
+<script src="03-auth.js?v=20260415d" defer></script>
+<script src="05-api.js?v=20260415d" defer></script>
+<script src="10-ui.js?v=20260415d" defer></script>
 
-<script src="06-post-create.js?v=20260415c" defer></script>
-<script defer src="render/dashboard.js?v=20260415c"></script>
-<script defer src="render/client.js?v=20260415c"></script>
-<script defer src="render/pipeline.js?v=20260415c"></script>
-<script defer src="render/brief.js?v=20260415c"></script>
-<script defer src="actions/pcs.js?v=20260415c"></script>
-<script defer src="actions/pcs-longpress.js?v=20260415c"></script>
-<script src="ai-config.js?v=20260415c" defer></script>
-<script src="07-post-load.js?v=20260415c" defer></script>
-<script src="08-post-actions.js?v=20260415c" defer></script>
-<script src="09-library.js?v=20260415c" defer></script>
-<script src="09-approval.js?v=20260415c" defer></script>
-<script src="04-router.js?v=20260415c" defer></script>
+<script src="06-post-create.js?v=20260415d" defer></script>
+<script defer src="render/dashboard.js?v=20260415d"></script>
+<script defer src="render/client.js?v=20260415d"></script>
+<script defer src="render/pipeline.js?v=20260415d"></script>
+<script defer src="render/brief.js?v=20260415d"></script>
+<script defer src="actions/pcs.js?v=20260415d"></script>
+<script defer src="actions/pcs-longpress.js?v=20260415d"></script>
+<script src="ai-config.js?v=20260415d" defer></script>
+<script src="07-post-load.js?v=20260415d" defer></script>
+<script src="08-post-actions.js?v=20260415d" defer></script>
+<script src="09-library.js?v=20260415d" defer></script>
+<script src="09-approval.js?v=20260415d" defer></script>
+<script src="04-router.js?v=20260415d" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -91,8 +91,13 @@ describe('Notification badge', function() {
     expect(body).toContain('AppState.user.effectiveRole');
   });
 
-  it('updateNotifBadge updates all 4 badge element IDs', function() {
-    var match = uiSrc.match(/function updateNotifBadge\(\)[\s\S]*?\.catch/);
+  it('_setBadgeCount updates all 4 badge element IDs', function() {
+    // The DOM writer was extracted from updateNotifBadge into a
+    // shared helper (_setBadgeCount) so both the REST-backed fallback
+    // AND the local-recompute fast path use the same code. Assert the
+    // helper still touches all four badge spans.
+    var match = uiSrc.match(/function _setBadgeCount\(count\)[\s\S]*?\n\}/);
+    expect(match).not.toBeNull();
     var body = match[0];
     var expectedIds = [
       'notif-bell-badge',
@@ -106,9 +111,25 @@ describe('Notification badge', function() {
   });
 
   it('badge shows 9+ for counts above 9', function() {
-    var match = uiSrc.match(/function updateNotifBadge\(\)[\s\S]*?\.catch/);
+    // 9+ cap lives in _setBadgeCount now (extracted from
+    // updateNotifBadge).
+    var match = uiSrc.match(/function _setBadgeCount\(count\)[\s\S]*?\n\}/);
+    expect(match).not.toBeNull();
     var body = match[0];
     expect(body).toContain("'9+'");
+  });
+
+  it('_recomputeBadgeLocal filters _notifData for unread count', function() {
+    // Local-recompute fast path: every mark-read caller and every
+    // realtime handler avoids the redundant GET /notifications round
+    // trip by deriving the badge from _notifData (which already has
+    // the `read` field from the loadNotifications SELECT).
+    var match = uiSrc.match(/function _recomputeBadgeLocal\(\)[\s\S]*?\n\}/);
+    expect(match).not.toBeNull();
+    var body = match[0];
+    expect(body).toContain('window._notifData');
+    expect(body).toContain('!n.read');
+    expect(body).toContain('_setBadgeCount');
   });
 
   it('periodic badge refresh interval is set on AppState.timers', function() {
@@ -263,10 +284,17 @@ describe('Mark as read', function() {
     expect(mapIdx).toBeLessThan(apiIdx);
   });
 
-  it('markNotifRead calls updateNotifBadge', function() {
+  it('markNotifRead calls _recomputeBadgeLocal (local fast path)', function() {
+    // Badge refresh was a redundant GET /notifications round trip on
+    // every mark-read — _notifData.map() already flipped the row's
+    // `read` field on the line above, so a local recompute gives the
+    // correct count without hitting the server.
     var match = uiSrc.match(/function markNotifRead\(id\)[\s\S]*?catch/);
     var body = match[0];
-    expect(body).toContain('updateNotifBadge()');
+    expect(body).toContain('_recomputeBadgeLocal()');
+    // Guard against regressions: the REST-backed path must not come
+    // back into this caller.
+    expect(body).not.toContain('updateNotifBadge()');
   });
 
   it('markAllNotificationsRead patches all unread for current role', function() {
@@ -278,14 +306,32 @@ describe('Mark as read', function() {
     expect(body).toContain("method: 'PATCH'");
   });
 
-  it('markAllNotificationsRead hides all 4 badge elements', function() {
+  it('markAllNotificationsRead hides all 4 badge elements via _recomputeBadgeLocal', function() {
+    // After the redundant-API audit, markAllNotificationsRead flips
+    // every _notifData row to read=true and then calls
+    // _recomputeBadgeLocal(), which writes count=0 to the four badge
+    // spans through _setBadgeCount (assertion below). The old manual
+    // forEach that duplicated the hide loop was removed — it was
+    // running immediately after the REST badge refetch, so both the
+    // fetch AND the duplicated DOM writes are now gone.
     var match = uiSrc.match(/function markAllNotificationsRead\(\)[\s\S]*?catch\(e\)/);
     var body = match[0];
-    expect(body).toContain('notif-bell-badge');
-    expect(body).toContain('notif-pipeline-badge');
-    expect(body).toContain('notif-lib-badge');
-    expect(body).toContain('notif-ins-badge');
-    expect(body).toContain("display = 'none'");
+    expect(body).toContain('_recomputeBadgeLocal()');
+    // The manual badge-hide forEach MUST be gone — it was the
+    // duplicate that the audit flagged. Assert the function body no
+    // longer references the four badge IDs directly (they live in
+    // _setBadgeCount now). The nchip-count-* belt-and-braces loop
+    // is unrelated and stays.
+    expect(body).not.toContain('notif-bell-badge');
+    expect(body).not.toContain('notif-pipeline-badge');
+    expect(body).not.toContain('notif-lib-badge');
+    expect(body).not.toContain('notif-ins-badge');
+    // And _setBadgeCount (called transitively) still references the
+    // four badge IDs, so the four-spans guarantee survives.
+    var helper = uiSrc.match(/function _setBadgeCount\(count\)[\s\S]*?\n\}/);
+    var helperBody = helper[0];
+    ['notif-bell-badge','notif-pipeline-badge','notif-lib-badge','notif-ins-badge']
+      .forEach(function(id) { expect(helperBody).toContain(id); });
   });
 
 });


### PR DESCRIPTION
## Summary

Redundant-API audit flagged `updateNotifBadge` as the single biggest source of unnecessary REST traffic. Every caller already had `_notifData` in memory with the `read` field, so the extra `GET /notifications?read=eq.false` round trip was pure overhead. Also slowed the `click_log` flush cadence.

- **6 redundant `GET /notifications` round trips eliminated** — badge now derived locally from `_notifData`
- **`click_log` flush interval bumped 5s → 30s** — `beforeunload` keepalive still guarantees no data loss on tab close
- **Rough impact: ~1,000–1,500 fewer REST requests/day** for 5 users (baseline was 5,336/day)

## Changes

**10-ui.js**
- Extract `_setBadgeCount(count)` from `updateNotifBadge` — shared DOM writer for the four badge spans
- Add `_recomputeBadgeLocal()` — derives unread count from `_notifData.filter(!n.read).length` and calls `_setBadgeCount`
- Replace 4 redundant `updateNotifBadge()` callers with `_recomputeBadgeLocal()`:
  - `loadNotifications` (was firing a second GET immediately after the first)
  - `markNotifRead` (the map() on the previous line already flipped the row)
  - `deleteNotification` (the filter() on the previous line already spliced the row)
  - `markAllNotificationsRead` (the map() already flipped every row)
- Drop the duplicate "hide all 4 badge spans" `forEach` in `markAllNotificationsRead` — `_setBadgeCount(0)` covers the same DOM writes cleanly
- Bump `setInterval(_flushClickBuffer, 5000)` → `30000`

**07-post-load.js**
- `_onClientNotificationInsert` / `_onAgencyNotificationInsert`: push `payload.new` into `_notifData` (with id-dedupe for stash + WS reconnect overlap), then call `_recomputeBadgeLocal()` instead of firing a full `GET /notifications` round trip per incoming realtime event. Under active comment volume this was the single biggest source of redundant REST traffic.

**tests/notifications.test.js**
- New assertions: `_setBadgeCount updates all 4 badge element IDs`, `_recomputeBadgeLocal filters _notifData for unread count`, `badge shows 9+ for counts above 9` now matches `_setBadgeCount`
- `markNotifRead calls _recomputeBadgeLocal (local fast path)` — guards against regression back to the REST-backed path
- `markAllNotificationsRead hides all 4 badge elements via _recomputeBadgeLocal` — asserts the duplicate `forEach` is gone and the four-span guarantee survives via `_setBadgeCount`

**index.html**
- Bump all 23 `?v=` strings: `20260415c` → `20260415d`

## What did NOT change

- `updateNotifBadge` itself stays wired for the 20s agency fallback timer (cold-start safety net when the Supabase WS fails to establish)
- Zero changes to polling cadences (10s agency realtime fallback, 20s notifBadgeTimer, 50min token refresh) except for `click_log`
- Zero changes to auth, session, or Realtime subscription logic
- `post_comments` SELECT list unchanged (R6 in the audit was deferred — optimization only, not a bug)

## Test plan

- [x] `npx vitest run` — **544/544 passing** (was 543/543 — added one test for `_recomputeBadgeLocal`)
- [ ] Smoke-test on srtd.io after merge: open bell, mark-read, delete, mark-all, make sure badge count stays accurate across a brand-new notification arriving via Realtime
- [ ] Cloudflare cache purge after merge (per CLAUDE.md §7)

https://claude.ai/code/session_016nhTnkK1YN6acGC1PCk21D