### PR TITLE
fix(notif-v7.1): expanded state flips to jet black + single-pass blue→black fade

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -934,7 +934,7 @@ function _notifBuildThreadHtml(n, post, postTitle) {
   // Reply pill (round send button inside a rounded input) + shared
   // footer row that puts "VISIBLE TO ALL" on the left and the
   // "Open full post →" link on the right.
-  var replyPlaceholder = 'Reply to ' + (postTitle || 'post') + '\u2026';
+  var replyPlaceholder = 'Comment on ' + (postTitle || 'post') + '\u2026';
   var replyHtml =
     '<div class="reply-zone">' +
       '<div class="reply-pill">' +
@@ -1013,6 +1013,15 @@ function _notifToggleExpand(item) {
   }
 
   // Expand — mount the thread drawer content if it hasn't been built yet.
+  // Strip .unread BEFORE flipping .expanded so the 0.3s background
+  // transition on `.notif-item` drives the blue → jet black fade in a
+  // single animation pass (instead of two competing transitions from
+  // the click handler firing markNotifRead in parallel).
+  if (item.classList.contains('unread')) {
+    item.classList.remove('unread');
+    item.classList.add('read');
+    markNotifRead(notifId);
+  }
   set.add(notifId);
   var drawer = item.querySelector(':scope > .thread-drawer');
   if (drawer && !drawer.innerHTML) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417h">
+ <link rel="stylesheet" href="styles.css?v=20260417i">
 
 </head>
 <body>
@@ -1247,32 +1247,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417h"></script>
-<script src="00-appstate-compat.js?v=20260417h"></script>
-<script src="01-config.js?v=20260417h" defer></script>
-<script src="02-session.js?v=20260417h" defer></script>
-<script src="utils.js?v=20260417h" defer></script>
-<script src="12-profiles.js?v=20260417h" defer></script>
-<script src="03-auth.js?v=20260417h" defer></script>
-<script src="05-api.js?v=20260417h" defer></script>
-<script src="10-ui.js?v=20260417h" defer></script>
+<script src="00-appstate.js?v=20260417i"></script>
+<script src="00-appstate-compat.js?v=20260417i"></script>
+<script src="01-config.js?v=20260417i" defer></script>
+<script src="02-session.js?v=20260417i" defer></script>
+<script src="utils.js?v=20260417i" defer></script>
+<script src="12-profiles.js?v=20260417i" defer></script>
+<script src="03-auth.js?v=20260417i" defer></script>
+<script src="05-api.js?v=20260417i" defer></script>
+<script src="10-ui.js?v=20260417i" defer></script>
 
-<script src="06-post-create.js?v=20260417h" defer></script>
-<script defer src="render/dashboard.js?v=20260417h"></script>
-<script defer src="render/client.js?v=20260417h"></script>
-<script defer src="render/pipeline.js?v=20260417h"></script>
-<script defer src="render/brief.js?v=20260417h"></script>
-<script defer src="actions/pcs.js?v=20260417h"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417h"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417h"></script>
-<script defer src="actions/pcs-polish.js?v=20260417h"></script>
-<script defer src="actions/pcs-select.js?v=20260417h"></script>
-<script src="ai-config.js?v=20260417h" defer></script>
-<script src="07-post-load.js?v=20260417h" defer></script>
-<script src="08-post-actions.js?v=20260417h" defer></script>
-<script src="09-library.js?v=20260417h" defer></script>
-<script src="09-approval.js?v=20260417h" defer></script>
-<script src="04-router.js?v=20260417h" defer></script>
+<script src="06-post-create.js?v=20260417i" defer></script>
+<script defer src="render/dashboard.js?v=20260417i"></script>
+<script defer src="render/client.js?v=20260417i"></script>
+<script defer src="render/pipeline.js?v=20260417i"></script>
+<script defer src="render/brief.js?v=20260417i"></script>
+<script defer src="actions/pcs.js?v=20260417i"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417i"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417i"></script>
+<script defer src="actions/pcs-polish.js?v=20260417i"></script>
+<script defer src="actions/pcs-select.js?v=20260417i"></script>
+<script src="ai-config.js?v=20260417i" defer></script>
+<script src="07-post-load.js?v=20260417i" defer></script>
+<script src="08-post-actions.js?v=20260417i" defer></script>
+<script src="09-library.js?v=20260417i" defer></script>
+<script src="09-approval.js?v=20260417i" defer></script>
+<script src="04-router.js?v=20260417i" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4224,9 +4224,23 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 .notif-mi-btn.wa:hover     { color: #22D87F; }
 .notif-mi-btn.delete:hover { color: #FF4B4B; }
+/* Explicit sizing rules — override the inline width/height on the
+   SVG so the brand WhatsApp glyph (fill-based) and the trash icon
+   (stroke-based) each get the right rendering treatment. */
 .notif-mi-btn svg {
   display: block;
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
   pointer-events: none;
+}
+.notif-mi-btn.wa svg {
+  fill: currentColor;
+  stroke: none;
+  width: 16px;
+  height: 16px;
 }
 .notif-item.unread .notif-mi-btn { color: #2A3A5A; }
 .notif-item.unread .notif-mi-btn:hover {
@@ -4312,15 +4326,19 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .notif-item { flex-direction: column; }
 
 /* Expanded card — keeps the blue highlight when expanded. */
+/* Expanded card — flips to jet black so the drawer reads as a neutral
+   conversation surface, not an ongoing unread state. The glowing blue
+   dot is also suppressed on expand since tapping = marking read. */
 .notif-item.expanded {
-  background: var(--unread-bg);
+  background: var(--notif-bg);
   padding: 14px 20px 0;
   margin-bottom: 8px;
   border-left: none;
   border-radius: 0;
 }
-.notif-item.expanded:hover { background: var(--unread-bg); }
-.notif-item.unread.expanded { background: var(--unread-bg); }
+.notif-item.expanded::before { display: none; }
+.notif-item.expanded:hover { background: var(--notif-bg); }
+.notif-item.unread.expanded { background: var(--notif-bg); }
 
 /* ── EXPAND CHIP ── */
 .expand-chip {
@@ -4376,7 +4394,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   opacity: 1;
   margin-top: 12px;
   padding: 14px 0 16px;
-  border-top: 1px solid var(--unread-border);
+  border-top: 1px solid var(--notif-line);
 }
 /* .thread-area is now a transparent passthrough — no inner box. */
 .thread-area {
@@ -4472,11 +4490,13 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 
 /* ── REPLY ZONE — pill input + share row ── */
+/* Neutral borders (--notif-line) since the drawer sits on a jet-black
+   expanded card, not the blue unread block anymore. */
 .reply-zone,
 .thread-reply {
   margin-top: 14px;
   padding-top: 14px;
-  border-top: 1px solid var(--unread-border);
+  border-top: 1px solid var(--notif-line);
 }
 .reply-pill,
 .reply-row {
@@ -4485,7 +4505,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   gap: 6px;
   padding: 6px 6px 6px 14px;
   background: #FFFFFF08;              /* rgba(255,255,255,0.03) */
-  border: 1px solid var(--unread-border);
+  border: 1px solid var(--notif-line);
   border-radius: 22px;
   transition: border-color 0.2s ease;
 }


### PR DESCRIPTION
## Summary

Follow-up fix to PR #896 — the v7 redesign. In that PR the expanded state kept the blue `--unread-bg` surface, which made the thread drawer read as an ongoing unread state. This corrects it.

- **Expanded card flips to jet black.** `.notif-item.expanded` now uses `--notif-bg` (`#000000`) and hides the `::before` glowing blue dot. The drawer reads as a neutral conversation surface on jet black, not on the unread highlight.
- **Neutral borders on the drawer.** `.thread-drawer`, `.reply-zone` / `.thread-reply`, and `.reply-pill` / `.reply-row` borders switch from `--unread-border` (blue `#1E3A6E`) to `--notif-line` (neutral `#1A1A20`) so internal divisions match the new jet surface.
- **Single-pass blue → jet black fade.** `_notifToggleExpand` now removes `.unread` + calls `markNotifRead` **before** flipping `.expanded`, so the 0.3s `.notif-item` background transition drives a single fade in one pass instead of competing with the click delegate's separate mark-read call.
- **Explicit SVG render rules.** `.notif-mi-btn svg` (stroke) and `.notif-mi-btn.wa svg` (fill) CSS rules lock correct rendering for the brand WhatsApp glyph vs the trash icon regardless of inline SVG attributes.
- **Placeholder wording.** `Reply to <title>…` → `Comment on <title>…` so the pill reads as a comment composer, not a threaded reply.
- **Version:** all 26 `?v=` strings bumped `20260417h` → `20260417i`.

Out of scope (PR 2): the ✦ Polish button, any AI logic.

## Test plan

- [x] `npx vitest run` — **544/544 passing** across 22 files
- [ ] Visual QA on iPhone Safari — tap an unread comment → single smooth fade from blue to jet black as the drawer opens
- [ ] Expanded card shows NO blue dot on the left edge
- [ ] Thread drawer border-top, reply-zone top-border, and reply-pill border all read as neutral grey, not blue
- [ ] WhatsApp glyph still fills green on hover; trash glyph still strokes red
- [ ] Reply placeholder now reads "Comment on …"

https://claude.ai/code/session_018g9pHmjxc1HwDCfobn1X2f