### PR TITLE
add withRetry wrapper for transient Supabase 401 / network failures

### DIFF
--- a/05-api.js
+++ b/05-api.js
@@ -100,6 +100,36 @@ async function apiFetch(path, options = {}, meta) {
   return text ? JSON.parse(text) : [];
 }
 
+// withRetry — thin one-shot recovery wrapper for transient Supabase
+// auth/network hiccups ahead of the Mumbai region migration. On the
+// FIRST failure, inspects the error message; if transient (401,
+// session expired, Failed to fetch, Load failed, NetworkError, or a
+// post-refresh "server"/"network" classification surfaced by apiFetch),
+// forces ONE explicit refreshSession() and replays fn exactly once. If
+// that refresh itself hit a 500 (server) or network blip, waits 500ms
+// and retries the refresh once before replaying fn. On final failure,
+// rethrows — the caller's existing try/catch or .catch() path still
+// logs to error_log unchanged.
+async function withRetry(fn) {
+  try {
+    return await fn();
+  } catch (err) {
+    const msg = (err && err.message) || '';
+    const transient =
+      /401|session expired|Failed to fetch|Load failed|NetworkError|refresh server|refresh network/i
+        .test(msg);
+    if (!transient) throw err;
+    let r = null;
+    try { r = await refreshSession(); } catch (e) { /* swallow */ }
+    if (r && (r.error === 'server' || r.error === 'network')) {
+      await new Promise(function(res) { setTimeout(res, 500); });
+      try { r = await refreshSession(); } catch (e) { /* swallow */ }
+    }
+    return await fn();
+  }
+}
+window.withRetry = withRetry;
+
 function normalise(rows) {
   if (!Array.isArray(rows)) return [];
   return rows.map(r => ({
@@ -180,11 +210,11 @@ async function uploadPostAsset(file, postId) {
 // app degrades gracefully if workspace_settings is unreachable.
 async function loadWorkspaceSettings() {
   try {
-    const rows = await apiFetch(
+    const rows = await withRetry(function() { return apiFetch(
       '/workspace_settings?workspace_id=eq.default&select=*&limit=1',
       {},
       { allowLogout: false }
-    );
+    ); });
     window.AppState.workspace = (Array.isArray(rows) && rows[0]) ? rows[0] : {};
   } catch (err) {
     window.AppState.workspace = window.AppState.workspace || {};

--- a/07-post-load.js
+++ b/07-post-load.js
@@ -7,10 +7,10 @@ console.log("LOADED:", "07-post-load.js");
 window._activityLogs = [];
 async function _fetchActivityLogs() {
   try {
-    var data = await apiFetch(
+    var data = await withRetry(function() { return apiFetch(
       '/activity_log?select=post_id,new_stage,created_at' +
       '&order=created_at.desc&limit=500'
-    );
+    ); });
     window._activityLogs = Array.isArray(data) ? data : [];
   } catch(e) {
     console.error('[post-load] fetchActivityLogs failed', e);
@@ -186,7 +186,7 @@ async function loadPosts(fromPoll) {
     const isDraftFilter = (window.AppState.user.effectiveRole === 'Admin')
       ? ''
       : '&is_draft=eq.false';
-    const data = await apiFetch('/posts?select=*' + isDraftFilter + '&order=id.desc', {}, _apiMeta);
+    const data = await withRetry(function() { return apiFetch('/posts?select=*' + isDraftFilter + '&order=id.desc', {}, _apiMeta); });
     if (!_commitPostsResult(reqId, 'network')) return;
     // Fetch pending requests and merge as brief-stage entries
     var reqData = [];
@@ -290,12 +290,12 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
   try {
     const allowedStages =
       'awaiting_approval,awaiting_brand_input,published,brief,brief_done,scheduled,in_production';
-    var data  = await apiFetch(
+    var data  = await withRetry(function() { return apiFetch(
       '/posts?stage=in.(' + allowedStages +
       ')&is_draft=eq.false&select=*&order=created_at.desc',
       {},
       _apiMeta
-    );
+    ); });
     if (!_commitPostsResult(reqId, 'network')) return;
 
     // Fetch pending requests for client view (shows as brief cards)
@@ -334,12 +334,12 @@ async function loadPostsForClient(skipRenderIfUnchanged, fromPoll) {
     var postIds = data.map(function(p) { return p.post_id || p.id; }).filter(Boolean);
     if (postIds.length) {
       try {
-        var comments = await apiFetch(
+        var comments = await withRetry(function() { return apiFetch(
           '/post_comments?post_id=in.(' + postIds.join(',') +
           ')&order=created_at.asc',
           {},
           _apiMeta
-        );
+        ); });
         if (Array.isArray(comments)) {
           data.forEach(function(p) {
             var pid = p.post_id || p.id;
@@ -476,7 +476,7 @@ function startRealtime() {
       return;
     }
     try {
-      const data  = await apiFetch('/posts?select=*&order=created_at.desc', {}, { allowLogout: false });
+      const data  = await withRetry(function() { return apiFetch('/posts?select=*&order=created_at.desc', {}, { allowLogout: false }); });
       const fresh = normalise(data);
       if (_postsFingerprint(fresh) !== _postsFingerprint(window.AppState.posts.all)) {
         mergePosts(fresh);
@@ -994,7 +994,7 @@ window.stopAgencyRealtime = stopAgencyRealtime;
 
 async function loadTasks() {
   try {
-    const data = await apiFetch('/tasks?order=created_at.desc&limit=50');
+    const data = await withRetry(function() { return apiFetch('/tasks?order=created_at.desc&limit=50'); });
     allTasks = Array.isArray(data) ? data : [];
   } catch (e) { console.error('[post-load] loadTasks failed', e); window.logError && window.logError(e && e.message, e && e.stack, 'load-tasks'); allTasks = []; }
   renderTaskBanner();
@@ -2333,10 +2333,10 @@ async function _updateStreakLines() {
   try {
     var today = new Date();
 
-    var logs = await apiFetch(
+    var logs = await withRetry(function() { return apiFetch(
       '/activity_log?select=actor,created_at,action,new_stage,old_stage' +
       '&order=created_at.desc&limit=200'
-    );
+    ); });
     if (!Array.isArray(logs)) return;
 
     logs = logs.map(function(l) {

--- a/10-ui.js
+++ b/10-ui.js
@@ -1275,7 +1275,7 @@ function updateNotifBadge() {
     encodeURIComponent(_badgeRole) + '&select=id';
   if (_badgeActor) _badgeUrl += '&actor=neq.' + encodeURIComponent(_badgeActor);
 
-  apiFetch(_badgeUrl, {}, { allowLogout: false })
+  withRetry(function() { return apiFetch(_badgeUrl, {}, { allowLogout: false }); })
   .then(function(rows) {
     var count = Array.isArray(rows) ? rows.length : 0;
     _setBadgeCount(count);

--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -432,7 +432,7 @@ window._cwApplyDraft = async function(text) {
   if (typeof _startSaveTimeout === 'function') _startSaveTimeout(post, postId);
 
   try {
-    await apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
+    await withRetry(function() { return apiFetch('/posts?post_id=eq.' + encodeURIComponent(postId), {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json', 'Prefer': 'return=minimal' },
       body: JSON.stringify({
@@ -440,7 +440,7 @@ window._cwApplyDraft = async function(text) {
         updated_at: new Date().toISOString(),
         updated_by: window.AppState.user.email || ''
       })
-    });
+    }); });
     Object.assign(post, { caption: text, updated_at: new Date().toISOString() });
     if (typeof _clearSaveTimeout === 'function') _clearSaveTimeout(post);
     post._isSaving = false;

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -320,11 +320,11 @@ window._pcsApplyRewrite = function(id) {
   // Persist the new caption through the existing API surface
   (async function() {
     try {
-      await apiFetch('/posts?post_id=eq.' + encodeURIComponent(id), {
+      await withRetry(function() { return apiFetch('/posts?post_id=eq.' + encodeURIComponent(id), {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', 'Prefer': 'return=minimal' },
         body: JSON.stringify({ caption: newCaption, updated_at: new Date().toISOString() })
-      });
+      }); });
       post.caption = newCaption;
       window._pcsDismissRewrite(id);
       if (typeof _renderPCS === 'function') _renderPCS(id);
@@ -1312,18 +1312,18 @@ window.loadPcsComments = async function(postId) {
   var _name = window.AppState.user.name || '';
 
   try {
-    var rows = await apiFetch(
+    var rows = await withRetry(function() { return apiFetch(
       '/post_comments?post_id=eq.' +
       encodeURIComponent(postId) +
       '&order=created_at.asc&limit=100'
-    );
+    ); });
     if (!Array.isArray(rows)) rows = [];
 
-    var internalData = await apiFetch(
+    var internalData = await withRetry(function() { return apiFetch(
       '/internal_notes?post_id=eq.' +
       encodeURIComponent(postId) +
       '&order=created_at.asc&limit=100'
-    );
+    ); });
     if (!Array.isArray(internalData)) internalData = [];
 
     // Fetch reactions for this post
@@ -2537,10 +2537,10 @@ window._saveCaptionEdit = async function(postId) {
   }
 
   try {
-    await apiFetch('/posts?post_id=eq.' + postId, {
+    await withRetry(function() { return apiFetch('/posts?post_id=eq.' + postId, {
       method: 'PATCH',
       body: JSON.stringify({ caption: newCaption, updated_by: resolveActor(), updated_at: new Date().toISOString() })
-    });
+    }); });
   } catch (err) {
     console.error('[pcs] save caption failed', err);
     window.logError && window.logError(err && err.message, err && err.stack, 'pcs-save-caption');

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417g">
+ <link rel="stylesheet" href="styles.css?v=20260417h">
 
 </head>
 <body>
@@ -1248,32 +1248,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417g"></script>
-<script src="00-appstate-compat.js?v=20260417g"></script>
-<script src="01-config.js?v=20260417g" defer></script>
-<script src="02-session.js?v=20260417g" defer></script>
-<script src="utils.js?v=20260417g" defer></script>
-<script src="12-profiles.js?v=20260417g" defer></script>
-<script src="03-auth.js?v=20260417g" defer></script>
-<script src="05-api.js?v=20260417g" defer></script>
-<script src="10-ui.js?v=20260417g" defer></script>
+<script src="00-appstate.js?v=20260417h"></script>
+<script src="00-appstate-compat.js?v=20260417h"></script>
+<script src="01-config.js?v=20260417h" defer></script>
+<script src="02-session.js?v=20260417h" defer></script>
+<script src="utils.js?v=20260417h" defer></script>
+<script src="12-profiles.js?v=20260417h" defer></script>
+<script src="03-auth.js?v=20260417h" defer></script>
+<script src="05-api.js?v=20260417h" defer></script>
+<script src="10-ui.js?v=20260417h" defer></script>
 
-<script src="06-post-create.js?v=20260417g" defer></script>
-<script defer src="render/dashboard.js?v=20260417g"></script>
-<script defer src="render/client.js?v=20260417g"></script>
-<script defer src="render/pipeline.js?v=20260417g"></script>
-<script defer src="render/brief.js?v=20260417g"></script>
-<script defer src="actions/pcs.js?v=20260417g"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417g"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417g"></script>
-<script defer src="actions/pcs-polish.js?v=20260417g"></script>
-<script defer src="actions/pcs-select.js?v=20260417g"></script>
-<script src="ai-config.js?v=20260417g" defer></script>
-<script src="07-post-load.js?v=20260417g" defer></script>
-<script src="08-post-actions.js?v=20260417g" defer></script>
-<script src="09-library.js?v=20260417g" defer></script>
-<script src="09-approval.js?v=20260417g" defer></script>
-<script src="04-router.js?v=20260417g" defer></script>
+<script src="06-post-create.js?v=20260417h" defer></script>
+<script defer src="render/dashboard.js?v=20260417h"></script>
+<script defer src="render/client.js?v=20260417h"></script>
+<script defer src="render/pipeline.js?v=20260417h"></script>
+<script defer src="render/brief.js?v=20260417h"></script>
+<script defer src="actions/pcs.js?v=20260417h"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417h"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417h"></script>
+<script defer src="actions/pcs-polish.js?v=20260417h"></script>
+<script defer src="actions/pcs-select.js?v=20260417h"></script>
+<script src="ai-config.js?v=20260417h" defer></script>
+<script src="07-post-load.js?v=20260417h" defer></script>
+<script src="08-post-actions.js?v=20260417h" defer></script>
+<script src="09-library.js?v=20260417h" defer></script>
+<script src="09-approval.js?v=20260417h" defer></script>
+<script src="04-router.js?v=20260417h" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1554,7 +1554,7 @@ console.log('LOADED:', 'render/client.js');
     // client overlay is rendering. A transient 401 must not evict the
     // user. The visibilitychange handler and the 50-min proactive refresh
     // timer are the only paths that should ever trigger logout.
-    window._clientMentionRosterPromise = window.apiFetch('/user_roles?select=name,email,role', {}, { allowLogout: false })
+    window._clientMentionRosterPromise = window.withRetry(function() { return window.apiFetch('/user_roles?select=name,email,role', {}, { allowLogout: false }); })
       .then(function(rows) {
         if (Array.isArray(rows)) {
           window._clientMentionRoster = rows.filter(function(r) { return r && (r.name || r.email); });

--- a/render/dashboard.js
+++ b/render/dashboard.js
@@ -929,10 +929,10 @@ async function _updateStreakLines() {
   try {
     var today = new Date();
 
-    var logs = await apiFetch(
+    var logs = await withRetry(function() { return apiFetch(
       '/activity_log?select=actor,created_at,action,new_stage,old_stage' +
       '&order=created_at.desc&limit=200'
-    );
+    ); });
     if (!Array.isArray(logs)) return;
 
     logs = logs.map(function(l) {


### PR DESCRIPTION
## Summary

Bandaid ahead of Saturday's Mumbai region migration. Adds a single ~30-line `withRetry` helper in `05-api.js` that replays a wrapped `apiFetch` call ONCE after a forced `refreshSession()` when the first error message matches a transient pattern (401, session expired, Failed to fetch, Load failed, NetworkError, or a post-refresh server/network classification). On a 500 from `/auth/v1/token` inside the refresh, waits 500ms and tries the refresh one more time before the fn replay. On final failure, rethrows so the caller's existing `logError(...)` path still runs — persistent outages remain visible in `error_log` unchanged.

- No auth logic, session management, or `createClient` config changes.
- No schema changes.
- No CLAUDE.md edits (will happen in a follow-up as flagged in the brief).
- All 544 unit tests still green (`npx vitest run`).

## Wrapped call sites

Matched to the 7-day `error_log` volume report:

**HIGH priority:**
- `load-posts-client` (203 failures) — `07-post-load.js:293`
- `update-notif-badge` (132) — `10-ui.js:1278`
- `load-workspace-settings` (57) — `05-api.js:213`
- `load-posts` (16) — `07-post-load.js:189`
- `client-mention-roster` (11) — `render/client.js:1557`
- `update-streak-lines` (10) — wrapped in BOTH `render/dashboard.js:932` and the duplicate in `07-post-load.js:2336` (duplicate-definition bug flagged separately, not fixed here)
- `load-pcs-comments` (9) — `actions/pcs.js:1315` and `:1322`

**MED priority (GET / PATCH only):**
- `pcs-save-caption`, `fetch-activity-logs`, `load-tasks`, `cw-apply-draft`, `pcs-apply-rewrite`, `realtime-poll`, `client-comments-fetch`

## Intentionally NOT wrapped

- **POST inserts** (`do-submit-comment`, `submit-comment`, `submit-client-request`) — duplicate-row risk on retry is worse than asking the user to retry a failed send manually. Brief listed them as MED, reviewer approved the skip.
- **`send-magic-link`, `refresh-session`** — per brief.
- **`pcs-lb-download`** — no matching `logError()` call exists in code for this action name. Flagged as separate investigation ticket.

## Follow-up tickets flagged (NOT fixed in this PR — one problem per PR)

- **TICKET-1:** `pcs-lb-download` writes to `error_log` but has no matching `logError` call anywhere in code. Find the source.
- **TICKET-2:** `_updateStreakLines` defined twice (`render/dashboard.js:928` and `07-post-load.js:2332`) — second declaration overwrites first at module load.
- **TICKET-3:** `normalise()` in `05-api.js` duplicates `caption:` key in the returned object literal (lines 115 and 122).
- **TICKET-4:** `render/client.js:1568` uses confusing comma-operator in `logError` args.

## Version bump

All 26 `?v=` strings in `index.html` bumped from `20260417g` → `20260417h` (1 stylesheet + 25 scripts). Brief said "22 strings" — actual count matches CLAUDE.md §7 ("1 stylesheet + 25 scripts").

## Test plan

- [x] `npx vitest run` — 544/544 passing across 22 test files
- [ ] After merge: Cloudflare dash → srtd.io → Caching → Purge Everything
- [ ] Hard refresh on iPhone Safari client session; confirm no console errors
- [ ] Watch `error_log` rate on Saturday during migration — expect 401 / Failed-to-fetch volume to drop materially
- [ ] Spot-check a client-role session: comment thread loads, notification badge updates, @mention roster populates
- [ ] Spot-check an admin-role session: dashboard streak lines render, pipeline poll refreshes

https://claude.ai/code/session_01QdGC5JKtRRcu1nfrUpSjsv