### PR TITLE
Fix caption pre-load + remove QC/Ask Claude quick chips

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -241,7 +241,7 @@ function _cwRenderThread() {
   }
 
   if (!ws.messages.length) {
-    html = '<div class="cw-empty">' +
+    html += '<div class="cw-empty">' +
       '<div class="cw-empty-icon">\u2726</div>' +
       '<div class="cw-empty-text">Ask anything about this caption, or let Claude write one for you.</div>' +
     '</div>';
@@ -480,17 +480,6 @@ async function _cwFetchCostTotals() {
     }
     if (e.target && e.target.id === 'cw-back') {
       window.closeCaptionWorkspace();
-    }
-    if (e.target && e.target.dataset && e.target.dataset.action === 'cw-qc') {
-      var ws = window._captionWS;
-      var post = ws.postId ? (window.AppState.posts.all || []).find(function(p) { return (p.post_id || p.id) === ws.postId; }) : null;
-      var cap = post ? post.caption : '';
-      if (!cap) { if (typeof showToast === 'function') showToast('No caption to QC', 'error'); return; }
-      window.sendCaptionMessage('QC this LinkedIn caption against the brand guide. Caption:\n\n' + cap + '\n\nReturn a structured verdict with PASS or FLAG for each check.');
-    }
-    if (e.target && e.target.dataset && e.target.dataset.action === 'cw-ask') {
-      var cwInput = document.getElementById('cw-input');
-      if (cwInput) cwInput.focus();
     }
   });
   document.addEventListener('keydown', function(e) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260416l">
+ <link rel="stylesheet" href="styles.css?v=20260416m">
 
 </head>
 <body>
@@ -1099,10 +1099,6 @@
       </div>
       <div id="cw-thread"></div>
       <div id="cw-input-wrap">
-        <div class="cw-quick-chips" id="cw-quick-chips">
-          <button class="cw-qchip" data-action="cw-qc">&#x2726; QC Brand Guide</button>
-          <button class="cw-qchip" data-action="cw-ask">&#x2726; Ask Claude</button>
-        </div>
         <div id="cw-input-pill">
           <textarea id="cw-input" placeholder="Ask anything, or say what you want changed..." rows="1"></textarea>
           <button id="cw-send">&#x2191;</button>
@@ -1252,32 +1248,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260416l"></script>
-<script src="00-appstate-compat.js?v=20260416l"></script>
-<script src="01-config.js?v=20260416l" defer></script>
-<script src="02-session.js?v=20260416l" defer></script>
-<script src="utils.js?v=20260416l" defer></script>
-<script src="12-profiles.js?v=20260416l" defer></script>
-<script src="03-auth.js?v=20260416l" defer></script>
-<script src="05-api.js?v=20260416l" defer></script>
-<script src="10-ui.js?v=20260416l" defer></script>
+<script src="00-appstate.js?v=20260416m"></script>
+<script src="00-appstate-compat.js?v=20260416m"></script>
+<script src="01-config.js?v=20260416m" defer></script>
+<script src="02-session.js?v=20260416m" defer></script>
+<script src="utils.js?v=20260416m" defer></script>
+<script src="12-profiles.js?v=20260416m" defer></script>
+<script src="03-auth.js?v=20260416m" defer></script>
+<script src="05-api.js?v=20260416m" defer></script>
+<script src="10-ui.js?v=20260416m" defer></script>
 
-<script src="06-post-create.js?v=20260416l" defer></script>
-<script defer src="render/dashboard.js?v=20260416l"></script>
-<script defer src="render/client.js?v=20260416l"></script>
-<script defer src="render/pipeline.js?v=20260416l"></script>
-<script defer src="render/brief.js?v=20260416l"></script>
-<script defer src="actions/pcs.js?v=20260416l"></script>
-<script defer src="actions/pcs-longpress.js?v=20260416l"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260416l"></script>
-<script defer src="actions/pcs-polish.js?v=20260416l"></script>
-<script defer src="actions/pcs-select.js?v=20260416l"></script>
-<script src="ai-config.js?v=20260416l" defer></script>
-<script src="07-post-load.js?v=20260416l" defer></script>
-<script src="08-post-actions.js?v=20260416l" defer></script>
-<script src="09-library.js?v=20260416l" defer></script>
-<script src="09-approval.js?v=20260416l" defer></script>
-<script src="04-router.js?v=20260416l" defer></script>
+<script src="06-post-create.js?v=20260416m" defer></script>
+<script defer src="render/dashboard.js?v=20260416m"></script>
+<script defer src="render/client.js?v=20260416m"></script>
+<script defer src="render/pipeline.js?v=20260416m"></script>
+<script defer src="render/brief.js?v=20260416m"></script>
+<script defer src="actions/pcs.js?v=20260416m"></script>
+<script defer src="actions/pcs-longpress.js?v=20260416m"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260416m"></script>
+<script defer src="actions/pcs-polish.js?v=20260416m"></script>
+<script defer src="actions/pcs-select.js?v=20260416m"></script>
+<script src="ai-config.js?v=20260416m" defer></script>
+<script src="07-post-load.js?v=20260416m" defer></script>
+<script src="08-post-actions.js?v=20260416m" defer></script>
+<script src="09-library.js?v=20260416m" defer></script>
+<script src="09-approval.js?v=20260416m" defer></script>
+<script src="04-router.js?v=20260416m" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- **Fix 1**: Caption block was not showing in workspace chat mode. Root cause: `html =` (overwrite) on the empty-state branch wiped the caption block that was already built. Changed to `html +=` so caption block persists above the empty-state prompt.
- **Fix 2**: Removed QC Brand Guide and Ask Claude quick chips from workspace input area. Input placeholder is sufficient.

## Files changed (2)
- `actions/pcs-claude-caption.js` — `html =` → `html +=` on empty-state branch; removed QC/Ask chip click handlers
- `index.html` — removed `.cw-quick-chips` div + buttons; version bump `20260416l` → `20260416m` (26 strings)

## Test plan
- [x] `npx vitest run` — 544/544 passing
- [ ] Open PCS → Caption tab → "Edit with Claude" → workspace shows current caption at top
- [ ] No QC/Ask Claude chips above input pill
- [ ] Chat mode (no messages yet): caption block + empty prompt both visible

https://claude.ai/code/session_0156yc1bmx3YnnGmxuQGQa8D