### PR TITLE
fix(names): render display_name not email + strip role pills

### DIFF
--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -388,14 +388,17 @@ async function submitClientRequest() {
     });
     console.log('[REQUEST] API SUCCESS');
     await logActivity({ post_id: reqId, actor: email, actor_role: 'Client', action: 'New request: ' + brief.substring(0, 60) });
+    var _reqActor = (typeof getDisplayName === 'function' && email)
+      ? getDisplayName(email)
+      : (window.AppState.user.name || window.currentUserName || email || 'Client');
     apiFetch('/notifications', {
       method: 'POST',
       body: JSON.stringify({
         user_role: 'Servicing',
         post_id: reqId,
         type: 'new_request',
-        message: (window.AppState.user.name || 'Client') + ' submitted a new request: ' + _reqTitle,
-        actor: window.AppState.user.name || window.currentUserName || 'Client',
+        message: _reqActor + ' submitted a new request: ' + _reqTitle,
+        actor: _reqActor,
         read: false
       })
     }).catch(function(err){ console.error('[post-actions] notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'notification-post'); });
@@ -405,8 +408,8 @@ async function submitClientRequest() {
         user_role: 'Admin',
         post_id: reqId,
         type: 'new_request',
-        message: (window.AppState.user.name || 'Client') + ' submitted a new request: ' + _reqTitle,
-        actor: window.AppState.user.name || window.currentUserName || 'Client',
+        message: _reqActor + ' submitted a new request: ' + _reqTitle,
+        actor: _reqActor,
         read: false
       })
     }).catch(function(err){ console.error('[post-actions] admin notification', err); window.logError && window.logError(err&&err.message, err&&err.stack, 'notification-admin-req'); });

--- a/10-ui.js
+++ b/10-ui.js
@@ -1018,9 +1018,6 @@ function _notifThreadMsgHtml(c, opts) {
   var _authorDisplay = (typeof getDisplayName === 'function') ? getDisplayName(author) : author;
   var initial = _authorDisplay ? _authorDisplay.charAt(0).toUpperCase() : '?';
   var ts = _notifRelTime(c.created_at);
-  var roleTag = authorRole
-    ? '<span class="thread-role">' + esc(authorRole) + '</span>'
-    : '';
   // Optimistic rows (client-side only, no real id yet) carry
   // `data-optimistic="1"` so a later realtime echo with the real id
   // can replace the attribute instead of double-inserting.
@@ -1030,7 +1027,6 @@ function _notifThreadMsgHtml(c, opts) {
       '<div class="thread-content">' +
         '<div class="thread-header">' +
           '<span class="thread-author">' + esc(_authorDisplay) + '</span>' +
-          roleTag +
           '<span class="thread-time">' + esc(ts) + '</span>' +
         '</div>' +
         '<div class="thread-message">' + esc(c.message || '') + '</div>' +
@@ -1150,7 +1146,10 @@ async function _notifSubmitReply(sendBtn) {
   var notifMatch = _notifData.find(function(x) { return x.id === notifId; });
   var postTitle = (post && post.title) || (notifMatch && notifMatch.message) || postId;
 
-  var authorName = (window.AppState.user && window.AppState.user.email) || (window.AppState.user && window.AppState.user.name) || 'Unknown';
+  var _emailKey = (window.AppState.user && window.AppState.user.email) || '';
+  var authorName = (typeof getDisplayName === 'function' && _emailKey)
+    ? getDisplayName(_emailKey)
+    : ((window.AppState.user && window.AppState.user.name) || _emailKey || 'Unknown');
   var effRole = (window.AppState.user && window.AppState.user.effectiveRole) ||
                 (window.AppState.user && window.AppState.user.role) || 'Admin';
   var authorRole = effRole.charAt(0).toUpperCase() + effRole.slice(1).toLowerCase();

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1470,8 +1470,9 @@ window.loadPcsComments = async function(postId) {
         '</div>';
       }
       var _resolvedSvg = '<svg width="12" height="12" viewBox="0 0 18 18" style="vertical-align:middle;margin-right:3px"><circle cx="9" cy="9" r="7" fill="none" stroke="#3ECF8E" stroke-width="1.5"/><polyline points="6,9 8.5,11.5 12.5,6.5" fill="none" stroke="#3ECF8E" stroke-width="1.5"/></svg>';
+      var _resolvedDisplay = (typeof getDisplayName === 'function') ? getDisplayName(c.resolved_by) : c.resolved_by;
       var _resolvedLabel = (c.resolved && c.resolved_by)
-        ? '<div class="pcs-resolved-label">' + _resolvedSvg + 'Resolved by ' + esc(c.resolved_by) + '</div>'
+        ? '<div class="pcs-resolved-label">' + _resolvedSvg + 'Resolved by ' + esc(_resolvedDisplay) + '</div>'
         : '';
       var _escapedMsg = esc(c.message).replace(/'/g, '&#39;');
       var _cReactions = (window._pcsReactions && window._pcsReactions[c.id]) || [];
@@ -1484,11 +1485,12 @@ window.loadPcsComments = async function(postId) {
         ? '<span class="pcs-react-count">' + _reactCount + '</span>'
         : '';
       var _resolveBtnLabel = c.resolved ? 'Unresolve' : 'Resolve';
+      var _replyToDisplay = (typeof getDisplayName === 'function') ? getDisplayName(c.reply_to_author) : c.reply_to_author;
       return '<div class="pcs-comment-item" data-comment-id="' + esc(c.id) + '" data-author="' + esc(c.author) + '">' +
         '<div class="pcs-cmt-av">' + ((typeof renderAvatar === 'function') ? renderAvatar(c.author, c.author_role, 28, { classes: 'pcs-avatar', fontSize: '9px', fontFamily: "'IBM Plex Mono', monospace" }) : '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>') + '</div>' +
         '<div class="pcs-cmt-mid">' +
           (c.reply_to && c.reply_to_author ?
-            '<div class="pcs-cmt-reply-tag">&#8629; <span class="pcs-reply-name">' + esc(c.reply_to_author) + '</span></div>'
+            '<div class="pcs-cmt-reply-tag">&#8629; <span class="pcs-reply-name">' + esc(_replyToDisplay) + '</span></div>'
             : '') +
           '<div class="pcs-comment-meta">' +
             '<span class="pcs-comment-author">' + esc(_authorDisplay) + '</span>' +
@@ -1612,8 +1614,9 @@ window.loadPcsComments = async function(postId) {
         '</div>';
       }
       var _resolvedSvg = '<svg width="12" height="12" viewBox="0 0 18 18" style="vertical-align:middle;margin-right:3px"><circle cx="9" cy="9" r="7" fill="none" stroke="#3ECF8E" stroke-width="1.5"/><polyline points="6,9 8.5,11.5 12.5,6.5" fill="none" stroke="#3ECF8E" stroke-width="1.5"/></svg>';
+      var _resolvedDisplay = (typeof getDisplayName === 'function') ? getDisplayName(c.resolved_by) : c.resolved_by;
       var _resolvedLabel = (c.resolved && c.resolved_by)
-        ? '<div class="pcs-resolved-label">' + _resolvedSvg + 'Resolved by ' + esc(c.resolved_by) + '</div>'
+        ? '<div class="pcs-resolved-label">' + _resolvedSvg + 'Resolved by ' + esc(_resolvedDisplay) + '</div>'
         : '';
       var _escapedMsg = esc(c.message).replace(/'/g, '&#39;');
       var _cReactions = (window._pcsReactions && window._pcsReactions[c.id]) || [];
@@ -1626,12 +1629,13 @@ window.loadPcsComments = async function(postId) {
         ? '<span class="pcs-react-count">' + _reactCount + '</span>'
         : '';
       var _resolveBtnLabel = c.resolved ? 'Unresolve' : 'Resolve';
+      var _replyToDisplay = (typeof getDisplayName === 'function') ? getDisplayName(c.reply_to_author) : c.reply_to_author;
       return '<div class="pcs-note-item' +
         (c.resolved ? ' pcs-resolved' : '') + '" data-comment-id="' + esc(c.id) + '" data-author="' + esc(c.author) + '">' +
         '<div class="pcs-cmt-av">' + ((typeof renderAvatar === 'function') ? renderAvatar(c.author, c.author_role, 28, { classes: 'pcs-avatar', fontSize: '9px', fontFamily: "'IBM Plex Mono', monospace" }) : '<div class="' + _avatarClass(c) + '">' + esc(_initial) + '</div>') + '</div>' +
         '<div class="pcs-cmt-mid">' +
           (c.reply_to && c.reply_to_author ?
-            '<div class="pcs-cmt-reply-tag">&#8629; <span class="pcs-reply-name">' + esc(c.reply_to_author) + '</span></div>'
+            '<div class="pcs-cmt-reply-tag">&#8629; <span class="pcs-reply-name">' + esc(_replyToDisplay) + '</span></div>'
             : '') +
           '<div class="pcs-comment-meta">' +
             '<span class="pcs-comment-author">' + esc(_authorDisplay) + '</span>' +
@@ -2654,7 +2658,10 @@ window.submitPcsComment = async function(postId, message, visibility, isTask, is
   });
   var _realPostId = _post ? _post.post_id : postId;
   var _title = _post ? (_post.title || postId) : postId;
-  var _author = window.AppState.user.email || window.AppState.user.name || 'Team';
+  var _emailKey = window.AppState.user.email || '';
+  var _author = (typeof getDisplayName === 'function' && _emailKey)
+    ? getDisplayName(_emailKey)
+    : (window.AppState.user.name || _emailKey || 'Team');
   var _role = (window.AppState.user.effectiveRole || 'Admin');
   var _roleLower = _role.toLowerCase();
 
@@ -3334,7 +3341,8 @@ window._pcsSetReply = function(zone, commentId, author, message) {
   var tag = document.getElementById(tagId);
   var nameEl = document.getElementById(nameId);
   if (tag && nameEl) {
-    nameEl.textContent = author + ' \u00B7';
+    var _authorDisplay = (typeof getDisplayName === 'function') ? getDisplayName(author) : author;
+    nameEl.textContent = _authorDisplay + ' \u00B7';
     tag.style.display = 'inline-flex';
   }
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417m">
+ <link rel="stylesheet" href="styles.css?v=20260417n">
 
 </head>
 <body>
@@ -1247,32 +1247,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417m"></script>
-<script src="00-appstate-compat.js?v=20260417m"></script>
-<script src="01-config.js?v=20260417m" defer></script>
-<script src="02-session.js?v=20260417m" defer></script>
-<script src="utils.js?v=20260417m" defer></script>
-<script src="12-profiles.js?v=20260417m" defer></script>
-<script src="03-auth.js?v=20260417m" defer></script>
-<script src="05-api.js?v=20260417m" defer></script>
-<script src="10-ui.js?v=20260417m" defer></script>
+<script src="00-appstate.js?v=20260417n"></script>
+<script src="00-appstate-compat.js?v=20260417n"></script>
+<script src="01-config.js?v=20260417n" defer></script>
+<script src="02-session.js?v=20260417n" defer></script>
+<script src="utils.js?v=20260417n" defer></script>
+<script src="12-profiles.js?v=20260417n" defer></script>
+<script src="03-auth.js?v=20260417n" defer></script>
+<script src="05-api.js?v=20260417n" defer></script>
+<script src="10-ui.js?v=20260417n" defer></script>
 
-<script src="06-post-create.js?v=20260417m" defer></script>
-<script defer src="render/dashboard.js?v=20260417m"></script>
-<script defer src="render/client.js?v=20260417m"></script>
-<script defer src="render/pipeline.js?v=20260417m"></script>
-<script defer src="render/brief.js?v=20260417m"></script>
-<script defer src="actions/pcs.js?v=20260417m"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417m"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417m"></script>
-<script defer src="actions/pcs-polish.js?v=20260417m"></script>
-<script defer src="actions/pcs-select.js?v=20260417m"></script>
-<script src="ai-config.js?v=20260417m" defer></script>
-<script src="07-post-load.js?v=20260417m" defer></script>
-<script src="08-post-actions.js?v=20260417m" defer></script>
-<script src="09-library.js?v=20260417m" defer></script>
-<script src="09-approval.js?v=20260417m" defer></script>
-<script src="04-router.js?v=20260417m" defer></script>
+<script src="06-post-create.js?v=20260417n" defer></script>
+<script defer src="render/dashboard.js?v=20260417n"></script>
+<script defer src="render/client.js?v=20260417n"></script>
+<script defer src="render/pipeline.js?v=20260417n"></script>
+<script defer src="render/brief.js?v=20260417n"></script>
+<script defer src="actions/pcs.js?v=20260417n"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417n"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417n"></script>
+<script defer src="actions/pcs-polish.js?v=20260417n"></script>
+<script defer src="actions/pcs-select.js?v=20260417n"></script>
+<script src="ai-config.js?v=20260417n" defer></script>
+<script src="07-post-load.js?v=20260417n" defer></script>
+<script src="08-post-actions.js?v=20260417n" defer></script>
+<script src="09-library.js?v=20260417n" defer></script>
+<script src="09-approval.js?v=20260417n" defer></script>
+<script src="04-router.js?v=20260417n" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -98,7 +98,6 @@ function _briefCommentRowHtml(c) {
   try {
     if (typeof getDisplayName === 'function') displayName = getDisplayName(author);
   } catch (_) {}
-  var colors = _briefRoleColor(role);
   var timeStr = _briefFormatCommentTime(c.created_at);
   return '<div class="brief-cmt-row" data-cmt-id="' + esc(c.id || '') + '" ' +
     'style="display:flex;gap:10px;padding:10px 0;' +
@@ -109,13 +108,6 @@ function _briefCommentRowHtml(c) {
     'flex-wrap:wrap;">' +
     '<span style="font-family:\'DM Sans\',sans-serif;font-size:13px;' +
     'font-weight:700;color:#FFFFFF;">' + esc(displayName) + '</span>' +
-    (role ?
-      '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
-      'font-weight:600;letter-spacing:0.1em;text-transform:uppercase;' +
-      'padding:2px 6px;border-radius:4px;background:' + colors.bg + ';' +
-      'border:1px solid ' + colors.border + ';color:' + colors.text + ';">' +
-      esc(role) + '</span>'
-      : '') +
     '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
     'color:#777788;letter-spacing:0.04em;">' + esc(timeStr) + '</span>' +
     '</div>' +
@@ -918,7 +910,10 @@ window._assignBrief = function(postId, ownerRole, displayName, isReassign) {
   var post = (typeof getPostById === 'function') ? getPostById(postId) : null;
   if (!post) return;
 
-  var actorName = window.AppState.user.email || window.AppState.user.name || 'Unknown';
+  var _emailKey = window.AppState.user.email || '';
+  var actorName = (typeof getDisplayName === 'function' && _emailKey)
+    ? getDisplayName(_emailKey)
+    : (window.AppState.user.name || _emailKey || 'Unknown');
   var actorRole = window.AppState.user.effectiveRole || 'Admin';
   var _labelWho = displayName || ownerRole;
   var actionLabel = (isReassign ? 'Brief reassigned to ' : 'Brief assigned to ') + _labelWho;
@@ -983,13 +978,10 @@ window._assignBrief = function(postId, ownerRole, displayName, isReassign) {
           user_role: _assigneeRole,
           post_id:   postId,
           type:      'assign',
-          message:   (window.AppState.user.name ||
-                      window.AppState.user.email ||
-                      'Someone') +
+          message:   actorName +
                      ' assigned you a brief: "' +
                      (post.title || 'Untitled') + '"',
-          actor:     (window.AppState.user.name ||
-                      window.currentUserName || 'Admin'),
+          actor:     actorName,
           read:      false
         })
       }).catch(function(err) {
@@ -1056,13 +1048,10 @@ window._assignBrief = function(postId, ownerRole, displayName, isReassign) {
         user_role: _assigneeRole,
         post_id:   postId,
         type:      'assign',
-        message:   (window.AppState.user.name ||
-                    window.AppState.user.email ||
-                    'Someone') +
+        message:   actorName +
                    ' assigned you a brief: "' +
                    (post.title || 'Untitled') + '"',
-        actor:     (window.AppState.user.name ||
-                    window.currentUserName || 'Admin'),
+        actor:     actorName,
         read:      false
       })
     }).catch(function(err) {

--- a/render/client.js
+++ b/render/client.js
@@ -643,7 +643,6 @@ console.log('LOADED:', 'render/client.js');
       '</div>';
     }
     var _authorDisplay = (typeof getDisplayName === 'function') ? getDisplayName(c.author) : (c.author || '?');
-    var roleLabel = _esc((c.author_role || '').toUpperCase());
     var ts = _relativeTime(c.created_at);
     var avatarHtml = (typeof renderAvatar === 'function')
       ? renderAvatar(c.author, c.author_role, avSize || 32)
@@ -688,7 +687,6 @@ console.log('LOADED:', 'render/client.js');
         replyTagHtml +
         '<div style="display:flex;align-items:center;flex-wrap:nowrap;gap:6px;">' +
           '<span style="font-family:\'DM Sans\',sans-serif;font-weight:700;font-size:14px;color:#FFFFFF;">' + _esc(_authorDisplay) + '</span>' +
-          '<span style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;font-weight:600;text-transform:uppercase;color:#A0A0B0;">' + roleLabel + '</span>' +
           dotsBtnHtml +
         '</div>' +
         '<div class="client-comment-time" style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#909098;margin-top:1px;">' + ts + editedLabel + '</div>' +
@@ -735,7 +733,10 @@ console.log('LOADED:', 'render/client.js');
       html += _singleCommentHtml(parent);
       var replies = replyMap[parent.id] || [];
       if (!replies.length) continue;
-      var parentAuthor = parent.author || '';
+      var parentAuthorRaw = parent.author || '';
+      var parentAuthor = (typeof getDisplayName === 'function' && parentAuthorRaw)
+        ? getDisplayName(parentAuthorRaw)
+        : parentAuthorRaw;
       if (replies.length === 1) {
         html += _singleCommentHtml(replies[0], { isReply: true, parentAuthor: parentAuthor });
       } else if (replies.length === 2) {
@@ -1650,8 +1651,10 @@ console.log('LOADED:', 'render/client.js');
     var savedValue = input.value;
     input.value = '';
 
-    var authorName = window.AppState.user.email || window.AppState.user.name || 'Client';
-    var displayName = (typeof getDisplayName === 'function') ? getDisplayName(authorName) : (window.AppState.user.displayName || window.AppState.user.name || 'Client');
+    var _emailKey = window.AppState.user.email || '';
+    var authorName = (typeof getDisplayName === 'function' && _emailKey)
+      ? getDisplayName(_emailKey)
+      : (window.AppState.user.name || _emailKey || 'Client');
     var _mentioned = _parseMentions(message);
     var post = (window.AppState.posts.all || []).find(function (p) {
       return p.post_id === postId || p.id === postId;

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -230,10 +230,12 @@ describe('Client request notification', function() {
     expect(block).toContain('actor:');
   });
 
-  it('client request notification uses AppState.user.name', function() {
+  it('client request notification resolves actor via getDisplayName', function() {
     var idx = actionsSrc.indexOf("'new_request'");
-    var block = actionsSrc.substring(idx - 200, idx + 300);
-    expect(block).toContain('AppState.user.name');
+    var block = actionsSrc.substring(idx - 300, idx + 300);
+    // Post-PR #903: actor resolves to profile.display_name via
+    // getDisplayName(email); AppState.user.name is the fallback.
+    expect(block).toMatch(/getDisplayName|AppState\.user\.name/);
   });
 
   it('client request notification includes read:false', function() {


### PR DESCRIPTION
## Summary

Emails were rendering where names should have been (comment headers, reply-to chips, resolved-by footer, PCS reply pill, notification thread drawer). Write paths used `AppState.user.email || AppState.user.name` fallbacks so new rows occasionally landed with email-as-author — that's the root cause behind notifications.actor showing 9 distinct values for 5–6 people.

This PR wraps every render site in `getDisplayName()` (already in 12-profiles.js, resolves `email → profile.display_name` with safe fallbacks) and flips the four write-path fallbacks so new rows persist the resolved display name. Role pills (ADMIN/CLIENT/CREATIVE/SERVICING) are removed from comments, mentions, resolved-by, brief discussion, and thread drawers — Instagram-style, names only. `author_role` stays on every data row for the avatar palette lookup.

Mentions are already stored as `@<short-name>` by both pickers (audited; no data migration needed). `_notifActionText` already strips both email and display-name prefixes, so legacy notification rows with email prefixes still render cleanly — no backfill.

## Files changed

- `actions/pcs.js` — client-thread + notes-thread resolved-by + reply-to chips; `_pcsSetReply` composer pill; comment-submit `_author`
- `render/client.js` — role pill removed; threaded-reply parent author resolved via `getDisplayName`; comment-submit `authorName` flip
- `render/brief.js` — brief-discussion role badge removed; `_assignBrief` `actorName` + notification `message`/`actor` resolved via `getDisplayName`
- `10-ui.js` — thread-drawer role tag removed; `_submitNotifReply` `authorName` flip
- `08-post-actions.js` — new-request notifications (Servicing + Admin): `actor` + `message` now built from `getDisplayName(email)`
- `index.html` — all 26 `?v=` strings bumped `20260417m` → `20260417n`
- `tests/notifications.test.js` — relaxed "uses AppState.user.name" assertion to match `getDisplayName` OR `AppState.user.name` (intent preserved: actor still carries the user's name, just resolved via profile cache now)

## Edge functions (deploy separately, NOT in this PR)

`notify-stage`, `notify-comment`, `notify-request`, `notify-digest` live in Supabase and still build messages from raw email/name. They should be updated in a follow-up to resolve actors via `profiles.display_name` server-side so fan-out notifications match the new convention. Shubham deploys those via the Supabase connector.

## What's intentionally unchanged

- `author_role` stays on every comment row for avatar palette lookup
- Edge functions (see above)
- Notification panel header eyebrow (`<effectiveRole> · SORTED`) — labels the signed-in user's own panel mode, not another user
- Profile panel hero — self attribution, explicitly opt-in
- Legacy notification rows — no backfill (render-time resolver handles them)
- Composer CSS / reply-box spacing — out of scope; shrinking email strings may fix spacing as a side effect anyway

## Test plan

- [x] `npx vitest run` — 544/544 passing
- [ ] Manual: open a post with an existing resolved comment; confirm "Resolved by Shubham Gune" instead of email
- [ ] Manual: reply to a comment; confirm "Replying to Manisha" in the composer pill
- [ ] Manual: view a threaded reply in the client feed; confirm parent author shows as display name
- [ ] Manual: submit a new comment as Client role; verify the `post_comments.author` row lands with display name (not email)
- [ ] Manual: submit a new client request; verify the two Servicing/Admin notifications land with actor = display name
- [ ] Manual: expand a notification thread drawer; confirm no role pills next to author names
- [ ] Manual: post a brief discussion comment; confirm no role badge next to your name

## Deploy

1. Merge
2. Cloudflare dash → srtd.io → Caching → Purge Everything
3. Hard-refresh every device
4. Follow-up PR for edge functions (notify-stage / notify-comment / notify-request / notify-digest) to resolve actors via `profiles.display_name` server-side

https://claude.ai/code/session_01AXrorirqHEVQJGBm87HT5R