### PR TITLE
feat(notif-v7.2): Linear-style unread dot + date group headers + lifted typography

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -822,18 +822,40 @@ function renderNotifications(name, role) {
     '</div>';
   }
 
+  // Date-group headers carry a right-aligned count pill — "N new" when
+  // the bucket has unread items, otherwise "N items". The inner
+  // `.notif-day-label` span is preserved so source-pattern unit tests
+  // keep matching on the legacy class name.
+  function _buildGroupHeader(label, items, isFirst) {
+    if (!items || items.length === 0) return '';
+    var unreadCount = 0;
+    for (var i = 0; i < items.length; i++) { if (!items[i].read) unreadCount++; }
+    var countText = unreadCount > 0
+      ? unreadCount + ' new'
+      : items.length + (items.length === 1 ? ' item' : ' items');
+    var firstCls = isFirst ? ' ngh-first' : '';
+    return '<div class="notif-group-header' + firstCls + '">' +
+      '<span class="notif-group-label notif-day-label">' + label + '</span>' +
+      '<span class="notif-group-count">' + countText + '</span>' +
+    '</div>';
+  }
+
   var html = '';
+  var _isFirstGroup = true;
   if (groups.today.length > 0) {
-    html += '<div class="notif-day-label ndl-first">Today</div>';
+    html += _buildGroupHeader('Today', groups.today, _isFirstGroup);
     groups.today.forEach(function(n) { html += _buildItem(n); });
+    _isFirstGroup = false;
   }
   if (groups.yesterday.length > 0) {
-    html += '<div class="notif-day-label">Yesterday</div>';
+    html += _buildGroupHeader('Yesterday', groups.yesterday, _isFirstGroup);
     groups.yesterday.forEach(function(n) { html += _buildItem(n); });
+    _isFirstGroup = false;
   }
   if (groups.earlier.length > 0) {
-    html += '<div class="notif-day-label">Earlier</div>';
+    html += _buildGroupHeader('Earlier', groups.earlier, _isFirstGroup);
     groups.earlier.forEach(function(n) { html += _buildItem(n); });
+    _isFirstGroup = false;
   }
   html += '<div class="notif-foot">That\u2019s everything</div>';
   scroll.innerHTML = html;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417j">
+ <link rel="stylesheet" href="styles.css?v=20260417k">
 
 </head>
 <body>
@@ -1247,32 +1247,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417j"></script>
-<script src="00-appstate-compat.js?v=20260417j"></script>
-<script src="01-config.js?v=20260417j" defer></script>
-<script src="02-session.js?v=20260417j" defer></script>
-<script src="utils.js?v=20260417j" defer></script>
-<script src="12-profiles.js?v=20260417j" defer></script>
-<script src="03-auth.js?v=20260417j" defer></script>
-<script src="05-api.js?v=20260417j" defer></script>
-<script src="10-ui.js?v=20260417j" defer></script>
+<script src="00-appstate.js?v=20260417k"></script>
+<script src="00-appstate-compat.js?v=20260417k"></script>
+<script src="01-config.js?v=20260417k" defer></script>
+<script src="02-session.js?v=20260417k" defer></script>
+<script src="utils.js?v=20260417k" defer></script>
+<script src="12-profiles.js?v=20260417k" defer></script>
+<script src="03-auth.js?v=20260417k" defer></script>
+<script src="05-api.js?v=20260417k" defer></script>
+<script src="10-ui.js?v=20260417k" defer></script>
 
-<script src="06-post-create.js?v=20260417j" defer></script>
-<script defer src="render/dashboard.js?v=20260417j"></script>
-<script defer src="render/client.js?v=20260417j"></script>
-<script defer src="render/pipeline.js?v=20260417j"></script>
-<script defer src="render/brief.js?v=20260417j"></script>
-<script defer src="actions/pcs.js?v=20260417j"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417j"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417j"></script>
-<script defer src="actions/pcs-polish.js?v=20260417j"></script>
-<script defer src="actions/pcs-select.js?v=20260417j"></script>
-<script src="ai-config.js?v=20260417j" defer></script>
-<script src="07-post-load.js?v=20260417j" defer></script>
-<script src="08-post-actions.js?v=20260417j" defer></script>
-<script src="09-library.js?v=20260417j" defer></script>
-<script src="09-approval.js?v=20260417j" defer></script>
-<script src="04-router.js?v=20260417j" defer></script>
+<script src="06-post-create.js?v=20260417k" defer></script>
+<script defer src="render/dashboard.js?v=20260417k"></script>
+<script defer src="render/client.js?v=20260417k"></script>
+<script defer src="render/pipeline.js?v=20260417k"></script>
+<script defer src="render/brief.js?v=20260417k"></script>
+<script defer src="actions/pcs.js?v=20260417k"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417k"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417k"></script>
+<script defer src="actions/pcs-polish.js?v=20260417k"></script>
+<script defer src="actions/pcs-select.js?v=20260417k"></script>
+<script src="ai-config.js?v=20260417k" defer></script>
+<script src="07-post-load.js?v=20260417k" defer></script>
+<script src="08-post-actions.js?v=20260417k" defer></script>
+<script src="09-library.js?v=20260417k" defer></script>
+<script src="09-approval.js?v=20260417k" defer></script>
+<script src="04-router.js?v=20260417k" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -3831,23 +3831,22 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 #notif-overlay {
   /* Jet black palette — unified */
   --notif-bg: #000000;
-  --notif-line: #1A1A20;
-  --notif-line-soft: #141418;
+  --notif-line: #1F1F27;
+  --notif-line-soft: #17171D;
   --notif-bg-elevated: #141418;
 
-  /* Electric blue unread state */
-  --unread-bg: #0E1A35;
-  --unread-bg-hover: #14224A;
-  --unread-border: #1E3A6E;
+  /* Linear-style unread — dot only, no background tint */
   --unread-dot: #3B82F6;
-  --unread-dot-glow: #3B82F680;       /* rgba(59,130,246,0.50) */
 
-  /* Text hierarchy */
+  /* Text hierarchy (lifted tokens — text-soft/whisper raised for
+     legibility against the jet-black surface; text-ghost is reserved
+     for empty-state copy where we want the text to nearly disappear). */
   --text-loud: #F0F0F2;
   --text-bright: #E4E4E8;
   --text: #B8B8C0;
-  --text-soft: #78787E;
-  --text-whisper: #3A3A42;
+  --text-soft: #8E8E96;
+  --text-whisper: #5A5A62;
+  --text-ghost: #3A3A42;
 
   position: fixed;
   inset: 0;
@@ -3984,85 +3983,118 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 .notif-scroll::-webkit-scrollbar { display: none; }
 
-/* ── DAY LABEL ── */
-.notif-day-label {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  font-weight: 500;
-  letter-spacing: 1.6px;
-  color: var(--text-soft);
-  text-transform: uppercase;
-  padding: 18px 20px 8px;
+/* ── DATE GROUP HEADER — v7.2 ── */
+/* Replaces the old mono caps day label with a DM Sans 11px bold
+   header + a small count pill on the right ("N new" if the group
+   has unread items, "N items" otherwise). The old .notif-day-label
+   class is retained as an inner span so stale markup + unit tests
+   (notif-render.test.js looks for `notif-day-label` in source)
+   still match. */
+.notif-group-header {
+  padding: 22px 20px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
-.notif-day-label.ndl-first { padding-top: 14px; }
+.notif-group-header.ngh-first,
+.notif-group-header:first-child { padding-top: 16px; }
+.notif-group-label,
+.notif-day-label {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+.notif-group-count {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  color: var(--text-whisper);
+  text-transform: uppercase;
+}
 
 /* ── NOTIFICATION ITEM ── */
+/* Linear-style unread — no background tint. The unread state is
+   communicated by a small blue dot on the left edge + a quieter
+   text hierarchy shift (author loud + bold, headline loud,
+   preview lifted). Read items get the dimmer hierarchy. */
 .notif-item {
   position: relative;
   display: flex;
   align-items: flex-start;
-  gap: 12px;
+  gap: 14px;
   padding: 14px 20px;
   border-bottom: 1px solid var(--notif-line-soft);
   cursor: pointer;
   background: transparent;
-  transition: background 0.3s ease, border-color 0.3s ease;
+  transition: background 0.3s ease;
   min-height: 44px;
 }
-/* Read state matches the base state — no visual change. */
 .notif-item.read { background: transparent; }
 .notif-item:hover,
 .notif-item.read:hover {
   background: #FFFFFF05;              /* rgba(255,255,255,0.02) */
 }
 
-/* Unread: full-row electric blue + glowing blue dot on the left edge. */
-.notif-item.unread {
-  background: var(--unread-bg);
-  border-bottom-color: #1E3A6E4D;     /* rgba(30,58,110,0.30) */
-}
-.notif-item.unread:hover {
-  background: var(--unread-bg-hover);
-}
+/* Read hierarchy (default) — everything a notch quieter than unread. */
+.notif-item .notif-author   { color: var(--text-soft); }
+.notif-item .notif-headline { color: var(--text); }
+.notif-item .notif-headline strong { color: var(--text-bright); }
+.notif-item .notif-preview  { color: var(--text-whisper); }
+
+/* Unread: just the blue dot + loud text. No background, no border tint. */
 .notif-item.unread::before {
   content: '';
   position: absolute;
-  left: 7px;
+  left: 8px;
   top: 50%;
   transform: translateY(-50%);
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background: var(--unread-dot);
-  box-shadow: 0 0 10px var(--unread-dot-glow);
   pointer-events: none;
 }
+.notif-item.unread .notif-author {
+  color: var(--text-loud);
+  font-weight: 600;
+}
 .notif-item.unread .notif-headline { color: var(--text-loud); }
+.notif-item.unread .notif-headline strong { color: var(--text-loud); }
 .notif-item.unread .notif-preview  { color: var(--text); }
-.notif-item.unread .notif-author   { color: var(--text-bright); }
 
-/* ── AVATAR ── */
+/* ── AVATAR — 40x40 with a subtle white ring to lift it off the
+   jet-black surface without a hard border line. */
 .notif-av {
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   font-family: 'DM Sans', sans-serif;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 700;
   color: #FFFFFF;
   border: none;
   align-self: flex-start;
-  margin-top: 1px;
+  margin-top: 2px;
+  box-shadow: 0 0 0 1px #FFFFFF0D;     /* rgba(255,255,255,0.05) */
 }
 .nav-manisha, .nav-client    { background: #FF4B4B; border: none; color: #FFFFFF; }
 .nav-chitra,  .nav-servicing { background: #22D3EE; border: none; color: #FFFFFF; }
 .nav-pranav,  .nav-creative  { background: #9b87f5; border: none; color: #FFFFFF; }
 .nav-admin,   .nav-shubham   { background: #C8A84B; border: none; color: #FFFFFF; }
 .nav-system                  { background: #555566; border: none; color: #FFFFFF; }
+.notif-av.nav-system {
+  background: var(--notif-bg-elevated);
+  color: var(--text-soft);
+  box-shadow: 0 0 0 1px var(--notif-line);
+}
 
 /* ── BODY ── */
 .notif-body { flex: 1; min-width: 0; }
@@ -4182,16 +4214,17 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   align-self: flex-start;
 }
 .notif-thumb-wrap {
-  width: 60px;
-  height: 60px;
-  border-radius: 6px;
+  width: 68px;
+  height: 68px;
+  border-radius: 8px;
   overflow: hidden;
   background: var(--notif-bg-elevated);
   border: 1px solid var(--notif-line);
+  box-shadow: 0 2px 8px #0000004D;     /* rgba(0,0,0,0.30) — soft drop */
 }
 .notif-thumb {
-  width: 60px;
-  height: 60px;
+  width: 68px;
+  height: 68px;
   object-fit: cover;
   display: block;
 }
@@ -4199,13 +4232,13 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   display: flex;
   gap: 2px;
   justify-content: center;
-  width: 60px;
+  width: 68px;
 }
 
-/* Action buttons — 28x28 tap target (inside a 60px row). */
+/* Action buttons — 30x30 tap target (inside a 68px row). */
 .notif-mi-btn {
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
   padding: 0;
   background: none;
   border: none;
@@ -4242,10 +4275,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   width: 16px;
   height: 16px;
 }
-.notif-item.unread .notif-mi-btn { color: #2A3A5A; }
-.notif-item.unread .notif-mi-btn:hover {
-  background: #3B82F626;              /* rgba(59,130,246,0.15) */
-}
+/* Action buttons stay consistent across read/unread states in the
+   Linear-style redesign — no blue-tint override on unread. */
 
 /* Legacy .notif-meta kept as a hidden wrapper for any stale markup
    path; the v7 tree puts timestamp into .notif-top-line and actions
@@ -4417,64 +4448,84 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   flex-direction: column;
 }
 
-/* ── THREAD MESSAGE (v7 — bigger, more readable) ── */
+/* ── THREAD MESSAGE (v7.2 — bumped typography for legibility) ── */
 .thread-msg {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  padding: 10px 0;
+  gap: 10px;
+  padding: 12px 0;
   border-bottom: 1px solid var(--notif-line);
 }
 .thread-msg:last-of-type { border-bottom: none; }
 .thread-av {
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
   color: #FFFFFF;
   border: none;
   margin-top: 1px;
+  box-shadow: 0 0 0 1px #FFFFFF0D;     /* rgba(255,255,255,0.05) */
 }
 .thread-av.nav-system { background: #666666; }
 .thread-content {
   flex: 1;
   min-width: 0;
 }
+/* .thread-header — legacy; .thread-head is the v7.2 layout with
+   left-aligned author+role and an auto-justified timestamp. Both
+   emit the same semantic block; keep the old rule as a no-op
+   layout so stale cached markup still reads right. */
 .thread-header {
   display: flex;
   align-items: center;
   gap: 6px;
 }
+.thread-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+.thread-head-left {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+}
 .thread-author {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
   color: var(--text-loud);
 }
 .thread-role {
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 7px;
-  letter-spacing: 0.12em;
+  font-size: 8px;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--text-whisper);
-  padding: 2px 5px;
-  background: #FFFFFF0A;              /* rgba(255,255,255,0.04) */
-  border-radius: 2px;
+  color: var(--text-soft);
+  padding: 2px 6px;
+  background: #FFFFFF0F;              /* rgba(255,255,255,0.06) */
+  border-radius: 3px;
   font-weight: 600;
 }
 .thread-time {
-  font-size: 9px;
-  color: var(--text-whisper);
-  margin-left: auto;
   font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: var(--text-soft);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  margin-left: auto;
   white-space: nowrap;
 }
-.thread-message {
-  font-size: 12.5px;
+.thread-message,
+.thread-text {
+  font-size: 13px;
   color: var(--text);
   line-height: 1.5;
   margin-top: 3px;


### PR DESCRIPTION
## Summary

Switches the v7 notification panel from a full-row electric-blue unread **block** to a Linear-style **dot** + brighter text hierarchy, and nudges several sizes/tokens so the card reads cleaner against jet black on retina.

- **Unread = dot only.** `.notif-item.unread` no longer paints a background or border tint. State is communicated by a 7px blue dot pseudo-element on the left edge and an explicit read-vs-unread color cascade. `.notif-item` + expanded state keep the same jet-black surface across both, so mark-read stops flashing from blue to black.
- **Text tokens lifted.** `--text-soft` `#78787E → #8E8E96`, `--text-whisper` `#3A3A42 → #5A5A62`. New `--text-ghost` `#3A3A42` reserved for empty-state copy. `--notif-line` `#1A1A20 → #1F1F27`.
- **Read vs Unread cascade** — explicit per-field color rules:
    - Read: author=soft, headline=text, strong=bright, preview=whisper
    - Unread: author=loud + 600 weight, headline=loud, strong=loud, preview=text
- **Sizes bumped** for breathing room:
    - `.notif-av` 36→40 (+1px white ring)
    - `.thread-av` 28→32 (+1px white ring)
    - `.notif-thumb-wrap` 60→68 (r 6→8, soft shadow)
    - `.notif-actions-col` 60→68
    - `.notif-mi-btn` 28→30
  Unread mi-btn color override removed — buttons stay consistent.
- **Thread typography.** `.thread-msg` padding 10→12, gap 8→10. `.thread-author` 12→13/600. `.thread-role` 7→8, color whisper→soft, brighter bg. `.thread-time` 9→10, color whisper→soft, weight 500. `.thread-message`/`.thread-text` 12.5→13. Added `.thread-head` + `.thread-head-left` layout utilities; legacy `.thread-header` kept as a no-op layout so cached markup still reads right.
- **Date group headers.** `.notif-day-label` replaced by a flex `.notif-group-header` with a DM Sans 11px bold label on the left and a count pill on the right — `"N new"` when the bucket has unread items, `"N items"` otherwise. `.notif-day-label` retained as an inner span class so the notif-render test's source-pattern assertion keeps matching.

**Out of scope (already live):** Polish Reply ✦ remains admin-only and untouched.

**Versions:** 26 `?v=` strings bumped `20260417j` → `20260417k`.

## Test plan

- [x] `npx vitest run` — **544/544 passing** across 22 files
- [ ] Open notif panel — unread rows show a blue dot on the left edge, NO blue background; text is louder than read rows
- [ ] Tap an unread → dot disappears, text dims in-place, no jarring color flash
- [ ] Date group header shows `Today · N new` / `Yesterday · N items` with the count on the right in mono caps
- [ ] Thumbnails are larger (68px) with a soft shadow
- [ ] Avatars are larger (40px) with a faint 1px ring
- [ ] Thread drawer messages readable: 13px author, 10px timestamp, 8px role pill visible against the jet surface
- [ ] Single-comment post still opens inline drawer (v7.1 behavior preserved)
- [ ] Polish ✦ button still appears for Admin in reply pill

https://claude.ai/code/session_018g9pHmjxc1HwDCfobn1X2f