### PR TITLE
Strip caption headers/footers in _cwExtractCaption + tighten Worker prompts

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -314,58 +314,27 @@ function _cwBuildCommentsBlock(comments) {
 function _cwExtractCaption(fullText) {
   var text = fullText || '';
 
-  var separatorIdx = text.lastIndexOf('\n---\n');
-  if (separatorIdx !== -1) {
-    return text.substring(separatorIdx + 5).trim();
+  var sepIdx = text.lastIndexOf('\n---\n');
+  if (sepIdx !== -1) {
+    text = text.substring(sepIdx + 5);
   }
 
-  var lines = text.split('\n');
-  var captionStart = -1;
-  var skipPatterns = [
-    /^(PASS|FLAG|CHECK|NOTE|ISSUE|VERDICT|ANALYSIS|QC|REVIEW)[\s:]/i,
-    /^(Here is|Here's|Updated|Revised|Rewritten|New) (the |your |an )?(updated |revised |rewritten |new )?(caption|copy|version|draft)/i,
-    /^(Brand guide|Word count|Hashtag|Hook|Structure|Formatting|Length)/i,
-    /^[-\u2022\u2713\u2717\u2192\u25CF]/,
-    /^\d+\.\s*(PASS|FLAG|CHECK)/i
+  text = text.replace(/^\s*\*{0,2}(REVISED|UPDATED|REWRITTEN|NEW|CORRECTED|HERE'S THE|HERE IS THE)[\s\w]*:?\*{0,2}\s*\n/i, '');
+
+  var footerPatterns = [
+    /\n\s*\*{0,2}(Key improvements|Key changes|Changes made|What I changed|Summary of changes|Summary|Notes|Improvements|Changes|What changed|Edits made|Revisions)[\s:]*\*{0,2}\s*\n[\s\S]*/i,
+    /\n\s*\*{0,2}(Here'?s? what I|I'?ve? made the following|The main changes|I'?ve? (?:updated|revised|changed|improved))[\s\S]*/i
   ];
 
-  for (var i = 0; i < lines.length; i++) {
-    var line = lines[i].trim();
-    if (line === '') continue;
-
-    var isAnalysis = false;
-    for (var p = 0; p < skipPatterns.length; p++) {
-      if (skipPatterns[p].test(line)) {
-        isAnalysis = true;
-        break;
-      }
-    }
-
-    if (!isAnalysis && captionStart === -1) {
-      var prevWasAnalysis = false;
-      for (var j = i - 1; j >= 0; j--) {
-        var prevLine = lines[j].trim();
-        if (prevLine === '') continue;
-        for (var p2 = 0; p2 < skipPatterns.length; p2++) {
-          if (skipPatterns[p2].test(prevLine)) {
-            prevWasAnalysis = true;
-            break;
-          }
-        }
-        break;
-      }
-
-      if (prevWasAnalysis || i === 0) {
-        captionStart = i;
-      }
-    }
+  for (var i = 0; i < footerPatterns.length; i++) {
+    text = text.replace(footerPatterns[i], '');
   }
 
-  if (captionStart > 0) {
-    return lines.slice(captionStart).join('\n').trim();
-  }
+  text = text.replace(/\*\*/g, '');
 
-  return text.trim();
+  text = text.trim();
+
+  return text;
 }
 
 // ─── chip handler ────────────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417a">
+ <link rel="stylesheet" href="styles.css?v=20260417b">
 
 </head>
 <body>
@@ -1248,32 +1248,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417a"></script>
-<script src="00-appstate-compat.js?v=20260417a"></script>
-<script src="01-config.js?v=20260417a" defer></script>
-<script src="02-session.js?v=20260417a" defer></script>
-<script src="utils.js?v=20260417a" defer></script>
-<script src="12-profiles.js?v=20260417a" defer></script>
-<script src="03-auth.js?v=20260417a" defer></script>
-<script src="05-api.js?v=20260417a" defer></script>
-<script src="10-ui.js?v=20260417a" defer></script>
+<script src="00-appstate.js?v=20260417b"></script>
+<script src="00-appstate-compat.js?v=20260417b"></script>
+<script src="01-config.js?v=20260417b" defer></script>
+<script src="02-session.js?v=20260417b" defer></script>
+<script src="utils.js?v=20260417b" defer></script>
+<script src="12-profiles.js?v=20260417b" defer></script>
+<script src="03-auth.js?v=20260417b" defer></script>
+<script src="05-api.js?v=20260417b" defer></script>
+<script src="10-ui.js?v=20260417b" defer></script>
 
-<script src="06-post-create.js?v=20260417a" defer></script>
-<script defer src="render/dashboard.js?v=20260417a"></script>
-<script defer src="render/client.js?v=20260417a"></script>
-<script defer src="render/pipeline.js?v=20260417a"></script>
-<script defer src="render/brief.js?v=20260417a"></script>
-<script defer src="actions/pcs.js?v=20260417a"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417a"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417a"></script>
-<script defer src="actions/pcs-polish.js?v=20260417a"></script>
-<script defer src="actions/pcs-select.js?v=20260417a"></script>
-<script src="ai-config.js?v=20260417a" defer></script>
-<script src="07-post-load.js?v=20260417a" defer></script>
-<script src="08-post-actions.js?v=20260417a" defer></script>
-<script src="09-library.js?v=20260417a" defer></script>
-<script src="09-approval.js?v=20260417a" defer></script>
-<script src="04-router.js?v=20260417a" defer></script>
+<script src="06-post-create.js?v=20260417b" defer></script>
+<script defer src="render/dashboard.js?v=20260417b"></script>
+<script defer src="render/client.js?v=20260417b"></script>
+<script defer src="render/pipeline.js?v=20260417b"></script>
+<script defer src="render/brief.js?v=20260417b"></script>
+<script defer src="actions/pcs.js?v=20260417b"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417b"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417b"></script>
+<script defer src="actions/pcs-polish.js?v=20260417b"></script>
+<script defer src="actions/pcs-select.js?v=20260417b"></script>
+<script src="ai-config.js?v=20260417b" defer></script>
+<script src="07-post-load.js?v=20260417b" defer></script>
+<script src="08-post-actions.js?v=20260417b" defer></script>
+<script src="09-library.js?v=20260417b" defer></script>
+<script src="09-approval.js?v=20260417b" defer></script>
+<script src="04-router.js?v=20260417b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/srtd-ai-worker/src/index.js
+++ b/srtd-ai-worker/src/index.js
@@ -144,44 +144,58 @@ function buildSystemPrompt(feature, approvedContext, brandGuide, memoryContext) 
   const mem = memoryContext || '';
   const hasMem = mem.length > 100;
 
+  const captionOutputRule = 'When rewriting or revising a caption, return ONLY the caption text. '
+    + 'No headers like "Revised caption:". No footer analysis like "Key improvements:". '
+    + 'No markdown bold. Just the caption, exactly as it should appear on LinkedIn.';
+
   if (feature === 'writer') {
     if (hasMem) {
       return 'You are a LinkedIn content writer for Godavari Biorefineries Limited (GBL), a sugarcane biorefinery.\n\n'
         + mem + '\n\n'
         + 'Here are 5 high-performing posts for voice reference:\n\n' + ctx
-        + '\n\nReturn exactly 3 numbered copy options. Each option on its own. No preamble.';
+        + '\n\nReturn exactly 3 numbered copy options. Each option on its own. No preamble.'
+        + '\n\n' + captionOutputRule;
     }
     return 'You are a LinkedIn content writer for Godavari Biorefineries Limited (GBL), a sugarcane biorefinery. '
       + 'Write in their established voice. Here are 20 approved posts for reference:\n\n'
       + ctx
       + '\n\nBrand guide:\n'
       + bg
-      + '\n\nReturn exactly 3 numbered copy options. Each option on its own. No preamble.';
+      + '\n\nReturn exactly 3 numbered copy options. Each option on its own. No preamble.'
+      + '\n\n' + captionOutputRule;
   }
   if (feature === 'qc') {
     if (hasMem) {
       return 'You are a brand quality controller for GBL.\n\n'
         + mem
-        + '\n\nCheck the provided copy against these rules. Return PASS or FLAG for each item. Be specific. Be brief.';
+        + '\n\nCheck the provided copy against these rules. Return PASS or FLAG for each item. Be specific. Be brief.'
+        + '\n\nWhen doing QC: First list all checks as PASS or FLAG lines. Then write "---" on its own line. '
+        + 'Then write ONLY the corrected caption text after the separator. Nothing else after the caption.'
+        + '\n\n' + captionOutputRule;
     }
     return 'You are a brand quality controller for GBL. Check the provided copy against the brand voice and approved posts. '
       + 'Here are 20 approved posts:\n\n'
       + ctx
       + '\n\nBrand guide:\n'
       + bg
-      + '\n\nReturn a structured verdict: PASS or FLAG for each item checked. Be specific. Be brief.';
+      + '\n\nReturn a structured verdict: PASS or FLAG for each item checked. Be specific. Be brief.'
+      + '\n\nWhen doing QC: First list all checks as PASS or FLAG lines. Then write "---" on its own line. '
+      + 'Then write ONLY the corrected caption text after the separator. Nothing else after the caption.'
+      + '\n\n' + captionOutputRule;
   }
   if (feature === 'chat') {
     if (hasMem) {
       return 'You are a copy editor for GBL LinkedIn content.\n\n'
         + mem
-        + '\n\nHelp the user improve the copy. Be direct and brief.';
+        + '\n\nHelp the user improve the copy. Be direct and brief.'
+        + '\n\n' + captionOutputRule;
     }
     return 'You are a copy editor helping refine LinkedIn content for GBL. Here are 20 approved posts for reference:\n\n'
       + ctx
       + '\n\nBrand guide:\n'
       + bg
-      + '\n\nHelp the user improve the copy. Be direct and brief.';
+      + '\n\nHelp the user improve the copy. Be direct and brief.'
+      + '\n\n' + captionOutputRule;
   }
   if (feature === 'email_brief') {
     return 'You are a content strategist. Read the email below and identify every distinct post brief it contains. '


### PR DESCRIPTION
## Summary

Caption save was still letting Claude's analysis leak into the `caption` column — `REVISED CAPTION:`, `**Key improvements:**`, etc. This PR hardens the extraction and fixes the prompts.

### Frontend — `actions/pcs-claude-caption.js`
Rewrote `_cwExtractCaption` to:
1. Clean `---` separator (QC mode) — returns only the text after the separator.
2. Strip top-of-response header labels: `**REVISED CAPTION:**`, `REVISED CAPTION:`, `UPDATED CAPTION:`, `REWRITTEN CAPTION:`, `NEW CAPTION:`, `CORRECTED CAPTION:`, `HERE'S THE...:`, `HERE IS THE...:` (with or without markdown bold).
3. Strip footer analysis blocks: `**Key improvements:**`, `Key changes:`, `Changes made:`, `What I changed:`, `Summary of changes:`, `Summary:`, `Notes:`, `Improvements:`, `Changes:`, `What changed:`, `Edits made:`, `Revisions:`, and conversational footers like "Here's what I...", "I've made the following...", "The main changes...", "I've updated/revised/changed/improved...".
4. Strip any remaining `**` markdown bold markers.
5. Trim leading/trailing whitespace.

### Worker — `srtd-ai-worker/src/index.js`
`buildSystemPrompt` now appends this rule to every caption-producing feature (`writer`, `qc`, `chat`, both memory and non-memory branches):

> "When rewriting or revising a caption, return ONLY the caption text. No headers like 'Revised caption:'. No footer analysis like 'Key improvements:'. No markdown bold. Just the caption, exactly as it should appear on LinkedIn."

The QC system prompt also now carries the `---` separator instruction on the server side (previously only in the user-side prompt text in `openCaptionWorkspace`).

### ⚠️ Worker redeploy required
The Worker change only takes effect after redeploying `srtd-ai-worker`:
```
cd srtd-ai-worker && npx wrangler deploy
```
Until then the frontend extraction is the safety net and will still strip headers/footers from any analysis Claude emits.

### Version bump
All 26 `?v=` strings in `index.html` bumped `20260417a` → `20260417b`.

## Test plan
- [ ] Run QC mode → tap "Use this" → only the post-`---` caption lands in the `caption` column (no PASS/FLAG, no bold, no footer).
- [ ] Chat mode: ask Claude to rewrite with intro/outro analysis → tap "Use this" → extraction strips headers + footer.
- [ ] Pure caption rewrite (no analysis) → tap "Use this" → caption saved unchanged.
- [ ] Redeploy the Worker → confirm new captions no longer include `**REVISED CAPTION:**` / `**Key improvements:**` scaffolding at all.
- [ ] Hard refresh to pick up `?v=20260417b`.

https://claude.ai/code/session_01SW4H2hd4tunMYTryxehEud