### PR TITLE
Refresh Caption Claude cost meter after every call

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -107,6 +107,7 @@ window.openCaptionWorkspace = async function(mode, context) {
         var outTok = result.output_tokens || (result.usage && result.usage.output) || 0;
         ws.sessionCost += _cwCalcINR(inTok, outTok);
         _cwUpdateSessionMeter();
+        setTimeout(function() { _cwFetchCostTotals(); }, 800);
       } else {
         ws.messages.push({ role: 'assistant', content: 'Error: ' + ((result && result.error) || 'Request failed. Try again.') });
       }
@@ -206,6 +207,7 @@ window.sendCaptionMessage = async function(text) {
     var costINR = _cwCalcINR(inTok, outTok);
     ws.sessionCost += costINR;
     _cwUpdateSessionMeter();
+    setTimeout(function() { _cwFetchCostTotals(); }, 800);
   } else {
     ws.messages.push({ role: 'assistant', content: 'Error: ' + ((result && result.error) || 'Request failed. Try again.') });
   }

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417d">
+ <link rel="stylesheet" href="styles.css?v=20260417e">
 
 </head>
 <body>
@@ -1248,32 +1248,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417d"></script>
-<script src="00-appstate-compat.js?v=20260417d"></script>
-<script src="01-config.js?v=20260417d" defer></script>
-<script src="02-session.js?v=20260417d" defer></script>
-<script src="utils.js?v=20260417d" defer></script>
-<script src="12-profiles.js?v=20260417d" defer></script>
-<script src="03-auth.js?v=20260417d" defer></script>
-<script src="05-api.js?v=20260417d" defer></script>
-<script src="10-ui.js?v=20260417d" defer></script>
+<script src="00-appstate.js?v=20260417e"></script>
+<script src="00-appstate-compat.js?v=20260417e"></script>
+<script src="01-config.js?v=20260417e" defer></script>
+<script src="02-session.js?v=20260417e" defer></script>
+<script src="utils.js?v=20260417e" defer></script>
+<script src="12-profiles.js?v=20260417e" defer></script>
+<script src="03-auth.js?v=20260417e" defer></script>
+<script src="05-api.js?v=20260417e" defer></script>
+<script src="10-ui.js?v=20260417e" defer></script>
 
-<script src="06-post-create.js?v=20260417d" defer></script>
-<script defer src="render/dashboard.js?v=20260417d"></script>
-<script defer src="render/client.js?v=20260417d"></script>
-<script defer src="render/pipeline.js?v=20260417d"></script>
-<script defer src="render/brief.js?v=20260417d"></script>
-<script defer src="actions/pcs.js?v=20260417d"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417d"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417d"></script>
-<script defer src="actions/pcs-polish.js?v=20260417d"></script>
-<script defer src="actions/pcs-select.js?v=20260417d"></script>
-<script src="ai-config.js?v=20260417d" defer></script>
-<script src="07-post-load.js?v=20260417d" defer></script>
-<script src="08-post-actions.js?v=20260417d" defer></script>
-<script src="09-library.js?v=20260417d" defer></script>
-<script src="09-approval.js?v=20260417d" defer></script>
-<script src="04-router.js?v=20260417d" defer></script>
+<script src="06-post-create.js?v=20260417e" defer></script>
+<script defer src="render/dashboard.js?v=20260417e"></script>
+<script defer src="render/client.js?v=20260417e"></script>
+<script defer src="render/pipeline.js?v=20260417e"></script>
+<script defer src="render/brief.js?v=20260417e"></script>
+<script defer src="actions/pcs.js?v=20260417e"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417e"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417e"></script>
+<script defer src="actions/pcs-polish.js?v=20260417e"></script>
+<script defer src="actions/pcs-select.js?v=20260417e"></script>
+<script src="ai-config.js?v=20260417e" defer></script>
+<script src="07-post-load.js?v=20260417e" defer></script>
+<script src="08-post-actions.js?v=20260417e" defer></script>
+<script src="09-library.js?v=20260417e" defer></script>
+<script src="09-approval.js?v=20260417e" defer></script>
+<script src="04-router.js?v=20260417e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

TODAY and MONTH cost totals in the Claude workspace only refreshed on open, so the numbers went stale the moment Claude responded. This PR re-runs the aggregator 800 ms after every successful Worker call.

## Findings

- `_cwFetchCostTotals` already exists (`actions/pcs-claude-caption.js:638`) and reads `/ai_usage?select=cost_usd&created_at=gte.<boundary>` via `apiFetch`, then writes to `#cw-today-cost` and `#cw-month-cost`. No new function needed.
- `_cwUpdateSessionMeter` (`#cw-session-cost`) was already being called after every response — session meter was not broken.
- The task snippet proposed a new `_cwLoadMeter` using raw `fetch()` with `AppState.supabaseUrl/Key`. CLAUDE.md mandates "Always `apiFetch()`, never raw `fetch()`" — kept the existing function.

## Changes

### `actions/pcs-claude-caption.js`
After the two successful-response branches, schedule the meter refresh:

```js
setTimeout(function() { _cwFetchCostTotals(); }, 800);
```

1. `sendCaptionMessage` success branch — covers chat / QC / writer modes and every chip refinement (Shorter / Warmer / Sharper).
2. `openCaptionWorkspace` rewrite-branch success — the first response when a user opens the workspace in rewrite mode.

The 800 ms delay gives the Worker's fire-and-forget `ai_usage` insert time to commit before we read it back.

Open-time `_cwFetchCostTotals()` call (in `openCaptionWorkspace`) kept in place.

### `index.html`
- All 26 `?v=` strings bumped `20260417d` → `20260417e`.

## Test plan
- [ ] Open the workspace → note the TODAY / MONTH values.
- [ ] Send a chat message → ~1 s after the response, TODAY / MONTH tick up by the same amount the Session meter just added.
- [ ] Tap a refinement chip (Shorter/Warmer/Sharper) → TODAY / MONTH tick up again.
- [ ] Tap "Use this" → no Worker call, meters stay flat (confirms the refresh is gated on actual Claude calls).
- [ ] Hard refresh after Cloudflare purge to pick up `?v=20260417e`.

No Worker change required.

https://claude.ai/code/session_01SW4H2hd4tunMYTryxehEud