### PR TITLE
Admin guard + AI zone polish + AI memory edit corrections

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -180,6 +180,15 @@ function _cwRenderThread() {
   var html = '';
   var draftNum = 0;
 
+  var post = ws.postId ? (window.AppState.posts.all || []).find(function(p) { return (p.post_id || p.id) === ws.postId; }) : null;
+  var captionText = post ? post.caption : '';
+  html += '<div class="cw-caption-block">' +
+    '<div class="cw-caption-lbl">Current caption</div>' +
+    (captionText
+      ? '<div class="cw-caption-text">' + _cwEsc(captionText) + '</div>'
+      : '<div class="cw-caption-text empty">No caption yet</div>') +
+  '</div>';
+
   var commentsRendered = false;
   for (var i = 0; i < ws.messages.length; i++) {
     var m = ws.messages[i];
@@ -373,6 +382,17 @@ async function _cwFetchCostTotals() {
     }
     if (e.target && e.target.id === 'cw-back') {
       window.closeCaptionWorkspace();
+    }
+    if (e.target && e.target.dataset && e.target.dataset.action === 'cw-qc') {
+      var ws = window._captionWS;
+      var post = ws.postId ? (window.AppState.posts.all || []).find(function(p) { return (p.post_id || p.id) === ws.postId; }) : null;
+      var cap = post ? post.caption : '';
+      if (!cap) { if (typeof showToast === 'function') showToast('No caption to QC', 'error'); return; }
+      window.sendCaptionMessage('QC this LinkedIn caption against the brand guide. Caption:\n\n' + cap + '\n\nReturn a structured verdict with PASS or FLAG for each check.');
+    }
+    if (e.target && e.target.dataset && e.target.dataset.action === 'cw-ask') {
+      var cwInput = document.getElementById('cw-input');
+      if (cwInput) cwInput.focus();
     }
   });
   document.addEventListener('keydown', function(e) {

--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -11,7 +11,8 @@ window._captionWS = {
   sessionCost: 0,
   postId: null,
   mode: null,
-  _rewriteComments: null
+  _rewriteComments: null,
+  correctionsPrompt: ''
 };
 
 var _CW_USD_TO_INR = 100;
@@ -58,6 +59,7 @@ window.openCaptionWorkspace = async function(mode, context) {
 
   _cwUpdateSessionMeter();
   _cwFetchCostTotals();
+  if (!isResume) _cwLoadCorrections();
   _cwRenderThread();
 
   if (!isResume) {
@@ -78,7 +80,11 @@ window.openCaptionWorkspace = async function(mode, context) {
       var thread = document.getElementById('cw-thread');
       if (thread) { thread.insertAdjacentHTML('beforeend', _cwTypingHtml()); _cwScrollToBottom(); }
       var featureTag = 'chat';
-      var result = await _callSrtdAI(featureTag, ws.messages.map(function(m) { return { role: m.role, content: m.content }; }), ws.postId);
+      var rwApiMsgs = ws.messages.map(function(m) { return { role: m.role, content: m.content }; });
+      if (ws.correctionsPrompt && rwApiMsgs.length > 0) {
+        rwApiMsgs[0] = { role: rwApiMsgs[0].role, content: rwApiMsgs[0].content + ws.correctionsPrompt };
+      }
+      var result = await _callSrtdAI(featureTag, rwApiMsgs, ws.postId);
       var typingEl = thread && thread.querySelector('.cw-typing');
       if (typingEl) typingEl.remove();
       if (result && result.success) {
@@ -152,7 +158,12 @@ window.sendCaptionMessage = async function(text) {
 
   var featureTag = ws.mode === 'qc' ? 'qc' : ws.mode === 'write' ? 'writer' : 'chat';
 
-  var result = await _callSrtdAI(featureTag, ws.messages, ws.postId);
+  var apiMessages = ws.messages.map(function(m) { return { role: m.role, content: m.content }; });
+  if (ws.correctionsPrompt && apiMessages.length > 0) {
+    apiMessages[0] = { role: apiMessages[0].role, content: apiMessages[0].content + ws.correctionsPrompt };
+  }
+
+  var result = await _callSrtdAI(featureTag, apiMessages, ws.postId);
 
   var typingEl = thread && thread.querySelector('.cw-typing');
   if (typingEl) typingEl.remove();
@@ -211,7 +222,8 @@ function _cwRenderThread() {
             costLabel +
           '</div>' +
           '<div class="cw-draft-body" ' + (isLatest ? 'contenteditable="true"' : '') +
-            ' data-draft="' + draftNum + '">' +
+            ' data-draft="' + draftNum + '"' +
+            ' data-original="' + _cwEsc(m.content).replace(/"/g, '&quot;') + '">' +
             _cwEsc(m.content).replace(/\n/g, '<br>') +
           '</div>' +
           (isLatest
@@ -285,9 +297,16 @@ function _cwBuildCommentsBlock(comments) {
 
 window._cwHandleChip = function(chipType, draftNum) {
   if (chipType === 'use') {
-    var drafts = document.querySelectorAll('.cw-draft-body[data-draft="' + draftNum + '"]');
-    var text = drafts.length ? drafts[drafts.length - 1].innerText.trim() : '';
-    if (text) window._cwApplyDraft(text);
+    var draftEl = document.querySelector('.cw-draft-body[data-draft="' + draftNum + '"][contenteditable="true"]');
+    if (!draftEl) {
+      var allDrafts = document.querySelectorAll('.cw-draft-body[data-draft="' + draftNum + '"]');
+      draftEl = allDrafts.length ? allDrafts[allDrafts.length - 1] : null;
+    }
+    var text = draftEl ? draftEl.innerText.trim() : '';
+    if (!text) return;
+    var original = draftEl ? (draftEl.getAttribute('data-original') || '') : '';
+    _cwCaptureCorrection(original, text);
+    window._cwApplyDraft(text);
     return;
   }
   var label = chipType.charAt(0).toUpperCase() + chipType.slice(1);
@@ -333,6 +352,85 @@ window._cwApplyDraft = async function(text) {
     if (typeof showToast === 'function') showToast('Failed to update caption', 'error');
   }
 };
+
+// ─── AI memory: edit correction capture ─────────────────
+
+function _cwNormalize(s) {
+  return (s || '').trim().replace(/\s+/g, ' ');
+}
+
+function _cwCharDiff(a, b) {
+  var count = 0;
+  var len = Math.max(a.length, b.length);
+  for (var i = 0; i < len; i++) {
+    if (a.charAt(i) !== b.charAt(i)) count++;
+  }
+  return count + Math.abs(a.length - b.length);
+}
+
+function _cwCaptureCorrection(original, edited) {
+  try {
+    var normOrig = _cwNormalize(original);
+    var normEdit = _cwNormalize(edited);
+    if (normOrig === normEdit) return;
+    if (normEdit.length < 10) return;
+    if (_cwCharDiff(normOrig, normEdit) < 5) return;
+
+    var payload = {
+      workspace_id: 'default',
+      type: 'edit_correction',
+      content: JSON.stringify({
+        original: original.slice(0, 500),
+        edited: edited.slice(0, 500)
+      }),
+      post_id: window._captionWS.postId || null
+    };
+
+    apiFetch('/ai_memory', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Prefer': 'return=minimal' },
+      body: JSON.stringify(payload)
+    }).catch(function(err) {
+      console.warn('[cw] correction save failed:', err && err.message);
+    });
+  } catch (e) {
+    console.warn('[cw] correction capture error:', e && e.message);
+  }
+}
+
+// ─── AI memory: load corrections into prompt ────────────
+
+async function _cwLoadCorrections() {
+  try {
+    var rows = await apiFetch(
+      '/ai_memory?type=eq.edit_correction&workspace_id=eq.default&order=created_at.desc&limit=10&select=content'
+    );
+    if (!Array.isArray(rows) || rows.length === 0) {
+      window._captionWS.correctionsPrompt = '';
+      return;
+    }
+    var lines = [];
+    rows.forEach(function(r) {
+      try {
+        var c = typeof r.content === 'string' ? JSON.parse(r.content) : r.content;
+        if (c && c.original && c.edited) {
+          var origPreview = c.original.length > 100 ? c.original.slice(0, 100) + '...' : c.original;
+          var editPreview = c.edited.length > 100 ? c.edited.slice(0, 100) + '...' : c.edited;
+          lines.push('- User changed: "' + origPreview + '" \u2192 "' + editPreview + '"');
+        }
+      } catch (_) {}
+    });
+    if (lines.length > 0) {
+      window._captionWS.correctionsPrompt =
+        '\n\nSTYLE CORRECTIONS FROM THIS USER (apply these patterns to all future drafts):\n' +
+        lines.join('\n');
+    } else {
+      window._captionWS.correctionsPrompt = '';
+    }
+  } catch (e) {
+    window._captionWS.correctionsPrompt = '';
+  }
+}
 
 // ─── cost totals ─────────────────────────────────────────────
 

--- a/actions/pcs-select.js
+++ b/actions/pcs-select.js
@@ -173,8 +173,7 @@ window._updateSelectStripVisibility = function() {
   var strip = document.getElementById('pcs-select-strip');
   if (!strip) return;
   var role = (window.AppState.user.effectiveRole || '').toLowerCase();
-  var aiEnabled = !!(window.AppState.workspace && window.AppState.workspace.ai_chat);
-  strip.style.display = (role === 'admin' || aiEnabled) ? 'flex' : 'none';
+  strip.style.display = (role === 'admin') ? 'flex' : 'none';
 };
 
 // ─── event wiring ────────────────────────────────────────────

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -248,67 +248,8 @@ window._pcsAiChat = async function(id) {
 
 function _pcsBuildAiZoneHtml(rawId, commentCount) {
   var id = esc(rawId);
-  var showQC = !!(window.AppState.workspace && window.AppState.workspace.ai_qc);
-  var showChat = !!(window.AppState.workspace && window.AppState.workspace.ai_chat);
-
-  var ICON_QC = '<svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>';
-  var ICON_CHAT = '<svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>';
-  var ICON_SPARK = '<svg viewBox="0 0 24 24" stroke-linejoin="round" stroke-linecap="round"><path d="M12 2l2 7 7 2-7 2-2 7-2-7-7-2 7-2z"/></svg>';
-
-  var dotsMenuHtml = '';
-  if (showQC) {
-    dotsMenuHtml += '<div class="pcs-dots-menu-item" onclick="window._pcsOpenQcSheet(\'' + id + '\')">' +
-      ICON_QC +
-      '<span class="pcs-dots-menu-item-lbl">QC Brand Guide</span>' +
-    '</div>';
-  }
-  if (showChat) {
-    dotsMenuHtml += '<div class="pcs-dots-menu-item" onclick="window._pcsOpenChatSheet(\'' + id + '\')">' +
-      ICON_CHAT +
-      '<span class="pcs-dots-menu-item-lbl">Ask Claude</span>' +
-    '</div>';
-  }
 
   return '<div class="pcs-zone-ai" id="pcs-zone-ai-' + id + '">' +
-    // Header row
-    '<div class="pcs-zone-ai-header">' +
-      '<span class="pcs-zone-ai-label">\u2726 AI</span>' +
-      '<div class="pcs-zone-ai-dots-wrap">' +
-        '<button class="pcs-zone-ai-dots" onclick="window._pcsToggleDotsMenu(\'' + id + '\')" aria-label="AI menu">' +
-          '<span></span><span></span><span></span>' +
-        '</button>' +
-        '<div class="pcs-dots-menu" id="pcs-dots-menu-' + id + '">' +
-          dotsMenuHtml +
-        '</div>' +
-      '</div>' +
-    '</div>' +
-    // QC sheet (hidden by default; slides in from dots menu)
-    (showQC ?
-      '<div class="pcs-qc-sheet" id="pcs-qc-sheet-' + id + '">' +
-        '<div class="pcs-qc-sheet-row">' +
-          '<button class="pcs-qc-sheet-btn" onclick="window._pcsRunQC(\'' + id + '\', this)">' +
-            '<div class="pcs-qc-sheet-text">' +
-              '<div class="pcs-qc-lbl">QC against Brand Guide</div>' +
-              '<div class="pcs-qc-sub">Check tone, voice and brand language</div>' +
-            '</div>' +
-            '<span class="pcs-qc-arr">\u2192</span>' +
-          '</button>' +
-          '<button class="pcs-qc-sheet-close" onclick="window._pcsCloseQcSheet(\'' + id + '\')" aria-label="Close">\u2715</button>' +
-        '</div>' +
-        '<div class="pcs-qc-result" id="pcs-qc-result-' + id + '" style="display:none"></div>' +
-      '</div>'
-    : '') +
-    // Chat sheet (hidden by default; slides in from dots menu)
-    (showChat ?
-      '<div class="pcs-chat-sheet" id="pcs-chat-sheet-' + id + '">' +
-        '<div class="pcs-chat-thread" id="pcs-chat-thread-' + id + '"></div>' +
-        '<div class="pcs-chat-row">' +
-          '<input class="pcs-chat-input" id="pcs-chat-input-' + id + '" type="text" placeholder="Rewrite, shorten, add a hook...">' +
-          '<button class="pcs-chat-send" onclick="window._pcsAiChat(\'' + id + '\')">Send</button>' +
-          '<button class="pcs-chat-sheet-close" onclick="window._pcsCloseChatSheet(\'' + id + '\')" aria-label="Close">\u2715</button>' +
-        '</div>' +
-      '</div>'
-    : '') +
     // Single "Edit with Claude" / "Continue conversation" entry point
     (function() {
       var _ws = window._captionWS;
@@ -341,61 +282,12 @@ function _pcsBuildAiZoneHtml(rawId, commentCount) {
   '</div>';
 }
 
-// --- Dots menu (open/close + outside-click) ---
-window._pcsToggleDotsMenu = function(id) {
-  var menu = document.getElementById('pcs-dots-menu-' + id);
-  if (!menu) return;
-  var isOpen = menu.classList.contains('open');
-  // Always close any open menus first
-  document.querySelectorAll('.pcs-dots-menu.open').forEach(function(m) { m.classList.remove('open'); });
-  if (!isOpen) {
-    menu.classList.add('open');
-    // Install a one-shot outside-click handler (deferred so the click
-    // that opened the menu does not immediately close it)
-    setTimeout(function() {
-      var handler = function(e) {
-        if (!menu.contains(e.target) && !e.target.closest('.pcs-zone-ai-dots')) {
-          menu.classList.remove('open');
-          document.removeEventListener('click', handler, true);
-        }
-      };
-      document.addEventListener('click', handler, true);
-    }, 0);
-  }
-};
-
-// --- QC / Chat sheet mutex: only one open at a time ---
-window._pcsOpenQcSheet = function(id) {
-  var qc = document.getElementById('pcs-qc-sheet-' + id);
-  var ch = document.getElementById('pcs-chat-sheet-' + id);
-  if (ch) ch.style.display = 'none';
-  if (qc) qc.style.display = 'block';
-  var menu = document.getElementById('pcs-dots-menu-' + id);
-  if (menu) menu.classList.remove('open');
-};
-
-window._pcsCloseQcSheet = function(id) {
-  var qc = document.getElementById('pcs-qc-sheet-' + id);
-  if (qc) qc.style.display = 'none';
-  var result = document.getElementById('pcs-qc-result-' + id);
-  if (result) result.style.display = 'none';
-};
-
-window._pcsOpenChatSheet = function(id) {
-  var qc = document.getElementById('pcs-qc-sheet-' + id);
-  var ch = document.getElementById('pcs-chat-sheet-' + id);
-  if (qc) qc.style.display = 'none';
-  if (ch) ch.style.display = 'block';
-  var menu = document.getElementById('pcs-dots-menu-' + id);
-  if (menu) menu.classList.remove('open');
-  var input = document.getElementById('pcs-chat-input-' + id);
-  if (input) { try { input.focus(); } catch (_) {} }
-};
-
-window._pcsCloseChatSheet = function(id) {
-  var ch = document.getElementById('pcs-chat-sheet-' + id);
-  if (ch) ch.style.display = 'none';
-};
+// Legacy sheet stubs — kept as no-ops in case any external path still calls them.
+window._pcsToggleDotsMenu = function() {};
+window._pcsOpenQcSheet = function() {};
+window._pcsCloseQcSheet = function() {};
+window._pcsOpenChatSheet = function() {};
+window._pcsCloseChatSheet = function() {};
 
 // --- Manual zone dim/undim mutex ---
 function _pcsDimManualZone(on) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260416i">
+ <link rel="stylesheet" href="styles.css?v=20260416j">
 
 </head>
 <body>
@@ -1009,7 +1009,7 @@
               <button class="pcs-ibar-plus" onclick="window._pcsTogglePlusMenu(this,'client')">+</button>
             </div>
             <span class="pcs-reply-tag" id="pcs-client-reply-tag" style="display:none"><span id="pcs-client-reply-name"></span><button class="pcs-reply-tag-x" onclick="window._pcsClearReply('client')">&#x2715;</button></span>
-            <textarea id="pcs-comment-input" class="pcs-ibar-input" placeholder="Reply to client..." rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.45';var pb=this.parentNode.querySelector('.pcs-ibar-polish');if(pb)pb.style.display=this.value.trim()?'flex':'none'"></textarea>
+            <textarea id="pcs-comment-input" class="pcs-ibar-input" placeholder="Reply to client..." rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.45';var pb=this.parentNode.querySelector('.pcs-ibar-polish');if(pb)pb.style.display=(this.value.trim()&&(window.AppState.user.effectiveRole||'').toLowerCase()==='admin')?'flex':'none'"></textarea>
             <button class="pcs-ibar-polish" style="display:none" data-zone="client">&#x2726;</button>
             <button id="pcs-send-btn-client" class="pcs-ibar-send" onclick="window.submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',false)">&#x2191;</button>
           </div>
@@ -1043,7 +1043,7 @@
               <button class="pcs-ibar-plus" onclick="window._pcsTogglePlusMenu(this,'note')">+</button>
             </div>
             <span class="pcs-reply-tag" id="pcs-note-reply-tag" style="display:none"><span id="pcs-note-reply-name"></span><button class="pcs-reply-tag-x" onclick="window._pcsClearReply('note')">&#x2715;</button></span>
-            <textarea id="pcs-note-input" class="pcs-ibar-input" placeholder="Add note... @mention" rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.45';var pb=this.parentNode.querySelector('.pcs-ibar-polish');if(pb)pb.style.display=this.value.trim()?'flex':'none'"></textarea>
+            <textarea id="pcs-note-input" class="pcs-ibar-input" placeholder="Add note... @mention" rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.45';var pb=this.parentNode.querySelector('.pcs-ibar-polish');if(pb)pb.style.display=(this.value.trim()&&(window.AppState.user.effectiveRole||'').toLowerCase()==='admin')?'flex':'none'"></textarea>
             <button class="pcs-ibar-polish" style="display:none" data-zone="notes">&#x2726;</button>
             <button id="pcs-send-btn-note" class="pcs-ibar-send" onclick="submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-note-input')?document.getElementById('pcs-note-input').value:'',window._pcsNoteVisibility||'all',false,true)">&#x2191;</button>
           </div>
@@ -1248,32 +1248,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260416i"></script>
-<script src="00-appstate-compat.js?v=20260416i"></script>
-<script src="01-config.js?v=20260416i" defer></script>
-<script src="02-session.js?v=20260416i" defer></script>
-<script src="utils.js?v=20260416i" defer></script>
-<script src="12-profiles.js?v=20260416i" defer></script>
-<script src="03-auth.js?v=20260416i" defer></script>
-<script src="05-api.js?v=20260416i" defer></script>
-<script src="10-ui.js?v=20260416i" defer></script>
+<script src="00-appstate.js?v=20260416j"></script>
+<script src="00-appstate-compat.js?v=20260416j"></script>
+<script src="01-config.js?v=20260416j" defer></script>
+<script src="02-session.js?v=20260416j" defer></script>
+<script src="utils.js?v=20260416j" defer></script>
+<script src="12-profiles.js?v=20260416j" defer></script>
+<script src="03-auth.js?v=20260416j" defer></script>
+<script src="05-api.js?v=20260416j" defer></script>
+<script src="10-ui.js?v=20260416j" defer></script>
 
-<script src="06-post-create.js?v=20260416i" defer></script>
-<script defer src="render/dashboard.js?v=20260416i"></script>
-<script defer src="render/client.js?v=20260416i"></script>
-<script defer src="render/pipeline.js?v=20260416i"></script>
-<script defer src="render/brief.js?v=20260416i"></script>
-<script defer src="actions/pcs.js?v=20260416i"></script>
-<script defer src="actions/pcs-longpress.js?v=20260416i"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260416i"></script>
-<script defer src="actions/pcs-polish.js?v=20260416i"></script>
-<script defer src="actions/pcs-select.js?v=20260416i"></script>
-<script src="ai-config.js?v=20260416i" defer></script>
-<script src="07-post-load.js?v=20260416i" defer></script>
-<script src="08-post-actions.js?v=20260416i" defer></script>
-<script src="09-library.js?v=20260416i" defer></script>
-<script src="09-approval.js?v=20260416i" defer></script>
-<script src="04-router.js?v=20260416i" defer></script>
+<script src="06-post-create.js?v=20260416j" defer></script>
+<script defer src="render/dashboard.js?v=20260416j"></script>
+<script defer src="render/client.js?v=20260416j"></script>
+<script defer src="render/pipeline.js?v=20260416j"></script>
+<script defer src="render/brief.js?v=20260416j"></script>
+<script defer src="actions/pcs.js?v=20260416j"></script>
+<script defer src="actions/pcs-longpress.js?v=20260416j"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260416j"></script>
+<script defer src="actions/pcs-polish.js?v=20260416j"></script>
+<script defer src="actions/pcs-select.js?v=20260416j"></script>
+<script src="ai-config.js?v=20260416j" defer></script>
+<script src="07-post-load.js?v=20260416j" defer></script>
+<script src="08-post-actions.js?v=20260416j" defer></script>
+<script src="09-library.js?v=20260416j" defer></script>
+<script src="09-approval.js?v=20260416j" defer></script>
+<script src="04-router.js?v=20260416j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260416k">
+ <link rel="stylesheet" href="styles.css?v=20260416l">
 
 </head>
 <body>
@@ -1252,32 +1252,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260416k"></script>
-<script src="00-appstate-compat.js?v=20260416k"></script>
-<script src="01-config.js?v=20260416k" defer></script>
-<script src="02-session.js?v=20260416k" defer></script>
-<script src="utils.js?v=20260416k" defer></script>
-<script src="12-profiles.js?v=20260416k" defer></script>
-<script src="03-auth.js?v=20260416k" defer></script>
-<script src="05-api.js?v=20260416k" defer></script>
-<script src="10-ui.js?v=20260416k" defer></script>
+<script src="00-appstate.js?v=20260416l"></script>
+<script src="00-appstate-compat.js?v=20260416l"></script>
+<script src="01-config.js?v=20260416l" defer></script>
+<script src="02-session.js?v=20260416l" defer></script>
+<script src="utils.js?v=20260416l" defer></script>
+<script src="12-profiles.js?v=20260416l" defer></script>
+<script src="03-auth.js?v=20260416l" defer></script>
+<script src="05-api.js?v=20260416l" defer></script>
+<script src="10-ui.js?v=20260416l" defer></script>
 
-<script src="06-post-create.js?v=20260416k" defer></script>
-<script defer src="render/dashboard.js?v=20260416k"></script>
-<script defer src="render/client.js?v=20260416k"></script>
-<script defer src="render/pipeline.js?v=20260416k"></script>
-<script defer src="render/brief.js?v=20260416k"></script>
-<script defer src="actions/pcs.js?v=20260416k"></script>
-<script defer src="actions/pcs-longpress.js?v=20260416k"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260416k"></script>
-<script defer src="actions/pcs-polish.js?v=20260416k"></script>
-<script defer src="actions/pcs-select.js?v=20260416k"></script>
-<script src="ai-config.js?v=20260416k" defer></script>
-<script src="07-post-load.js?v=20260416k" defer></script>
-<script src="08-post-actions.js?v=20260416k" defer></script>
-<script src="09-library.js?v=20260416k" defer></script>
-<script src="09-approval.js?v=20260416k" defer></script>
-<script src="04-router.js?v=20260416k" defer></script>
+<script src="06-post-create.js?v=20260416l" defer></script>
+<script defer src="render/dashboard.js?v=20260416l"></script>
+<script defer src="render/client.js?v=20260416l"></script>
+<script defer src="render/pipeline.js?v=20260416l"></script>
+<script defer src="render/brief.js?v=20260416l"></script>
+<script defer src="actions/pcs.js?v=20260416l"></script>
+<script defer src="actions/pcs-longpress.js?v=20260416l"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260416l"></script>
+<script defer src="actions/pcs-polish.js?v=20260416l"></script>
+<script defer src="actions/pcs-select.js?v=20260416l"></script>
+<script src="ai-config.js?v=20260416l" defer></script>
+<script src="07-post-load.js?v=20260416l" defer></script>
+<script src="08-post-actions.js?v=20260416l" defer></script>
+<script src="09-library.js?v=20260416l" defer></script>
+<script src="09-approval.js?v=20260416l" defer></script>
+<script src="04-router.js?v=20260416l" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260416j">
+ <link rel="stylesheet" href="styles.css?v=20260416k">
 
 </head>
 <body>
@@ -1099,6 +1099,10 @@
       </div>
       <div id="cw-thread"></div>
       <div id="cw-input-wrap">
+        <div class="cw-quick-chips" id="cw-quick-chips">
+          <button class="cw-qchip" data-action="cw-qc">&#x2726; QC Brand Guide</button>
+          <button class="cw-qchip" data-action="cw-ask">&#x2726; Ask Claude</button>
+        </div>
         <div id="cw-input-pill">
           <textarea id="cw-input" placeholder="Ask anything, or say what you want changed..." rows="1"></textarea>
           <button id="cw-send">&#x2191;</button>
@@ -1248,32 +1252,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260416j"></script>
-<script src="00-appstate-compat.js?v=20260416j"></script>
-<script src="01-config.js?v=20260416j" defer></script>
-<script src="02-session.js?v=20260416j" defer></script>
-<script src="utils.js?v=20260416j" defer></script>
-<script src="12-profiles.js?v=20260416j" defer></script>
-<script src="03-auth.js?v=20260416j" defer></script>
-<script src="05-api.js?v=20260416j" defer></script>
-<script src="10-ui.js?v=20260416j" defer></script>
+<script src="00-appstate.js?v=20260416k"></script>
+<script src="00-appstate-compat.js?v=20260416k"></script>
+<script src="01-config.js?v=20260416k" defer></script>
+<script src="02-session.js?v=20260416k" defer></script>
+<script src="utils.js?v=20260416k" defer></script>
+<script src="12-profiles.js?v=20260416k" defer></script>
+<script src="03-auth.js?v=20260416k" defer></script>
+<script src="05-api.js?v=20260416k" defer></script>
+<script src="10-ui.js?v=20260416k" defer></script>
 
-<script src="06-post-create.js?v=20260416j" defer></script>
-<script defer src="render/dashboard.js?v=20260416j"></script>
-<script defer src="render/client.js?v=20260416j"></script>
-<script defer src="render/pipeline.js?v=20260416j"></script>
-<script defer src="render/brief.js?v=20260416j"></script>
-<script defer src="actions/pcs.js?v=20260416j"></script>
-<script defer src="actions/pcs-longpress.js?v=20260416j"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260416j"></script>
-<script defer src="actions/pcs-polish.js?v=20260416j"></script>
-<script defer src="actions/pcs-select.js?v=20260416j"></script>
-<script src="ai-config.js?v=20260416j" defer></script>
-<script src="07-post-load.js?v=20260416j" defer></script>
-<script src="08-post-actions.js?v=20260416j" defer></script>
-<script src="09-library.js?v=20260416j" defer></script>
-<script src="09-approval.js?v=20260416j" defer></script>
-<script src="04-router.js?v=20260416j" defer></script>
+<script src="06-post-create.js?v=20260416k" defer></script>
+<script defer src="render/dashboard.js?v=20260416k"></script>
+<script defer src="render/client.js?v=20260416k"></script>
+<script defer src="render/pipeline.js?v=20260416k"></script>
+<script defer src="render/brief.js?v=20260416k"></script>
+<script defer src="actions/pcs.js?v=20260416k"></script>
+<script defer src="actions/pcs-longpress.js?v=20260416k"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260416k"></script>
+<script defer src="actions/pcs-polish.js?v=20260416k"></script>
+<script defer src="actions/pcs-select.js?v=20260416k"></script>
+<script src="ai-config.js?v=20260416k" defer></script>
+<script src="07-post-load.js?v=20260416k" defer></script>
+<script src="08-post-actions.js?v=20260416k" defer></script>
+<script src="09-library.js?v=20260416k" defer></script>
+<script src="09-approval.js?v=20260416k" defer></script>
+<script src="04-router.js?v=20260416k" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -8442,6 +8442,64 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   padding: 4px 4px 0;
 }
 
+/* Quick action chips above input */
+.cw-quick-chips {
+  display: flex;
+  gap: 6px;
+  padding-bottom: 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.cw-quick-chips::-webkit-scrollbar { display: none; }
+.cw-qchip {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #C15F3C;
+  padding: 5px 9px;
+  background: transparent;
+  border: 1px solid #5A3A2C;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  border-radius: 6px;
+}
+
+/* Caption preview block at top of thread */
+.cw-caption-block {
+  background: #252320;
+  border: 1px solid #3A3632;
+  border-radius: 10px;
+  padding: 12px;
+  margin-bottom: 8px;
+}
+.cw-caption-lbl {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 7px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #7A7670;
+  margin-bottom: 6px;
+}
+.cw-caption-text {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  color: #B1ADA1;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  max-height: 150px;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+.cw-caption-text::-webkit-scrollbar { display: none; }
+.cw-caption-text.empty {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  color: #4A4640;
+  letter-spacing: 0.06em;
+}
+
 /* Comment block (rewrite mode) */
 .cw-comments-block {
   background: #201E1A;
@@ -8737,6 +8795,16 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 /* "Edit with Claude" entry button (caption tab) */
+@keyframes claude-glow {
+  0%, 100% {
+    box-shadow: 0 0 0 0 #C15F3C00;
+    border-color: #5A3A2C;
+  }
+  50% {
+    box-shadow: 0 0 12px 2px #C15F3C26;
+    border-color: #C15F3C;
+  }
+}
 .pcs-claude-entry {
   margin: 6px 16px 8px;
   padding: 14px;
@@ -8748,8 +8816,14 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   display: flex;
   align-items: center;
   gap: 12px;
+  animation: claude-glow 3s ease-in-out infinite;
 }
-.pcs-claude-entry:active { background: #2A1A10; }
+.pcs-claude-entry:active {
+  animation: none;
+  background: #2A1A10;
+  border-color: #C15F3C;
+  box-shadow: 0 0 12px 2px #C15F3C33;
+}
 .pcs-ce-icon {
   width: 32px;
   height: 32px;


### PR DESCRIPTION
## Summary
- Admin-only guard for polish button + selection strip
- AI zone: glow animation, dead code removal, quick chips, caption preview
- AI Memory: captures edit corrections when users modify drafts before "Use this", loads last 10 into system prompt

## Test plan
- [x] 544/544 tests passing
- [ ] Edit draft → Use this → ai_memory row created
- [ ] Skip edit → Use this → no row
- [ ] Reopen workspace → corrections in prompt

https://claude.ai/code/session_0156yc1bmx3YnnGmxuQGQa8D