### PR TITLE
Edit with Claude button + comment selection mode

### DIFF
--- a/actions/pcs-select.js
+++ b/actions/pcs-select.js
@@ -1,0 +1,216 @@
+/* ═══════════════════════════════════════════════════════════════
+   pcs-select.js — Comment selection mode for rewrite-with-context
+   Lets the user pick specific comments on the Client tab, then
+   opens the caption workspace in rewrite mode with those comments.
+   ═══════════════════════════════════════════════════════════════ */
+console.log('LOADED:', 'pcs-select.js');
+
+window._commentSelectMode = {
+  active: false,
+  selected: new Set()
+};
+
+window.enterCommentSelectMode = function() {
+  var st = window._commentSelectMode;
+  if (st.active) return;
+  st.active = true;
+  st.selected.clear();
+
+  var strip = document.getElementById('pcs-select-strip');
+  if (strip) {
+    strip.classList.add('pcs-ss-active');
+    var textEl = strip.querySelector('.pcs-ss-text');
+    if (textEl) {
+      var total = document.querySelectorAll('#pcs-comments-list .pcs-comment-item').length;
+      textEl.innerHTML = '<em>0</em> of ' + total + ' selected';
+    }
+  }
+
+  document.querySelectorAll('#pcs-comments-list .pcs-comment-item').forEach(function(item) {
+    if (item.querySelector('.pcs-sel-check')) return;
+    var check = document.createElement('div');
+    check.className = 'pcs-sel-check';
+    item.insertBefore(check, item.firstChild);
+    item.classList.add('pcs-sel-off');
+  });
+
+  var ibar = document.querySelector('#pcs-pane-client .pcs-ibar-wrap.client');
+  if (ibar) ibar.style.display = 'none';
+
+  var rwBar = document.getElementById('pcs-rewrite-bar');
+  if (rwBar) rwBar.style.display = 'block';
+};
+
+window.exitCommentSelectMode = function() {
+  var st = window._commentSelectMode;
+  st.active = false;
+  st.selected.clear();
+
+  var strip = document.getElementById('pcs-select-strip');
+  if (strip) {
+    strip.classList.remove('pcs-ss-active');
+    var textEl = strip.querySelector('.pcs-ss-text');
+    if (textEl) textEl.textContent = 'Select comments to rewrite caption';
+  }
+
+  document.querySelectorAll('#pcs-comments-list .pcs-sel-check').forEach(function(el) {
+    el.remove();
+  });
+  document.querySelectorAll('#pcs-comments-list .pcs-comment-item').forEach(function(item) {
+    item.classList.remove('pcs-sel-on', 'pcs-sel-off');
+  });
+
+  var rwBar = document.getElementById('pcs-rewrite-bar');
+  if (rwBar) rwBar.style.display = 'none';
+
+  var ibar = document.querySelector('#pcs-pane-client .pcs-ibar-wrap.client');
+  if (ibar) ibar.style.display = '';
+
+  var sendBtn = document.getElementById('pcs-rewrite-send');
+  if (sendBtn) { sendBtn.disabled = true; sendBtn.innerHTML = '&#x2726; Select comments first'; }
+};
+
+window.toggleCommentSelection = function(commentId) {
+  var st = window._commentSelectMode;
+  if (!st.active) return;
+
+  if (st.selected.has(commentId)) {
+    st.selected.delete(commentId);
+  } else {
+    st.selected.add(commentId);
+  }
+
+  document.querySelectorAll('#pcs-comments-list .pcs-comment-item').forEach(function(item) {
+    var cid = item.getAttribute('data-comment-id');
+    if (st.selected.has(cid)) {
+      item.classList.add('pcs-sel-on');
+      item.classList.remove('pcs-sel-off');
+    } else {
+      item.classList.remove('pcs-sel-on');
+      item.classList.add('pcs-sel-off');
+    }
+  });
+
+  window._updateSelectionCount();
+};
+
+window._updateSelectionCount = function() {
+  var st = window._commentSelectMode;
+  var count = st.selected.size;
+
+  var strip = document.getElementById('pcs-select-strip');
+  if (strip) {
+    var textEl = strip.querySelector('.pcs-ss-text');
+    if (textEl) {
+      var total = document.querySelectorAll('#pcs-comments-list .pcs-comment-item').length;
+      textEl.innerHTML = '<em>' + count + '</em> of ' + total + ' selected';
+    }
+  }
+
+  var sendBtn = document.getElementById('pcs-rewrite-send');
+  if (sendBtn) {
+    if (count > 0) {
+      sendBtn.disabled = false;
+      sendBtn.innerHTML = '&#x2726; Rewrite with ' + count + ' comment' + (count === 1 ? '' : 's');
+    } else {
+      sendBtn.disabled = true;
+      sendBtn.innerHTML = '&#x2726; Select comments first';
+    }
+  }
+};
+
+window.submitSelectedComments = function() {
+  var st = window._commentSelectMode;
+  if (st.selected.size === 0) return;
+
+  var post = window.AppState.pcs.post;
+  if (!post) return;
+
+  var allComments = post.post_comments || post._comments || [];
+  var selectedComments = [];
+  st.selected.forEach(function(cid) {
+    var c = allComments.find(function(x) { return x.id === cid; });
+    if (c) {
+      selectedComments.push({
+        author: c.author || 'Unknown',
+        role: c.author_role || 'client',
+        text: c.message || '',
+        created_at: c.created_at || ''
+      });
+    }
+  });
+
+  if (!selectedComments.length) {
+    document.querySelectorAll('#pcs-comments-list .pcs-comment-item').forEach(function(item) {
+      if (!st.selected.has(item.getAttribute('data-comment-id'))) return;
+      var textEl = item.querySelector('.pcs-comment-text');
+      var authorEl = item.querySelector('.pcs-comment-author');
+      if (textEl) {
+        selectedComments.push({
+          author: authorEl ? authorEl.textContent : 'Unknown',
+          role: 'client',
+          text: textEl.textContent.trim()
+        });
+      }
+    });
+  }
+
+  window.exitCommentSelectMode();
+
+  if (typeof openCaptionWorkspace === 'function') {
+    openCaptionWorkspace('rewrite', {
+      postId: post.post_id || post.id,
+      caption: post.caption,
+      title: post.title || '',
+      comments: selectedComments
+    });
+  }
+};
+
+// ─── strip visibility on tab switch / render ─────────────────
+
+window._updateSelectStripVisibility = function() {
+  var strip = document.getElementById('pcs-select-strip');
+  if (!strip) return;
+  var role = (window.AppState.user.effectiveRole || '').toLowerCase();
+  var aiEnabled = !!(window.AppState.workspace && window.AppState.workspace.ai_chat);
+  strip.style.display = (role === 'admin' || aiEnabled) ? 'flex' : 'none';
+};
+
+// ─── event wiring ────────────────────────────────────────────
+
+(function _selectWireEvents() {
+  document.addEventListener('click', function(e) {
+    var target = e.target;
+
+    if (target.closest && target.closest('[data-action="pcs-exit-select"]')) {
+      e.stopPropagation();
+      window.exitCommentSelectMode();
+      return;
+    }
+
+    if (target.closest && target.closest('[data-action="pcs-enter-select"]')) {
+      if (window._commentSelectMode.active) return;
+      e.stopPropagation();
+      window.enterCommentSelectMode();
+      return;
+    }
+
+    if (target.id === 'pcs-rewrite-send') {
+      e.stopPropagation();
+      window.submitSelectedComments();
+      return;
+    }
+
+    if (window._commentSelectMode.active) {
+      var commentItem = target.closest && target.closest('.pcs-comment-item');
+      if (commentItem && commentItem.closest('#pcs-comments-list')) {
+        e.stopPropagation();
+        e.preventDefault();
+        var cid = commentItem.getAttribute('data-comment-id');
+        if (cid) window.toggleCommentSelection(cid);
+        return;
+      }
+    }
+  }, true);
+})();

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -309,7 +309,7 @@ function _pcsBuildAiZoneHtml(rawId, commentCount) {
         '</div>' +
       '</div>'
     : '') +
-    // Primary button: "Continue conversation" if session exists, else "Rewrite from comments"
+    // Single "Edit with Claude" / "Continue conversation" entry point
     (function() {
       var _ws = window._captionWS;
       var _hasSession = _ws && _ws.messages && _ws.messages.length > 0 && _ws.postId === rawId;
@@ -320,65 +320,24 @@ function _pcsBuildAiZoneHtml(rawId, commentCount) {
           if (_ws.messages[_mi].role === 'assistant') { _lastDraft = _ws.messages[_mi].content || ''; break; }
         }
         var _preview = _lastDraft.length > 30 ? _lastDraft.slice(0, 30) + '\u2026' : _lastDraft;
-        return '<button class="pcs-rewrite-btn" id="pcs-rewrite-btn-' + id + '" onclick="window.openCaptionWorkspace(\'resume\',{postId:\'' + id + '\',title:getTitle(getPostById(\'' + id + '\'))})">' +
-          '<div class="pcs-rw-icon">' + ICON_SPARK + '</div>' +
-          '<div class="pcs-rw-text">' +
-            '<div class="pcs-rw-title">\u2726 Continue conversation</div>' +
-            '<div class="pcs-rw-sub">Draft ' + _draftCount + ' \u00B7 ' + esc(_preview) + '</div>' +
+        return '<div class="pcs-claude-entry" onclick="window.openCaptionWorkspace(\'resume\',{postId:\'' + id + '\',title:getTitle(getPostById(\'' + id + '\'))})">' +
+          '<div class="pcs-ce-icon">\u2726</div>' +
+          '<div class="pcs-ce-text">' +
+            '<div class="pcs-ce-title">Continue conversation</div>' +
+            '<div class="pcs-ce-sub">Draft ' + _draftCount + ' \u00B7 ' + esc(_preview) + '</div>' +
           '</div>' +
-          '<span class="pcs-rw-arr">\u2192</span>' +
-        '</button>';
+          '<span class="pcs-ce-arr">\u2192</span>' +
+        '</div>';
       }
-      return '<button class="pcs-rewrite-btn" id="pcs-rewrite-btn-' + id + '" onclick="window._pcsRewriteFromComments(\'' + id + '\')">' +
-        '<div class="pcs-rw-icon">' + ICON_SPARK + '</div>' +
-        '<div class="pcs-rw-text">' +
-          '<div class="pcs-rw-title">\u2726 Rewrite from comments</div>' +
-          '<div class="pcs-rw-sub">' + commentCount + ' comment' + (commentCount === 1 ? '' : 's') + ' on this post</div>' +
+      return '<div class="pcs-claude-entry" onclick="window.openCaptionWorkspace(\'chat\',{postId:\'' + id + '\',caption:(getPostById(\'' + id + '\')||{}).caption||\'\',title:getTitle(getPostById(\'' + id + '\'))})">' +
+        '<div class="pcs-ce-icon">\u2726</div>' +
+        '<div class="pcs-ce-text">' +
+          '<div class="pcs-ce-title">Edit with Claude</div>' +
+          '<div class="pcs-ce-sub">Open workspace with this caption</div>' +
         '</div>' +
-        '<span class="pcs-rw-arr">\u2192</span>' +
-      '</button>';
+        '<span class="pcs-ce-arr">\u2192</span>' +
+      '</div>';
     })() +
-    // Rewrite result panel (hidden by default, expands inline)
-    '<div class="pcs-rewrite-result" id="pcs-rewrite-result-' + id + '">' +
-      '<div class="pcs-rwr-flags"></div>' +
-      '<div class="pcs-rwr-sep"></div>' +
-      '<div class="pcs-rwr-caption"></div>' +
-      '<div class="pcs-rwr-actions">' +
-        '<button class="pcs-rwr-apply" onclick="window._pcsApplyRewrite(\'' + id + '\')">Apply to caption</button>' +
-        '<button class="pcs-rwr-btn" onclick="window._pcsOpenRefine(\'' + id + '\')">Refine</button>' +
-        '<button class="pcs-rwr-btn-close" onclick="window._pcsDismissRewrite(\'' + id + '\')" aria-label="Dismiss">\u2715</button>' +
-      '</div>' +
-      '<div class="pcs-refine-wrap" id="pcs-refine-wrap-' + id + '">' +
-        '<div class="pcs-refine-row">' +
-          '<input class="pcs-refine-input" id="pcs-refine-input-' + id + '" type="text" placeholder="Tell Claude what to change...">' +
-          '<button class="pcs-refine-send" onclick="window._pcsRefineSend(\'' + id + '\')">Send</button>' +
-        '</div>' +
-        '<button class="pcs-refine-cancel" onclick="window._pcsRefineCancel(\'' + id + '\')">\u2715 Cancel</button>' +
-      '</div>' +
-    '</div>' +
-    // Secondary button: "Start fresh" if session exists, else "Write fresh options"
-    (function() {
-      var _ws2 = window._captionWS;
-      var _hasSession2 = _ws2 && _ws2.messages && _ws2.messages.length > 0 && _ws2.postId === rawId;
-      if (_hasSession2) {
-        return '<button class="pcs-write-btn" id="pcs-write-btn-' + id + '" onclick="window._captionWS.messages=[];window._captionWS.sessionCost=0;window._pcsAiWrite(\'' + id + '\')">' +
-          '<div class="pcs-rw-icon pcs-rw-icon--dim">' + ICON_SPARK + '</div>' +
-          '<div class="pcs-rw-text">' +
-            '<div class="pcs-rw-title pcs-rw-title--dim">\u2726 Start fresh</div>' +
-          '</div>' +
-          '<span class="pcs-rw-arr">\u2192</span>' +
-        '</button>';
-      }
-      return '<button class="pcs-write-btn" id="pcs-write-btn-' + id + '" onclick="window._pcsAiWrite(\'' + id + '\')">' +
-        '<div class="pcs-rw-icon pcs-rw-icon--dim">' + ICON_SPARK + '</div>' +
-        '<div class="pcs-rw-text">' +
-          '<div class="pcs-rw-title pcs-rw-title--dim">\u2726 Write fresh options</div>' +
-        '</div>' +
-        '<span class="pcs-rw-arr">\u2192</span>' +
-      '</button>';
-    })() +
-    // Write options panel (populated lazily by _pcsAiWrite)
-    '<div class="pcs-write-opts" id="pcs-write-opts-' + id + '"></div>' +
   '</div>';
 }
 
@@ -812,6 +771,8 @@ window._pcsTabSwitch = function(tab) {
   if (pCaption) pCaption.style.display = tab === 'caption' ? '' : 'none';
   if (pClient) pClient.style.display = tab === 'client' ? '' : 'none';
   if (pInternal) pInternal.style.display = tab === 'internal' ? '' : 'none';
+  if (tab === 'client' && typeof _updateSelectStripVisibility === 'function') _updateSelectStripVisibility();
+  if (tab !== 'client' && typeof exitCommentSelectMode === 'function' && window._commentSelectMode && window._commentSelectMode.active) exitCommentSelectMode();
 }
 
 // -- Photo grid builder (LinkedIn style, responsive to count) --

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260416h">
+ <link rel="stylesheet" href="styles.css?v=20260416i">
 
 </head>
 <body>
@@ -992,6 +992,14 @@
       <!-- Tab pane: Client -->
       <div id="pcs-pane-client" class="pcs-tab-pane" style="display:none;flex:1;flex-direction:column;overflow:hidden">
         <span id="pcs-comments-count" style="display:none">0</span>
+        <div id="pcs-select-strip" class="pcs-select-strip" style="display:none" data-action="pcs-enter-select">
+          <div class="pcs-ss-left">
+            <span class="pcs-ss-icon">&#x2726;</span>
+            <span class="pcs-ss-text">Select comments to rewrite caption</span>
+          </div>
+          <span class="pcs-ss-arr">&rarr;</span>
+          <button class="pcs-ss-cancel" data-action="pcs-exit-select">Cancel</button>
+        </div>
         <div id="pcs-comments-list" style="flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:12px 16px;scrollbar-width:none;min-height:0"></div>
         <div class="pcs-ibar-wrap client">
           <div id="pcs-client-img-previews"></div>
@@ -1008,6 +1016,10 @@
           <div class="pcs-ibar-hint">Client + Agency · Visible to all</div>
           <input type="file" id="pcs-client-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg&&_pcsHandleCommentImg('client')">
           <button id="pcs-task-btn-client" style="display:none" onclick="window.submitPcsComment&&submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',true,false)"></button>
+        </div>
+        <div id="pcs-rewrite-bar" class="pcs-rewrite-bar">
+          <button id="pcs-rewrite-send" class="pcs-rw-send" disabled>&#x2726; Select comments first</button>
+          <div class="pcs-rw-hint">Selected comments become Claude's context</div>
         </div>
       </div>
 
@@ -1236,31 +1248,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260416h"></script>
-<script src="00-appstate-compat.js?v=20260416h"></script>
-<script src="01-config.js?v=20260416h" defer></script>
-<script src="02-session.js?v=20260416h" defer></script>
-<script src="utils.js?v=20260416h" defer></script>
-<script src="12-profiles.js?v=20260416h" defer></script>
-<script src="03-auth.js?v=20260416h" defer></script>
-<script src="05-api.js?v=20260416h" defer></script>
-<script src="10-ui.js?v=20260416h" defer></script>
+<script src="00-appstate.js?v=20260416i"></script>
+<script src="00-appstate-compat.js?v=20260416i"></script>
+<script src="01-config.js?v=20260416i" defer></script>
+<script src="02-session.js?v=20260416i" defer></script>
+<script src="utils.js?v=20260416i" defer></script>
+<script src="12-profiles.js?v=20260416i" defer></script>
+<script src="03-auth.js?v=20260416i" defer></script>
+<script src="05-api.js?v=20260416i" defer></script>
+<script src="10-ui.js?v=20260416i" defer></script>
 
-<script src="06-post-create.js?v=20260416h" defer></script>
-<script defer src="render/dashboard.js?v=20260416h"></script>
-<script defer src="render/client.js?v=20260416h"></script>
-<script defer src="render/pipeline.js?v=20260416h"></script>
-<script defer src="render/brief.js?v=20260416h"></script>
-<script defer src="actions/pcs.js?v=20260416h"></script>
-<script defer src="actions/pcs-longpress.js?v=20260416h"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260416h"></script>
-<script defer src="actions/pcs-polish.js?v=20260416h"></script>
-<script src="ai-config.js?v=20260416h" defer></script>
-<script src="07-post-load.js?v=20260416h" defer></script>
-<script src="08-post-actions.js?v=20260416h" defer></script>
-<script src="09-library.js?v=20260416h" defer></script>
-<script src="09-approval.js?v=20260416h" defer></script>
-<script src="04-router.js?v=20260416h" defer></script>
+<script src="06-post-create.js?v=20260416i" defer></script>
+<script defer src="render/dashboard.js?v=20260416i"></script>
+<script defer src="render/client.js?v=20260416i"></script>
+<script defer src="render/pipeline.js?v=20260416i"></script>
+<script defer src="render/brief.js?v=20260416i"></script>
+<script defer src="actions/pcs.js?v=20260416i"></script>
+<script defer src="actions/pcs-longpress.js?v=20260416i"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260416i"></script>
+<script defer src="actions/pcs-polish.js?v=20260416i"></script>
+<script defer src="actions/pcs-select.js?v=20260416i"></script>
+<script src="ai-config.js?v=20260416i" defer></script>
+<script src="07-post-load.js?v=20260416i" defer></script>
+<script src="08-post-actions.js?v=20260416i" defer></script>
+<script src="09-library.js?v=20260416i" defer></script>
+<script src="09-approval.js?v=20260416i" defer></script>
+<script src="04-router.js?v=20260416i" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -8736,6 +8736,175 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   cursor: pointer;
 }
 
+/* "Edit with Claude" entry button (caption tab) */
+.pcs-claude-entry {
+  margin: 6px 16px 8px;
+  padding: 14px;
+  background: linear-gradient(180deg, #1E1610 0%, #120C08 100%);
+  border: 1px solid #5A3A2C;
+  border-left: 3px solid #C15F3C;
+  border-radius: 0 10px 10px 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.pcs-claude-entry:active { background: #2A1A10; }
+.pcs-ce-icon {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2A1A12;
+  border: 1px solid #5A3A2C;
+  border-radius: 8px;
+  color: #C15F3C;
+  font-size: 15px;
+  flex-shrink: 0;
+}
+.pcs-ce-text { flex: 1; }
+.pcs-ce-title {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #C15F3C;
+  font-weight: 600;
+}
+.pcs-ce-sub {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 11px;
+  color: #7A7670;
+  margin-top: 2px;
+}
+.pcs-ce-arr {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px;
+  color: #5A3A2C;
+}
+
+/* Comment selection strip + mode (client tab) */
+.pcs-select-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: linear-gradient(180deg, #1E1610 0%, #0A0804 100%);
+  border-bottom: 1px solid #3A2E14;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.pcs-select-strip:active { background: #2A1A10; }
+.pcs-ss-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.pcs-ss-icon { color: #C15F3C; font-size: 12px; }
+.pcs-ss-text {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #C15F3C;
+  font-weight: 600;
+}
+.pcs-ss-arr {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: #5A3A2C;
+}
+.pcs-select-strip.pcs-ss-active {
+  cursor: default;
+}
+.pcs-select-strip.pcs-ss-active .pcs-ss-text {
+  color: #B8B8C0;
+}
+.pcs-select-strip.pcs-ss-active .pcs-ss-text em {
+  color: #C15F3C;
+  font-style: normal;
+  font-weight: 700;
+}
+.pcs-ss-cancel {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8E8E93;
+  background: none;
+  border: 1px solid #2A2A35;
+  padding: 5px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: none;
+}
+.pcs-ss-active .pcs-ss-cancel { display: block; }
+.pcs-ss-active .pcs-ss-arr { display: none; }
+
+.pcs-sel-check {
+  width: 22px;
+  height: 22px;
+  border: 1.5px solid #5A3A2C;
+  border-radius: 5px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 4px;
+  margin-top: 2px;
+  cursor: pointer;
+}
+.pcs-sel-on .pcs-sel-check {
+  background: #C15F3C;
+  border-color: #C15F3C;
+}
+.pcs-sel-on .pcs-sel-check::after {
+  content: '\2713';
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+}
+.pcs-sel-on { background: #1A1208; }
+.pcs-sel-off { opacity: 0.35; }
+
+.pcs-rewrite-bar {
+  display: none;
+  flex-shrink: 0;
+  padding: 10px 14px 14px;
+  background: #000;
+  border-top: 1px solid #3A2E14;
+}
+.pcs-rw-send {
+  width: 100%;
+  padding: 14px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(180deg, #D46840 0%, #B85430 100%);
+  border: none;
+  border-radius: 8px;
+  text-align: center;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 #FFA06440;
+}
+.pcs-rw-send:disabled {
+  opacity: 0.3;
+  pointer-events: none;
+}
+.pcs-rw-hint {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 6px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4A4640;
+  text-align: center;
+  padding: 6px 4px 0;
+}
+
 /* ═══════════════════════════════════════════════════════════
    PR 4 — Gmail import in New Post form (Admin only).
    Zero rgba() — 8-digit hex throughout, per CLAUDE.md §4.


### PR DESCRIPTION
## Summary
- **Change 1**: AI zone on caption tab replaced with single "Edit with Claude" entry button (terracotta left-border accent). Shows "Continue conversation" with draft preview when a workspace session exists. Dots menu (QC Brand Guide, Ask Claude) preserved.
- **Change 2**: Client tab gains a selection strip for picking specific comments as Claude rewrite context. Enter selection mode → checkboxes on comments → tap to select → "✦ Rewrite with N comments" opens caption workspace in rewrite mode with only selected comments.

## Files changed (4 + 1 new)
- `actions/pcs-select.js` — **NEW** — selection mode state, enter/exit/toggle/submit, strip visibility, event wiring
- `actions/pcs.js` — `_pcsBuildAiZoneHtml` replaced two-button layout with single `.pcs-claude-entry`; tab switch wires strip visibility + exits selection on tab change
- `styles.css` — `.pcs-claude-entry`, `.pcs-select-strip`, `.pcs-sel-check`, `.pcs-rewrite-bar` + all selection mode classes
- `index.html` — selection strip + rewrite bar HTML in client pane, script tag, version bump `20260416h` → `20260416i` (26 strings)

## Test plan
- [x] `npx vitest run` — 544/544 passing
- [ ] Open PCS → Caption tab → single "Edit with Claude" button visible instead of two buttons
- [ ] Tap it → workspace opens in chat mode with current caption
- [ ] Close workspace, reopen PCS → "Continue conversation" shows with draft preview
- [ ] Client tab → selection strip visible (admin role)
- [ ] Tap strip → checkboxes appear on comments, input bar hidden, rewrite bar shown
- [ ] Select 3 comments → "✦ Rewrite with 3 comments" button activates
- [ ] Tap rewrite → exits selection, opens workspace in rewrite mode with those 3 comments
- [ ] Cancel → exits selection, restores normal comment interactions
- [ ] Switch tabs while in selection mode → auto-exits

https://claude.ai/code/session_0156yc1bmx3YnnGmxuQGQa8D