### PR TITLE
feat: Polish Reply (✦) in notification drawer — admin-only

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -934,13 +934,32 @@ function _notifBuildThreadHtml(n, post, postTitle) {
   // Reply pill (round send button inside a rounded input) + shared
   // footer row that puts "VISIBLE TO ALL" on the left and the
   // "Open full post →" link on the right.
+  //
+  // Polish Reply ✦ button — Admin-only. Inserted between the textarea
+  // and the circular send button inside `.reply-pill`. An eyebrow
+  // line above the pill nudges the user to tap it. Non-admin users
+  // see the pill WITHOUT either element, matching the pre-Polish
+  // layout exactly.
   var replyPlaceholder = 'Comment on ' + (postTitle || 'post') + '\u2026';
+  var _canPolish = !!(window.AppState && window.AppState.user &&
+                      window.AppState.user.effectiveRole === 'Admin');
+  var polishHintHtml = _canPolish
+    ? '<div class="polish-pre-hint">\u2726 Tap to polish your draft</div>'
+    : '';
+  var polishBtnHtml = _canPolish
+    ? '<button class="reply-polish" data-action="notif-polish"' +
+        ' data-post-id="' + esc(postId) + '"' +
+        ' data-notif-id="' + esc(n.id || '') + '"' +
+        ' aria-label="Polish with Claude" type="button">\u2726</button>'
+    : '';
   var replyHtml =
     '<div class="reply-zone">' +
+      polishHintHtml +
       '<div class="reply-pill">' +
         '<textarea class="reply-input" rows="1"' +
           ' data-post-id="' + esc(postId) + '"' +
           ' placeholder="' + esc(replyPlaceholder) + '"></textarea>' +
+        polishBtnHtml +
         '<button class="reply-send" data-action="notif-reply-send"' +
           ' data-post-id="' + esc(postId) + '"' +
           ' data-notif-id="' + esc(n.id || '') + '" aria-label="Send reply">' +
@@ -2106,6 +2125,7 @@ function openNotifications() {
       var expandBtn = e.target.closest('.expand-chip');
       var replyInput = e.target.closest('.reply-input');
       var replySend = e.target.closest('.reply-send');
+      var replyPolish = e.target.closest('.reply-polish, [data-action="notif-polish"]');
       // Both the footer "Open full post ->" link and the top-of-drawer
       // "View all N comments" overflow link route through the same
       // open-post handler below.
@@ -2117,6 +2137,22 @@ function openNotifications() {
       if (replySend) {                       // submit the reply
         e.stopPropagation();
         _notifSubmitReply(replySend);
+        return;
+      }
+      if (replyPolish) {                     // Polish Reply ✦ (admin-only)
+        e.preventDefault();
+        e.stopPropagation();
+        // Defensive double-check — the button is only rendered for
+        // Admin in `_buildItem`, but a stale page shouldn't let a
+        // downgraded user invoke the modal.
+        if (!window.AppState || !window.AppState.user ||
+            window.AppState.user.effectiveRole !== 'Admin') {
+          console.warn('Polish requires admin role');
+          return;
+        }
+        if (typeof window.openPolishModal === 'function') {
+          window.openPolishModal('notif');
+        }
         return;
       }
       if (threadOpen) {                      // "Open full post ->" link

--- a/actions/pcs-polish.js
+++ b/actions/pcs-polish.js
@@ -14,27 +14,69 @@ window._polishState = {
   postId: null
 };
 
+// Scoped lookup for the notification thread drawer's reply input —
+// it lives on `.notif-item.expanded .reply-input` (no unique ID, the
+// expanded card is the scope). Returns null when no drawer is open.
+function _polishFindNotifInput() {
+  return document.querySelector('.notif-item.expanded .reply-input');
+}
+function _polishFindNotifExpandedItem() {
+  return document.querySelector('.notif-item.expanded');
+}
+
 window.openPolishModal = async function(zone) {
   var st = window._polishState;
-  var inputId = zone === 'notes' ? 'pcs-note-input' : 'pcs-comment-input';
-  var input = document.getElementById(inputId);
-  if (!input || !input.value.trim()) return;
+  var input;
 
-  st.rawText = input.value.trim();
-  st.zone = zone;
-  st.polishedText = '';
-  st.isOpen = true;
+  if (zone === 'notif') {
+    // Defensive admin check — the button is only rendered for Admin
+    // in `_buildItem`, but a cached page shouldn't let a downgraded
+    // user trigger the modal either.
+    var _role = window.AppState && window.AppState.user && window.AppState.user.effectiveRole;
+    if (_role !== 'Admin') {
+      console.warn('Polish requires admin role');
+      return;
+    }
+    input = _polishFindNotifInput();
+    if (!input || !input.value.trim()) {
+      if (typeof window.showToast === 'function')
+        window.showToast('Type a draft first, then tap \u2726', 'error');
+      return;
+    }
+    var expandedItem = _polishFindNotifExpandedItem();
+    var notifPostId = expandedItem ? expandedItem.getAttribute('data-post-id') : null;
+    if (!notifPostId) {
+      if (typeof window.showToast === 'function')
+        window.showToast('Open a comment thread first', 'error');
+      return;
+    }
+    st.rawText = input.value.trim();
+    st.zone = 'notif';
+    st.polishedText = '';
+    st.isOpen = true;
+    st.postId = notifPostId;
+    st.replyTo = null;
+  } else {
+    var inputId = zone === 'notes' ? 'pcs-note-input' : 'pcs-comment-input';
+    input = document.getElementById(inputId);
+    if (!input || !input.value.trim()) return;
 
-  var postIdEl = document.getElementById('pcs-post-id');
-  st.postId = postIdEl ? postIdEl.value : null;
+    st.rawText = input.value.trim();
+    st.zone = zone;
+    st.polishedText = '';
+    st.isOpen = true;
 
-  var replyTagId = zone === 'notes' ? 'pcs-note-reply-tag' : 'pcs-client-reply-tag';
-  var replyNameId = zone === 'notes' ? 'pcs-note-reply-name' : 'pcs-client-reply-name';
-  var replyTag = document.getElementById(replyTagId);
-  var replyName = document.getElementById(replyNameId);
-  st.replyTo = (replyTag && replyTag.style.display !== 'none' && replyName && replyName.textContent)
-    ? { author: replyName.textContent }
-    : null;
+    var postIdEl = document.getElementById('pcs-post-id');
+    st.postId = postIdEl ? postIdEl.value : null;
+
+    var replyTagId = zone === 'notes' ? 'pcs-note-reply-tag' : 'pcs-client-reply-tag';
+    var replyNameId = zone === 'notes' ? 'pcs-note-reply-name' : 'pcs-client-reply-name';
+    var replyTag = document.getElementById(replyTagId);
+    var replyName = document.getElementById(replyNameId);
+    st.replyTo = (replyTag && replyTag.style.display !== 'none' && replyName && replyName.textContent)
+      ? { author: replyName.textContent }
+      : null;
+  }
 
   var overlay = document.getElementById('pcs-polish-overlay');
   if (!overlay) return;
@@ -110,6 +152,25 @@ window.sendPolished = function() {
   var resultEl = document.getElementById('polish-result');
   var finalText = resultEl ? resultEl.innerText.trim() : st.polishedText;
   if (!finalText) return;
+
+  // Notification-zone flow is scoped to the currently-expanded
+  // `.notif-item` — the textarea has no unique ID, so we pump the
+  // polished text into the class-scoped input and click its own
+  // `.reply-send` button, which runs `_notifSubmitReply` (10-ui.js)
+  // and POSTs to `/post_comments` instead of the PCS submission path.
+  if (st.zone === 'notif') {
+    var notifInput = _polishFindNotifInput();
+    if (!notifInput) return;
+    notifInput.value = finalText;
+    // Fire `input` so `_notifReplyInputResize` enables `.reply-send.active`.
+    notifInput.dispatchEvent(new Event('input', { bubbles: true }));
+    window.closePolishModal();
+    setTimeout(function() {
+      var sendBtn = document.querySelector('.notif-item.expanded .reply-send');
+      if (sendBtn) sendBtn.click();
+    }, 100);
+    return;
+  }
 
   var inputId = st.zone === 'notes' ? 'pcs-note-input' : 'pcs-comment-input';
   var input = document.getElementById(inputId);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417i">
+ <link rel="stylesheet" href="styles.css?v=20260417j">
 
 </head>
 <body>
@@ -1247,32 +1247,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417i"></script>
-<script src="00-appstate-compat.js?v=20260417i"></script>
-<script src="01-config.js?v=20260417i" defer></script>
-<script src="02-session.js?v=20260417i" defer></script>
-<script src="utils.js?v=20260417i" defer></script>
-<script src="12-profiles.js?v=20260417i" defer></script>
-<script src="03-auth.js?v=20260417i" defer></script>
-<script src="05-api.js?v=20260417i" defer></script>
-<script src="10-ui.js?v=20260417i" defer></script>
+<script src="00-appstate.js?v=20260417j"></script>
+<script src="00-appstate-compat.js?v=20260417j"></script>
+<script src="01-config.js?v=20260417j" defer></script>
+<script src="02-session.js?v=20260417j" defer></script>
+<script src="utils.js?v=20260417j" defer></script>
+<script src="12-profiles.js?v=20260417j" defer></script>
+<script src="03-auth.js?v=20260417j" defer></script>
+<script src="05-api.js?v=20260417j" defer></script>
+<script src="10-ui.js?v=20260417j" defer></script>
 
-<script src="06-post-create.js?v=20260417i" defer></script>
-<script defer src="render/dashboard.js?v=20260417i"></script>
-<script defer src="render/client.js?v=20260417i"></script>
-<script defer src="render/pipeline.js?v=20260417i"></script>
-<script defer src="render/brief.js?v=20260417i"></script>
-<script defer src="actions/pcs.js?v=20260417i"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417i"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417i"></script>
-<script defer src="actions/pcs-polish.js?v=20260417i"></script>
-<script defer src="actions/pcs-select.js?v=20260417i"></script>
-<script src="ai-config.js?v=20260417i" defer></script>
-<script src="07-post-load.js?v=20260417i" defer></script>
-<script src="08-post-actions.js?v=20260417i" defer></script>
-<script src="09-library.js?v=20260417i" defer></script>
-<script src="09-approval.js?v=20260417i" defer></script>
-<script src="04-router.js?v=20260417i" defer></script>
+<script src="06-post-create.js?v=20260417j" defer></script>
+<script defer src="render/dashboard.js?v=20260417j"></script>
+<script defer src="render/client.js?v=20260417j"></script>
+<script defer src="render/pipeline.js?v=20260417j"></script>
+<script defer src="render/brief.js?v=20260417j"></script>
+<script defer src="actions/pcs.js?v=20260417j"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417j"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417j"></script>
+<script defer src="actions/pcs-polish.js?v=20260417j"></script>
+<script defer src="actions/pcs-select.js?v=20260417j"></script>
+<script src="ai-config.js?v=20260417j" defer></script>
+<script src="07-post-load.js?v=20260417j" defer></script>
+<script src="08-post-actions.js?v=20260417j" defer></script>
+<script src="09-library.js?v=20260417j" defer></script>
+<script src="09-approval.js?v=20260417j" defer></script>
+<script src="04-router.js?v=20260417j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -4531,6 +4531,51 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .reply-input::placeholder { color: var(--text-whisper); }
 .reply-input:disabled { opacity: 0.6; }
 
+/* ── POLISH REPLY — terracotta ✦ button + eyebrow nudge ── */
+/* Admin-only. Emitted by `_notifBuildThreadHtml` between the textarea
+   and `.reply-send` when `effectiveRole === 'Admin'`. A subtle
+   terracotta glow pulses at 2.5s to signal tap-to-polish without
+   dominating the drawer. Non-admin users never see these elements. */
+.polish-pre-hint {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #C15F3C;
+  font-weight: 600;
+  padding: 0 8px;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.reply-polish {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid #5A3A2C;
+  background: linear-gradient(180deg, #2A1A12 0%, #1A0E08 100%);
+  color: #C15F3C;
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: transform 0.15s ease, box-shadow 0.3s ease;
+  animation: polish-glow 2.5s ease-in-out infinite;
+  -webkit-tap-highlight-color: transparent;
+}
+.reply-polish:active { transform: scale(0.92); }
+.reply-polish:hover {
+  animation: none;
+  box-shadow: 0 0 16px 3px #C15F3C59;   /* rgba(193,95,60,0.35) */
+}
+@keyframes polish-glow {
+  0%, 100% { box-shadow: 0 0 0 0 #C15F3C00; }      /* rgba(193,95,60,0) */
+  50%      { box-shadow: 0 0 14px 2px #C15F3C40; } /* rgba(193,95,60,0.25) */
+}
+
 .reply-send {
   width: 32px;
   height: 32px;


### PR DESCRIPTION
## Summary

Adds a Polish Reply ✦ button to the inline reply pill in the notification panel's expanded thread drawer. **Admin-only.** Admins can type a rough draft, tap ✦, and let Claude rewrite it professionally before sending. Non-admin users see the pill unchanged.

- **`actions/pcs-polish.js`** — new `zone === 'notif'` branch in `openPolishModal()` that reads from `.notif-item.expanded .reply-input` (class-scoped, no unique ID), pulls `postId` from the expanded card's `data-post-id`, and carries `replyTo: null` since the drawer doesn't track comment-of-comment yet. Defensive `effectiveRole === 'Admin'` check; empty-draft + missing-postId paths show a toast instead of silent no-op.
- **`sendPolished()`** — matching `zone === 'notif'` branch stuffs polished text into the notification input, dispatches an `input` event so `_notifReplyInputResize` flips `.reply-send.active`, then clicks `.notif-item.expanded .reply-send` to re-use the existing `_notifSubmitReply` path. PCS submission path is explicitly skipped.
- **`10-ui.js _notifBuildThreadHtml`** emits `.polish-pre-hint` + `.reply-polish` inside `.reply-pill` ONLY when `AppState.user.effectiveRole === 'Admin'`. Non-admin markup is byte-identical to the pre-Polish layout.
- **`10-ui.js` click delegate** handles `.reply-polish` / `[data-action="notif-polish"]` before `.thread-open-post` and `.thread-msg` so the tap doesn't bleed into the open-post handler. Defensive admin check in the handler too.
- **`styles.css`** adds `.polish-pre-hint` (terracotta uppercase eyebrow), `.reply-polish` (32 px round, terracotta gradient, 2.5 s subtle pulse via `@keyframes polish-glow`), and hover / active affordances. All translucent values as 8-digit hex per CLAUDE.md §4.

**Cost tracking:** already handled by the existing `_callSrtdAI('chat', ...)` call — no new wiring needed.

**Versions:** 26 `?v=` strings bumped `20260417i` → `20260417j`.

## Test plan

- [x] `npx vitest run` — **544/544 passing** across 22 files
- [ ] Admin: open notif panel → expand a comment thread → pill shows the terracotta ✦ button + eyebrow hint, gentle pulse visible
- [ ] Admin: type a draft, tap ✦ → Polish modal opens with raw + polished side-by-side, Send button updates to "✦ Send reply"
- [ ] Admin: Send polished → text lands in reply pill → reply-send triggers → comment POSTs to `/post_comments` with the polished content
- [ ] Admin: tap ✦ with empty input → toast "Type a draft first, then tap ✦", no modal
- [ ] Admin: preview-as-Client in admin debug → expanded drawer shows NO ✦ button
- [ ] Non-admin user (Servicing/Creative/Client) — expand a thread → NO ✦ button, NO eyebrow, layout identical to PR #898
- [ ] Tap on ✦ does NOT also trigger "Open full post" routing or collapse the drawer

https://claude.ai/code/session_018g9pHmjxc1HwDCfobn1X2f