### PR TITLE
Add memorize: command to Caption Claude (zero-cost rule capture)

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -91,7 +91,9 @@ window.openCaptionWorkspace = async function(mode, context) {
       var thread = document.getElementById('cw-thread');
       if (thread) { thread.insertAdjacentHTML('beforeend', _cwTypingHtml()); _cwScrollToBottom(); }
       var featureTag = 'chat';
-      var rwApiMsgs = ws.messages.map(function(m) { return { role: m.role, content: m.content }; });
+      var rwApiMsgs = ws.messages
+        .filter(function(m) { return m.role === 'user' || m.role === 'assistant'; })
+        .map(function(m) { return { role: m.role, content: m.content }; });
       if (ws.correctionsPrompt && rwApiMsgs.length > 0) {
         rwApiMsgs[0] = { role: rwApiMsgs[0].role, content: rwApiMsgs[0].content + ws.correctionsPrompt };
       }
@@ -144,11 +146,24 @@ window.closeCaptionWorkspace = function() {
 
 // ─── send message ────────────────────────────────────────────
 
+var _CW_MEMORY_REGEX = /^(memoris[ez]e|remember(?:\s+this)?|never\s+forget|always(?:\s+do)?|never(?:\s+do)?|from\s+now\s+on|henceforth|make\s+sure(?:\s+you)?|going\s+forward|(?:new\s+)?rule|note|important)\s*:\s*([\s\S]+)$/i;
+
 window.sendCaptionMessage = async function(text) {
   if (!text || !text.trim()) return;
   var ws = window._captionWS;
 
-  ws.messages.push({ role: 'user', content: text.trim() });
+  var trimmed = text.trim();
+  var match = trimmed.match(_CW_MEMORY_REGEX);
+  if (match) {
+    var trigger = match[1];
+    var instruction = match[2].trim();
+    if (instruction.length > 3) {
+      _cwSaveMemory(trigger, instruction);
+      return;
+    }
+  }
+
+  ws.messages.push({ role: 'user', content: trimmed });
   _cwRenderThread();
   _cwScrollToBottom();
 
@@ -171,7 +186,9 @@ window.sendCaptionMessage = async function(text) {
 
   var featureTag = ws.mode === 'qc' ? 'qc' : ws.mode === 'write' ? 'writer' : 'chat';
 
-  var apiMessages = ws.messages.map(function(m) { return { role: m.role, content: m.content }; });
+  var apiMessages = ws.messages
+    .filter(function(m) { return m.role === 'user' || m.role === 'assistant'; })
+    .map(function(m) { return { role: m.role, content: m.content }; });
   if (ws.correctionsPrompt && apiMessages.length > 0) {
     apiMessages[0] = { role: apiMessages[0].role, content: apiMessages[0].content + ws.correctionsPrompt };
   }
@@ -225,6 +242,8 @@ function _cwRenderThread() {
       var displayText = m._display || m.content;
       html += '<div class="cw-msg cw-msg-user"><div class="cw-msg-bubble">' +
         _cwEsc(displayText).replace(/\n/g, '<br>') + '</div></div>';
+    } else if (m.role === 'memory') {
+      html += '<div class="cw-memorized">' + _cwEsc(m.content) + '</div>';
     } else if (m.role === 'assistant') {
       draftNum++;
       var isLatest = (i === ws.messages.length - 1);
@@ -480,12 +499,48 @@ function _cwCaptureCorrection(original, edited) {
   }
 }
 
+// ─── AI memory: explicit user instruction capture ──────
+
+function _cwSaveMemory(trigger, instruction) {
+  var ws = window._captionWS;
+
+  ws.messages.push({ role: 'user', content: trigger + ': ' + instruction });
+  ws.messages.push({ role: 'memory', content: '\u2726 Locked in. Claude will follow this rule in every future session.' });
+
+  apiFetch('/ai_memory', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Prefer': 'return=minimal' },
+    body: JSON.stringify({
+      workspace_id: 'default',
+      type: 'user_instruction',
+      content: instruction,
+      post_id: ws.postId || null
+    })
+  }).catch(function(err) {
+    console.warn('[cw] memory save failed:', err && err.message);
+  });
+
+  ws.memoryPrompt = 'USER INSTRUCTION (highest priority, NEVER violate): ' + instruction
+    + (ws.memoryPrompt ? '\n\n' + ws.memoryPrompt : '');
+
+  _cwRenderThread();
+  _cwScrollToBottom();
+
+  var input = document.getElementById('cw-input');
+  if (input) {
+    input.value = '';
+    input.style.height = 'auto';
+  }
+  var btn = document.getElementById('cw-send');
+  if (btn) btn.style.opacity = '0.55';
+}
+
 // ─── AI memory: load all memory types into prompt ───────
 
 async function _cwLoadMemory() {
   try {
     var rows = await apiFetch(
-      '/ai_memory?workspace_id=eq.default&order=created_at.desc&limit=30&select=type,content'
+      '/ai_memory?workspace_id=eq.default&order=created_at.desc&limit=50&select=type,content'
     );
     if (!Array.isArray(rows) || rows.length === 0) {
       window._captionWS.memoryPrompt = '';
@@ -493,16 +548,36 @@ async function _cwLoadMemory() {
       return;
     }
 
-    var style = [];
-    var client = [];
+    var instructions = [];
+    var zeroTolerance = [];
+    var brandSummary = [];
+    var clientPattern = [];
+    var clientPatternAuto = [];
+    var styleDna = [];
+    var companyIdentity = [];
+    var productKnowledge = [];
     var corrections = [];
+
+    function _str(c) { return typeof c === 'string' ? c : JSON.stringify(c); }
 
     rows.forEach(function(r) {
       try {
-        if (r.type === 'style_dna') {
-          style.push(typeof r.content === 'string' ? r.content : JSON.stringify(r.content));
+        var s = _str(r.content);
+        if (r.type === 'user_instruction') {
+          instructions.push('- ' + s);
+        } else if (r.type === 'brand_guide_summary') {
+          if (s.indexOf('ZERO TOLERANCE') !== -1) zeroTolerance.push(s);
+          else brandSummary.push(s);
         } else if (r.type === 'client_pattern') {
-          client.push(typeof r.content === 'string' ? r.content : JSON.stringify(r.content));
+          clientPattern.push(s);
+        } else if (r.type === 'client_pattern_auto') {
+          clientPatternAuto.push(s);
+        } else if (r.type === 'style_dna') {
+          styleDna.push(s);
+        } else if (r.type === 'company_identity') {
+          companyIdentity.push(s);
+        } else if (r.type === 'product_knowledge') {
+          productKnowledge.push(s);
         } else if (r.type === 'edit_correction') {
           var c = typeof r.content === 'string' ? JSON.parse(r.content) : r.content;
           if (c && c.original && c.edited) {
@@ -515,14 +590,32 @@ async function _cwLoadMemory() {
     });
 
     var blocks = [];
-    if (style.length > 0) {
-      blocks.push('WRITING STYLE FOR THIS BRAND:\n' + style.join('\n'));
+    if (instructions.length > 0) {
+      blocks.push('USER INSTRUCTIONS \u2014 NEVER VIOLATE THESE. These are direct commands from the user.\n' + instructions.join('\n'));
     }
-    if (client.length > 0) {
-      blocks.push('CLIENT FEEDBACK PATTERNS (never repeat these mistakes):\n' + client.join('\n'));
+    if (zeroTolerance.length > 0) {
+      blocks.push('ZERO TOLERANCE RULES:\n' + zeroTolerance.join('\n'));
+    }
+    if (brandSummary.length > 0) {
+      blocks.push('BRAND GUIDE:\n' + brandSummary.join('\n'));
+    }
+    if (clientPattern.length > 0) {
+      blocks.push('CLIENT FEEDBACK PATTERNS (never repeat these mistakes):\n' + clientPattern.join('\n'));
+    }
+    if (clientPatternAuto.length > 0) {
+      blocks.push('CLIENT FEEDBACK PATTERNS (auto-detected):\n' + clientPatternAuto.join('\n'));
+    }
+    if (styleDna.length > 0) {
+      blocks.push('WRITING STYLE FOR THIS BRAND:\n' + styleDna.join('\n'));
+    }
+    if (companyIdentity.length > 0) {
+      blocks.push('COMPANY IDENTITY:\n' + companyIdentity.join('\n'));
+    }
+    if (productKnowledge.length > 0) {
+      blocks.push('PRODUCT KNOWLEDGE:\n' + productKnowledge.join('\n'));
     }
     if (corrections.length > 0) {
-      blocks.push('STYLE CORRECTIONS FROM USER EDITS:\n' + corrections.join('\n'));
+      blocks.push('STYLE PREFERENCES (learned from user edits):\n' + corrections.join('\n'));
     }
 
     window._captionWS.memoryPrompt = blocks.length > 0 ? blocks.join('\n\n') : '';

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417c">
+ <link rel="stylesheet" href="styles.css?v=20260417d">
 
 </head>
 <body>
@@ -1103,7 +1103,7 @@
           <textarea id="cw-input" placeholder="Ask anything, or say what you want changed..." rows="1"></textarea>
           <button id="cw-send">&#x2191;</button>
         </div>
-        <div id="cw-input-hint">Tap &#x2713; Use this to update your caption</div>
+        <div id="cw-input-hint">Tap &#x2713; Use this to update &#xB7; Start with &#x2018;memorize:&#x2019; to teach Claude a rule</div>
       </div>
     </div>
   </div>
@@ -1248,32 +1248,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417c"></script>
-<script src="00-appstate-compat.js?v=20260417c"></script>
-<script src="01-config.js?v=20260417c" defer></script>
-<script src="02-session.js?v=20260417c" defer></script>
-<script src="utils.js?v=20260417c" defer></script>
-<script src="12-profiles.js?v=20260417c" defer></script>
-<script src="03-auth.js?v=20260417c" defer></script>
-<script src="05-api.js?v=20260417c" defer></script>
-<script src="10-ui.js?v=20260417c" defer></script>
+<script src="00-appstate.js?v=20260417d"></script>
+<script src="00-appstate-compat.js?v=20260417d"></script>
+<script src="01-config.js?v=20260417d" defer></script>
+<script src="02-session.js?v=20260417d" defer></script>
+<script src="utils.js?v=20260417d" defer></script>
+<script src="12-profiles.js?v=20260417d" defer></script>
+<script src="03-auth.js?v=20260417d" defer></script>
+<script src="05-api.js?v=20260417d" defer></script>
+<script src="10-ui.js?v=20260417d" defer></script>
 
-<script src="06-post-create.js?v=20260417c" defer></script>
-<script defer src="render/dashboard.js?v=20260417c"></script>
-<script defer src="render/client.js?v=20260417c"></script>
-<script defer src="render/pipeline.js?v=20260417c"></script>
-<script defer src="render/brief.js?v=20260417c"></script>
-<script defer src="actions/pcs.js?v=20260417c"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417c"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417c"></script>
-<script defer src="actions/pcs-polish.js?v=20260417c"></script>
-<script defer src="actions/pcs-select.js?v=20260417c"></script>
-<script src="ai-config.js?v=20260417c" defer></script>
-<script src="07-post-load.js?v=20260417c" defer></script>
-<script src="08-post-actions.js?v=20260417c" defer></script>
-<script src="09-library.js?v=20260417c" defer></script>
-<script src="09-approval.js?v=20260417c" defer></script>
-<script src="04-router.js?v=20260417c" defer></script>
+<script src="06-post-create.js?v=20260417d" defer></script>
+<script defer src="render/dashboard.js?v=20260417d"></script>
+<script defer src="render/client.js?v=20260417d"></script>
+<script defer src="render/pipeline.js?v=20260417d"></script>
+<script defer src="render/brief.js?v=20260417d"></script>
+<script defer src="actions/pcs.js?v=20260417d"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417d"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417d"></script>
+<script defer src="actions/pcs-polish.js?v=20260417d"></script>
+<script defer src="actions/pcs-select.js?v=20260417d"></script>
+<script src="ai-config.js?v=20260417d" defer></script>
+<script src="07-post-load.js?v=20260417d" defer></script>
+<script src="08-post-actions.js?v=20260417d" defer></script>
+<script src="09-library.js?v=20260417d" defer></script>
+<script src="09-approval.js?v=20260417d" defer></script>
+<script src="04-router.js?v=20260417d" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -8312,6 +8312,35 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   padding-left: 10px;
   margin: 8px 0;
 }
+.cw-memorized {
+  text-align: center;
+  padding: 14px 16px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #C15F3C;
+  background: linear-gradient(180deg, #1E1610 0%, #1A1816 100%);
+  border: 1px solid #5A3A2C;
+  border-radius: 8px;
+  margin: 6px 0;
+  font-weight: 600;
+  animation: memorized-pulse 2s ease-out;
+}
+@keyframes memorized-pulse {
+  0% {
+    box-shadow: 0 0 0 0 #C15F3C66;
+    transform: scale(0.98);
+  }
+  50% {
+    box-shadow: 0 0 20px 4px #C15F3C40;
+    transform: scale(1);
+  }
+  100% {
+    box-shadow: 0 0 0 0 #C15F3C00;
+    transform: scale(1);
+  }
+}
 .cw-draft-hint {
   padding: 0 14px 6px;
   font-family: 'IBM Plex Mono', monospace;


### PR DESCRIPTION
## Summary

Adds a zero-cost "memorize:" command to Caption Claude. Users teach Claude persistent rules without spending a single Worker call.

### Trigger phrases (case-insensitive, at start of message, followed by `:`)
`memorize` / `memorise`, `remember` / `remember this`, `never forget`, `always` / `always do`, `never` / `never do`, `from now on`, `henceforth`, `make sure` / `make sure you`, `going forward`, `rule` / `new rule`, `note`, `important`

Example: `memorize: never use the word "passionate"` → instantly saved, never sent to Claude.

### Frontend — `actions/pcs-claude-caption.js`
- `_CW_MEMORY_REGEX` matches the trigger phrase + colon at the start of the message; capture group 2 is the instruction body (must be > 3 chars).
- Interceptor at the top of `sendCaptionMessage` short-circuits before any Worker call when the regex matches.
- New `_cwSaveMemory(trigger, instruction)`:
  1. Pushes a normal user-bubble entry into `ws.messages` (so the original "memorize: …" line shows in the thread).
  2. Pushes a new `role:'memory'` entry which `_cwRenderThread` renders as a `.cw-memorized` confirmation card ("✦ Locked in. Claude will follow this rule in every future session.").
  3. POSTs to `/ai_memory` with `type: 'user_instruction'` via `apiFetch` (per CLAUDE.md "Never raw `fetch()`").
  4. Prepends the rule to `ws.memoryPrompt` with the highest-priority marker `USER INSTRUCTION (highest priority, NEVER violate): …` so it applies immediately within the current session.
  5. Clears the textarea and dims the send button.
- API message builder filters out `role:'memory'` so Anthropic only receives `user`/`assistant` turns. Filter applied to both `sendCaptionMessage` and the `rewrite` branch of `openCaptionWorkspace`.
- `_cwLoadMemory` rebuilt with strict priority order:
  1. USER INSTRUCTIONS — NEVER VIOLATE THESE (`user_instruction`)
  2. ZERO TOLERANCE RULES (any `brand_guide_summary` row containing `ZERO TOLERANCE`)
  3. BRAND GUIDE (other `brand_guide_summary`)
  4. CLIENT FEEDBACK PATTERNS (`client_pattern`)
  5. CLIENT FEEDBACK PATTERNS (auto) (`client_pattern_auto`)
  6. WRITING STYLE (`style_dna`)
  7. COMPANY IDENTITY (`company_identity`)
  8. PRODUCT KNOWLEDGE (`product_knowledge`)
  9. STYLE PREFERENCES from user edits (`edit_correction`)

  Row limit bumped 30 → 50 to fit the extra types.

### CSS — `styles.css`
`.cw-memorized` is an 8px mono-caps terracotta card on a dark gradient with a one-shot `memorized-pulse` keyframe (scale 0.98 → 1, box-shadow glow 0 → 20px → 0). Per CLAUDE.md design rules, every alpha value uses 8-digit hex (`#C15F3C66`, `#C15F3C40`, `#C15F3C00`) instead of `rgba()`.

### `index.html`
- `#cw-input-hint` updated:
  > Tap ✓ Use this to update · Start with 'memorize:' to teach Claude a rule
- All 26 `?v=` strings bumped `20260417c` → `20260417d`.

## Test plan
- [ ] `memorize: never end with hashtags` → no Worker call, terracotta pulse appears, row visible in `ai_memory` (`type=user_instruction`).
- [ ] `Remember this: cite specific molecules in chemistry posts` → captured.
- [ ] `Make sure you: keep captions under 100 words` → captured (multi-word phrase).
- [ ] `memorize: hi` → too short, falls through to a normal Claude call.
- [ ] Send a normal "rewrite this" prompt after capturing → Worker request includes the new instruction at the top of `memory_context` (verify in Network tab).
- [ ] Reopen the workspace on a different post → `_cwLoadMemory` re-fetches, USER INSTRUCTIONS section renders first.
- [ ] Hard refresh after Cloudflare purge to pick up `?v=20260417d`.

No Worker change required.

https://claude.ai/code/session_01SW4H2hd4tunMYTryxehEud