### PR TITLE
Fix caption workspace bugs: caption context, toast on Use this, strip QC from save

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -13,10 +13,19 @@ window._captionWS = {
   mode: null,
   _rewriteComments: null,
   correctionsPrompt: '',
-  memoryPrompt: ''
+  memoryPrompt: '',
+  caption: ''
 };
 
 var _CW_USD_TO_INR = 100;
+
+function _cwBuildAiOpts() {
+  var ws = window._captionWS;
+  var mem = ws.memoryPrompt || '';
+  var cap = ws.caption || '';
+  var combined = mem + (cap ? (mem ? '\n\n' : '') + 'CURRENT CAPTION:\n' + cap : '');
+  return combined ? { memory_context: combined } : undefined;
+}
 
 // ─── cost helpers ────────────────────────────────────────────
 
@@ -46,6 +55,7 @@ window.openCaptionWorkspace = async function(mode, context) {
     ws.postId = context.postId || null;
     ws.mode = mode;
     ws._rewriteComments = null;
+    ws.caption = context.caption || '';
   }
   ws.isOpen = true;
 
@@ -85,7 +95,7 @@ window.openCaptionWorkspace = async function(mode, context) {
       if (ws.correctionsPrompt && rwApiMsgs.length > 0) {
         rwApiMsgs[0] = { role: rwApiMsgs[0].role, content: rwApiMsgs[0].content + ws.correctionsPrompt };
       }
-      var rwAiOpts = ws.memoryPrompt ? { memory_context: ws.memoryPrompt } : undefined;
+      var rwAiOpts = _cwBuildAiOpts();
       var result = await _callSrtdAI(featureTag, rwApiMsgs, ws.postId, rwAiOpts);
       var typingEl = thread && thread.querySelector('.cw-typing');
       if (typingEl) typingEl.remove();
@@ -110,7 +120,10 @@ window.openCaptionWorkspace = async function(mode, context) {
     } else if (mode === 'qc') {
       var msg3 = 'QC this LinkedIn caption against the brand guide. Caption:\n\n' +
         (context.caption || '(no caption)') +
-        '\n\nReturn a structured verdict with PASS or FLAG for each check.';
+        '\n\nReturn a structured verdict with PASS or FLAG for each check. ' +
+        'When doing QC: First list all checks as PASS or FLAG lines. ' +
+        'Then write "---" on its own line. ' +
+        'Then write ONLY the corrected caption text after the separator. Nothing else after the caption.';
       window.sendCaptionMessage(msg3);
     }
     // 'chat' mode: user types first message
@@ -165,7 +178,7 @@ window.sendCaptionMessage = async function(text) {
     apiMessages[0] = { role: apiMessages[0].role, content: apiMessages[0].content + ws.correctionsPrompt };
   }
 
-  var aiOpts = ws.memoryPrompt ? { memory_context: ws.memoryPrompt } : undefined;
+  var aiOpts = _cwBuildAiOpts();
   var result = await _callSrtdAI(featureTag, apiMessages, ws.postId, aiOpts);
 
   var typingEl = thread && thread.querySelector('.cw-typing');
@@ -296,6 +309,65 @@ function _cwBuildCommentsBlock(comments) {
   return html;
 }
 
+// ─── caption extraction (strip QC analysis) ─────────────────
+
+function _cwExtractCaption(fullText) {
+  var text = fullText || '';
+
+  var separatorIdx = text.lastIndexOf('\n---\n');
+  if (separatorIdx !== -1) {
+    return text.substring(separatorIdx + 5).trim();
+  }
+
+  var lines = text.split('\n');
+  var captionStart = -1;
+  var skipPatterns = [
+    /^(PASS|FLAG|CHECK|NOTE|ISSUE|VERDICT|ANALYSIS|QC|REVIEW)[\s:]/i,
+    /^(Here is|Here's|Updated|Revised|Rewritten|New) (the |your |an )?(updated |revised |rewritten |new )?(caption|copy|version|draft)/i,
+    /^(Brand guide|Word count|Hashtag|Hook|Structure|Formatting|Length)/i,
+    /^[-\u2022\u2713\u2717\u2192\u25CF]/,
+    /^\d+\.\s*(PASS|FLAG|CHECK)/i
+  ];
+
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i].trim();
+    if (line === '') continue;
+
+    var isAnalysis = false;
+    for (var p = 0; p < skipPatterns.length; p++) {
+      if (skipPatterns[p].test(line)) {
+        isAnalysis = true;
+        break;
+      }
+    }
+
+    if (!isAnalysis && captionStart === -1) {
+      var prevWasAnalysis = false;
+      for (var j = i - 1; j >= 0; j--) {
+        var prevLine = lines[j].trim();
+        if (prevLine === '') continue;
+        for (var p2 = 0; p2 < skipPatterns.length; p2++) {
+          if (skipPatterns[p2].test(prevLine)) {
+            prevWasAnalysis = true;
+            break;
+          }
+        }
+        break;
+      }
+
+      if (prevWasAnalysis || i === 0) {
+        captionStart = i;
+      }
+    }
+  }
+
+  if (captionStart > 0) {
+    return lines.slice(captionStart).join('\n').trim();
+  }
+
+  return text.trim();
+}
+
 // ─── chip handler ────────────────────────────────────────────
 
 window._cwHandleChip = function(chipType, draftNum) {
@@ -305,7 +377,9 @@ window._cwHandleChip = function(chipType, draftNum) {
       var allDrafts = document.querySelectorAll('.cw-draft-body[data-draft="' + draftNum + '"]');
       draftEl = allDrafts.length ? allDrafts[allDrafts.length - 1] : null;
     }
-    var text = draftEl ? draftEl.innerText.trim() : '';
+    var rawText = draftEl ? draftEl.innerText.trim() : '';
+    if (!rawText) return;
+    var text = _cwExtractCaption(rawText);
     if (!text) return;
     var original = draftEl ? (draftEl.getAttribute('data-original') || '') : '';
     _cwCaptureCorrection(original, text);
@@ -345,9 +419,10 @@ window._cwApplyDraft = async function(text) {
     Object.assign(post, { caption: text, updated_at: new Date().toISOString() });
     if (typeof _clearSaveTimeout === 'function') _clearSaveTimeout(post);
     post._isSaving = false;
-    window.closeCaptionWorkspace();
-    if (typeof _renderPCS === 'function') _renderPCS(postId);
+    ws.caption = text;
     if (typeof showToast === 'function') showToast('Caption updated', 'success');
+    if (typeof _renderPCS === 'function') _renderPCS(postId);
+    setTimeout(function() { window.closeCaptionWorkspace(); }, 500);
   } catch (err) {
     if (typeof _clearSaveTimeout === 'function') _clearSaveTimeout(post);
     post._isSaving = false;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260416o">
+ <link rel="stylesheet" href="styles.css?v=20260417a">
 
 </head>
 <body>
@@ -1248,32 +1248,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260416o"></script>
-<script src="00-appstate-compat.js?v=20260416o"></script>
-<script src="01-config.js?v=20260416o" defer></script>
-<script src="02-session.js?v=20260416o" defer></script>
-<script src="utils.js?v=20260416o" defer></script>
-<script src="12-profiles.js?v=20260416o" defer></script>
-<script src="03-auth.js?v=20260416o" defer></script>
-<script src="05-api.js?v=20260416o" defer></script>
-<script src="10-ui.js?v=20260416o" defer></script>
+<script src="00-appstate.js?v=20260417a"></script>
+<script src="00-appstate-compat.js?v=20260417a"></script>
+<script src="01-config.js?v=20260417a" defer></script>
+<script src="02-session.js?v=20260417a" defer></script>
+<script src="utils.js?v=20260417a" defer></script>
+<script src="12-profiles.js?v=20260417a" defer></script>
+<script src="03-auth.js?v=20260417a" defer></script>
+<script src="05-api.js?v=20260417a" defer></script>
+<script src="10-ui.js?v=20260417a" defer></script>
 
-<script src="06-post-create.js?v=20260416o" defer></script>
-<script defer src="render/dashboard.js?v=20260416o"></script>
-<script defer src="render/client.js?v=20260416o"></script>
-<script defer src="render/pipeline.js?v=20260416o"></script>
-<script defer src="render/brief.js?v=20260416o"></script>
-<script defer src="actions/pcs.js?v=20260416o"></script>
-<script defer src="actions/pcs-longpress.js?v=20260416o"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260416o"></script>
-<script defer src="actions/pcs-polish.js?v=20260416o"></script>
-<script defer src="actions/pcs-select.js?v=20260416o"></script>
-<script src="ai-config.js?v=20260416o" defer></script>
-<script src="07-post-load.js?v=20260416o" defer></script>
-<script src="08-post-actions.js?v=20260416o" defer></script>
-<script src="09-library.js?v=20260416o" defer></script>
-<script src="09-approval.js?v=20260416o" defer></script>
-<script src="04-router.js?v=20260416o" defer></script>
+<script src="06-post-create.js?v=20260417a" defer></script>
+<script defer src="render/dashboard.js?v=20260417a"></script>
+<script defer src="render/client.js?v=20260417a"></script>
+<script defer src="render/pipeline.js?v=20260417a"></script>
+<script defer src="render/brief.js?v=20260417a"></script>
+<script defer src="actions/pcs.js?v=20260417a"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417a"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417a"></script>
+<script defer src="actions/pcs-polish.js?v=20260417a"></script>
+<script defer src="actions/pcs-select.js?v=20260417a"></script>
+<script src="ai-config.js?v=20260417a" defer></script>
+<script src="07-post-load.js?v=20260417a" defer></script>
+<script src="08-post-actions.js?v=20260417a" defer></script>
+<script src="09-library.js?v=20260417a" defer></script>
+<script src="09-approval.js?v=20260417a" defer></script>
+<script src="04-router.js?v=20260417a" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

Three bugs fixed in `actions/pcs-claude-caption.js`.

### Bug 1 — Claude was never receiving the caption
- Added `caption` slot to `window._captionWS`, populated from `context.caption` in `openCaptionWorkspace`.
- New `_cwBuildAiOpts()` helper combines `memoryPrompt` + `\n\nCURRENT CAPTION:\n<caption>` into `memory_context` on every Worker call. Used by both `sendCaptionMessage` and the rewrite branch of `openCaptionWorkspace`.
- `_cwApplyDraft` now also updates `ws.caption` after a successful PATCH so the in-memory context stays in sync.

### Bug 2 — No toast on "Use this"
- `_cwApplyDraft` now shows `showToast('Caption updated', 'success')` immediately on PATCH success, and defers `closeCaptionWorkspace()` by 500 ms so the toast is visible.

### Bug 3 — "Use this" was saving the QC analysis text into the caption
- New `_cwExtractCaption(fullText)` helper strips QC analysis when saving.
- Checks for a clean `\n---\n` separator first (Claude is now instructed to emit one).
- Falls back to heuristic line-by-line detection of `PASS:`, `FLAG:`, `CHECK:`, `NOTE:`, `VERDICT:`, bullet glyphs, and "Here is the updated caption" style intros.
- Returns the full text unchanged when no analysis markers are detected (pure rewrites still work).
- QC mode prompt now instructs Claude to write `PASS`/`FLAG` lines, then `---`, then only the corrected caption.
- `_cwHandleChip('use', ...)` applies `_cwExtractCaption()` before both `_cwCaptureCorrection` and `_cwApplyDraft`, so the correction memory also sees a clean caption diff.

### Version bump
- All 26 `?v=` strings in `index.html` bumped from `20260416o` → `20260417a`.

## Test plan
- [ ] Open Caption Claude on a post with an existing caption → chat normally → confirm Claude references the caption content.
- [ ] Generate a draft → tap "Use this" → toast appears, workspace closes after ~500 ms, caption is saved.
- [ ] Run QC mode → tap "Use this" on the draft → only the caption text lands in the `caption` column, PASS/FLAG lines are stripped.
- [ ] Hard refresh (Cloudflare purge) to pick up `?v=20260417a`.

https://claude.ai/code/session_01SW4H2hd4tunMYTryxehEud