### PR TITLE
Use &lt;caption&gt; XML tags to delimit applyable captions

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -121,9 +121,7 @@ window.openCaptionWorkspace = async function(mode, context) {
       var msg3 = 'QC this LinkedIn caption against the brand guide. Caption:\n\n' +
         (context.caption || '(no caption)') +
         '\n\nReturn a structured verdict with PASS or FLAG for each check. ' +
-        'When doing QC: First list all checks as PASS or FLAG lines. ' +
-        'Then write "---" on its own line. ' +
-        'Then write ONLY the corrected caption text after the separator. Nothing else after the caption.';
+        'If you are providing a corrected caption, wrap ONLY that corrected caption in <caption>...</caption> tags at the end.';
       window.sendCaptionMessage(msg3);
     }
     // 'chat' mode: user types first message
@@ -239,8 +237,9 @@ function _cwRenderThread() {
           '</div>' +
           '<div class="cw-draft-body" ' + (isLatest ? 'contenteditable="true"' : '') +
             ' data-draft="' + draftNum + '"' +
+            ' data-raw="' + _cwEsc(m.content).replace(/"/g, '&quot;') + '"' +
             ' data-original="' + _cwEsc(m.content).replace(/"/g, '&quot;') + '">' +
-            _cwEsc(m.content).replace(/\n/g, '<br>') +
+            _cwFormatAssistantHtml(m.content) +
           '</div>' +
           (isLatest
             ? '<div class="cw-draft-hint">Tap to edit before using</div>'
@@ -281,6 +280,25 @@ function _cwEsc(s) {
   return (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+function _cwFormatAssistantHtml(raw) {
+  var src = raw || '';
+  var hasTag = /<caption>[\s\S]*?<\/caption>/i.test(src);
+  if (hasTag) {
+    var out = '';
+    var lastIdx = 0;
+    var re = /<caption>([\s\S]*?)<\/caption>/gi;
+    var mm;
+    while ((mm = re.exec(src)) !== null) {
+      out += _cwEsc(src.slice(lastIdx, mm.index)).replace(/\n/g, '<br>');
+      out += '<div class="cw-caption-output">' + _cwEsc(mm[1]).replace(/\n/g, '<br>') + '</div>';
+      lastIdx = mm.index + mm[0].length;
+    }
+    out += _cwEsc(src.slice(lastIdx)).replace(/\n/g, '<br>');
+    return out;
+  }
+  return _cwEsc(src).replace(/\n/g, '<br>');
+}
+
 function _cwScrollToBottom() {
   var thread = document.getElementById('cw-thread');
   if (thread) setTimeout(function() { thread.scrollTop = thread.scrollHeight; }, 50);
@@ -309,17 +327,28 @@ function _cwBuildCommentsBlock(comments) {
   return html;
 }
 
-// ─── caption extraction (strip QC analysis) ─────────────────
+// ─── caption extraction (tag-based with legacy fallback) ────
 
 function _cwExtractCaption(fullText) {
   var text = fullText || '';
+
+  var tagRegex = /<caption>([\s\S]*?)<\/caption>/gi;
+  var matches = [];
+  var m;
+  while ((m = tagRegex.exec(text)) !== null) {
+    matches.push(m[1]);
+  }
+
+  if (matches.length > 0) {
+    return matches[matches.length - 1].trim();
+  }
 
   var sepIdx = text.lastIndexOf('\n---\n');
   if (sepIdx !== -1) {
     text = text.substring(sepIdx + 5);
   }
 
-  text = text.replace(/^\s*\*{0,2}(REVISED|UPDATED|REWRITTEN|NEW|CORRECTED|HERE'S THE|HERE IS THE)[\s\w]*:?\*{0,2}\s*\n/i, '');
+  text = text.replace(/^\s*\*{0,2}(REVISED|UPDATED|REWRITTEN|NEW|CORRECTED|HERE'S THE|HERE IS THE|FINAL)[\s\w]*:?\*{0,2}\s*\n/i, '');
 
   var footerPatterns = [
     /\n\s*\*{0,2}(Key improvements|Key changes|Changes made|What I changed|Summary of changes|Summary|Notes|Improvements|Changes|What changed|Edits made|Revisions)[\s:]*\*{0,2}\s*\n[\s\S]*/i,
@@ -332,9 +361,7 @@ function _cwExtractCaption(fullText) {
 
   text = text.replace(/\*\*/g, '');
 
-  text = text.trim();
-
-  return text;
+  return text.trim();
 }
 
 // ─── chip handler ────────────────────────────────────────────
@@ -346,8 +373,16 @@ window._cwHandleChip = function(chipType, draftNum) {
       var allDrafts = document.querySelectorAll('.cw-draft-body[data-draft="' + draftNum + '"]');
       draftEl = allDrafts.length ? allDrafts[allDrafts.length - 1] : null;
     }
-    var rawText = draftEl ? draftEl.innerText.trim() : '';
-    if (!rawText) return;
+    var rawSource = draftEl ? (draftEl.getAttribute('data-raw') || '') : '';
+    var rawText = rawSource || (draftEl ? draftEl.innerText : '');
+    if (!rawText || !rawText.trim()) return;
+
+    var hasTag = /<caption>[\s\S]*?<\/caption>/i.test(rawSource);
+    if (!hasTag && draftEl) {
+      var edited = draftEl.innerText;
+      if (edited && edited.trim()) rawText = edited;
+    }
+
     var text = _cwExtractCaption(rawText);
     if (!text) return;
     var original = draftEl ? (draftEl.getAttribute('data-original') || '') : '';

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417b">
+ <link rel="stylesheet" href="styles.css?v=20260417c">
 
 </head>
 <body>
@@ -1248,32 +1248,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417b"></script>
-<script src="00-appstate-compat.js?v=20260417b"></script>
-<script src="01-config.js?v=20260417b" defer></script>
-<script src="02-session.js?v=20260417b" defer></script>
-<script src="utils.js?v=20260417b" defer></script>
-<script src="12-profiles.js?v=20260417b" defer></script>
-<script src="03-auth.js?v=20260417b" defer></script>
-<script src="05-api.js?v=20260417b" defer></script>
-<script src="10-ui.js?v=20260417b" defer></script>
+<script src="00-appstate.js?v=20260417c"></script>
+<script src="00-appstate-compat.js?v=20260417c"></script>
+<script src="01-config.js?v=20260417c" defer></script>
+<script src="02-session.js?v=20260417c" defer></script>
+<script src="utils.js?v=20260417c" defer></script>
+<script src="12-profiles.js?v=20260417c" defer></script>
+<script src="03-auth.js?v=20260417c" defer></script>
+<script src="05-api.js?v=20260417c" defer></script>
+<script src="10-ui.js?v=20260417c" defer></script>
 
-<script src="06-post-create.js?v=20260417b" defer></script>
-<script defer src="render/dashboard.js?v=20260417b"></script>
-<script defer src="render/client.js?v=20260417b"></script>
-<script defer src="render/pipeline.js?v=20260417b"></script>
-<script defer src="render/brief.js?v=20260417b"></script>
-<script defer src="actions/pcs.js?v=20260417b"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417b"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417b"></script>
-<script defer src="actions/pcs-polish.js?v=20260417b"></script>
-<script defer src="actions/pcs-select.js?v=20260417b"></script>
-<script src="ai-config.js?v=20260417b" defer></script>
-<script src="07-post-load.js?v=20260417b" defer></script>
-<script src="08-post-actions.js?v=20260417b" defer></script>
-<script src="09-library.js?v=20260417b" defer></script>
-<script src="09-approval.js?v=20260417b" defer></script>
-<script src="04-router.js?v=20260417b" defer></script>
+<script src="06-post-create.js?v=20260417c" defer></script>
+<script defer src="render/dashboard.js?v=20260417c"></script>
+<script defer src="render/client.js?v=20260417c"></script>
+<script defer src="render/pipeline.js?v=20260417c"></script>
+<script defer src="render/brief.js?v=20260417c"></script>
+<script defer src="actions/pcs.js?v=20260417c"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417c"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417c"></script>
+<script defer src="actions/pcs-polish.js?v=20260417c"></script>
+<script defer src="actions/pcs-select.js?v=20260417c"></script>
+<script src="ai-config.js?v=20260417c" defer></script>
+<script src="07-post-load.js?v=20260417c" defer></script>
+<script src="08-post-actions.js?v=20260417c" defer></script>
+<script src="09-library.js?v=20260417c" defer></script>
+<script src="09-approval.js?v=20260417c" defer></script>
+<script src="04-router.js?v=20260417c" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/srtd-ai-worker/src/index.js
+++ b/srtd-ai-worker/src/index.js
@@ -144,9 +144,18 @@ function buildSystemPrompt(feature, approvedContext, brandGuide, memoryContext) 
   const mem = memoryContext || '';
   const hasMem = mem.length > 100;
 
-  const captionOutputRule = 'When rewriting or revising a caption, return ONLY the caption text. '
-    + 'No headers like "Revised caption:". No footer analysis like "Key improvements:". '
-    + 'No markdown bold. Just the caption, exactly as it should appear on LinkedIn.';
+  const captionOutputRule = 'CRITICAL OUTPUT FORMAT: Whenever you produce a caption the user might apply to their post, '
+    + 'wrap the final caption in <caption>...</caption> tags. The caption inside these tags must be publishable-ready text only: '
+    + 'no headers, no labels like "Revised caption:", no analysis, no markdown, no commentary. '
+    + 'Any analysis, reasoning, or explanation must appear OUTSIDE the tags (before or after them). '
+    + 'If you are only analyzing without producing a new caption (pure QC pass), do not emit any <caption> tags.';
+
+  const writerTagRule = 'For 3 options: Wrap each option in its own tags: '
+    + '<caption>option 1 text</caption> then <caption>option 2 text</caption> then <caption>option 3 text</caption>. '
+    + 'Separate options by numbering OUTSIDE the tags (e.g., "1." before the first tag).';
+
+  const qcTagRule = 'For QC: First list your analysis (PASS/FLAG lines). '
+    + 'Then if you are providing a corrected version, wrap ONLY the corrected caption in <caption>...</caption> tags.';
 
   if (feature === 'writer') {
     if (hasMem) {
@@ -154,7 +163,8 @@ function buildSystemPrompt(feature, approvedContext, brandGuide, memoryContext) 
         + mem + '\n\n'
         + 'Here are 5 high-performing posts for voice reference:\n\n' + ctx
         + '\n\nReturn exactly 3 numbered copy options. Each option on its own. No preamble.'
-        + '\n\n' + captionOutputRule;
+        + '\n\n' + captionOutputRule
+        + '\n\n' + writerTagRule;
     }
     return 'You are a LinkedIn content writer for Godavari Biorefineries Limited (GBL), a sugarcane biorefinery. '
       + 'Write in their established voice. Here are 20 approved posts for reference:\n\n'
@@ -162,16 +172,16 @@ function buildSystemPrompt(feature, approvedContext, brandGuide, memoryContext) 
       + '\n\nBrand guide:\n'
       + bg
       + '\n\nReturn exactly 3 numbered copy options. Each option on its own. No preamble.'
-      + '\n\n' + captionOutputRule;
+      + '\n\n' + captionOutputRule
+      + '\n\n' + writerTagRule;
   }
   if (feature === 'qc') {
     if (hasMem) {
       return 'You are a brand quality controller for GBL.\n\n'
         + mem
         + '\n\nCheck the provided copy against these rules. Return PASS or FLAG for each item. Be specific. Be brief.'
-        + '\n\nWhen doing QC: First list all checks as PASS or FLAG lines. Then write "---" on its own line. '
-        + 'Then write ONLY the corrected caption text after the separator. Nothing else after the caption.'
-        + '\n\n' + captionOutputRule;
+        + '\n\n' + captionOutputRule
+        + '\n\n' + qcTagRule;
     }
     return 'You are a brand quality controller for GBL. Check the provided copy against the brand voice and approved posts. '
       + 'Here are 20 approved posts:\n\n'
@@ -179,9 +189,8 @@ function buildSystemPrompt(feature, approvedContext, brandGuide, memoryContext) 
       + '\n\nBrand guide:\n'
       + bg
       + '\n\nReturn a structured verdict: PASS or FLAG for each item checked. Be specific. Be brief.'
-      + '\n\nWhen doing QC: First list all checks as PASS or FLAG lines. Then write "---" on its own line. '
-      + 'Then write ONLY the corrected caption text after the separator. Nothing else after the caption.'
-      + '\n\n' + captionOutputRule;
+      + '\n\n' + captionOutputRule
+      + '\n\n' + qcTagRule;
   }
   if (feature === 'chat') {
     if (hasMem) {

--- a/styles.css
+++ b/styles.css
@@ -8307,6 +8307,11 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .cw-draft-body[contenteditable="true"] {
   cursor: text;
 }
+.cw-caption-output {
+  border-left: 2px solid #C15F3C;
+  padding-left: 10px;
+  margin: 8px 0;
+}
 .cw-draft-hint {
   padding: 0 14px 6px;
   font-family: 'IBM Plex Mono', monospace;


### PR DESCRIPTION
## Summary

Switch caption extraction to `<caption>...</caption>` XML tag delimiters. `---` was unreliable — Claude uses it in normal prose. XML tags never appear naturally.

### Worker — `srtd-ai-worker/src/index.js`
Replaced the `---` rule with a tag rule in every caption-producing branch (writer/qc/chat, memory + no-memory):

> **CRITICAL OUTPUT FORMAT:** Whenever you produce a caption the user might apply to their post, wrap the final caption in `<caption>...</caption>` tags. The caption inside these tags must be publishable-ready text only: no headers, no labels, no analysis, no markdown, no commentary. Any analysis or explanation appears OUTSIDE the tags. If you are only analyzing without producing a new caption (pure QC pass), do not emit any `<caption>` tags.

- **Writer** gets the 3-options rule: each option wrapped in its own tag pair, numbering lives outside the tags.
- **QC** gets the split rule: analysis first, then a single `<caption>` pair only if Claude is offering a corrected version.

### Frontend — `actions/pcs-claude-caption.js`
- **`_cwExtractCaption`**: primary path grabs the **last** `<caption>...</caption>` match (so nested/analysis tags are ignored). Falls through to the legacy `---` + header/footer regex cleanup if no tags are present — keeps backward compat if Claude forgets tags.
- **`_cwFormatAssistantHtml`** (new): renders assistant messages with `<caption>` contents wrapped in a `.cw-caption-output` div (terracotta left border) and strips the raw tag markers from the visible DOM.
- **Draft body** now carries `data-raw` with the original tagged string. `_cwHandleChip('use')` reads `data-raw` when tags are detected so the tag-stripped DOM can't leak into the saved caption. Untagged drafts still honor the user's in-place contenteditable edits.
- **QC user prompt** now asks for `<caption>` wrapping instead of `---`.

### CSS — `styles.css`
```css
.cw-caption-output {
  border-left: 2px solid #C15F3C;
  padding-left: 10px;
  margin: 8px 0;
}
```

### Version bump
All 26 `?v=` strings: `20260417b` → `20260417c`.

### ⚠️ Worker redeploy required
```
cd srtd-ai-worker && npx wrangler deploy
```
Until redeployed, the frontend tag-detection is the safety net. Once redeployed, Claude wraps captions every time and the visual terracotta outline makes "what will be saved" explicit to the user.

## Test plan
- [ ] QC mode → tap "Use this" → only the content inside the last `<caption>` pair is saved (analysis above is ignored).
- [ ] Chat mode with tags → terracotta-bordered block appears in the thread; "Use this" saves only that block.
- [ ] Chat mode without tags (older Worker build / ignored instruction) → legacy header/footer cleanup still trims the analysis.
- [ ] Edit untagged draft in place → "Use this" picks up the edit.
- [ ] Redeploy Worker → fresh responses all emit `<caption>` tags.
- [ ] Hard refresh to pick up `?v=20260417c`.

https://claude.ai/code/session_01SW4H2hd4tunMYTryxehEud