### PR TITLE
fix: allow ai_learn_from_comment trigger to write ai_memory on client comments

### DIFF
--- a/sql/005-ai-learn-comment-security-definer.sql
+++ b/sql/005-ai-learn-comment-security-definer.sql
@@ -1,0 +1,71 @@
+-- ═══════════════════════════════════════════════════════════════
+-- FIX — ai_learn_from_comment() must run SECURITY DEFINER
+-- ═══════════════════════════════════════════════════════════════
+--
+-- PROBLEM:
+--   The trigger function ai_learn_from_comment() fires on
+--   post_comments INSERT and writes auto-captured feedback
+--   patterns into ai_memory. It was created with SECURITY
+--   INVOKER (Postgres default), so the INSERT into ai_memory
+--   runs under the caller's JWT. ai_memory has RLS enabled
+--   with zero policies (the table is trigger-only by design).
+--   Result: every comment INSERT by the Client role returns
+--   403 "new row violates row-level security policy for table
+--   'ai_memory'" and the comment INSERT rolls back.
+--
+-- SOLUTION:
+--   ALTER the function to SECURITY DEFINER so it runs with
+--   the function owner's privileges and bypasses RLS on
+--   ai_memory. Pin search_path to a known-safe value
+--   (public, pg_temp) — this is the standard security
+--   hardening for SECURITY DEFINER functions so a malicious
+--   caller cannot shadow built-in names with objects in their
+--   own schema.
+--
+-- SAFETY:
+--   - No schema change (no ALTER TABLE, no CREATE POLICY).
+--   - Trigger body is unchanged.
+--   - ALTER FUNCTION is atomic and idempotent when re-run.
+--   - Does NOT touch on_comment_insert (notify-comment edge
+--     function trigger) — that one uses the service-role key
+--     via pg_net and is unaffected.
+--   - Does NOT add or remove RLS policies on ai_memory —
+--     ai_memory remains trigger-only by design.
+--
+-- PRE-REQUISITE:
+--   The function public.ai_learn_from_comment() must already
+--   exist (created by whoever wired the ai_memory learning
+--   feature). This migration only flips the security mode.
+-- ═══════════════════════════════════════════════════════════════
+
+ALTER FUNCTION public.ai_learn_from_comment()
+  SECURITY DEFINER
+  SET search_path = public, pg_temp;
+
+COMMENT ON FUNCTION public.ai_learn_from_comment() IS
+  'Trigger fn on post_comments INSERT. Writes to ai_memory with '
+  'auto-captured client feedback patterns. Runs as SECURITY '
+  'DEFINER because ai_memory has RLS enabled with no policies - '
+  'this is intentional (only the trigger should write). DO NOT '
+  'modify this function to accept dynamic SQL or untrusted '
+  'table/column names - SECURITY DEFINER makes such changes a '
+  'privilege escalation vulnerability.';
+
+-- ═══════════════════════════════════════════════════════════════
+-- VERIFICATION (run after applying):
+--
+--   SELECT proname, prosecdef
+--   FROM   pg_proc
+--   WHERE  proname = 'ai_learn_from_comment';
+--   -- Expected: prosecdef = true
+--
+--   -- Confirm search_path is pinned:
+--   SELECT proname, proconfig
+--   FROM   pg_proc
+--   WHERE  proname = 'ai_learn_from_comment';
+--   -- Expected: proconfig contains 'search_path=public, pg_temp'
+--
+--   -- Smoke test — submit a comment as the client user and
+--   -- confirm the row lands in post_comments AND ai_memory
+--   -- without a 403.
+-- ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Client user could not submit comments. Every submit returned:

```
Supabase 403: new row violates row-level security policy for table "ai_memory"
```

## Root cause

A Postgres trigger on `post_comments` INSERT fires
`ai_learn_from_comment()` which writes auto-captured client
feedback patterns into `ai_memory`. The function was created
with the default `SECURITY INVOKER`, so its INSERT runs under
the caller's JWT. `ai_memory` has RLS enabled with zero
policies (trigger-only by design), so the INSERT is denied,
the trigger fails, and the entire `/post_comments` INSERT
rolls back. The error surfaces to the frontend's
`_handleSubmitComment` catch at `render/client.js:1750` with
the `submit-comment` action tag.

## Fix

Single migration. Flip `ai_learn_from_comment()` to
`SECURITY DEFINER` so it runs with the function owner's
privileges and bypasses RLS on `ai_memory`. Pin
`search_path = public, pg_temp` — standard hardening for
SECURITY DEFINER functions. Trigger body is unchanged.

- **No frontend changes.** The comment submit path is correct.
- **No new RLS policies on ai_memory.** The table remains
  trigger-only by design.
- **`on_comment_insert` is not touched.** That trigger drives
  the `notify-comment` edge function via the service-role key
  and is unaffected.
- **Schema precedent.** The trigger and function already
  existed in production — this PR only changes the privilege
  level so the trigger can do what it was always meant to do.

## Files changed

- `sql/005-ai-learn-comment-security-definer.sql` (new)

## Deploy steps

1. Merge this PR (no code runs from the merge — GitHub Pages
   does not apply SQL).
2. Apply the migration in the Supabase SQL editor:
   ```
   ALTER FUNCTION public.ai_learn_from_comment()
     SECURITY DEFINER
     SET search_path = public, pg_temp;
   ```
   plus the `COMMENT ON FUNCTION` in the migration file.
3. Verify:
   ```sql
   SELECT proname, prosecdef
   FROM   pg_proc
   WHERE  proname = 'ai_learn_from_comment';
   -- Expected: prosecdef = true
   ```
4. Smoke-test: submit a comment as the client user and confirm
   the row lands in `post_comments` AND `ai_memory` with no
   403.

## Test plan

- [ ] Apply migration in Supabase SQL editor
- [ ] Verify `prosecdef = true` in `pg_proc`
- [ ] Client user submits a comment → no 403, row persists
- [ ] Agency user submits a comment → no regression
- [ ] `error_log` shows no new `ai_memory` RLS entries after
      deploy

## Non-goals / deliberately not changed

- Frontend JS (the 3 `ai_memory` calls in
  `actions/pcs-claude-caption.js` are unrelated to this
  incident — they continue to run under the caller's JWT and
  will start succeeding for agency users as a side effect of
  this fix, but that is not the motivation here).
- `index.html` `?v=` version bumps (pure DB change; no static
  asset changed).
- `CLAUDE.md` (no architectural change; the trigger was
  already part of the production schema, this PR only
  corrects its privilege level).
