### PR TITLE
Caption Claude Workspace — AI caption editing modal

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -1,0 +1,342 @@
+/* ═══════════════════════════════════════════════════════════════
+   pcs-claude-caption.js — Caption Claude Workspace
+   Full-screen modal for AI caption editing with conversation
+   memory, editable drafts, refinement chips, and live cost meter.
+   ═══════════════════════════════════════════════════════════════ */
+console.log('LOADED:', 'pcs-claude-caption.js');
+
+window._captionWS = {
+  isOpen: false,
+  messages: [],
+  sessionCost: 0,
+  postId: null,
+  mode: null
+};
+
+var _CW_USD_TO_INR = 84;
+
+// ─── cost helpers ────────────────────────────────────────────
+
+function _cwCalcINR(inputTokens, outputTokens) {
+  var usd = (inputTokens * 3 / 1000000) + (outputTokens * 15 / 1000000);
+  return usd * _CW_USD_TO_INR;
+}
+
+function _cwFormatINR(v) {
+  if (v < 1) return '\u20B9' + v.toFixed(2);
+  if (v < 100) return '\u20B9' + v.toFixed(2);
+  return '\u20B9' + Math.round(v);
+}
+
+// ─── open workspace ──────────────────────────────────────────
+
+window.openCaptionWorkspace = async function(mode, context) {
+  var overlay = document.getElementById('caption-workspace-overlay');
+  if (!overlay) return;
+
+  var ws = window._captionWS;
+  var isResume = mode === 'resume' && ws.messages.length > 0;
+
+  if (!isResume) {
+    ws.messages = [];
+    ws.sessionCost = 0;
+    ws.postId = context.postId || null;
+    ws.mode = mode;
+  }
+  ws.isOpen = true;
+
+  overlay.style.display = 'flex';
+  overlay.style.transform = 'translateY(100%)';
+  overlay.offsetHeight; // force reflow
+  overlay.style.transition = 'transform 280ms ease';
+  overlay.style.transform = 'translateY(0)';
+
+  var titleEl = document.getElementById('cw-context-title');
+  if (titleEl) titleEl.textContent = context.title || 'Untitled post';
+
+  _cwUpdateSessionMeter();
+  _cwFetchCostTotals();
+  _cwRenderThread();
+
+  if (!isResume) {
+    if (mode === 'rewrite') {
+      var commentList = (context.comments || []).map(function(c) {
+        return (c.author || 'Unknown') + ': ' + (c.text || c.message || '');
+      }).join('\n');
+      var msg = 'Current caption:\n' + (context.caption || '(empty)') +
+        '\n\nHere are the comments on this post:\n' + (commentList || 'No comments yet.') +
+        '\n\nRewrite the caption addressing the feedback. Return ONLY the revised caption.';
+      window.sendCaptionMessage(msg);
+    } else if (mode === 'write') {
+      var msg2 = 'Generate 3 alternative caption options for this post: ' +
+        (context.title || '') + '.' +
+        (context.caption ? '\nCurrent caption: ' + context.caption : '') +
+        '\n\nReturn exactly 3 numbered options. No preamble.';
+      window.sendCaptionMessage(msg2);
+    } else if (mode === 'qc') {
+      var msg3 = 'QC this LinkedIn caption against the brand guide. Caption:\n\n' +
+        (context.caption || '(no caption)') +
+        '\n\nReturn a structured verdict with PASS or FLAG for each check.';
+      window.sendCaptionMessage(msg3);
+    }
+    // 'chat' mode: user types first message
+  }
+};
+
+// ─── close workspace ─────────────────────────────────────────
+
+window.closeCaptionWorkspace = function() {
+  var overlay = document.getElementById('caption-workspace-overlay');
+  if (!overlay) return;
+  overlay.style.transition = 'transform 280ms ease';
+  overlay.style.transform = 'translateY(100%)';
+  setTimeout(function() {
+    overlay.style.display = 'none';
+    overlay.style.transition = '';
+  }, 290);
+  window._captionWS.isOpen = false;
+};
+
+// ─── send message ────────────────────────────────────────────
+
+window.sendCaptionMessage = async function(text) {
+  if (!text || !text.trim()) return;
+  var ws = window._captionWS;
+
+  ws.messages.push({ role: 'user', content: text.trim() });
+  _cwRenderThread();
+  _cwScrollToBottom();
+
+  var thread = document.getElementById('cw-thread');
+  if (thread) {
+    thread.insertAdjacentHTML('beforeend', _cwTypingHtml());
+    _cwScrollToBottom();
+  }
+
+  var post = ws.postId ? (window.AppState.posts.all || []).find(function(p) {
+    return (p.post_id || p.id) === ws.postId;
+  }) : null;
+
+  var systemCtx = '';
+  if (post) {
+    systemCtx = 'Post title: ' + (post.title || '') + '\n';
+    if (post.caption) systemCtx += 'Current caption: ' + post.caption + '\n';
+    if (post.content_pillar) systemCtx += 'Content pillar: ' + post.content_pillar + '\n';
+  }
+
+  var featureTag = ws.mode === 'qc' ? 'qc' : ws.mode === 'write' ? 'writer' : 'chat';
+
+  var result = await _callSrtdAI(featureTag, ws.messages, ws.postId);
+
+  var typingEl = thread && thread.querySelector('.cw-typing');
+  if (typingEl) typingEl.remove();
+
+  if (result && result.success) {
+    ws.messages.push({ role: 'assistant', content: result.content || '' });
+    var inTok = result.input_tokens || (result.usage && result.usage.input) || 0;
+    var outTok = result.output_tokens || (result.usage && result.usage.output) || 0;
+    var costINR = _cwCalcINR(inTok, outTok);
+    ws.sessionCost += costINR;
+    _cwUpdateSessionMeter();
+  } else {
+    ws.messages.push({ role: 'assistant', content: 'Error: ' + ((result && result.error) || 'Request failed. Try again.') });
+  }
+  _cwRenderThread();
+  _cwScrollToBottom();
+};
+
+// ─── render thread ───────────────────────────────────────────
+
+function _cwRenderThread() {
+  var thread = document.getElementById('cw-thread');
+  if (!thread) return;
+  var ws = window._captionWS;
+  var html = '';
+  var draftNum = 0;
+
+  for (var i = 0; i < ws.messages.length; i++) {
+    var m = ws.messages[i];
+    if (m.role === 'user') {
+      html += '<div class="cw-msg cw-msg-user"><div class="cw-msg-bubble">' +
+        _cwEsc(m.content).replace(/\n/g, '<br>') + '</div></div>';
+    } else if (m.role === 'assistant') {
+      draftNum++;
+      var isLatest = (i === ws.messages.length - 1);
+      var costLabel = '';
+      html += '<div class="cw-msg cw-msg-claude">' +
+        '<div class="cw-draft">' +
+          '<div class="cw-draft-header">' +
+            '<span class="cw-draft-label">\u2726 Claude \u00B7 Draft ' + draftNum + '</span>' +
+            costLabel +
+          '</div>' +
+          '<div class="cw-draft-body" ' + (isLatest ? 'contenteditable="true"' : '') +
+            ' data-draft="' + draftNum + '">' +
+            _cwEsc(m.content).replace(/\n/g, '<br>') +
+          '</div>' +
+          (isLatest
+            ? '<div class="cw-draft-hint">Tap to edit before using</div>'
+            : '') +
+          '<div class="cw-chips">' +
+            _cwChipHtml('shorter', draftNum, isLatest) +
+            _cwChipHtml('warmer', draftNum, isLatest) +
+            _cwChipHtml('sharper', draftNum, isLatest) +
+            (isLatest ? '<button class="cw-chip cw-chip-use" onclick="window._cwHandleChip(\'use\',' + draftNum + ')">\u2713 Use this</button>' : '') +
+          '</div>' +
+        '</div>' +
+      '</div>';
+    }
+  }
+
+  if (!ws.messages.length) {
+    html = '<div class="cw-empty">' +
+      '<div class="cw-empty-icon">\u2726</div>' +
+      '<div class="cw-empty-text">Ask anything about this caption, or let Claude write one for you.</div>' +
+    '</div>';
+  }
+
+  thread.innerHTML = html;
+}
+
+function _cwChipHtml(type, draftNum, isLatest) {
+  var labels = { shorter: 'Shorter', warmer: 'Warmer', sharper: 'Sharper' };
+  return '<button class="cw-chip' + (isLatest ? '' : ' cw-chip-dim') + '" ' +
+    (isLatest ? 'onclick="window._cwHandleChip(\'' + type + '\',' + draftNum + ')"' : 'disabled') +
+    '>' + labels[type] + '</button>';
+}
+
+function _cwTypingHtml() {
+  return '<div class="cw-typing"><span class="cw-typing-dot"></span><span class="cw-typing-dot"></span><span class="cw-typing-dot"></span></div>';
+}
+
+function _cwEsc(s) {
+  return (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function _cwScrollToBottom() {
+  var thread = document.getElementById('cw-thread');
+  if (thread) setTimeout(function() { thread.scrollTop = thread.scrollHeight; }, 50);
+}
+
+// ─── chip handler ────────────────────────────────────────────
+
+window._cwHandleChip = function(chipType, draftNum) {
+  if (chipType === 'use') {
+    var drafts = document.querySelectorAll('.cw-draft-body[data-draft="' + draftNum + '"]');
+    var text = drafts.length ? drafts[drafts.length - 1].innerText.trim() : '';
+    if (text) window._cwApplyDraft(text);
+    return;
+  }
+  var label = chipType.charAt(0).toUpperCase() + chipType.slice(1);
+  window.sendCaptionMessage('Make draft ' + draftNum + ' ' + label.toLowerCase() + '. Keep the same structure. Return ONLY the revised caption.');
+};
+
+// ─── apply draft to caption ──────────────────────────────────
+
+window._cwApplyDraft = async function(text) {
+  var ws = window._captionWS;
+  var post = (window.AppState.posts.all || []).find(function(p) {
+    return (p.post_id || p.id) === ws.postId;
+  });
+  if (!post) {
+    if (typeof showToast === 'function') showToast('Post not found', 'error');
+    return;
+  }
+  var postId = post.post_id || post.id;
+
+  post._isSaving = true;
+  if (typeof _startSaveTimeout === 'function') _startSaveTimeout(post, postId);
+
+  try {
+    await apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'Prefer': 'return=minimal' },
+      body: JSON.stringify({
+        caption: text,
+        updated_at: new Date().toISOString(),
+        updated_by: window.AppState.user.email || ''
+      })
+    });
+    Object.assign(post, { caption: text, updated_at: new Date().toISOString() });
+    if (typeof _clearSaveTimeout === 'function') _clearSaveTimeout(post);
+    post._isSaving = false;
+    window.closeCaptionWorkspace();
+    if (typeof _renderPCS === 'function') _renderPCS(postId);
+    if (typeof showToast === 'function') showToast('Caption updated', 'success');
+  } catch (err) {
+    if (typeof _clearSaveTimeout === 'function') _clearSaveTimeout(post);
+    post._isSaving = false;
+    window.logError && window.logError(err && err.message, err && err.stack, 'cw-apply-draft');
+    if (typeof showToast === 'function') showToast('Failed to update caption', 'error');
+  }
+};
+
+// ─── cost totals ─────────────────────────────────────────────
+
+function _cwUpdateSessionMeter() {
+  var el = document.getElementById('cw-session-cost');
+  if (el) el.textContent = _cwFormatINR(window._captionWS.sessionCost);
+}
+
+async function _cwFetchCostTotals() {
+  try {
+    var now = new Date();
+    var todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+    var monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+
+    var todayRows = await apiFetch(
+      '/ai_usage?select=cost_usd&created_at=gte.' + todayMidnight
+    );
+    var monthRows = await apiFetch(
+      '/ai_usage?select=cost_usd&created_at=gte.' + monthStart
+    );
+
+    var todayUSD = 0;
+    var monthUSD = 0;
+    if (Array.isArray(todayRows)) todayRows.forEach(function(r) { todayUSD += (r.cost_usd || 0); });
+    if (Array.isArray(monthRows)) monthRows.forEach(function(r) { monthUSD += (r.cost_usd || 0); });
+
+    var todayEl = document.getElementById('cw-today-cost');
+    var monthEl = document.getElementById('cw-month-cost');
+    if (todayEl) todayEl.textContent = _cwFormatINR(todayUSD * _CW_USD_TO_INR) + ' today';
+    if (monthEl) monthEl.textContent = _cwFormatINR(monthUSD * _CW_USD_TO_INR) + ' this month';
+  } catch (e) {
+    // non-critical
+  }
+}
+
+// ─── input handling ──────────────────────────────────────────
+
+(function _cwWireInput() {
+  document.addEventListener('click', function(e) {
+    if (e.target && e.target.id === 'cw-send') {
+      var input = document.getElementById('cw-input');
+      if (input && input.value.trim()) {
+        window.sendCaptionMessage(input.value);
+        input.value = '';
+        input.style.height = 'auto';
+      }
+    }
+    if (e.target && e.target.id === 'cw-back') {
+      window.closeCaptionWorkspace();
+    }
+  });
+  document.addEventListener('keydown', function(e) {
+    if (e.target && e.target.id === 'cw-input' && e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      var input = e.target;
+      if (input.value.trim()) {
+        window.sendCaptionMessage(input.value);
+        input.value = '';
+        input.style.height = 'auto';
+      }
+    }
+  });
+  document.addEventListener('input', function(e) {
+    if (e.target && e.target.id === 'cw-input') {
+      e.target.style.height = 'auto';
+      e.target.style.height = Math.min(e.target.scrollHeight, 100) + 'px';
+      var btn = document.getElementById('cw-send');
+      if (btn) btn.style.opacity = e.target.value.trim() ? '1' : '0.55';
+    }
+  });
+})();

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -207,70 +207,9 @@ async function _callSrtdAI(feature, messages, postId) {
 window._pcsAiWrite = async function(id) {
   var post = (window.AppState.posts.all || []).find(function(p) { return p.post_id === id; });
   if (!post) return;
-
-  var wrap = document.getElementById('pcs-write-opts-' + id);
-  var writeBtn = document.getElementById('pcs-write-btn-' + id);
-  if (!wrap || !writeBtn) return;
-
-  // Toggle off if already open
-  if (wrap.style.display === 'block') {
-    wrap.style.display = 'none';
-    wrap.innerHTML = '';
-    _pcsDimManualZone(false);
-    return;
+  if (typeof openCaptionWorkspace === 'function') {
+    openCaptionWorkspace('write', { postId: id, caption: post.caption, title: post.title });
   }
-
-  // Loading state inside the write-opts wrap
-  wrap.innerHTML = '<div class="pcs-write-loading">\u2726 Generating options\u2026</div>';
-  wrap.style.display = 'block';
-  _pcsDimManualZone(true);
-
-  var brief = post.title || '';
-  var pillar = post.content_pillar || '';
-  var messages = [{
-    role: 'user',
-    content: 'Write 3 LinkedIn caption options for this post.\n\nTitle: ' + brief +
-      '\nContent pillar: ' + pillar +
-      (post.caption ? '\nExisting draft: ' + post.caption : '')
-  }];
-
-  var result = await _callSrtdAI('writer', messages, id);
-
-  if (!result.success) {
-    wrap.innerHTML = '<div class="pcs-write-error">Error \u2014 tap Write to retry</div>';
-    return;
-  }
-
-  // Parse 3 options from response (numbered "1." / "2." / "3." or "Option 01" etc.)
-  var raw = result.content || '';
-  var opts = [];
-  var lines = raw.split('\n');
-  var current = '';
-  lines.forEach(function(line) {
-    if (/^(option\s*0?[123]|[123][.):])/i.test(line.trim())) {
-      if (current.trim()) opts.push(current.trim());
-      current = line.replace(/^(option\s*0?[123]|[123][.):]\s*)/i, '').trim();
-    } else {
-      current += (current ? '\n' : '') + line;
-    }
-  });
-  if (current.trim()) opts.push(current.trim());
-  while (opts.length < 3) opts.push(raw);
-  opts = opts.slice(0, 3);
-
-  var optsHtml = '';
-  opts.forEach(function(txt, i) {
-    optsHtml += '<div class="pcs-write-opt" data-idx="' + i + '" onclick="window._pcsPickWriteOpt(this, \'' + esc(id) + '\')">' +
-      '<div class="pcs-ai-opt-n">Option 0' + (i + 1) + ' <span class="pcs-ai-opt-tag">Tap to select</span></div>' +
-      '<div class="pcs-ai-opt-txt">' + txt.replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</div>' +
-      '<div class="pcs-ai-sel-dot"></div>' +
-    '</div>';
-  });
-  optsHtml +=
-    '<button class="pcs-write-use-btn" onclick="window._pcsUseWriteSelection(\'' + esc(id) + '\')">Use selected</button>' +
-    '<button class="pcs-write-collapse" onclick="window._pcsCollapseWrite(\'' + esc(id) + '\')">\u2715 Collapse</button>';
-
-  wrap.innerHTML = optsHtml;
 };
 
 // --- Legacy PR 2 option picker (kept for any external caller) ---
@@ -288,85 +227,19 @@ window._pcsPickAiOpt = function(el, id) {
 window._pcsRunQC = async function(id, btn) {
   var post = (window.AppState.posts.all || []).find(function(p) { return p.post_id === id; });
   if (!post || !post.caption) {
-    var subNoCap = btn.querySelector('.pcs-qc-sub');
-    if (subNoCap) subNoCap.textContent = 'No caption to check';
+    if (btn) { var subNoCap = btn.querySelector('.pcs-qc-sub'); if (subNoCap) subNoCap.textContent = 'No caption to check'; }
     return;
   }
-
-  // Zone 1 sheet uses .pcs-qc-lbl; fall back to legacy .pcs-qc-title for any
-  // path that still renders the old button shape.
-  var titleEl = btn.querySelector('.pcs-qc-lbl') || btn.querySelector('.pcs-qc-title');
-  var subEl   = btn.querySelector('.pcs-qc-sub');
-  if (titleEl) titleEl.textContent = 'Checking...';
-  btn.disabled = true;
-
-  var messages = [{ role: 'user', content: 'Check this LinkedIn caption:\n\n' + post.caption }];
-  var result = await _callSrtdAI('qc', messages, id);
-
-  if (titleEl) titleEl.textContent = 'QC against Brand Guide';
-  if (subEl)   subEl.textContent   = 'Check tone, voice and brand language';
-  btn.disabled = false;
-
-  var resultDiv = document.getElementById('pcs-qc-result-' + id);
-  if (!resultDiv) return;
-
-  if (!result.success) {
-    resultDiv.innerHTML = '<div class="pcs-qc-error">QC failed. Try again.</div>';
-    resultDiv.style.display = 'block';
-    return;
+  if (typeof openCaptionWorkspace === 'function') {
+    openCaptionWorkspace('qc', { postId: id, caption: post.caption, title: post.title });
   }
-
-  resultDiv.innerHTML =
-    '<div class="pcs-qc-rh">' +
-      '<span class="pcs-qc-rs-lbl">Brand QC Result</span>' +
-      '<span class="pcs-qc-rt">Just now</span>' +
-    '</div>' +
-    '<div class="pcs-qc-body">' +
-      (result.content || '').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>') +
-    '</div>' +
-    '<button class="pcs-qc-dis" onclick="document.getElementById(\'pcs-qc-result-' + id + '\').style.display=\'none\'">Dismiss</button>';
-  resultDiv.style.display = 'block';
 };
 
 window._pcsAiChat = async function(id) {
-  var input = document.getElementById('pcs-chat-input-' + id);
-  var thread = document.getElementById('pcs-chat-thread-' + id);
-  if (!input || !thread) return;
-  var val = input.value.trim();
-  if (!val) return;
-
   var post = (window.AppState.posts.all || []).find(function(p) { return p.post_id === id; });
-  var capContext = post && post.caption ? 'Current caption:\n' + post.caption + '\n\n' : '';
-
-  thread.innerHTML += '<div class="pcs-chat-msg">' +
-      '<div class="pcs-chat-who-you">You</div>' +
-      '<div class="pcs-chat-txt">' + val.replace(/</g, '&lt;') + '</div>' +
-    '</div>';
-  input.value = '';
-
-  var thinkingId = 'thinking-' + Date.now();
-  thread.innerHTML += '<div id="' + thinkingId + '" class="pcs-chat-msg">' +
-      '<div class="pcs-chat-who-claude">Claude</div>' +
-      '<div class="pcs-chat-txt pcs-chat-thinking">...</div>' +
-    '</div>';
-  thread.scrollTop = 99999;
-
-  var messages = [{ role: 'user', content: capContext + val }];
-  var result = await _callSrtdAI('chat', messages, id);
-
-  var thinking = document.getElementById(thinkingId);
-  if (thinking) {
-    var thinkingTxt = thinking.querySelector('.pcs-chat-txt');
-    if (result.success) {
-      if (thinkingTxt) {
-        thinkingTxt.textContent = result.content || '';
-        thinkingTxt.classList.remove('pcs-chat-thinking');
-      }
-    } else {
-      if (thinkingTxt) thinkingTxt.textContent = 'Error. Try again.';
-    }
+  if (typeof openCaptionWorkspace === 'function') {
+    openCaptionWorkspace('chat', { postId: id, caption: post ? post.caption : '', title: post ? post.title : '' });
   }
-  thread.scrollTop = 99999;
 };
 
 // ═══════════════════════════════════════════════════════════════
@@ -436,15 +309,35 @@ function _pcsBuildAiZoneHtml(rawId, commentCount) {
         '</div>' +
       '</div>'
     : '') +
-    // Rewrite from comments button (always visible in Zone 1)
-    '<button class="pcs-rewrite-btn" id="pcs-rewrite-btn-' + id + '" onclick="window._pcsRewriteFromComments(\'' + id + '\')">' +
-      '<div class="pcs-rw-icon">' + ICON_SPARK + '</div>' +
-      '<div class="pcs-rw-text">' +
-        '<div class="pcs-rw-title">\u2726 Rewrite from comments</div>' +
-        '<div class="pcs-rw-sub">' + commentCount + ' comment' + (commentCount === 1 ? '' : 's') + ' on this post</div>' +
-      '</div>' +
-      '<span class="pcs-rw-arr">\u2192</span>' +
-    '</button>' +
+    // Primary button: "Continue conversation" if session exists, else "Rewrite from comments"
+    (function() {
+      var _ws = window._captionWS;
+      var _hasSession = _ws && _ws.messages && _ws.messages.length > 0 && _ws.postId === rawId;
+      if (_hasSession) {
+        var _draftCount = _ws.messages.filter(function(m) { return m.role === 'assistant'; }).length;
+        var _lastDraft = '';
+        for (var _mi = _ws.messages.length - 1; _mi >= 0; _mi--) {
+          if (_ws.messages[_mi].role === 'assistant') { _lastDraft = _ws.messages[_mi].content || ''; break; }
+        }
+        var _preview = _lastDraft.length > 30 ? _lastDraft.slice(0, 30) + '\u2026' : _lastDraft;
+        return '<button class="pcs-rewrite-btn" id="pcs-rewrite-btn-' + id + '" onclick="window.openCaptionWorkspace(\'resume\',{postId:\'' + id + '\',title:getTitle(getPostById(\'' + id + '\'))})">' +
+          '<div class="pcs-rw-icon">' + ICON_SPARK + '</div>' +
+          '<div class="pcs-rw-text">' +
+            '<div class="pcs-rw-title">\u2726 Continue conversation</div>' +
+            '<div class="pcs-rw-sub">Draft ' + _draftCount + ' \u00B7 ' + esc(_preview) + '</div>' +
+          '</div>' +
+          '<span class="pcs-rw-arr">\u2192</span>' +
+        '</button>';
+      }
+      return '<button class="pcs-rewrite-btn" id="pcs-rewrite-btn-' + id + '" onclick="window._pcsRewriteFromComments(\'' + id + '\')">' +
+        '<div class="pcs-rw-icon">' + ICON_SPARK + '</div>' +
+        '<div class="pcs-rw-text">' +
+          '<div class="pcs-rw-title">\u2726 Rewrite from comments</div>' +
+          '<div class="pcs-rw-sub">' + commentCount + ' comment' + (commentCount === 1 ? '' : 's') + ' on this post</div>' +
+        '</div>' +
+        '<span class="pcs-rw-arr">\u2192</span>' +
+      '</button>';
+    })() +
     // Rewrite result panel (hidden by default, expands inline)
     '<div class="pcs-rewrite-result" id="pcs-rewrite-result-' + id + '">' +
       '<div class="pcs-rwr-flags"></div>' +
@@ -463,14 +356,27 @@ function _pcsBuildAiZoneHtml(rawId, commentCount) {
         '<button class="pcs-refine-cancel" onclick="window._pcsRefineCancel(\'' + id + '\')">\u2715 Cancel</button>' +
       '</div>' +
     '</div>' +
-    // Write fresh options button (always visible below rewrite section)
-    '<button class="pcs-write-btn" id="pcs-write-btn-' + id + '" onclick="window._pcsAiWrite(\'' + id + '\')">' +
-      '<div class="pcs-rw-icon pcs-rw-icon--dim">' + ICON_SPARK + '</div>' +
-      '<div class="pcs-rw-text">' +
-        '<div class="pcs-rw-title pcs-rw-title--dim">\u2726 Write fresh options</div>' +
-      '</div>' +
-      '<span class="pcs-rw-arr">\u2192</span>' +
-    '</button>' +
+    // Secondary button: "Start fresh" if session exists, else "Write fresh options"
+    (function() {
+      var _ws2 = window._captionWS;
+      var _hasSession2 = _ws2 && _ws2.messages && _ws2.messages.length > 0 && _ws2.postId === rawId;
+      if (_hasSession2) {
+        return '<button class="pcs-write-btn" id="pcs-write-btn-' + id + '" onclick="window._captionWS.messages=[];window._captionWS.sessionCost=0;window._pcsAiWrite(\'' + id + '\')">' +
+          '<div class="pcs-rw-icon pcs-rw-icon--dim">' + ICON_SPARK + '</div>' +
+          '<div class="pcs-rw-text">' +
+            '<div class="pcs-rw-title pcs-rw-title--dim">\u2726 Start fresh</div>' +
+          '</div>' +
+          '<span class="pcs-rw-arr">\u2192</span>' +
+        '</button>';
+      }
+      return '<button class="pcs-write-btn" id="pcs-write-btn-' + id + '" onclick="window._pcsAiWrite(\'' + id + '\')">' +
+        '<div class="pcs-rw-icon pcs-rw-icon--dim">' + ICON_SPARK + '</div>' +
+        '<div class="pcs-rw-text">' +
+          '<div class="pcs-rw-title pcs-rw-title--dim">\u2726 Write fresh options</div>' +
+        '</div>' +
+        '<span class="pcs-rw-arr">\u2192</span>' +
+      '</button>';
+    })() +
     // Write options panel (populated lazily by _pcsAiWrite)
     '<div class="pcs-write-opts" id="pcs-write-opts-' + id + '"></div>' +
   '</div>';
@@ -604,107 +510,30 @@ window._pcsRefineCancel = function(id) {
 };
 
 window._pcsRefineSend = async function(id) {
-  var input = document.getElementById('pcs-refine-input-' + id);
-  if (!input) return;
-  var instruction = (input.value || '').trim();
-  if (!instruction) return;
-
-  var result = document.getElementById('pcs-rewrite-result-' + id);
-  if (!result) return;
-  var currentCaption = result.dataset.newCaption || '';
-
-  // Close refine row immediately and show a thinking state in the caption
-  var capEl = result.querySelector('.pcs-rwr-caption');
-  if (capEl) capEl.textContent = 'Refining\u2026';
-  window._pcsRefineCancel(id);
-
-  var messages = [{
-    role: 'user',
-    content: 'Current caption:\n' + currentCaption + '\n\nRefinement instruction:\n' + instruction + '\n\nReturn ONLY the revised caption, no preamble.'
-  }];
-  var response = await _callSrtdAI('chat', messages, id);
-
-  if (!response.success) {
-    if (capEl) capEl.textContent = currentCaption;
-    if (typeof showToast === 'function') showToast('Refine failed, try again', 'error');
-    return;
+  var post = (window.AppState.posts.all || []).find(function(p) { return p.post_id === id; });
+  if (typeof openCaptionWorkspace === 'function') {
+    openCaptionWorkspace('chat', { postId: id, caption: post ? post.caption : '', title: post ? post.title : '' });
   }
-
-  var revised = (response.content || '').trim();
-  result.dataset.newCaption = revised;
-  if (capEl) capEl.textContent = revised;
 };
 
 window._pcsRewriteFromComments = async function(id) {
   var post = (window.AppState.posts.all || []).find(function(p) { return p.post_id === id; });
   if (!post) return;
 
-  var rewriteResult = document.getElementById('pcs-rewrite-result-' + id);
-  var rewriteBtn = document.getElementById('pcs-rewrite-btn-' + id);
-  if (!rewriteResult || !rewriteBtn) return;
-
-  // Idempotent: if the result panel is already open, do nothing
-  if (rewriteResult.style.display === 'block') return;
-
-  // Collect visible client comments from the DOM
   var commentEls = document.querySelectorAll('#pcs-pane-client .pcs-comment-text');
-  var commentTexts = [];
+  var comments = [];
   commentEls.forEach(function(el) {
     var text = el.textContent.trim();
-    if (text && text !== 'This message was deleted.') commentTexts.push(text);
-  });
-  var commentContext = commentTexts.length
-    ? 'Client comments on this post:\n' + commentTexts.slice(0, 15).join('\n---\n')
-    : 'No comments yet.';
-
-  // Update button state
-  var titleEl = rewriteBtn.querySelector('.pcs-rw-title');
-  var subEl = rewriteBtn.querySelector('.pcs-rw-sub');
-  if (titleEl) titleEl.textContent = '\u2726 Reading comments\u2026';
-  if (subEl) subEl.textContent = 'Analysing ' + commentTexts.length + ' comments...';
-
-  var messages = [{
-    role: 'user',
-    content: 'Current caption:\n' + (post.caption || '') + '\n\n' + commentContext + '\n\nRewrite the caption addressing the client feedback. Return: 1) A brief list of what you changed and why (one line per change, prefix with CHANGE:). 2) Then the full revised caption. Separate them with ---'
-  }];
-
-  var result = await _callSrtdAI('chat', messages, id);
-
-  if (!result.success) {
-    if (titleEl) titleEl.textContent = '\u2726 Rewrite from comments';
-    if (subEl) subEl.textContent = 'Error \u2014 tap to retry';
-    return;
-  }
-
-  if (titleEl) titleEl.textContent = '\u2726 Rewrite ready';
-  if (subEl) subEl.textContent = 'Based on ' + commentTexts.length + ' comments';
-
-  // Parse response: split on ---
-  var parts = (result.content || '').split('---');
-  var changesRaw = parts[0] || '';
-  var newCaption = (parts[1] || result.content || '').trim();
-
-  // Build flags HTML from CHANGE: lines
-  var flagsHtml = '';
-  changesRaw.split('\n').forEach(function(line) {
-    var clean = line.replace(/^CHANGE:\s*/i, '').trim();
-    if (clean) {
-      flagsHtml += '<div class="pcs-rwr-flag"><div class="pcs-rwr-flag-txt">' + clean.replace(/</g,'&lt;').replace(/>/g,'&gt;') + '</div></div>';
+    if (text && text !== 'This message was deleted.') {
+      var item = el.closest('.pcs-comment-item');
+      var authorEl = item && item.querySelector('.pcs-comment-author');
+      comments.push({ author: authorEl ? authorEl.textContent : 'Unknown', text: text });
     }
   });
 
-  var flagsEl = rewriteResult.querySelector('.pcs-rwr-flags');
-  if (flagsEl) flagsEl.innerHTML = flagsHtml;
-
-  var capEl2 = rewriteResult.querySelector('.pcs-rwr-caption');
-  if (capEl2) capEl2.textContent = newCaption;
-
-  // Store new caption for Apply
-  rewriteResult.dataset.newCaption = newCaption;
-  rewriteResult.style.display = 'block';
-
-  // Dim manual zone
-  _pcsDimManualZone(true);
+  if (typeof openCaptionWorkspace === 'function') {
+    openCaptionWorkspace('rewrite', { postId: id, caption: post.caption, title: post.title, comments: comments });
+  }
 };
 
 // --- Write fresh options (Zone 1 version) ---

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260416d">
+ <link rel="stylesheet" href="styles.css?v=20260416e">
 
 </head>
 <body>
@@ -1058,6 +1058,36 @@
 
     </div>
   </div>
+
+  <!-- Caption Claude Workspace -->
+  <div id="caption-workspace-overlay" style="display:none;position:fixed;inset:0;z-index:9600;background:#1A1816">
+    <div id="caption-workspace" style="display:flex;flex-direction:column;width:100%;max-width:480px;margin:0 auto;height:100%">
+      <div id="cw-topbar">
+        <button id="cw-back">&larr; Back to Post</button>
+        <div id="cw-cost-meter">
+          <span id="cw-session-cost">&rupee;0</span>
+          <span>This session</span>
+        </div>
+      </div>
+      <div id="cw-context">
+        <span style="color:#C15F3C;font-size:12px">&starf;</span>
+        <span id="cw-context-title"></span>
+        <div id="cw-totals">
+          <span id="cw-today-cost"></span>
+          <span id="cw-month-cost"></span>
+        </div>
+      </div>
+      <div id="cw-thread"></div>
+      <div id="cw-input-wrap">
+        <div id="cw-input-pill">
+          <textarea id="cw-input" placeholder="Ask anything, or say what you want changed..." rows="1"></textarea>
+          <button id="cw-send">&#x2191;</button>
+        </div>
+        <div id="cw-input-hint">Tap &#x2713; Use this to update your caption</div>
+      </div>
+    </div>
+  </div>
+
 </div>
 
 <div id="toast"></div>
@@ -1166,29 +1196,30 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260416d"></script>
-<script src="00-appstate-compat.js?v=20260416d"></script>
-<script src="01-config.js?v=20260416d" defer></script>
-<script src="02-session.js?v=20260416d" defer></script>
-<script src="utils.js?v=20260416d" defer></script>
-<script src="12-profiles.js?v=20260416d" defer></script>
-<script src="03-auth.js?v=20260416d" defer></script>
-<script src="05-api.js?v=20260416d" defer></script>
-<script src="10-ui.js?v=20260416d" defer></script>
+<script src="00-appstate.js?v=20260416e"></script>
+<script src="00-appstate-compat.js?v=20260416e"></script>
+<script src="01-config.js?v=20260416e" defer></script>
+<script src="02-session.js?v=20260416e" defer></script>
+<script src="utils.js?v=20260416e" defer></script>
+<script src="12-profiles.js?v=20260416e" defer></script>
+<script src="03-auth.js?v=20260416e" defer></script>
+<script src="05-api.js?v=20260416e" defer></script>
+<script src="10-ui.js?v=20260416e" defer></script>
 
-<script src="06-post-create.js?v=20260416d" defer></script>
-<script defer src="render/dashboard.js?v=20260416d"></script>
-<script defer src="render/client.js?v=20260416d"></script>
-<script defer src="render/pipeline.js?v=20260416d"></script>
-<script defer src="render/brief.js?v=20260416d"></script>
-<script defer src="actions/pcs.js?v=20260416d"></script>
-<script defer src="actions/pcs-longpress.js?v=20260416d"></script>
-<script src="ai-config.js?v=20260416d" defer></script>
-<script src="07-post-load.js?v=20260416d" defer></script>
-<script src="08-post-actions.js?v=20260416d" defer></script>
-<script src="09-library.js?v=20260416d" defer></script>
-<script src="09-approval.js?v=20260416d" defer></script>
-<script src="04-router.js?v=20260416d" defer></script>
+<script src="06-post-create.js?v=20260416e" defer></script>
+<script defer src="render/dashboard.js?v=20260416e"></script>
+<script defer src="render/client.js?v=20260416e"></script>
+<script defer src="render/pipeline.js?v=20260416e"></script>
+<script defer src="render/brief.js?v=20260416e"></script>
+<script defer src="actions/pcs.js?v=20260416e"></script>
+<script defer src="actions/pcs-longpress.js?v=20260416e"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260416e"></script>
+<script src="ai-config.js?v=20260416e" defer></script>
+<script src="07-post-load.js?v=20260416e" defer></script>
+<script src="08-post-actions.js?v=20260416e" defer></script>
+<script src="09-library.js?v=20260416e" defer></script>
+<script src="09-approval.js?v=20260416e" defer></script>
+<script src="04-router.js?v=20260416e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/srtd-ai-worker/src/index.js
+++ b/srtd-ai-worker/src/index.js
@@ -224,7 +224,8 @@ async function handleComplete(request, env) {
     }
 
     const feature     = body && body.feature;
-    const messages    = body && body.messages;
+    const rawMessages = body && body.messages;
+    const rawPrompt   = body && body.prompt;
     const postId      = (body && body.post_id) || null;
     const workspaceId = (body && body.workspace_id) || 'default';
     const createdBy   = (body && body.created_by) || '';
@@ -232,7 +233,14 @@ async function handleComplete(request, env) {
     if (!feature || !FEATURE_FLAGS[feature]) {
       return errorResponse('Invalid or missing feature', 400);
     }
-    if (!Array.isArray(messages) || messages.length === 0) {
+
+    // Backward compat: accept `prompt` string or `messages` array
+    const messages = Array.isArray(rawMessages) && rawMessages.length > 0
+      ? rawMessages
+      : (typeof rawPrompt === 'string' && rawPrompt.length > 0)
+        ? [{ role: 'user', content: rawPrompt }]
+        : null;
+    if (!messages) {
       return errorResponse('Invalid or missing messages', 400);
     }
 
@@ -269,6 +277,8 @@ async function handleComplete(request, env) {
     return jsonResponse({
       success: true,
       content: responseText,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
       usage: { input: inputTokens, output: outputTokens }
     });
   } catch (err) {

--- a/styles.css
+++ b/styles.css
@@ -8177,6 +8177,272 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 /* Done button is NEVER dimmed — always active */
 
 /* ═══════════════════════════════════════════════════════════
+   Caption Claude Workspace — warm dark theme
+   ═══════════════════════════════════════════════════════════ */
+#caption-workspace-overlay {
+  font-family: 'DM Sans', sans-serif;
+}
+#cw-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: #201E1A;
+  border-bottom: 1px solid #3A3632;
+  flex-shrink: 0;
+}
+#cw-back {
+  background: none;
+  border: none;
+  color: #9b87f5;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  letter-spacing: .04em;
+  cursor: pointer;
+  padding: 6px 0;
+}
+#cw-cost-meter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  color: #7A7670;
+}
+#cw-session-cost {
+  color: #F6A623;
+  font-weight: 600;
+  font-size: 11px;
+}
+#cw-context {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: #201E1A;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #B1ADA1;
+  border-bottom: 1px solid #3A3632;
+  flex-shrink: 0;
+}
+#cw-context-title {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #F4F3EE;
+  font-size: 11px;
+  font-family: 'DM Sans', sans-serif;
+  font-weight: 600;
+}
+#cw-totals {
+  display: flex;
+  gap: 10px;
+  font-size: 8px;
+  color: #7A7670;
+  flex-shrink: 0;
+}
+#cw-thread {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  scrollbar-width: none;
+  min-height: 0;
+}
+#cw-thread::-webkit-scrollbar { display: none; }
+
+.cw-msg { display: flex; }
+.cw-msg-user { justify-content: flex-end; }
+.cw-msg-bubble {
+  max-width: 85%;
+  padding: 10px 14px;
+  background: #252320;
+  border: 1px solid #3A3632;
+  border-radius: 16px 16px 4px 16px;
+  font-size: 13px;
+  color: #F4F3EE;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.cw-msg-claude { flex-direction: column; }
+.cw-draft {
+  background: #201810;
+  border: 1px solid #5A3A2C;
+  border-radius: 12px;
+  overflow: hidden;
+}
+.cw-draft-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid #3A3220;
+}
+.cw-draft-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: #C15F3C;
+}
+.cw-draft-body {
+  padding: 12px 14px;
+  font-size: 14px;
+  color: #F4F3EE;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  outline: none;
+  min-height: 40px;
+}
+.cw-draft-body:focus {
+  border-left: 2px solid #C15F3C;
+  padding-left: 12px;
+}
+.cw-draft-body[contenteditable="true"] {
+  cursor: text;
+}
+.cw-draft-hint {
+  padding: 0 14px 6px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  color: #4A4640;
+  letter-spacing: .06em;
+}
+.cw-chips {
+  display: flex;
+  gap: 6px;
+  padding: 8px 12px;
+  border-top: 1px solid #3A3220;
+  flex-wrap: wrap;
+}
+.cw-chip {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: #C15F3C;
+  background: none;
+  border: 1px solid #5A3A2C;
+  padding: 7px 12px;
+  cursor: pointer;
+}
+.cw-chip:active { opacity: .7; }
+.cw-chip-dim {
+  color: #4A4640;
+  border-color: #3A3632;
+  cursor: default;
+}
+.cw-chip-use {
+  color: #F4F3EE;
+  background: linear-gradient(180deg, #D46840, #B85430);
+  border: none;
+  font-weight: 600;
+}
+
+.cw-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 40px 20px;
+}
+.cw-empty-icon { font-size: 24px; color: #C15F3C; opacity: .4; }
+.cw-empty-text {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #7A7670;
+  text-align: center;
+  line-height: 1.7;
+  letter-spacing: .04em;
+}
+
+.cw-typing {
+  display: flex;
+  gap: 4px;
+  padding: 12px 14px;
+}
+.cw-typing-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #C15F3C;
+  animation: cwDotPulse 1.4s infinite;
+}
+.cw-typing-dot:nth-child(2) { animation-delay: .2s; }
+.cw-typing-dot:nth-child(3) { animation-delay: .4s; }
+@keyframes cwDotPulse {
+  0%, 80%, 100% { opacity: .2; }
+  40% { opacity: 1; }
+}
+
+#cw-input-wrap {
+  flex-shrink: 0;
+  padding: 8px 14px;
+  padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
+  background: #1A1816;
+  border-top: 1px solid #3A3632;
+}
+#cw-input-pill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 6px 6px 14px;
+  border-radius: 14px;
+  background: #201C18;
+  border: 1px solid #5A3A2C;
+}
+#cw-input {
+  flex: 1;
+  background: none;
+  border: none;
+  font-size: 14px;
+  color: #F4F3EE;
+  outline: none;
+  font-family: 'DM Sans', sans-serif;
+  line-height: 1.4;
+  padding: 4px 0;
+  resize: none;
+  max-height: 100px;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+#cw-input::-webkit-scrollbar { display: none; }
+#cw-input::placeholder { color: #4A4640; }
+#cw-send {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  color: #F4F3EE;
+  font-size: 15px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  opacity: 0.55;
+  background: linear-gradient(180deg, #D46840, #B85430);
+  transition: opacity .15s;
+}
+#cw-send:active { transform: translateY(1px); }
+#cw-input-hint {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  color: #4A4640;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  padding: 4px 4px 0;
+}
+
+/* ═══════════════════════════════════════════════════════════
    PR 4 — Gmail import in New Post form (Admin only).
    Zero rgba() — 8-digit hex throughout, per CLAUDE.md §4.
    ═══════════════════════════════════════════════════════════ */


### PR DESCRIPTION
## ⚠️ AFTER MERGE: Copy the updated `srtd-ai-worker/src/index.js` to Cloudflare dashboard for the Worker changes to take effect.

## Summary
- New full-screen modal for AI caption editing with conversation memory, editable drafts, refinement chips (Shorter/Warmer/Sharper), and live INR cost meter
- Worker `/ai/complete` now accepts `prompt` string (backward compat) or `messages` array, returns `input_tokens`/`output_tokens` at top level
- All 5 PCS AI call sites (write, QC, chat, refine, rewrite) now route through the workspace instead of inline panels
- AI zone shows "Continue conversation" / "Start fresh" when a session exists for the current post
- Warm dark theme (`#1A1816` base, `#C15F3C` terracotta accents) distinct from PCS jet black

## Files changed (5)
- `actions/pcs-claude-caption.js` — **NEW** — workspace state, rendering, input handling, cost meter, draft application
- `actions/pcs.js` — 5 AI call sites replaced with `openCaptionWorkspace()` calls; AI zone builder updated with session-aware buttons
- `srtd-ai-worker/src/index.js` — backward-compatible `prompt`→`messages` wrapping; `input_tokens`/`output_tokens` in response
- `index.html` — workspace overlay HTML + new script tag (24 version strings bumped to `20260416e`)
- `styles.css` — workspace CSS (warm dark theme, 266 lines)

## Test plan
- [x] `npx vitest run` — 544/544 passing
- [ ] Open PCS → Caption tab → tap "✦ Rewrite from comments" → workspace slides up with warm dark theme
- [ ] Type refinement → Claude responds → editable draft appears with chips
- [ ] Tap "Shorter" chip → new draft appears
- [ ] Tap "✓ Use this" → caption updates, workspace closes, PCS re-renders
- [ ] Reopen AI zone → "Continue conversation" button shows with preview
- [ ] Tap "Start fresh" → clears session, opens fresh workspace
- [ ] Cost meter shows session cost in ₹, today/month totals load from Supabase
- [ ] **WORKER**: Deploy updated `srtd-ai-worker/src/index.js` to Cloudflare dashboard

https://claude.ai/code/session_0156yc1bmx3YnnGmxuQGQa8D