### PR TITLE
fix(caption-meter): kill Today/Month refetch race, increment locally

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -9,6 +9,8 @@ window._captionWS = {
   isOpen: false,
   messages: [],
   sessionCost: 0,
+  todayCostINR: 0,
+  monthCostINR: 0,
   postId: null,
   mode: null,
   _rewriteComments: null,
@@ -105,9 +107,11 @@ window.openCaptionWorkspace = async function(mode, context) {
         ws.messages.push({ role: 'assistant', content: result.content || '' });
         var inTok = result.input_tokens || (result.usage && result.usage.input) || 0;
         var outTok = result.output_tokens || (result.usage && result.usage.output) || 0;
-        ws.sessionCost += _cwCalcINR(inTok, outTok);
-        _cwUpdateSessionMeter();
-        setTimeout(function() { _cwFetchCostTotals(); }, 800);
+        var rwCostINR = _cwCalcINR(inTok, outTok);
+        ws.sessionCost += rwCostINR;
+        ws.todayCostINR += rwCostINR;
+        ws.monthCostINR += rwCostINR;
+        _cwUpdateMeters();
       } else {
         ws.messages.push({ role: 'assistant', content: 'Error: ' + ((result && result.error) || 'Request failed. Try again.') });
       }
@@ -206,8 +210,9 @@ window.sendCaptionMessage = async function(text) {
     var outTok = result.output_tokens || (result.usage && result.usage.output) || 0;
     var costINR = _cwCalcINR(inTok, outTok);
     ws.sessionCost += costINR;
-    _cwUpdateSessionMeter();
-    setTimeout(function() { _cwFetchCostTotals(); }, 800);
+    ws.todayCostINR += costINR;
+    ws.monthCostINR += costINR;
+    _cwUpdateMeters();
   } else {
     ws.messages.push({ role: 'assistant', content: 'Error: ' + ((result && result.error) || 'Request failed. Try again.') });
   }
@@ -637,6 +642,16 @@ function _cwUpdateSessionMeter() {
   if (el) el.textContent = _cwFormatINR(window._captionWS.sessionCost);
 }
 
+function _cwUpdateMeters() {
+  var ws = window._captionWS;
+  var sEl = document.getElementById('cw-session-cost');
+  var tEl = document.getElementById('cw-today-cost');
+  var mEl = document.getElementById('cw-month-cost');
+  if (sEl) sEl.textContent = _cwFormatINR(ws.sessionCost);
+  if (tEl) tEl.textContent = _cwFormatINR(ws.todayCostINR);
+  if (mEl) mEl.textContent = _cwFormatINR(ws.monthCostINR);
+}
+
 async function _cwFetchCostTotals() {
   try {
     var now = new Date();
@@ -655,10 +670,9 @@ async function _cwFetchCostTotals() {
     if (Array.isArray(todayRows)) todayRows.forEach(function(r) { todayUSD += (r.cost_usd || 0); });
     if (Array.isArray(monthRows)) monthRows.forEach(function(r) { monthUSD += (r.cost_usd || 0); });
 
-    var todayEl = document.getElementById('cw-today-cost');
-    var monthEl = document.getElementById('cw-month-cost');
-    if (todayEl) todayEl.textContent = _cwFormatINR(todayUSD * _CW_USD_TO_INR);
-    if (monthEl) monthEl.textContent = _cwFormatINR(monthUSD * _CW_USD_TO_INR);
+    window._captionWS.todayCostINR = todayUSD * _CW_USD_TO_INR;
+    window._captionWS.monthCostINR = monthUSD * _CW_USD_TO_INR;
+    _cwUpdateMeters();
   } catch (e) {
     // non-critical
   }

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417l">
+ <link rel="stylesheet" href="styles.css?v=20260417m">
 
 </head>
 <body>
@@ -1247,32 +1247,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417l"></script>
-<script src="00-appstate-compat.js?v=20260417l"></script>
-<script src="01-config.js?v=20260417l" defer></script>
-<script src="02-session.js?v=20260417l" defer></script>
-<script src="utils.js?v=20260417l" defer></script>
-<script src="12-profiles.js?v=20260417l" defer></script>
-<script src="03-auth.js?v=20260417l" defer></script>
-<script src="05-api.js?v=20260417l" defer></script>
-<script src="10-ui.js?v=20260417l" defer></script>
+<script src="00-appstate.js?v=20260417m"></script>
+<script src="00-appstate-compat.js?v=20260417m"></script>
+<script src="01-config.js?v=20260417m" defer></script>
+<script src="02-session.js?v=20260417m" defer></script>
+<script src="utils.js?v=20260417m" defer></script>
+<script src="12-profiles.js?v=20260417m" defer></script>
+<script src="03-auth.js?v=20260417m" defer></script>
+<script src="05-api.js?v=20260417m" defer></script>
+<script src="10-ui.js?v=20260417m" defer></script>
 
-<script src="06-post-create.js?v=20260417l" defer></script>
-<script defer src="render/dashboard.js?v=20260417l"></script>
-<script defer src="render/client.js?v=20260417l"></script>
-<script defer src="render/pipeline.js?v=20260417l"></script>
-<script defer src="render/brief.js?v=20260417l"></script>
-<script defer src="actions/pcs.js?v=20260417l"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417l"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417l"></script>
-<script defer src="actions/pcs-polish.js?v=20260417l"></script>
-<script defer src="actions/pcs-select.js?v=20260417l"></script>
-<script src="ai-config.js?v=20260417l" defer></script>
-<script src="07-post-load.js?v=20260417l" defer></script>
-<script src="08-post-actions.js?v=20260417l" defer></script>
-<script src="09-library.js?v=20260417l" defer></script>
-<script src="09-approval.js?v=20260417l" defer></script>
-<script src="04-router.js?v=20260417l" defer></script>
+<script src="06-post-create.js?v=20260417m" defer></script>
+<script defer src="render/dashboard.js?v=20260417m"></script>
+<script defer src="render/client.js?v=20260417m"></script>
+<script defer src="render/pipeline.js?v=20260417m"></script>
+<script defer src="render/brief.js?v=20260417m"></script>
+<script defer src="actions/pcs.js?v=20260417m"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417m"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417m"></script>
+<script defer src="actions/pcs-polish.js?v=20260417m"></script>
+<script defer src="actions/pcs-select.js?v=20260417m"></script>
+<script src="ai-config.js?v=20260417m" defer></script>
+<script src="07-post-load.js?v=20260417m" defer></script>
+<script src="08-post-actions.js?v=20260417m" defer></script>
+<script src="09-library.js?v=20260417m" defer></script>
+<script src="09-approval.js?v=20260417m" defer></script>
+<script src="04-router.js?v=20260417m" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

Caption Workspace AI usage meter: Today and This Month values stayed frozen at whatever they were when the overlay first opened, even though Session incremented correctly and the DB had the fresh data.

**Root cause:** 800ms `setTimeout` refetch after each AI call raced against `srtd-ai` worker's fire-and-forget `ai_usage` insert (no `ctx.waitUntil`). The browser read the DB before the just-logged row landed. Over a session this compounded and the meter looked stuck.

**Fix:** Mirror the Session counter pattern.
- Added `todayCostINR` and `monthCostINR` to `window._captionWS`.
- `_cwFetchCostTotals()` now writes baselines into those fields on workspace open (query unchanged — still workspace total, no user filter).
- After each successful AI call, increment all three counters from the same `costINR` that already feeds `sessionCost`, then push via new `_cwUpdateMeters()` helper.
- Removed both `setTimeout(_cwFetchCostTotals, 800)` calls — they were the race.
- Baseline re-fetches on every reopen, so any drift self-corrects.

**Scope kept tight:** workspace total only (single AI writer today). Per-user scoping and USD→INR rate are separate concerns, not touched here.

**Version bump:** All 26 `?v=` strings bumped `20260417l` → `20260417m`. (Task brief said bump from `j` to `k`, but main was already at `l`, so I bumped to `m` to avoid regression.)

## Files

- `actions/pcs-claude-caption.js` — counters, `_cwUpdateMeters` helper, removed setTimeout refetches
- `index.html` — `?v=` bump

## Test plan

- [x] `npx vitest run` — 544/544 passing
- [ ] Open Caption Workspace → verify Today/Month show baseline from DB
- [ ] Make 3-4 AI calls in-session → Session, Today, Month all advance in lockstep
- [ ] Close workspace, reopen → Today/Month reflect the fresh DB total (baseline re-fetch)
- [ ] Repeat with `rewrite` mode → same behaviour from the rewrite branch

https://claude.ai/code/session_01YPP7HuN7Rv5QcrPzPTDKV7