### PR TITLE
Polish Reply: ✦ button for Claude comment rewriting

### DIFF
--- a/actions/pcs-polish.js
+++ b/actions/pcs-polish.js
@@ -1,0 +1,148 @@
+/* ═══════════════════════════════════════════════════════════════
+   pcs-polish.js — Polish Reply half-modal
+   Tap ✦ in the comment input bar to have Claude rewrite a draft
+   comment professionally before sending.
+   ═══════════════════════════════════════════════════════════════ */
+console.log('LOADED:', 'pcs-polish.js');
+
+window._polishState = {
+  isOpen: false,
+  rawText: '',
+  polishedText: '',
+  zone: null,
+  replyTo: null,
+  postId: null
+};
+
+window.openPolishModal = async function(zone) {
+  var st = window._polishState;
+  var inputId = zone === 'notes' ? 'pcs-note-input' : 'pcs-comment-input';
+  var input = document.getElementById(inputId);
+  if (!input || !input.value.trim()) return;
+
+  st.rawText = input.value.trim();
+  st.zone = zone;
+  st.polishedText = '';
+  st.isOpen = true;
+
+  var postIdEl = document.getElementById('pcs-post-id');
+  st.postId = postIdEl ? postIdEl.value : null;
+
+  var replyTagId = zone === 'notes' ? 'pcs-note-reply-tag' : 'pcs-client-reply-tag';
+  var replyNameId = zone === 'notes' ? 'pcs-note-reply-name' : 'pcs-client-reply-name';
+  var replyTag = document.getElementById(replyTagId);
+  var replyName = document.getElementById(replyNameId);
+  st.replyTo = (replyTag && replyTag.style.display !== 'none' && replyName && replyName.textContent)
+    ? { author: replyName.textContent }
+    : null;
+
+  var overlay = document.getElementById('pcs-polish-overlay');
+  if (!overlay) return;
+  overlay.style.display = 'block';
+
+  var rawEl = document.getElementById('polish-raw-text');
+  if (rawEl) rawEl.textContent = st.rawText;
+
+  var resultEl = document.getElementById('polish-result');
+  if (resultEl) resultEl.textContent = '';
+
+  var replyLabel = document.getElementById('polish-reply-label');
+  if (replyLabel) replyLabel.textContent = st.replyTo ? 'Replying to ' + st.replyTo.author : '';
+
+  var sendBtn = document.getElementById('polish-send');
+  if (sendBtn) { sendBtn.textContent = 'Polishing\u2026'; sendBtn.style.opacity = '0.4'; sendBtn.style.pointerEvents = 'none'; }
+
+  requestAnimationFrame(function() {
+    overlay.classList.add('open');
+  });
+
+  var prompt = 'Rewrite this comment reply professionally. Keep the exact same meaning and intent. Be direct, constructive, and brief. Do not add pleasantries or filler. Return ONLY the rewritten text, nothing else.';
+  if (st.replyTo) {
+    var replyToItem = _polishFindReplyComment(zone);
+    if (replyToItem) prompt += '\n\nComment being replied to: "' + replyToItem + '"';
+  }
+  prompt += '\n\nMy draft reply: "' + st.rawText + '"';
+
+  var messages = [{ role: 'user', content: prompt }];
+  var result = await _callSrtdAI('chat', messages, st.postId);
+
+  if (result && result.success) {
+    st.polishedText = (result.content || '').trim();
+  } else {
+    st.polishedText = st.rawText;
+  }
+
+  var resultEl2 = document.getElementById('polish-result');
+  if (resultEl2) resultEl2.textContent = st.polishedText;
+
+  var sendBtn2 = document.getElementById('polish-send');
+  if (sendBtn2) { sendBtn2.innerHTML = '&#x2726; Send reply'; sendBtn2.style.opacity = '1'; sendBtn2.style.pointerEvents = ''; }
+};
+
+function _polishFindReplyComment(zone) {
+  var listId = zone === 'notes' ? 'pcs-notes-list' : 'pcs-comments-list';
+  var list = document.getElementById(listId);
+  if (!list) return '';
+  var highlighted = list.querySelector('.pcs-comment-replying-to');
+  if (highlighted) {
+    var textEl = highlighted.querySelector('.pcs-comment-text');
+    if (textEl) return textEl.textContent.trim();
+  }
+  return '';
+}
+
+window.closePolishModal = function() {
+  var overlay = document.getElementById('pcs-polish-overlay');
+  if (!overlay) return;
+  overlay.classList.remove('open');
+  setTimeout(function() {
+    overlay.style.display = 'none';
+  }, 260);
+  window._polishState.isOpen = false;
+};
+
+window.undoPolish = function() {
+  window.closePolishModal();
+};
+
+window.sendPolished = function() {
+  var st = window._polishState;
+  var resultEl = document.getElementById('polish-result');
+  var finalText = resultEl ? resultEl.innerText.trim() : st.polishedText;
+  if (!finalText) return;
+
+  var inputId = st.zone === 'notes' ? 'pcs-note-input' : 'pcs-comment-input';
+  var input = document.getElementById(inputId);
+  if (input) input.value = finalText;
+
+  window.closePolishModal();
+
+  setTimeout(function() {
+    var sendId = st.zone === 'notes' ? 'pcs-send-btn-note' : 'pcs-send-btn-client';
+    var sendBtn = document.getElementById(sendId);
+    if (sendBtn) sendBtn.click();
+  }, 100);
+};
+
+(function _polishWireEvents() {
+  document.addEventListener('click', function(e) {
+    if (e.target && e.target.classList.contains('pcs-ibar-polish')) {
+      e.preventDefault();
+      e.stopPropagation();
+      window.openPolishModal(e.target.dataset.zone || 'client');
+      return;
+    }
+    if (e.target && e.target.id === 'polish-undo') {
+      window.undoPolish();
+      return;
+    }
+    if (e.target && e.target.id === 'polish-send') {
+      window.sendPolished();
+      return;
+    }
+    if (e.target && (e.target.id === 'pcs-polish-backdrop' || e.target.dataset.action === 'polish-close')) {
+      window.closePolishModal();
+      return;
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260416g">
+ <link rel="stylesheet" href="styles.css?v=20260416h">
 
 </head>
 <body>
@@ -1001,7 +1001,8 @@
               <button class="pcs-ibar-plus" onclick="window._pcsTogglePlusMenu(this,'client')">+</button>
             </div>
             <span class="pcs-reply-tag" id="pcs-client-reply-tag" style="display:none"><span id="pcs-client-reply-name"></span><button class="pcs-reply-tag-x" onclick="window._pcsClearReply('client')">&#x2715;</button></span>
-            <textarea id="pcs-comment-input" class="pcs-ibar-input" placeholder="Reply to client..." rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.45'"></textarea>
+            <textarea id="pcs-comment-input" class="pcs-ibar-input" placeholder="Reply to client..." rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.45';var pb=this.parentNode.querySelector('.pcs-ibar-polish');if(pb)pb.style.display=this.value.trim()?'flex':'none'"></textarea>
+            <button class="pcs-ibar-polish" style="display:none" data-zone="client">&#x2726;</button>
             <button id="pcs-send-btn-client" class="pcs-ibar-send" onclick="window.submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',false)">&#x2191;</button>
           </div>
           <div class="pcs-ibar-hint">Client + Agency · Visible to all</div>
@@ -1030,7 +1031,8 @@
               <button class="pcs-ibar-plus" onclick="window._pcsTogglePlusMenu(this,'note')">+</button>
             </div>
             <span class="pcs-reply-tag" id="pcs-note-reply-tag" style="display:none"><span id="pcs-note-reply-name"></span><button class="pcs-reply-tag-x" onclick="window._pcsClearReply('note')">&#x2715;</button></span>
-            <textarea id="pcs-note-input" class="pcs-ibar-input" placeholder="Add note... @mention" rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.45'"></textarea>
+            <textarea id="pcs-note-input" class="pcs-ibar-input" placeholder="Add note... @mention" rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.45';var pb=this.parentNode.querySelector('.pcs-ibar-polish');if(pb)pb.style.display=this.value.trim()?'flex':'none'"></textarea>
+            <button class="pcs-ibar-polish" style="display:none" data-zone="notes">&#x2726;</button>
             <button id="pcs-send-btn-note" class="pcs-ibar-send" onclick="submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-note-input')?document.getElementById('pcs-note-input').value:'',window._pcsNoteVisibility||'all',false,true)">&#x2191;</button>
           </div>
           <div class="pcs-ibar-hint">Agency only · Visibility set above</div>
@@ -1090,6 +1092,38 @@
           <button id="cw-send">&#x2191;</button>
         </div>
         <div id="cw-input-hint">Tap &#x2713; Use this to update your caption</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Polish Reply half-modal -->
+  <div id="pcs-polish-overlay" style="display:none;position:fixed;inset:0;z-index:9700">
+    <div id="pcs-polish-backdrop" data-action="polish-close" style="position:absolute;inset:0;background:#00000080"></div>
+    <div id="pcs-polish-modal">
+      <div class="polish-handle"><span></span></div>
+      <div class="polish-head">
+        <div class="polish-head-l">
+          <span class="polish-icon">&#x2726;</span>
+          <span class="polish-title">Polish reply</span>
+        </div>
+        <span class="polish-reply-to" id="polish-reply-label"></span>
+      </div>
+      <div class="polish-raw" id="polish-raw-block">
+        <div class="polish-raw-lbl">Your draft</div>
+        <div class="polish-raw-text" id="polish-raw-text"></div>
+      </div>
+      <div class="polish-arrow"><div class="polish-arrow-circle">&darr;</div></div>
+      <div class="polish-result-wrap" id="polish-result-wrap">
+        <div class="polish-result-lbl">&#x2726; Claude's version</div>
+        <div class="polish-result" id="polish-result" contenteditable="true"></div>
+        <div class="polish-result-hint">Tap to edit before sending</div>
+      </div>
+      <div class="polish-actions">
+        <div class="polish-btns">
+          <button class="polish-undo" id="polish-undo">Undo</button>
+          <button class="polish-send" id="polish-send">&#x2726; Send reply</button>
+        </div>
+        <div class="polish-hint">Polished by Claude &middot; editable &middot; client sees final version only</div>
       </div>
     </div>
   </div>
@@ -1202,30 +1236,31 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260416g"></script>
-<script src="00-appstate-compat.js?v=20260416g"></script>
-<script src="01-config.js?v=20260416g" defer></script>
-<script src="02-session.js?v=20260416g" defer></script>
-<script src="utils.js?v=20260416g" defer></script>
-<script src="12-profiles.js?v=20260416g" defer></script>
-<script src="03-auth.js?v=20260416g" defer></script>
-<script src="05-api.js?v=20260416g" defer></script>
-<script src="10-ui.js?v=20260416g" defer></script>
+<script src="00-appstate.js?v=20260416h"></script>
+<script src="00-appstate-compat.js?v=20260416h"></script>
+<script src="01-config.js?v=20260416h" defer></script>
+<script src="02-session.js?v=20260416h" defer></script>
+<script src="utils.js?v=20260416h" defer></script>
+<script src="12-profiles.js?v=20260416h" defer></script>
+<script src="03-auth.js?v=20260416h" defer></script>
+<script src="05-api.js?v=20260416h" defer></script>
+<script src="10-ui.js?v=20260416h" defer></script>
 
-<script src="06-post-create.js?v=20260416g" defer></script>
-<script defer src="render/dashboard.js?v=20260416g"></script>
-<script defer src="render/client.js?v=20260416g"></script>
-<script defer src="render/pipeline.js?v=20260416g"></script>
-<script defer src="render/brief.js?v=20260416g"></script>
-<script defer src="actions/pcs.js?v=20260416g"></script>
-<script defer src="actions/pcs-longpress.js?v=20260416g"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260416g"></script>
-<script src="ai-config.js?v=20260416g" defer></script>
-<script src="07-post-load.js?v=20260416g" defer></script>
-<script src="08-post-actions.js?v=20260416g" defer></script>
-<script src="09-library.js?v=20260416g" defer></script>
-<script src="09-approval.js?v=20260416g" defer></script>
-<script src="04-router.js?v=20260416g" defer></script>
+<script src="06-post-create.js?v=20260416h" defer></script>
+<script defer src="render/dashboard.js?v=20260416h"></script>
+<script defer src="render/client.js?v=20260416h"></script>
+<script defer src="render/pipeline.js?v=20260416h"></script>
+<script defer src="render/brief.js?v=20260416h"></script>
+<script defer src="actions/pcs.js?v=20260416h"></script>
+<script defer src="actions/pcs-longpress.js?v=20260416h"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260416h"></script>
+<script defer src="actions/pcs-polish.js?v=20260416h"></script>
+<script src="ai-config.js?v=20260416h" defer></script>
+<script src="07-post-load.js?v=20260416h" defer></script>
+<script src="08-post-actions.js?v=20260416h" defer></script>
+<script src="09-library.js?v=20260416h" defer></script>
+<script src="09-approval.js?v=20260416h" defer></script>
+<script src="04-router.js?v=20260416h" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -8522,6 +8522,221 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 /* ═══════════════════════════════════════════════════════════
+   Polish Reply half-modal
+   ═══════════════════════════════════════════════════════════ */
+#pcs-polish-modal {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  max-width: 480px;
+  margin: 0 auto;
+  background: #1A1816;
+  border-top: 1px solid #3A3632;
+  border-radius: 16px 16px 0 0;
+  display: flex;
+  flex-direction: column;
+  max-height: 68%;
+  transform: translateY(100%);
+  transition: transform 250ms ease;
+}
+#pcs-polish-overlay.open #pcs-polish-modal {
+  transform: translateY(0);
+}
+.polish-handle {
+  display: flex;
+  justify-content: center;
+  padding: 10px 0 4px;
+}
+.polish-handle span {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: #3A3632;
+}
+.polish-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 16px 14px;
+  border-bottom: 1px solid #3A3632;
+}
+.polish-head-l {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.polish-icon {
+  color: #C15F3C;
+  font-size: 14px;
+}
+.polish-title {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #C15F3C;
+  font-weight: 600;
+}
+.polish-reply-to {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #B1ADA1;
+}
+.polish-raw {
+  margin: 14px 16px 0;
+  padding: 10px 12px;
+  background: #252320;
+  border: 1px solid #3A3632;
+  border-radius: 10px;
+}
+.polish-raw-lbl {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 6px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #7A7670;
+  margin-bottom: 5px;
+}
+.polish-raw-text {
+  font-size: 13px;
+  color: #7A7670;
+  line-height: 1.4;
+  text-decoration: line-through;
+  text-decoration-color: #3A363280;
+}
+.polish-arrow {
+  display: flex;
+  justify-content: center;
+  padding: 8px 0;
+}
+.polish-arrow-circle {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #252320;
+  border: 1px solid #3A3632;
+  border-radius: 50%;
+  color: #C15F3C;
+  font-size: 13px;
+}
+.polish-result-wrap {
+  margin: 0 16px;
+  padding: 14px;
+  background: #201810;
+  border: 1px solid #5A3A2C;
+  border-radius: 12px;
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  scrollbar-width: none;
+}
+.polish-result-wrap::-webkit-scrollbar { display: none; }
+.polish-result-lbl {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #C15F3C;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+.polish-result {
+  font-size: 14px;
+  color: #F4F3EE;
+  line-height: 1.6;
+  outline: none;
+  cursor: text;
+  font-family: 'DM Sans', sans-serif;
+  letter-spacing: -0.005em;
+  min-height: 40px;
+}
+.polish-result:empty::before {
+  content: 'Polishing\2026';
+  color: #7A7670;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.polish-result-hint {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 6px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #7A7670;
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid #3A3632;
+}
+.polish-actions {
+  padding: 14px 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.polish-btns {
+  display: flex;
+  gap: 8px;
+}
+.polish-undo {
+  flex: 0 0 auto;
+  padding: 14px 18px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #B1ADA1;
+  background: #252320;
+  border: 1px solid #3A3632;
+  border-radius: 10px;
+  cursor: pointer;
+}
+.polish-send {
+  flex: 1;
+  padding: 14px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(180deg, #D46840 0%, #B85430 100%);
+  border: none;
+  border-radius: 10px;
+  text-align: center;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 #FFA06440;
+}
+.polish-hint {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 6px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7A7670;
+  text-align: center;
+}
+
+.pcs-ibar-polish {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid #5A3A2C;
+  background: linear-gradient(180deg, #2A1A12 0%, #1A0E08 100%);
+  color: #C15F3C;
+  font-size: 13px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+/* ═══════════════════════════════════════════════════════════
    PR 4 — Gmail import in New Post form (Admin only).
    Zero rgba() — 8-digit hex throughout, per CLAUDE.md §4.
    ═══════════════════════════════════════════════════════════ */


### PR DESCRIPTION
## Summary
- **New feature**: Tap ✦ in the comment input bar to have Claude rewrite your draft reply professionally before sending
- Half-modal slides up showing raw text (struck through) vs Claude's polished version (editable)
- "Send reply" puts polished text into the existing textarea and clicks the existing send button — zero new posting logic
- Works in both Client and Internal Notes input bars
- ✦ button appears only when textarea has text

## Files changed (3 + 1 new)
- `actions/pcs-polish.js` — **NEW** — polish modal state, open/close/undo/send, Worker call, event wiring
- `styles.css` — Polish modal CSS (warm Claude theme: `#1A1816` base, `#C15F3C` accents)
- `index.html` — Polish overlay HTML, ✦ buttons in both input pills, script tag, version bump `20260416g` → `20260416h` (25 strings)

## Test plan
- [x] `npx vitest run` — 544/544 passing
- [ ] Open PCS → Client tab → type a reply → ✦ button appears between textarea and send
- [ ] Tap ✦ → half-modal slides up with raw text struck through, "Polishing..." loading state
- [ ] Claude responds → editable polished text appears, "✦ Send reply" button activates
- [ ] Edit polished text → tap "✦ Send reply" → comment posts with polished text
- [ ] Tap "Undo" → modal closes, original text stays in textarea
- [ ] Same flow works in Internal Notes tab
- [ ] ✦ button hidden when textarea is empty

https://claude.ai/code/session_0156yc1bmx3YnnGmxuQGQa8D