### PR TITLE
Wire ai_memory into workspace system prompt

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -12,7 +12,8 @@ window._captionWS = {
   postId: null,
   mode: null,
   _rewriteComments: null,
-  correctionsPrompt: ''
+  correctionsPrompt: '',
+  memoryPrompt: ''
 };
 
 var _CW_USD_TO_INR = 100;
@@ -59,7 +60,7 @@ window.openCaptionWorkspace = async function(mode, context) {
 
   _cwUpdateSessionMeter();
   _cwFetchCostTotals();
-  if (!isResume) _cwLoadCorrections();
+  if (!isResume) _cwLoadMemory();
   _cwRenderThread();
 
   if (!isResume) {
@@ -84,7 +85,8 @@ window.openCaptionWorkspace = async function(mode, context) {
       if (ws.correctionsPrompt && rwApiMsgs.length > 0) {
         rwApiMsgs[0] = { role: rwApiMsgs[0].role, content: rwApiMsgs[0].content + ws.correctionsPrompt };
       }
-      var result = await _callSrtdAI(featureTag, rwApiMsgs, ws.postId);
+      var rwAiOpts = ws.memoryPrompt ? { memory_context: ws.memoryPrompt } : undefined;
+      var result = await _callSrtdAI(featureTag, rwApiMsgs, ws.postId, rwAiOpts);
       var typingEl = thread && thread.querySelector('.cw-typing');
       if (typingEl) typingEl.remove();
       if (result && result.success) {
@@ -163,7 +165,8 @@ window.sendCaptionMessage = async function(text) {
     apiMessages[0] = { role: apiMessages[0].role, content: apiMessages[0].content + ws.correctionsPrompt };
   }
 
-  var result = await _callSrtdAI(featureTag, apiMessages, ws.postId);
+  var aiOpts = ws.memoryPrompt ? { memory_context: ws.memoryPrompt } : undefined;
+  var result = await _callSrtdAI(featureTag, apiMessages, ws.postId, aiOpts);
 
   var typingEl = thread && thread.querySelector('.cw-typing');
   if (typingEl) typingEl.remove();
@@ -398,36 +401,57 @@ function _cwCaptureCorrection(original, edited) {
   }
 }
 
-// ─── AI memory: load corrections into prompt ────────────
+// ─── AI memory: load all memory types into prompt ───────
 
-async function _cwLoadCorrections() {
+async function _cwLoadMemory() {
   try {
     var rows = await apiFetch(
-      '/ai_memory?type=eq.edit_correction&workspace_id=eq.default&order=created_at.desc&limit=10&select=content'
+      '/ai_memory?workspace_id=eq.default&order=created_at.desc&limit=30&select=type,content'
     );
     if (!Array.isArray(rows) || rows.length === 0) {
+      window._captionWS.memoryPrompt = '';
       window._captionWS.correctionsPrompt = '';
       return;
     }
-    var lines = [];
+
+    var style = [];
+    var client = [];
+    var corrections = [];
+
     rows.forEach(function(r) {
       try {
-        var c = typeof r.content === 'string' ? JSON.parse(r.content) : r.content;
-        if (c && c.original && c.edited) {
-          var origPreview = c.original.length > 100 ? c.original.slice(0, 100) + '...' : c.original;
-          var editPreview = c.edited.length > 100 ? c.edited.slice(0, 100) + '...' : c.edited;
-          lines.push('- User changed: "' + origPreview + '" \u2192 "' + editPreview + '"');
+        if (r.type === 'style_dna') {
+          style.push(typeof r.content === 'string' ? r.content : JSON.stringify(r.content));
+        } else if (r.type === 'client_pattern') {
+          client.push(typeof r.content === 'string' ? r.content : JSON.stringify(r.content));
+        } else if (r.type === 'edit_correction') {
+          var c = typeof r.content === 'string' ? JSON.parse(r.content) : r.content;
+          if (c && c.original && c.edited) {
+            var origP = c.original.length > 100 ? c.original.slice(0, 100) + '...' : c.original;
+            var editP = c.edited.length > 100 ? c.edited.slice(0, 100) + '...' : c.edited;
+            corrections.push('- Changed: "' + origP + '" \u2192 "' + editP + '"');
+          }
         }
       } catch (_) {}
     });
-    if (lines.length > 0) {
-      window._captionWS.correctionsPrompt =
-        '\n\nSTYLE CORRECTIONS FROM THIS USER (apply these patterns to all future drafts):\n' +
-        lines.join('\n');
-    } else {
-      window._captionWS.correctionsPrompt = '';
+
+    var blocks = [];
+    if (style.length > 0) {
+      blocks.push('WRITING STYLE FOR THIS BRAND:\n' + style.join('\n'));
     }
+    if (client.length > 0) {
+      blocks.push('CLIENT FEEDBACK PATTERNS (never repeat these mistakes):\n' + client.join('\n'));
+    }
+    if (corrections.length > 0) {
+      blocks.push('STYLE CORRECTIONS FROM USER EDITS:\n' + corrections.join('\n'));
+    }
+
+    window._captionWS.memoryPrompt = blocks.length > 0 ? blocks.join('\n\n') : '';
+    window._captionWS.correctionsPrompt = corrections.length > 0
+      ? '\n\nSTYLE CORRECTIONS FROM THIS USER (apply these patterns to all future drafts):\n' + corrections.join('\n')
+      : '';
   } catch (e) {
+    window._captionWS.memoryPrompt = '';
     window._captionWS.correctionsPrompt = '';
   }
 }

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -179,23 +179,25 @@ window.forcePCSReset = function() {
 // PR-1 ai-config.js script failed to ship.
 // ═══════════════════════════════════════════════════════════════
 
-async function _callSrtdAI(feature, messages, postId) {
+async function _callSrtdAI(feature, messages, postId, opts) {
   var cfg = window.AI_CONFIG;
   if (!cfg || !cfg.workerUrl) return { success: false, error: 'AI not configured' };
   try {
+    var payload = {
+      feature: feature,
+      messages: messages,
+      post_id: postId || null,
+      workspace_id: 'default',
+      created_by: (window.AppState.user.email || '')
+    };
+    if (opts && opts.memory_context) payload.memory_context = opts.memory_context;
     var res = await fetch(cfg.workerUrl + '/ai/complete', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'X-AI-Secret': cfg.secret
       },
-      body: JSON.stringify({
-        feature: feature,
-        messages: messages,
-        post_id: postId || null,
-        workspace_id: 'default',
-        created_by: (window.AppState.user.email || '')
-      })
+      body: JSON.stringify(payload)
     });
     var data = await res.json();
     return data;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260416m">
+ <link rel="stylesheet" href="styles.css?v=20260416n">
 
 </head>
 <body>
@@ -1248,32 +1248,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260416m"></script>
-<script src="00-appstate-compat.js?v=20260416m"></script>
-<script src="01-config.js?v=20260416m" defer></script>
-<script src="02-session.js?v=20260416m" defer></script>
-<script src="utils.js?v=20260416m" defer></script>
-<script src="12-profiles.js?v=20260416m" defer></script>
-<script src="03-auth.js?v=20260416m" defer></script>
-<script src="05-api.js?v=20260416m" defer></script>
-<script src="10-ui.js?v=20260416m" defer></script>
+<script src="00-appstate.js?v=20260416n"></script>
+<script src="00-appstate-compat.js?v=20260416n"></script>
+<script src="01-config.js?v=20260416n" defer></script>
+<script src="02-session.js?v=20260416n" defer></script>
+<script src="utils.js?v=20260416n" defer></script>
+<script src="12-profiles.js?v=20260416n" defer></script>
+<script src="03-auth.js?v=20260416n" defer></script>
+<script src="05-api.js?v=20260416n" defer></script>
+<script src="10-ui.js?v=20260416n" defer></script>
 
-<script src="06-post-create.js?v=20260416m" defer></script>
-<script defer src="render/dashboard.js?v=20260416m"></script>
-<script defer src="render/client.js?v=20260416m"></script>
-<script defer src="render/pipeline.js?v=20260416m"></script>
-<script defer src="render/brief.js?v=20260416m"></script>
-<script defer src="actions/pcs.js?v=20260416m"></script>
-<script defer src="actions/pcs-longpress.js?v=20260416m"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260416m"></script>
-<script defer src="actions/pcs-polish.js?v=20260416m"></script>
-<script defer src="actions/pcs-select.js?v=20260416m"></script>
-<script src="ai-config.js?v=20260416m" defer></script>
-<script src="07-post-load.js?v=20260416m" defer></script>
-<script src="08-post-actions.js?v=20260416m" defer></script>
-<script src="09-library.js?v=20260416m" defer></script>
-<script src="09-approval.js?v=20260416m" defer></script>
-<script src="04-router.js?v=20260416m" defer></script>
+<script src="06-post-create.js?v=20260416n" defer></script>
+<script defer src="render/dashboard.js?v=20260416n"></script>
+<script defer src="render/client.js?v=20260416n"></script>
+<script defer src="render/pipeline.js?v=20260416n"></script>
+<script defer src="render/brief.js?v=20260416n"></script>
+<script defer src="actions/pcs.js?v=20260416n"></script>
+<script defer src="actions/pcs-longpress.js?v=20260416n"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260416n"></script>
+<script defer src="actions/pcs-polish.js?v=20260416n"></script>
+<script defer src="actions/pcs-select.js?v=20260416n"></script>
+<script src="ai-config.js?v=20260416n" defer></script>
+<script src="07-post-load.js?v=20260416n" defer></script>
+<script src="08-post-actions.js?v=20260416n" defer></script>
+<script src="09-library.js?v=20260416n" defer></script>
+<script src="09-approval.js?v=20260416n" defer></script>
+<script src="04-router.js?v=20260416n" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/srtd-ai-worker/src/index.js
+++ b/srtd-ai-worker/src/index.js
@@ -138,10 +138,19 @@ async function loadApprovedContext() {
   }
 }
 
-function buildSystemPrompt(feature, approvedContext, brandGuide) {
+function buildSystemPrompt(feature, approvedContext, brandGuide, memoryContext) {
   const ctx = approvedContext || '';
   const bg  = brandGuide || '';
+  const mem = memoryContext || '';
+  const hasMem = mem.length > 100;
+
   if (feature === 'writer') {
+    if (hasMem) {
+      return 'You are a LinkedIn content writer for Godavari Biorefineries Limited (GBL), a sugarcane biorefinery.\n\n'
+        + mem + '\n\n'
+        + 'Here are 5 high-performing posts for voice reference:\n\n' + ctx
+        + '\n\nReturn exactly 3 numbered copy options. Each option on its own. No preamble.';
+    }
     return 'You are a LinkedIn content writer for Godavari Biorefineries Limited (GBL), a sugarcane biorefinery. '
       + 'Write in their established voice. Here are 20 approved posts for reference:\n\n'
       + ctx
@@ -150,6 +159,11 @@ function buildSystemPrompt(feature, approvedContext, brandGuide) {
       + '\n\nReturn exactly 3 numbered copy options. Each option on its own. No preamble.';
   }
   if (feature === 'qc') {
+    if (hasMem) {
+      return 'You are a brand quality controller for GBL.\n\n'
+        + mem
+        + '\n\nCheck the provided copy against these rules. Return PASS or FLAG for each item. Be specific. Be brief.';
+    }
     return 'You are a brand quality controller for GBL. Check the provided copy against the brand voice and approved posts. '
       + 'Here are 20 approved posts:\n\n'
       + ctx
@@ -158,6 +172,11 @@ function buildSystemPrompt(feature, approvedContext, brandGuide) {
       + '\n\nReturn a structured verdict: PASS or FLAG for each item checked. Be specific. Be brief.';
   }
   if (feature === 'chat') {
+    if (hasMem) {
+      return 'You are a copy editor for GBL LinkedIn content.\n\n'
+        + mem
+        + '\n\nHelp the user improve the copy. Be direct and brief.';
+    }
     return 'You are a copy editor helping refine LinkedIn content for GBL. Here are 20 approved posts for reference:\n\n'
       + ctx
       + '\n\nBrand guide:\n'
@@ -249,9 +268,16 @@ async function handleComplete(request, env) {
       return jsonResponse({ success: false, error: gate.reason }, 403);
     }
 
+    const memoryContext   = (body && body.memory_context) || '';
     const brandGuide      = await loadBrandGuide(env);
-    const approvedContext = await loadApprovedContext();
-    const systemPrompt    = buildSystemPrompt(feature, approvedContext, brandGuide);
+    let   approvedContext = await loadApprovedContext();
+
+    if (memoryContext && memoryContext.length > 100) {
+      const posts = approvedContext.split('\n---\n');
+      approvedContext = posts.slice(0, 5).join('\n---\n');
+    }
+
+    const systemPrompt    = buildSystemPrompt(feature, approvedContext, brandGuide, memoryContext);
 
     const anthropicRes = await callAnthropic(env, systemPrompt, messages);
 


### PR DESCRIPTION
## ⚠️ AFTER MERGE: Copy updated `srtd-ai-worker/src/index.js` to Cloudflare Workers dashboard (srtd-ai). The Worker now accepts `memory_context` and uses it to skip the heavy brand guide.

## Summary
- Frontend `_cwLoadCorrections()` → `_cwLoadMemory()`: fetches all `ai_memory` types (style_dna, client_pattern, edit_correction) in one query, builds `memoryPrompt` from three grouped blocks
- `_callSrtdAI()` accepts new 4th arg `opts.memory_context` to forward to Worker
- Worker `buildSystemPrompt()` accepts `memory_context`: when >100 chars, uses it as primary context instead of full brand guide (5000 words saved). Approved posts truncated 20→5 for writer, skipped for chat/qc
- Falls back to existing full prompt when no memory (email_brief untouched)

## Files changed (4)
- `actions/pcs-claude-caption.js` — `_cwLoadMemory()`, `memoryPrompt` state, memory_context passed to both API call paths
- `actions/pcs.js` — `_callSrtdAI()` 4th arg for memory_context
- `srtd-ai-worker/src/index.js` — `buildSystemPrompt()` 4th param, memory-aware prompts, approved posts truncation
- `index.html` — version bump `20260416m` → `20260416n` (26 strings)

## Test plan
- [x] `npx vitest run` — 544/544 passing
- [ ] Open workspace with ai_memory rows → Worker receives memory_context (check Worker logs)
- [ ] Drafts reflect learned style from corrections
- [ ] Open workspace with NO ai_memory rows → falls back to full brand guide
- [ ] Email brief flow still works (no memory_context sent)
- [ ] **Deploy Worker to Cloudflare dashboard**

https://claude.ai/code/session_0156yc1bmx3YnnGmxuQGQa8D