### PR TITLE
fix: populate AppState.pcs.post so Rewrite-with-comments opens workspace

### DIFF
--- a/actions/pcs-select.js
+++ b/actions/pcs-select.js
@@ -146,9 +146,15 @@ window.submitSelectedComments = function() {
       var textEl = item.querySelector('.pcs-comment-text');
       var authorEl = item.querySelector('.pcs-comment-author');
       if (textEl) {
+        var authorAttr = item.getAttribute('data-author') || '';
+        var authorText = authorEl ? authorEl.textContent : 'Unknown';
+        var resolvedRole = '';
+        if (typeof getRoleFor === 'function') {
+          resolvedRole = getRoleFor(authorAttr) || getRoleFor(authorText) || '';
+        }
         selectedComments.push({
-          author: authorEl ? authorEl.textContent : 'Unknown',
-          role: 'client',
+          author: authorText,
+          role: (resolvedRole || 'client').toLowerCase(),
           text: textEl.textContent.trim()
         });
       }

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -50,6 +50,13 @@ window.openPCS = function(postId, listKey) {
   window._pcs.idx     = idx >= 0 ? idx : 0;
   window._pcs.postId  = postId;
 
+  // Point AppState.pcs.post at the SAME object reference in posts.all
+  // so Object.assign mutations from mergePosts/poll refresh flow through
+  // (see CLAUDE.md §4 "AppState shape"). Consumers like submitSelectedComments
+  // (actions/pcs-select.js) and the drive-link handler (10-ui.js) read this.
+  var _openPost = (typeof getPostById === 'function') ? getPostById(postId) : null;
+  window.AppState.pcs.post = _openPost || null;
+
   var overlay = document.getElementById('pcs-overlay');
   if (!overlay) return;
   var screen = document.getElementById('pcs-screen');
@@ -150,6 +157,7 @@ window.forcePCSReset = function() {
 
   // 6. Clear PCS context
   window._pcs.postId = null;
+  window.AppState.pcs.post = null;
   window.AppState.pcs.openedFrom = null;
 
   // 7. Flush any deferred background renders
@@ -459,6 +467,11 @@ window._renderPCS = function(postId) {
   // 1. Fetch post
   var post = getPostById(postId);
   if (!post) { closePCS(); return; }
+
+  // Keep AppState.pcs.post in sync on every render — realtime/poll refresh
+  // calls _renderPCS directly while PCS is open, so we re-point at the
+  // (same-reference) post row on each pass.
+  window.AppState.pcs.post = post;
 
   // 2. Compute derived state
   var id          = getPostId(post);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417f">
+ <link rel="stylesheet" href="styles.css?v=20260417g">
 
 </head>
 <body>
@@ -1248,32 +1248,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417f"></script>
-<script src="00-appstate-compat.js?v=20260417f"></script>
-<script src="01-config.js?v=20260417f" defer></script>
-<script src="02-session.js?v=20260417f" defer></script>
-<script src="utils.js?v=20260417f" defer></script>
-<script src="12-profiles.js?v=20260417f" defer></script>
-<script src="03-auth.js?v=20260417f" defer></script>
-<script src="05-api.js?v=20260417f" defer></script>
-<script src="10-ui.js?v=20260417f" defer></script>
+<script src="00-appstate.js?v=20260417g"></script>
+<script src="00-appstate-compat.js?v=20260417g"></script>
+<script src="01-config.js?v=20260417g" defer></script>
+<script src="02-session.js?v=20260417g" defer></script>
+<script src="utils.js?v=20260417g" defer></script>
+<script src="12-profiles.js?v=20260417g" defer></script>
+<script src="03-auth.js?v=20260417g" defer></script>
+<script src="05-api.js?v=20260417g" defer></script>
+<script src="10-ui.js?v=20260417g" defer></script>
 
-<script src="06-post-create.js?v=20260417f" defer></script>
-<script defer src="render/dashboard.js?v=20260417f"></script>
-<script defer src="render/client.js?v=20260417f"></script>
-<script defer src="render/pipeline.js?v=20260417f"></script>
-<script defer src="render/brief.js?v=20260417f"></script>
-<script defer src="actions/pcs.js?v=20260417f"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417f"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417f"></script>
-<script defer src="actions/pcs-polish.js?v=20260417f"></script>
-<script defer src="actions/pcs-select.js?v=20260417f"></script>
-<script src="ai-config.js?v=20260417f" defer></script>
-<script src="07-post-load.js?v=20260417f" defer></script>
-<script src="08-post-actions.js?v=20260417f" defer></script>
-<script src="09-library.js?v=20260417f" defer></script>
-<script src="09-approval.js?v=20260417f" defer></script>
-<script src="04-router.js?v=20260417f" defer></script>
+<script src="06-post-create.js?v=20260417g" defer></script>
+<script defer src="render/dashboard.js?v=20260417g"></script>
+<script defer src="render/client.js?v=20260417g"></script>
+<script defer src="render/pipeline.js?v=20260417g"></script>
+<script defer src="render/brief.js?v=20260417g"></script>
+<script defer src="actions/pcs.js?v=20260417g"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417g"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417g"></script>
+<script defer src="actions/pcs-polish.js?v=20260417g"></script>
+<script defer src="actions/pcs-select.js?v=20260417g"></script>
+<script src="ai-config.js?v=20260417g" defer></script>
+<script src="07-post-load.js?v=20260417g" defer></script>
+<script src="08-post-actions.js?v=20260417g" defer></script>
+<script src="09-library.js?v=20260417g" defer></script>
+<script src="09-approval.js?v=20260417g" defer></script>
+<script src="04-router.js?v=20260417g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

- Tapping **"Rewrite with N comments"** in PCS comment-selection mode was a silent no-op because `AppState.pcs.post` was initialised to `null` in `00-appstate.js:34` and never assigned anywhere in the codebase, despite CLAUDE.md §4 documenting it as the live reference to the currently-open post.
- `submitSelectedComments` (`actions/pcs-select.js:127`) read it, saw `null`, and returned before reaching `openCaptionWorkspace('rewrite', ...)`.
- Now `openPCS` + `_renderPCS` assign `AppState.pcs.post` to the same object reference returned by `getPostById`, and `forcePCSReset` clears it back to `null` on close. The existing null-guard in `submitSelectedComments` stays intact as a safety net.
- Hardened the DOM-scrape fallback: author role is now resolved via `getRoleFor(data-author)` instead of hardcoded `'client'`, so rewrites originating from agency comments carry the correct role hint.
- The `10-ui.js:2495` drive-link handler (which also reads `AppState.pcs.post`) starts working correctly as a side-effect.
- 26 `?v=` strings bumped `20260417f` → `20260417g`. Zero CLAUDE.md changes (will fold notes into the next cycle's update).

## Files touched

- `actions/pcs.js` — assign `AppState.pcs.post` in `openPCS` + `_renderPCS`; null it in `forcePCSReset`
- `actions/pcs-select.js` — DOM-scrape fallback uses `getRoleFor(data-author)` for accurate role
- `index.html` — all 26 `?v=` strings bumped

## Test plan

- [x] `npx vitest run` → 544/544 passing, 22 test files
- [ ] Open PCS from pipeline → `AppState.pcs.post` populated (check via devtools)
- [ ] Tap "Edit with Claude" → workspace opens with current caption
- [ ] Enter comment-select mode → tap a checkbox → "Rewrite with N comments" label enables
- [ ] Tap "Rewrite with N comments" → caption workspace slides up with selected comments as context
- [ ] Close PCS → `AppState.pcs.post` nulls out
- [ ] Open a different post → `AppState.pcs.post` points at new post (not stale previous)
- [ ] Drive-link edit (admin) still works (same handler, now reads a populated value)

https://claude.ai/code/session_01F16D7YjHgKb38uv4GF4uGN