### PR TITLE
Workspace display fixes: comment block + stacked cost meter

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -10,7 +10,8 @@ window._captionWS = {
   messages: [],
   sessionCost: 0,
   postId: null,
-  mode: null
+  mode: null,
+  _rewriteComments: null
 };
 
 var _CW_USD_TO_INR = 100;
@@ -24,8 +25,8 @@ function _cwCalcINR(inputTokens, outputTokens) {
 
 function _cwFormatINR(v) {
   if (v < 1) return '\u20B9' + v.toFixed(2);
-  if (v < 100) return '\u20B9' + v.toFixed(2);
-  return '\u20B9' + Math.round(v);
+  if (v < 1000) return '\u20B9' + Math.round(v);
+  return '\u20B9' + Math.round(v).toLocaleString('en-IN');
 }
 
 // ─── open workspace ──────────────────────────────────────────
@@ -42,6 +43,7 @@ window.openCaptionWorkspace = async function(mode, context) {
     ws.sessionCost = 0;
     ws.postId = context.postId || null;
     ws.mode = mode;
+    ws._rewriteComments = null;
   }
   ws.isOpen = true;
 
@@ -60,13 +62,37 @@ window.openCaptionWorkspace = async function(mode, context) {
 
   if (!isResume) {
     if (mode === 'rewrite') {
-      var commentList = (context.comments || []).map(function(c) {
-        return (c.author || 'Unknown') + ': ' + (c.text || c.message || '');
+      ws._rewriteComments = (context.comments || []).map(function(c) {
+        return { author: c.author || 'Unknown', role: (c.role || c.author_role || 'client').toLowerCase(), text: c.text || c.message || '' };
+      });
+      var commentList = ws._rewriteComments.map(function(c) {
+        return c.author + ': ' + c.text;
       }).join('\n');
-      var msg = 'Current caption:\n' + (context.caption || '(empty)') +
+      var apiMsg = 'Current caption:\n' + (context.caption || '(empty)') +
         '\n\nHere are the comments on this post:\n' + (commentList || 'No comments yet.') +
         '\n\nRewrite the caption addressing the feedback. Return ONLY the revised caption.';
-      window.sendCaptionMessage(msg);
+      var displayMsg = 'Rewrite the caption addressing the feedback above.';
+      ws.messages.push({ role: 'user', content: apiMsg, _display: displayMsg });
+      _cwRenderThread();
+      _cwScrollToBottom();
+      var thread = document.getElementById('cw-thread');
+      if (thread) { thread.insertAdjacentHTML('beforeend', _cwTypingHtml()); _cwScrollToBottom(); }
+      var featureTag = 'chat';
+      var result = await _callSrtdAI(featureTag, ws.messages.map(function(m) { return { role: m.role, content: m.content }; }), ws.postId);
+      var typingEl = thread && thread.querySelector('.cw-typing');
+      if (typingEl) typingEl.remove();
+      if (result && result.success) {
+        ws.messages.push({ role: 'assistant', content: result.content || '' });
+        var inTok = result.input_tokens || (result.usage && result.usage.input) || 0;
+        var outTok = result.output_tokens || (result.usage && result.usage.output) || 0;
+        ws.sessionCost += _cwCalcINR(inTok, outTok);
+        _cwUpdateSessionMeter();
+      } else {
+        ws.messages.push({ role: 'assistant', content: 'Error: ' + ((result && result.error) || 'Request failed. Try again.') });
+      }
+      _cwRenderThread();
+      _cwScrollToBottom();
+      return;
     } else if (mode === 'write') {
       var msg2 = 'Generate 3 alternative caption options for this post: ' +
         (context.title || '') + '.' +
@@ -154,11 +180,17 @@ function _cwRenderThread() {
   var html = '';
   var draftNum = 0;
 
+  var commentsRendered = false;
   for (var i = 0; i < ws.messages.length; i++) {
     var m = ws.messages[i];
     if (m.role === 'user') {
+      if (!commentsRendered && ws._rewriteComments && ws._rewriteComments.length > 0 && i === 0) {
+        html += _cwBuildCommentsBlock(ws._rewriteComments);
+        commentsRendered = true;
+      }
+      var displayText = m._display || m.content;
       html += '<div class="cw-msg cw-msg-user"><div class="cw-msg-bubble">' +
-        _cwEsc(m.content).replace(/\n/g, '<br>') + '</div></div>';
+        _cwEsc(displayText).replace(/\n/g, '<br>') + '</div></div>';
     } else if (m.role === 'assistant') {
       draftNum++;
       var isLatest = (i === ws.messages.length - 1);
@@ -215,6 +247,29 @@ function _cwEsc(s) {
 function _cwScrollToBottom() {
   var thread = document.getElementById('cw-thread');
   if (thread) setTimeout(function() { thread.scrollTop = thread.scrollHeight; }, 50);
+}
+
+// ─── comment block builder ───────────────────────────────────
+
+function _cwBuildCommentsBlock(comments) {
+  var SHOW = 4;
+  var roleMap = { client: 'client', servicing: 'servicing', admin: 'admin', creative: 'creative' };
+  var html = '<div class="cw-comments-block">' +
+    '<div class="cw-comments-header">\u2726 ' + comments.length + ' COMMENT' + (comments.length === 1 ? '' : 'S') + ' LOADED</div>';
+  for (var i = 0; i < comments.length; i++) {
+    var c = comments[i];
+    var cls = roleMap[c.role] || 'client';
+    var label = (c.role || 'client').charAt(0).toUpperCase() + (c.role || 'client').slice(1);
+    html += '<div class="cw-cmt-item' + (i >= SHOW ? ' cw-cmt-hidden' : '') + '">' +
+      '<span class="cw-cmt-author cw-cmt-' + cls + '">' + _cwEsc(label) + '</span>' +
+      '<span class="cw-cmt-text">' + _cwEsc(c.text) + '</span>' +
+    '</div>';
+  }
+  if (comments.length > SHOW) {
+    html += '<button class="cw-cmt-more" onclick="this.parentNode.querySelectorAll(\'.cw-cmt-hidden\').forEach(function(e){e.classList.remove(\'cw-cmt-hidden\')});this.remove()">Show ' + (comments.length - SHOW) + ' more \u2193</button>';
+  }
+  html += '</div>';
+  return html;
 }
 
 // ─── chip handler ────────────────────────────────────────────
@@ -297,8 +352,8 @@ async function _cwFetchCostTotals() {
 
     var todayEl = document.getElementById('cw-today-cost');
     var monthEl = document.getElementById('cw-month-cost');
-    if (todayEl) todayEl.textContent = _cwFormatINR(todayUSD * _CW_USD_TO_INR) + ' today';
-    if (monthEl) monthEl.textContent = _cwFormatINR(monthUSD * _CW_USD_TO_INR) + ' this month';
+    if (todayEl) todayEl.textContent = _cwFormatINR(todayUSD * _CW_USD_TO_INR);
+    if (monthEl) monthEl.textContent = _cwFormatINR(monthUSD * _CW_USD_TO_INR);
   } catch (e) {
     // non-critical
   }

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260416f">
+ <link rel="stylesheet" href="styles.css?v=20260416g">
 
 </head>
 <body>
@@ -1072,9 +1072,15 @@
       <div id="cw-context">
         <span style="color:#C15F3C;font-size:12px">&starf;</span>
         <span id="cw-context-title"></span>
-        <div id="cw-totals">
-          <span id="cw-today-cost"></span>
-          <span id="cw-month-cost"></span>
+        <div id="cw-totals" style="display:flex;gap:12px">
+          <span class="cw-tot">
+            <span class="cw-tot-label">Today</span>
+            <span class="cw-tot-value" id="cw-today-cost"></span>
+          </span>
+          <span class="cw-tot">
+            <span class="cw-tot-label">Month</span>
+            <span class="cw-tot-value" id="cw-month-cost"></span>
+          </span>
         </div>
       </div>
       <div id="cw-thread"></div>
@@ -1196,30 +1202,30 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260416f"></script>
-<script src="00-appstate-compat.js?v=20260416f"></script>
-<script src="01-config.js?v=20260416f" defer></script>
-<script src="02-session.js?v=20260416f" defer></script>
-<script src="utils.js?v=20260416f" defer></script>
-<script src="12-profiles.js?v=20260416f" defer></script>
-<script src="03-auth.js?v=20260416f" defer></script>
-<script src="05-api.js?v=20260416f" defer></script>
-<script src="10-ui.js?v=20260416f" defer></script>
+<script src="00-appstate.js?v=20260416g"></script>
+<script src="00-appstate-compat.js?v=20260416g"></script>
+<script src="01-config.js?v=20260416g" defer></script>
+<script src="02-session.js?v=20260416g" defer></script>
+<script src="utils.js?v=20260416g" defer></script>
+<script src="12-profiles.js?v=20260416g" defer></script>
+<script src="03-auth.js?v=20260416g" defer></script>
+<script src="05-api.js?v=20260416g" defer></script>
+<script src="10-ui.js?v=20260416g" defer></script>
 
-<script src="06-post-create.js?v=20260416f" defer></script>
-<script defer src="render/dashboard.js?v=20260416f"></script>
-<script defer src="render/client.js?v=20260416f"></script>
-<script defer src="render/pipeline.js?v=20260416f"></script>
-<script defer src="render/brief.js?v=20260416f"></script>
-<script defer src="actions/pcs.js?v=20260416f"></script>
-<script defer src="actions/pcs-longpress.js?v=20260416f"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260416f"></script>
-<script src="ai-config.js?v=20260416f" defer></script>
-<script src="07-post-load.js?v=20260416f" defer></script>
-<script src="08-post-actions.js?v=20260416f" defer></script>
-<script src="09-library.js?v=20260416f" defer></script>
-<script src="09-approval.js?v=20260416f" defer></script>
-<script src="04-router.js?v=20260416f" defer></script>
+<script src="06-post-create.js?v=20260416g" defer></script>
+<script defer src="render/dashboard.js?v=20260416g"></script>
+<script defer src="render/client.js?v=20260416g"></script>
+<script defer src="render/pipeline.js?v=20260416g"></script>
+<script defer src="render/brief.js?v=20260416g"></script>
+<script defer src="actions/pcs.js?v=20260416g"></script>
+<script defer src="actions/pcs-longpress.js?v=20260416g"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260416g"></script>
+<script src="ai-config.js?v=20260416g" defer></script>
+<script src="07-post-load.js?v=20260416g" defer></script>
+<script src="08-post-actions.js?v=20260416g" defer></script>
+<script src="09-library.js?v=20260416g" defer></script>
+<script src="09-approval.js?v=20260416g" defer></script>
+<script src="04-router.js?v=20260416g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -8442,6 +8442,85 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   padding: 4px 4px 0;
 }
 
+/* Comment block (rewrite mode) */
+.cw-comments-block {
+  background: #201E1A;
+  border: 1px solid #3A3632;
+  border-radius: 12px;
+  padding: 12px;
+  margin-bottom: 4px;
+}
+.cw-comments-header {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #C15F3C;
+  margin-bottom: 10px;
+  font-weight: 600;
+}
+.cw-cmt-item {
+  padding: 8px 0;
+  border-bottom: 1px solid #2A2622;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.cw-cmt-item:last-of-type { border-bottom: none; }
+.cw-cmt-item.cw-cmt-hidden { display: none; }
+.cw-cmt-author {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.cw-cmt-client { color: #FF4B4B; }
+.cw-cmt-servicing { color: #22D3EE; }
+.cw-cmt-creative { color: #9b87f5; }
+.cw-cmt-admin { color: #C8A84B; }
+.cw-cmt-text {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  color: #B1ADA1;
+  line-height: 1.45;
+}
+.cw-cmt-more {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #C15F3C;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 10px 0 2px;
+  display: block;
+  width: 100%;
+}
+
+/* Stacked cost totals */
+.cw-tot {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+}
+.cw-tot-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7A7670;
+}
+.cw-tot-value {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  font-weight: 600;
+  color: #B1ADA1;
+  letter-spacing: 0.02em;
+}
+
 /* ═══════════════════════════════════════════════════════════
    PR 4 — Gmail import in New Post form (Admin only).
    Zero rgba() — 8-digit hex throughout, per CLAUDE.md §4.


### PR DESCRIPTION
## Summary
- **Fix 1**: Rewrite mode comments now show in a styled block with role-colored author labels (first 4 visible, rest behind "Show N more ↓"), above a clean "Rewrite the caption addressing the feedback above" user bubble. Full comment text still sent to Claude API unchanged.
- **Fix 2**: Cost meter in context bar now stacked layout (label on top, value below) with updated formatting — whole numbers ≥₹1, decimals <₹1, comma-separated ≥₹1,000.

## Files changed (3)
- `actions/pcs-claude-caption.js` — comment block builder, `_display` field for user messages, formatting updates
- `styles.css` — `.cw-comments-block`, `.cw-cmt-*`, `.cw-tot`, `.cw-tot-label`, `.cw-tot-value`
- `index.html` — stacked totals HTML structure + version bump `20260416f` → `20260416g` (24 strings)

## Test plan
- [x] `npx vitest run` — 544/544 passing
- [ ] Open PCS → "✦ Rewrite from comments" → workspace shows styled comment block with role colors, then clean user bubble
- [ ] Comments > 4 → "Show N more ↓" button reveals rest on tap
- [ ] Context bar shows "Today / ₹3" and "Month / ₹88" stacked

https://claude.ai/code/session_0156yc1bmx3YnnGmxuQGQa8D