### PR TITLE
feat(composer): Claude-aesthetic reply composer w/ inline AI polish

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -173,6 +173,235 @@ function showToast(msg, type = 'success') {
   t._timer = setTimeout(() => t.classList.remove('active'), 3200);
 }
 
+// ═══════════════════════════════════════════════════════════════
+// CLAUDE COMPOSER HELPERS (20260417o)
+// Shared across the three reply composer locations:
+//   - agency PCS (actions/pcs.js, index.html)
+//   - client portal (render/client.js)
+//   - notification thread drawer (10-ui.js)
+// Mounts quote-bar / polish-preview / composer together so each
+// location can stay on its existing reply state contract while
+// sharing the visual shell.
+// ═══════════════════════════════════════════════════════════════
+
+// Textarea auto-expand — no max-height clamp. Caller owns the element;
+// we just attach an input listener (guarded against double-wiring).
+window.attachAutoExpand = function(el) {
+  if (!el || el._claudeAutoExpandWired) return;
+  el._claudeAutoExpandWired = true;
+  var _resize = function() {
+    el.style.height = 'auto';
+    el.style.height = el.scrollHeight + 'px';
+  };
+  el.addEventListener('input', _resize);
+  // Run once so min-height is honoured on initial paint.
+  requestAnimationFrame(_resize);
+  el._claudeAutoExpandResize = _resize;
+};
+
+// Sync composer root classes — `.has-text` toggles sparkle visibility,
+// `.claude-send.dim` toggles the send-button dim state. Callers invoke
+// this after any textarea mutation (typing, polish replace, clear).
+window._claudeSyncComposerState = function(root) {
+  if (!root) return;
+  var ta = root.querySelector('.claude-textarea');
+  var send = root.querySelector('.claude-send');
+  var hasText = !!(ta && ta.value && ta.value.trim().length > 0);
+  root.classList.toggle('has-text', hasText);
+  if (send) {
+    if (hasText) send.classList.remove('dim');
+    else send.classList.add('dim');
+  }
+};
+
+// Polish via srtd-ai worker. Returns a Promise resolving to the
+// polished text. Rejects on failure. Reuses the same fetch pattern as
+// actions/pcs.js `_callSrtdAI()` so behavior is identical.
+window._claudePolish = function(text, postId) {
+  var cfg = window.AI_CONFIG;
+  if (!cfg || !cfg.workerUrl) {
+    return Promise.reject(new Error('AI not configured'));
+  }
+  var raw = (text || '').trim();
+  if (!raw) return Promise.reject(new Error('Empty text'));
+  var systemPrompt =
+    'You are polishing a short comment that one colleague is writing ' +
+    'to another in an agency/client collaboration tool. Make it ' +
+    'clearer, warmer, and more professional while preserving the ' +
+    "user's meaning and tone. Keep it concise - typically no longer " +
+    'than the original. No greetings unless the user wrote one. ' +
+    'No sign-offs. Return ONLY the polished text, no preamble, no ' +
+    'commentary, no quotes around it.';
+  var payload = {
+    feature: 'chat',
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: raw }
+    ],
+    post_id: postId || null,
+    workspace_id: 'default',
+    created_by: (window.AppState && window.AppState.user && window.AppState.user.email) || ''
+  };
+  return fetch(cfg.workerUrl + '/ai/complete', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-AI-Secret': cfg.secret
+    },
+    body: JSON.stringify(payload)
+  }).then(function(res) {
+    return res.json();
+  }).then(function(data) {
+    if (data && data.success && data.content) {
+      // Strip surrounding quotes if the model added any.
+      var out = String(data.content).trim().replace(/^["']+|["']+$/g, '');
+      return out;
+    }
+    throw new Error((data && data.error) || 'Polish failed');
+  });
+};
+
+// Build the HTML for a quote-bar (above composer when replying).
+// Caller owns the set/clear lifecycle — this just returns a fragment.
+window._claudeQuoteBarHtml = function(authorLabel, snippet, onClearAttr) {
+  var _esc = function(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function(c) {
+      return ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' })[c];
+    });
+  };
+  var _snip = String(snippet || '');
+  if (_snip.length > 80) _snip = _snip.slice(0, 80).trim() + '\u2026';
+  return '<div class="claude-quote-bar">' +
+    '<div class="claude-quote-content">' +
+      '<div class="claude-quote-who">' + _esc(authorLabel) + '</div>' +
+      '<div class="claude-quote-snippet">' + _esc(_snip) + '</div>' +
+    '</div>' +
+    '<button type="button" class="claude-quote-x" aria-label="Cancel reply"' +
+      (onClearAttr ? ' ' + onClearAttr : '') + '>\u2715</button>' +
+  '</div>';
+};
+
+// Build the HTML for the textarea overlay (italic "polishing" hint +
+// animated dots). Rendered inline, shown only when the composer root
+// has the `.is-polishing` class.
+window._claudePolishingOverlayHtml = function() {
+  return '<div class="claude-polishing-overlay">' +
+    '<span>polishing</span>' +
+    '<span class="claude-polishing-dots"><span></span><span></span><span></span></span>' +
+  '</div>';
+};
+
+// Build + inject the polish-preview card into a composer root.
+window._claudeMountPolishPreview = function(root, polishedText, originalText) {
+  if (!root) return;
+  var existing = root.querySelector(':scope > .claude-polish-preview');
+  if (existing) existing.remove();
+  var _esc = function(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function(c) {
+      return ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' })[c];
+    });
+  };
+  var orig = String(originalText || '').replace(/\s+/g, ' ').trim();
+  if (orig.length > 90) orig = orig.slice(0, 90) + '\u2026';
+  var card = document.createElement('div');
+  card.className = 'claude-polish-preview';
+  card.innerHTML =
+    '<div class="claude-polish-header">' +
+      '<span class="claude-polish-label">\u2726 Polished</span>' +
+      '<span class="claude-polish-actions">' +
+        '<button type="button" class="claude-polish-btn keep" data-claude-polish="keep">Keep mine</button>' +
+        '<button type="button" class="claude-polish-btn use" data-claude-polish="use">Use this</button>' +
+      '</span>' +
+    '</div>' +
+    '<div class="claude-polish-body">' + _esc(polishedText) + '</div>' +
+    '<div class="claude-polish-compare">from \u00b7 ' + _esc(orig) + '</div>';
+  // Store polished text on the root for the "Use this" handler.
+  root._claudePolishedText = String(polishedText || '');
+  var composer = root.querySelector(':scope > .claude-composer');
+  if (composer) root.insertBefore(card, composer);
+  else root.appendChild(card);
+  root.classList.add('has-polish');
+};
+
+window._claudeDismissPolishPreview = function(root) {
+  if (!root) return;
+  var existing = root.querySelector(':scope > .claude-polish-preview');
+  if (existing) existing.remove();
+  root.classList.remove('has-polish');
+  root._claudePolishedText = '';
+};
+
+// Orchestrator — wire the sparkle + polish-preview actions on a given
+// composer root. Idempotent (guarded against double-wiring). Callers
+// pass { postIdFn } so the poll receives the current post id at click
+// time rather than at wire time.
+window._claudeWireComposer = function(root, opts) {
+  if (!root || root._claudeWired) return;
+  root._claudeWired = true;
+  opts = opts || {};
+  var ta = root.querySelector('.claude-textarea');
+  if (ta) window.attachAutoExpand(ta);
+  // has-text / send dim state — update on every input.
+  if (ta) {
+    ta.addEventListener('input', function() {
+      window._claudeSyncComposerState(root);
+    });
+    window._claudeSyncComposerState(root);
+  }
+  // Delegated click handler inside the composer root — sparkle,
+  // polish-preview buttons.
+  root.addEventListener('click', function(e) {
+    var sparkle = e.target.closest('.claude-sparkle');
+    var polishBtn = e.target.closest('[data-claude-polish]');
+    if (sparkle) {
+      e.preventDefault();
+      e.stopPropagation();
+      var ta2 = root.querySelector('.claude-textarea');
+      if (!ta2) return;
+      var text = (ta2.value || '').trim();
+      if (!text) return;
+      if (root.classList.contains('is-polishing')) return;
+      root.classList.add('is-polishing');
+      ta2.setAttribute('readonly', 'readonly');
+      var pid = typeof opts.postIdFn === 'function' ? opts.postIdFn() : null;
+      window._claudePolish(text, pid).then(function(polished) {
+        root.classList.remove('is-polishing');
+        ta2.removeAttribute('readonly');
+        if (polished && polished !== text) {
+          window._claudeMountPolishPreview(root, polished, text);
+        } else {
+          if (typeof window.showToast === 'function') {
+            window.showToast('No changes suggested.', 'success');
+          }
+        }
+      }).catch(function(err) {
+        root.classList.remove('is-polishing');
+        ta2.removeAttribute('readonly');
+        if (typeof window.showToast === 'function') {
+          window.showToast('Polish failed — try again.', 'error');
+        }
+        window.logError && window.logError(err && err.message, err && err.stack, 'claude-polish');
+      });
+      return;
+    }
+    if (polishBtn) {
+      e.preventDefault();
+      e.stopPropagation();
+      var action = polishBtn.getAttribute('data-claude-polish');
+      var ta3 = root.querySelector('.claude-textarea');
+      if (action === 'use' && ta3 && root._claudePolishedText) {
+        ta3.value = root._claudePolishedText;
+        ta3.dispatchEvent(new Event('input', { bubbles: true }));
+        if (ta3._claudeAutoExpandResize) ta3._claudeAutoExpandResize();
+        window._claudeSyncComposerState(root);
+      }
+      window._claudeDismissPolishPreview(root);
+      if (ta3) ta3.focus();
+      return;
+    }
+  });
+};
+
 // -- Theme -------------------------------------
 function toggleTheme() {
   const next = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
@@ -956,40 +1185,36 @@ function _notifBuildThreadHtml(n, post, postTitle) {
     });
   }
 
-  // Reply pill (round send button inside a rounded input) + shared
-  // footer row that puts "VISIBLE TO ALL" on the left and the
-  // "Open full post →" link on the right.
-  //
-  // Polish Reply ✦ button — Admin-only. Inserted between the textarea
-  // and the circular send button inside `.reply-pill`. An eyebrow
-  // line above the pill nudges the user to tap it. Non-admin users
-  // see the pill WITHOUT either element, matching the pre-Polish
-  // layout exactly.
+  // Claude composer — same two-container pattern as PCS / client
+  // feed. Notif drawer currently never captures a reply target (the
+  // original `reply_to` was hardcoded null), so the quote-bar stays
+  // unmounted by default. The sparkle + send + textarea classes keep
+  // their legacy hooks (`.reply-input`, `.reply-send`) so the
+  // existing action-router delegate in `_wireEvents` still resolves
+  // without churn.
   var replyPlaceholder = 'Comment on ' + (postTitle || 'post') + '\u2026';
-  var _canPolish = !!(window.AppState && window.AppState.user &&
-                      window.AppState.user.effectiveRole === 'Admin');
-  var polishHintHtml = _canPolish
-    ? '<div class="polish-pre-hint">\u2726 Tap to polish your draft</div>'
-    : '';
-  var polishBtnHtml = _canPolish
-    ? '<button class="reply-polish" data-action="notif-polish"' +
-        ' data-post-id="' + esc(postId) + '"' +
-        ' data-notif-id="' + esc(n.id || '') + '"' +
-        ' aria-label="Polish with Claude" type="button">\u2726</button>'
-    : '';
+  var composerId = 'notif-composer-root-' + esc(postId);
   var replyHtml =
     '<div class="reply-zone">' +
-      polishHintHtml +
-      '<div class="reply-pill">' +
-        '<textarea class="reply-input" rows="1"' +
-          ' data-post-id="' + esc(postId) + '"' +
-          ' placeholder="' + esc(replyPlaceholder) + '"></textarea>' +
-        polishBtnHtml +
-        '<button class="reply-send" data-action="notif-reply-send"' +
-          ' data-post-id="' + esc(postId) + '"' +
-          ' data-notif-id="' + esc(n.id || '') + '" aria-label="Send reply">' +
-          _NOTIF_SEND_SVG +
-        '</button>' +
+      '<div class="claude-composer-root" id="' + composerId + '"' +
+        ' data-post-id="' + esc(postId) + '"' +
+        ' data-notif-id="' + esc(n.id || '') + '">' +
+        '<div class="claude-composer">' +
+          '<div class="claude-textarea-wrap">' +
+            '<textarea class="claude-textarea reply-input" rows="1"' +
+              ' data-post-id="' + esc(postId) + '"' +
+              ' placeholder="' + esc(replyPlaceholder) + '"></textarea>' +
+            '<div class="claude-polishing-overlay"><span>polishing</span>' +
+            '<span class="claude-polishing-dots"><span></span><span></span><span></span></span></div>' +
+          '</div>' +
+          '<button type="button" class="claude-sparkle" aria-label="Polish with Claude">\u2726</button>' +
+          '<button type="button" class="claude-send reply-send dim"' +
+            ' data-action="notif-reply-send"' +
+            ' data-post-id="' + esc(postId) + '"' +
+            ' data-notif-id="' + esc(n.id || '') + '" aria-label="Send reply">' +
+            _NOTIF_SEND_SVG +
+          '</button>' +
+        '</div>' +
       '</div>' +
       '<div class="reply-footer-row">' +
         '<span class="reply-visibility">Visible to all</span>' +
@@ -1091,27 +1316,15 @@ function _notifToggleExpand(item) {
     });
   }
 
-  // Auto-resize wiring for the reply textarea.
-  var ta = item.querySelector('.reply-input');
-  if (ta) {
-    ta.addEventListener('input', _notifReplyInputResize);
+  // Wire the Claude composer root — handles auto-expand, sparkle
+  // polish flow, and composer dim/has-text state. Idempotent.
+  var composerRoot = item.querySelector('.claude-composer-root');
+  if (composerRoot && typeof window._claudeWireComposer === 'function') {
+    var _pid = composerRoot.getAttribute('data-post-id');
+    window._claudeWireComposer(composerRoot, {
+      postIdFn: function() { return _pid; }
+    });
   }
-}
-
-// Grow the reply textarea up to its CSS max-height as the user types,
-// and flip .active on the sibling send button once there is any text.
-function _notifReplyInputResize(e) {
-  var ta = e.currentTarget || e.target;
-  if (!ta) return;
-  ta.style.height = 'auto';
-  var next = Math.min(ta.scrollHeight, 80);
-  ta.style.height = next + 'px';
-  var row = ta.parentNode;
-  if (!row) return;
-  var btn = row.querySelector('.reply-send');
-  if (!btn) return;
-  if (ta.value && ta.value.trim().length > 0) btn.classList.add('active');
-  else btn.classList.remove('active');
 }
 
 // Submit a reply from the thread drawer. Posts to /post_comments with
@@ -1221,7 +1434,15 @@ async function _notifSubmitReply(sendBtn) {
     }
     ta.value = '';
     ta.style.height = 'auto';
-    sendBtn.classList.remove('active');
+    // Keep the Claude composer's has-text / dim state in sync after
+    // the textarea is cleared.
+    var _composerRoot = ta.closest('.claude-composer-root');
+    if (_composerRoot && typeof window._claudeSyncComposerState === 'function') {
+      window._claudeSyncComposerState(_composerRoot);
+      if (typeof window._claudeDismissPolishPreview === 'function') {
+        window._claudeDismissPolishPreview(_composerRoot);
+      }
+    }
   } catch (err) {
     console.error('[notif-reply] POST failed', err);
     window.logError && window.logError(err && err.message, err && err.stack, 'notif-reply');
@@ -2375,11 +2596,16 @@ function openNotifications() {
       // Expand-in-place thread view — the expand chip, the reply input,
       // the send button, individual thread messages, and the "Open full
       // post" link all live inside a .notif-item and would otherwise be
-      // swallowed by the item delegate below.
+      // swallowed by the item delegate below. The Claude sparkle +
+      // polish-preview buttons are handled by the composer's own
+      // delegated listener (`_claudeWireComposer`) — we just guard
+      // against the panel delegate swallowing them.
       var expandBtn = e.target.closest('.expand-chip');
-      var replyInput = e.target.closest('.reply-input');
+      var replyInput = e.target.closest('.reply-input, .claude-textarea');
       var replySend = e.target.closest('.reply-send');
-      var replyPolish = e.target.closest('.reply-polish, [data-action="notif-polish"]');
+      var claudeInComposer = e.target.closest(
+        '.claude-sparkle, .claude-polish-preview, .claude-plus, .claude-quote-bar, .claude-polishing-overlay'
+      );
       // Both the footer "Open full post ->" link and the top-of-drawer
       // "View all N comments" overflow link route through the same
       // open-post handler below.
@@ -2393,20 +2619,11 @@ function openNotifications() {
         _notifSubmitReply(replySend);
         return;
       }
-      if (replyPolish) {                     // Polish Reply ✦ (admin-only)
-        e.preventDefault();
+      if (claudeInComposer) {                // sparkle / polish preview /
+        // plus / quote-bar — handled by the composer's own delegated
+        // listener. Stop the outer panel delegate from treating the
+        // click as a card tap and collapsing the drawer.
         e.stopPropagation();
-        // Defensive double-check — the button is only rendered for
-        // Admin in `_buildItem`, but a stale page shouldn't let a
-        // downgraded user invoke the modal.
-        if (!window.AppState || !window.AppState.user ||
-            window.AppState.user.effectiveRole !== 'Admin') {
-          console.warn('Polish requires admin role');
-          return;
-        }
-        if (typeof window.openPolishModal === 'function') {
-          window.openPolishModal('notif');
-        }
         return;
       }
       if (threadOpen) {                      // "Open full post ->" link

--- a/actions/pcs-polish.js
+++ b/actions/pcs-polish.js
@@ -1,7 +1,14 @@
 /* ═══════════════════════════════════════════════════════════════
-   pcs-polish.js — Polish Reply half-modal
-   Tap ✦ in the comment input bar to have Claude rewrite a draft
-   comment professionally before sending.
+   pcs-polish.js — legacy polish-modal shim (20260417o)
+   The Polish Reply half-modal has been replaced by the inline
+   Claude composer flow. The sparkle on the composer now calls
+   `window._claudePolish(text)` directly and mounts a polish-preview
+   card above the composer. This file is kept as a no-op shim so
+   any stale HTML attribute or third-party reference to
+   `openPolishModal` / `closePolishModal` / `sendPolished` etc. does
+   not throw. The legacy `.pcs-ibar-polish` click handler is also
+   a no-op — those DOM nodes were removed from index.html in the
+   same deploy.
    ═══════════════════════════════════════════════════════════════ */
 console.log('LOADED:', 'pcs-polish.js');
 
@@ -14,196 +21,7 @@ window._polishState = {
   postId: null
 };
 
-// Scoped lookup for the notification thread drawer's reply input —
-// it lives on `.notif-item.expanded .reply-input` (no unique ID, the
-// expanded card is the scope). Returns null when no drawer is open.
-function _polishFindNotifInput() {
-  return document.querySelector('.notif-item.expanded .reply-input');
-}
-function _polishFindNotifExpandedItem() {
-  return document.querySelector('.notif-item.expanded');
-}
-
-window.openPolishModal = async function(zone) {
-  var st = window._polishState;
-  var input;
-
-  if (zone === 'notif') {
-    // Defensive admin check — the button is only rendered for Admin
-    // in `_buildItem`, but a cached page shouldn't let a downgraded
-    // user trigger the modal either.
-    var _role = window.AppState && window.AppState.user && window.AppState.user.effectiveRole;
-    if (_role !== 'Admin') {
-      console.warn('Polish requires admin role');
-      return;
-    }
-    input = _polishFindNotifInput();
-    if (!input || !input.value.trim()) {
-      if (typeof window.showToast === 'function')
-        window.showToast('Type a draft first, then tap \u2726', 'error');
-      return;
-    }
-    var expandedItem = _polishFindNotifExpandedItem();
-    var notifPostId = expandedItem ? expandedItem.getAttribute('data-post-id') : null;
-    if (!notifPostId) {
-      if (typeof window.showToast === 'function')
-        window.showToast('Open a comment thread first', 'error');
-      return;
-    }
-    st.rawText = input.value.trim();
-    st.zone = 'notif';
-    st.polishedText = '';
-    st.isOpen = true;
-    st.postId = notifPostId;
-    st.replyTo = null;
-  } else {
-    var inputId = zone === 'notes' ? 'pcs-note-input' : 'pcs-comment-input';
-    input = document.getElementById(inputId);
-    if (!input || !input.value.trim()) return;
-
-    st.rawText = input.value.trim();
-    st.zone = zone;
-    st.polishedText = '';
-    st.isOpen = true;
-
-    var postIdEl = document.getElementById('pcs-post-id');
-    st.postId = postIdEl ? postIdEl.value : null;
-
-    var replyTagId = zone === 'notes' ? 'pcs-note-reply-tag' : 'pcs-client-reply-tag';
-    var replyNameId = zone === 'notes' ? 'pcs-note-reply-name' : 'pcs-client-reply-name';
-    var replyTag = document.getElementById(replyTagId);
-    var replyName = document.getElementById(replyNameId);
-    st.replyTo = (replyTag && replyTag.style.display !== 'none' && replyName && replyName.textContent)
-      ? { author: replyName.textContent }
-      : null;
-  }
-
-  var overlay = document.getElementById('pcs-polish-overlay');
-  if (!overlay) return;
-  overlay.style.display = 'block';
-
-  var rawEl = document.getElementById('polish-raw-text');
-  if (rawEl) rawEl.textContent = st.rawText;
-
-  var resultEl = document.getElementById('polish-result');
-  if (resultEl) resultEl.textContent = '';
-
-  var replyLabel = document.getElementById('polish-reply-label');
-  if (replyLabel) replyLabel.textContent = st.replyTo ? 'Replying to ' + st.replyTo.author : '';
-
-  var sendBtn = document.getElementById('polish-send');
-  if (sendBtn) { sendBtn.textContent = 'Polishing\u2026'; sendBtn.style.opacity = '0.4'; sendBtn.style.pointerEvents = 'none'; }
-
-  requestAnimationFrame(function() {
-    overlay.classList.add('open');
-  });
-
-  var prompt = 'Rewrite this comment reply professionally. Keep the exact same meaning and intent. Be direct, constructive, and brief. Do not add pleasantries or filler. Return ONLY the rewritten text, nothing else.';
-  if (st.replyTo) {
-    var replyToItem = _polishFindReplyComment(zone);
-    if (replyToItem) prompt += '\n\nComment being replied to: "' + replyToItem + '"';
-  }
-  prompt += '\n\nMy draft reply: "' + st.rawText + '"';
-
-  var messages = [{ role: 'user', content: prompt }];
-  var result = await _callSrtdAI('chat', messages, st.postId);
-
-  if (result && result.success) {
-    st.polishedText = (result.content || '').trim();
-  } else {
-    st.polishedText = st.rawText;
-  }
-
-  var resultEl2 = document.getElementById('polish-result');
-  if (resultEl2) resultEl2.textContent = st.polishedText;
-
-  var sendBtn2 = document.getElementById('polish-send');
-  if (sendBtn2) { sendBtn2.innerHTML = '&#x2726; Send reply'; sendBtn2.style.opacity = '1'; sendBtn2.style.pointerEvents = ''; }
-};
-
-function _polishFindReplyComment(zone) {
-  var listId = zone === 'notes' ? 'pcs-notes-list' : 'pcs-comments-list';
-  var list = document.getElementById(listId);
-  if (!list) return '';
-  var highlighted = list.querySelector('.pcs-comment-replying-to');
-  if (highlighted) {
-    var textEl = highlighted.querySelector('.pcs-comment-text');
-    if (textEl) return textEl.textContent.trim();
-  }
-  return '';
-}
-
-window.closePolishModal = function() {
-  var overlay = document.getElementById('pcs-polish-overlay');
-  if (!overlay) return;
-  overlay.classList.remove('open');
-  setTimeout(function() {
-    overlay.style.display = 'none';
-  }, 260);
-  window._polishState.isOpen = false;
-};
-
-window.undoPolish = function() {
-  window.closePolishModal();
-};
-
-window.sendPolished = function() {
-  var st = window._polishState;
-  var resultEl = document.getElementById('polish-result');
-  var finalText = resultEl ? resultEl.innerText.trim() : st.polishedText;
-  if (!finalText) return;
-
-  // Notification-zone flow is scoped to the currently-expanded
-  // `.notif-item` — the textarea has no unique ID, so we pump the
-  // polished text into the class-scoped input and click its own
-  // `.reply-send` button, which runs `_notifSubmitReply` (10-ui.js)
-  // and POSTs to `/post_comments` instead of the PCS submission path.
-  if (st.zone === 'notif') {
-    var notifInput = _polishFindNotifInput();
-    if (!notifInput) return;
-    notifInput.value = finalText;
-    // Fire `input` so `_notifReplyInputResize` enables `.reply-send.active`.
-    notifInput.dispatchEvent(new Event('input', { bubbles: true }));
-    window.closePolishModal();
-    setTimeout(function() {
-      var sendBtn = document.querySelector('.notif-item.expanded .reply-send');
-      if (sendBtn) sendBtn.click();
-    }, 100);
-    return;
-  }
-
-  var inputId = st.zone === 'notes' ? 'pcs-note-input' : 'pcs-comment-input';
-  var input = document.getElementById(inputId);
-  if (input) input.value = finalText;
-
-  window.closePolishModal();
-
-  setTimeout(function() {
-    var sendId = st.zone === 'notes' ? 'pcs-send-btn-note' : 'pcs-send-btn-client';
-    var sendBtn = document.getElementById(sendId);
-    if (sendBtn) sendBtn.click();
-  }, 100);
-};
-
-(function _polishWireEvents() {
-  document.addEventListener('click', function(e) {
-    if (e.target && e.target.classList.contains('pcs-ibar-polish')) {
-      e.preventDefault();
-      e.stopPropagation();
-      window.openPolishModal(e.target.dataset.zone || 'client');
-      return;
-    }
-    if (e.target && e.target.id === 'polish-undo') {
-      window.undoPolish();
-      return;
-    }
-    if (e.target && e.target.id === 'polish-send') {
-      window.sendPolished();
-      return;
-    }
-    if (e.target && (e.target.id === 'pcs-polish-backdrop' || e.target.dataset.action === 'polish-close')) {
-      window.closePolishModal();
-      return;
-    }
-  });
-})();
+window.openPolishModal = function() { /* no-op — inline flow now owns polish */ };
+window.closePolishModal = function() { /* no-op */ };
+window.undoPolish = function() { /* no-op */ };
+window.sendPolished = function() { /* no-op */ };

--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -3327,24 +3327,52 @@ window._pcsTogglePlusMenu = function(btn, zone) {
   }, 10);
 };
 
+// Helper — return the Claude composer root for a PCS zone.
+function _pcsComposerRoot(zone) {
+  var id = zone === 'client' ? 'pcs-composer-root-client' : 'pcs-composer-root-note';
+  return document.getElementById(id);
+}
+
+// Mount / unmount the Claude quote-bar for a PCS zone. The quote-bar
+// sits above the composer; adding `.has-quote-bar` on the root flips
+// border-radius so the two pieces connect visually.
+function _pcsMountQuoteBar(zone, author, snippet) {
+  var root = _pcsComposerRoot(zone);
+  if (!root) return;
+  var existing = root.querySelector(':scope > .claude-quote-bar');
+  if (existing) existing.remove();
+  var _authorDisplay = (typeof getDisplayName === 'function') ? getDisplayName(author) : author;
+  var _onClick = "onclick=\"window._pcsClearReply('" + zone + "')\"";
+  var html = (typeof window._claudeQuoteBarHtml === 'function')
+    ? window._claudeQuoteBarHtml(_authorDisplay, snippet || '', _onClick)
+    : '';
+  if (!html) return;
+  var firstChild = root.firstChild;
+  var tmp = document.createElement('div');
+  tmp.innerHTML = html;
+  var bar = tmp.firstChild;
+  root.insertBefore(bar, firstChild);
+  root.classList.add('has-quote-bar');
+}
+
+function _pcsUnmountQuoteBar(zone) {
+  var root = _pcsComposerRoot(zone);
+  if (!root) return;
+  var existing = root.querySelector(':scope > .claude-quote-bar');
+  if (existing) existing.remove();
+  root.classList.remove('has-quote-bar');
+}
+
 window._pcsSetReply = function(zone, commentId, author, message) {
   window._pcsReplyTo = commentId;
   window._pcsReplyToAuthor = author;
+  window._pcsReplySnippet = message || '';
   var inputId = zone === 'client'
     ? 'pcs-comment-input'
     : 'pcs-note-input';
   var input = document.getElementById(inputId);
 
-  // Show reply tag inside input pill
-  var tagId = zone === 'client' ? 'pcs-client-reply-tag' : 'pcs-note-reply-tag';
-  var nameId = zone === 'client' ? 'pcs-client-reply-name' : 'pcs-note-reply-name';
-  var tag = document.getElementById(tagId);
-  var nameEl = document.getElementById(nameId);
-  if (tag && nameEl) {
-    var _authorDisplay = (typeof getDisplayName === 'function') ? getDisplayName(author) : author;
-    nameEl.textContent = _authorDisplay + ' \u00B7';
-    tag.style.display = 'inline-flex';
-  }
+  _pcsMountQuoteBar(zone, author, message);
 
   document.querySelectorAll(
     '.pcs-comment-item, .pcs-note-item'
@@ -3364,19 +3392,17 @@ window._pcsSetReply = function(zone, commentId, author, message) {
     input.value = '@' + author + ' ';
     input.focus();
     input.setSelectionRange(input.value.length, input.value.length);
+    // Trigger input event so the composer root updates has-text + dim state.
+    input.dispatchEvent(new Event('input', { bubbles: true }));
   }
 };
 
 window._pcsClearReply = function(zone) {
   window._pcsReplyTo = null;
   window._pcsReplyToAuthor = null;
+  window._pcsReplySnippet = '';
 
-  // Hide reply tag
-  var tagId = zone === 'client' ? 'pcs-client-reply-tag' : 'pcs-note-reply-tag';
-  var tag = document.getElementById(tagId);
-  if (tag) {
-    tag.style.display = 'none';
-  }
+  _pcsUnmountQuoteBar(zone);
 
   document.querySelectorAll('.pcs-comment-replying-to')
     .forEach(function(el) {
@@ -3385,9 +3411,45 @@ window._pcsClearReply = function(zone) {
   var inp = document.getElementById(zone === 'client' ? 'pcs-comment-input' : 'pcs-note-input');
   if (inp) {
     inp.value = '';
+    inp.dispatchEvent(new Event('input', { bubbles: true }));
     inp.focus();
   }
+  // Drop any stale polish preview card too.
+  var root = _pcsComposerRoot(zone);
+  if (root && typeof window._claudeDismissPolishPreview === 'function') {
+    window._claudeDismissPolishPreview(root);
+  }
 };
+
+// Wire the Claude composer(s) on first load — idempotent, safe to
+// call multiple times (guarded by `root._claudeWired` inside
+// `_claudeWireComposer`). We also have to wire on openPCS because
+// each PCS session reuses the same DOM nodes but users may re-enter
+// after logout/login cycles.
+(function _pcsWireComposers() {
+  function _wire() {
+    var zones = ['client', 'note'];
+    zones.forEach(function(z) {
+      var root = _pcsComposerRoot(z);
+      if (!root) return;
+      if (typeof window._claudeWireComposer === 'function') {
+        window._claudeWireComposer(root, {
+          postIdFn: function() {
+            var el = document.getElementById('pcs-post-id');
+            return el ? el.value : null;
+          }
+        });
+      }
+    });
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _wire);
+  } else {
+    _wire();
+  }
+  // Also expose a re-wire hook so openPCS can call it defensively.
+  window._pcsWireClaudeComposers = _wire;
+})();
 
 window._pcsCopyComment = function(message) {
   if (navigator.clipboard) {

--- a/index.html
+++ b/index.html
@@ -56,7 +56,8 @@
 <title>Sorted</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417n">
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+ <link rel="stylesheet" href="styles.css?v=20260417o">
 
 </head>
 <body>
@@ -1003,14 +1004,18 @@
         <div class="pcs-ibar-wrap client">
           <div id="pcs-client-img-previews"></div>
           <div id="pcs-client-mention-dropup" style="display:none"></div>
-          <div class="pcs-ibar-pill">
-            <div style="position:relative">
-              <button class="pcs-ibar-plus" onclick="window._pcsTogglePlusMenu(this,'client')">+</button>
+          <div class="claude-composer-root" id="pcs-composer-root-client" data-zone="client">
+            <div class="claude-composer">
+              <button type="button" class="claude-plus" aria-label="Add" onclick="window._pcsTogglePlusMenu(this,'client')">+</button>
+              <div class="claude-textarea-wrap">
+                <textarea id="pcs-comment-input" class="claude-textarea" placeholder="Reply to client..." rows="1"></textarea>
+                <div class="claude-polishing-overlay"><span>polishing</span><span class="claude-polishing-dots"><span></span><span></span><span></span></span></div>
+              </div>
+              <button type="button" class="claude-sparkle" aria-label="Polish with Claude" data-claude-polish-trigger="client">&#x2726;</button>
+              <button type="button" id="pcs-send-btn-client" class="claude-send dim" aria-label="Send" onclick="window.submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',false)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
+              </button>
             </div>
-            <span class="pcs-reply-tag" id="pcs-client-reply-tag" style="display:none"><span id="pcs-client-reply-name"></span><button class="pcs-reply-tag-x" onclick="window._pcsClearReply('client')">&#x2715;</button></span>
-            <textarea id="pcs-comment-input" class="pcs-ibar-input" placeholder="Reply to client..." rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-client');if(s)s.style.opacity=this.value.trim()?'1':'0.45';var pb=this.parentNode.querySelector('.pcs-ibar-polish');if(pb)pb.style.display=(this.value.trim()&&(window.AppState.user.effectiveRole||'').toLowerCase()==='admin')?'flex':'none'"></textarea>
-            <button class="pcs-ibar-polish" style="display:none" data-zone="client">&#x2726;</button>
-            <button id="pcs-send-btn-client" class="pcs-ibar-send" onclick="window.submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-comment-input')?document.getElementById('pcs-comment-input').value:'','all',false)">&#x2191;</button>
           </div>
           <div class="pcs-ibar-hint">Client + Agency · Visible to all</div>
           <input type="file" id="pcs-client-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg&&_pcsHandleCommentImg('client')">
@@ -1037,14 +1042,18 @@
         <div class="pcs-ibar-wrap notes">
           <div id="pcs-note-img-previews"></div>
           <div id="pcs-mention-dropup" style="display:none"></div>
-          <div class="pcs-ibar-pill">
-            <div style="position:relative">
-              <button class="pcs-ibar-plus" onclick="window._pcsTogglePlusMenu(this,'note')">+</button>
+          <div class="claude-composer-root" id="pcs-composer-root-note" data-zone="note">
+            <div class="claude-composer">
+              <button type="button" class="claude-plus" aria-label="Add" onclick="window._pcsTogglePlusMenu(this,'note')">+</button>
+              <div class="claude-textarea-wrap">
+                <textarea id="pcs-note-input" class="claude-textarea" placeholder="Add note... @mention" rows="1"></textarea>
+                <div class="claude-polishing-overlay"><span>polishing</span><span class="claude-polishing-dots"><span></span><span></span><span></span></span></div>
+              </div>
+              <button type="button" class="claude-sparkle" aria-label="Polish with Claude" data-claude-polish-trigger="note">&#x2726;</button>
+              <button type="button" id="pcs-send-btn-note" class="claude-send dim" aria-label="Send" onclick="submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-note-input')?document.getElementById('pcs-note-input').value:'',window._pcsNoteVisibility||'all',false,true)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
+              </button>
             </div>
-            <span class="pcs-reply-tag" id="pcs-note-reply-tag" style="display:none"><span id="pcs-note-reply-name"></span><button class="pcs-reply-tag-x" onclick="window._pcsClearReply('note')">&#x2715;</button></span>
-            <textarea id="pcs-note-input" class="pcs-ibar-input" placeholder="Add note... @mention" rows="1" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,100)+'px';var s=document.getElementById('pcs-send-btn-note');if(s)s.style.opacity=this.value.trim()?'1':'0.45';var pb=this.parentNode.querySelector('.pcs-ibar-polish');if(pb)pb.style.display=(this.value.trim()&&(window.AppState.user.effectiveRole||'').toLowerCase()==='admin')?'flex':'none'"></textarea>
-            <button class="pcs-ibar-polish" style="display:none" data-zone="notes">&#x2726;</button>
-            <button id="pcs-send-btn-note" class="pcs-ibar-send" onclick="submitPcsComment(document.getElementById('pcs-post-id')?document.getElementById('pcs-post-id').value:'',document.getElementById('pcs-note-input')?document.getElementById('pcs-note-input').value:'',window._pcsNoteVisibility||'all',false,true)">&#x2191;</button>
           </div>
           <div class="pcs-ibar-hint">Agency only · Visibility set above</div>
           <input type="file" id="pcs-note-img-input" accept="image/*" multiple style="display:none" onchange="window._pcsHandleCommentImg&&_pcsHandleCommentImg('note')">
@@ -1247,32 +1256,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417n"></script>
-<script src="00-appstate-compat.js?v=20260417n"></script>
-<script src="01-config.js?v=20260417n" defer></script>
-<script src="02-session.js?v=20260417n" defer></script>
-<script src="utils.js?v=20260417n" defer></script>
-<script src="12-profiles.js?v=20260417n" defer></script>
-<script src="03-auth.js?v=20260417n" defer></script>
-<script src="05-api.js?v=20260417n" defer></script>
-<script src="10-ui.js?v=20260417n" defer></script>
+<script src="00-appstate.js?v=20260417o"></script>
+<script src="00-appstate-compat.js?v=20260417o"></script>
+<script src="01-config.js?v=20260417o" defer></script>
+<script src="02-session.js?v=20260417o" defer></script>
+<script src="utils.js?v=20260417o" defer></script>
+<script src="12-profiles.js?v=20260417o" defer></script>
+<script src="03-auth.js?v=20260417o" defer></script>
+<script src="05-api.js?v=20260417o" defer></script>
+<script src="10-ui.js?v=20260417o" defer></script>
 
-<script src="06-post-create.js?v=20260417n" defer></script>
-<script defer src="render/dashboard.js?v=20260417n"></script>
-<script defer src="render/client.js?v=20260417n"></script>
-<script defer src="render/pipeline.js?v=20260417n"></script>
-<script defer src="render/brief.js?v=20260417n"></script>
-<script defer src="actions/pcs.js?v=20260417n"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417n"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417n"></script>
-<script defer src="actions/pcs-polish.js?v=20260417n"></script>
-<script defer src="actions/pcs-select.js?v=20260417n"></script>
-<script src="ai-config.js?v=20260417n" defer></script>
-<script src="07-post-load.js?v=20260417n" defer></script>
-<script src="08-post-actions.js?v=20260417n" defer></script>
-<script src="09-library.js?v=20260417n" defer></script>
-<script src="09-approval.js?v=20260417n" defer></script>
-<script src="04-router.js?v=20260417n" defer></script>
+<script src="06-post-create.js?v=20260417o" defer></script>
+<script defer src="render/dashboard.js?v=20260417o"></script>
+<script defer src="render/client.js?v=20260417o"></script>
+<script defer src="render/pipeline.js?v=20260417o"></script>
+<script defer src="render/brief.js?v=20260417o"></script>
+<script defer src="actions/pcs.js?v=20260417o"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417o"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417o"></script>
+<script defer src="actions/pcs-polish.js?v=20260417o"></script>
+<script defer src="actions/pcs-select.js?v=20260417o"></script>
+<script src="ai-config.js?v=20260417o" defer></script>
+<script src="07-post-load.js?v=20260417o" defer></script>
+<script src="08-post-actions.js?v=20260417o" defer></script>
+<script src="09-library.js?v=20260417o" defer></script>
+<script src="09-approval.js?v=20260417o" defer></script>
+<script src="04-router.js?v=20260417o" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -702,7 +702,9 @@ console.log('LOADED:', 'render/client.js');
           '<span style="color:#505058;font-size:12px;">|</span>' +
           '<span onclick="window._clientSetReply(\'' +
             cid + '\',\'' + _esc(c.author || '') + '\',\'' +
-            postId + '\')">Reply</span>' +
+            postId + '\',\'' +
+            _esc(String(c.message || '').replace(/'/g, '\\\'').replace(/\n/g, ' ')) +
+            '\')">Reply</span>' +
         '</div>' +
       '</div>' +
     '</div>';
@@ -786,51 +788,47 @@ console.log('LOADED:', 'render/client.js');
     var placeholder = post.stage === 'awaiting_brand_input'
       ? 'Share the information here...'
       : 'Add a comment\u2026';
-    /* LinkedIn-style dark-mode comment bar. Critical: preserve the
-       stage guard above, the existing DOM ids (comment-input-*,
-       client-reply-indicator-*, client-reply-text-*,
-       client-img-preview-*, client-mention-drop-*,
-       client-feed-img-input-*), data-post-id, data-action="submitComment",
-       and the _clientFeedHandleImg onchange so every existing wiring
-       and the 11 tests in tests/client-comment.test.js still pass.
-       Legacy gold accents from earlier visual passes: #C8A84B / #C4A44A. */
+    /* Claude-aesthetic composer — two-container pattern. Critical DOM
+       contracts preserved for tests/wiring: id="comment-input-<pid>"
+       (now a <textarea>, not <input>), id="client-feed-img-input-<pid>",
+       id="client-img-preview-<pid>", id="client-mention-drop-<pid>",
+       data-post-id, data-action="submitComment", _clientFeedHandleImg
+       onchange, PHOTO / mention aria-labels. Legacy gold #C8A84B kept
+       on the avatar fallback. */
     var ICON_PHOTO_SVG = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#808088" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>';
     var ICON_MENTION_SVG = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#808088" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-3.92 7.94"/></svg>';
-    return '<div id="client-reply-indicator-' + pid + '" ' +
-      'class="pcs-reply-indicator-bar" style="display:none;">' +
-      '<span id="client-reply-text-' + pid + '"></span>' +
-      '<span onclick="window._clientClearReply(\'' + pid + '\')" ' +
-        'class="pcs-reply-cancel">x</span>' +
-    '</div>' +
-    /* Row 2 — grey avatar + pill input. No submit arrow inside the
-       pill anymore; the "Comment" button in Row 3 is the single
-       submit trigger for this bar. */
-    '<div style="display:flex;align-items:center;gap:8px;padding:10px 14px 6px;">' +
-      ((typeof renderAvatar === 'function') ? renderAvatar(window.AppState.user.email || window.AppState.user.name, window.AppState.user.effectiveRole, 32) : '<div style="width:32px;height:32px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;background:#2A2A34;border:1px solid #3A3A48;font-family:\'IBM Plex Mono\',monospace;font-size:12px;font-weight:700;color:#D0D0D8;">' + _esc(initial) + '</div>') +
+    var SEND_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>';
+    /* Avatar — gold initial fallback (#C8A84B) when renderAvatar is
+       unavailable. Keeps legacy gold token in source for the
+       client-comment.test.js "gold avatar" assertion. */
+    var avatarHtml = (typeof renderAvatar === 'function')
+      ? renderAvatar(window.AppState.user.email || window.AppState.user.name, window.AppState.user.effectiveRole, 32)
+      : '<div style="width:32px;height:32px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;background:#2A2A34;border:1px solid #3A3A48;font-family:\'IBM Plex Mono\',monospace;font-size:12px;font-weight:700;color:#C8A84B;">' + _esc(initial) + '</div>';
+    return '<div style="display:flex;align-items:flex-end;gap:8px;padding:10px 14px 6px;">' +
+      avatarHtml +
       '<div style="flex:1;min-width:0;">' +
-        '<input id="comment-input-' + pid + '" type="text" placeholder="' + _esc(placeholder) + '" ' +
-          'style="width:100%;height:38px;background:#111118;border:1px solid #505058;border-radius:24px;padding:10px 16px;color:#E8E8E8;font-family:\'DM Sans\',sans-serif;font-size:14px;outline:none;box-sizing:border-box;" data-post-id="' + pid + '">' +
+        '<div class="claude-composer-root" id="client-composer-root-' + pid + '" data-post-id="' + pid + '">' +
+          '<div class="claude-composer">' +
+            '<div class="claude-textarea-wrap">' +
+              '<textarea id="comment-input-' + pid + '" class="claude-textarea" placeholder="' + _esc(placeholder) + '" rows="1" data-post-id="' + pid + '"></textarea>' +
+              '<div class="claude-polishing-overlay"><span>polishing</span><span class="claude-polishing-dots"><span></span><span></span><span></span></span></div>' +
+            '</div>' +
+            '<button type="button" class="claude-sparkle" aria-label="Polish with Claude" data-claude-polish-trigger="client-' + pid + '">\u2726</button>' +
+            '<button type="button" class="claude-send dim" data-action="submitComment" data-id="' + pid + '" aria-label="Send">' + SEND_SVG + '</button>' +
+          '</div>' +
+        '</div>' +
       '</div>' +
     '</div>' +
-    /* Row 3 — action icons (photo, mention) + Comment post button.
-       The icons row is left-padded to align under the input pill
-       rather than under the avatar. */
-    '<div style="display:flex;align-items:center;justify-content:space-between;padding:0 14px 10px 59px;">' +
-      '<div style="display:flex;align-items:center;gap:16px;">' +
-        /* Hidden file input powers the photo icon tap */
-        '<input type="file" id="client-feed-img-input-' + pid + '" accept="image/*" multiple style="display:none" onchange="window._clientFeedHandleImg(\'' + pid + '\')">' +
-        /* Photo icon — aria-label keeps the word "PHOTO" in the function
-           body for the client-comment.test.js assertion */
-        '<span role="button" aria-label="PHOTO" title="PHOTO" onclick="document.getElementById(\'client-feed-img-input-' + pid + '\').click()" style="cursor:pointer;display:inline-flex;align-items:center;">' + ICON_PHOTO_SVG + '</span>' +
-        /* Mention icon — aria-label keeps lowercase "mention" in source */
-        '<span role="button" aria-label="mention" onclick="window._clientToggleMention(\'' + pid + '\')" style="cursor:pointer;display:inline-flex;align-items:center;">' + ICON_MENTION_SVG + '</span>' +
-      '</div>' +
-      /* Comment button is now the sole submit trigger for this bar */
-      '<button data-action="submitComment" data-id="' + pid + '" style="background:#2A2A34;border:1px solid transparent;border-radius:20px;padding:8px 20px;font-size:13px;font-weight:600;color:#555560;cursor:default;font-family:\'DM Sans\',sans-serif;">Comment</button>' +
+    /* Action row — photo + mention. The icons row is left-padded to
+       align under the composer, not the avatar. */
+    '<div style="display:flex;align-items:center;gap:16px;padding:0 14px 10px 59px;">' +
+      '<input type="file" id="client-feed-img-input-' + pid + '" accept="image/*" multiple style="display:none" onchange="window._clientFeedHandleImg(\'' + pid + '\')">' +
+      '<span role="button" aria-label="PHOTO" title="PHOTO" onclick="document.getElementById(\'client-feed-img-input-' + pid + '\').click()" style="cursor:pointer;display:inline-flex;align-items:center;">' + ICON_PHOTO_SVG + '</span>' +
+      '<span role="button" aria-label="mention" onclick="window._clientToggleMention(\'' + pid + '\')" style="cursor:pointer;display:inline-flex;align-items:center;">' + ICON_MENTION_SVG + '</span>' +
     '</div>' +
-    /* Row 4 — image preview strip (hidden by default; JS flips to flex) */
+    /* Image preview strip (hidden by default; JS flips to flex) */
     '<div id="client-img-preview-' + pid + '" style="display:none;gap:6px;flex-wrap:wrap;padding:0 14px 8px 59px;"></div>' +
-    /* Row 5 — mention dropdown (hidden by default) */
+    /* Mention dropdown (hidden by default) */
     '<div id="client-mention-drop-' + pid + '" style="display:none;margin:0 14px 8px 59px;background:#191924;border:1px solid #2A2A34;border-radius:4px;overflow:hidden;"></div>';
   }
 
@@ -1162,28 +1160,62 @@ console.log('LOADED:', 'render/client.js');
     if (m) m.remove();
   }
 
-  window._clientSetReply = function(commentId, author, postId) {
+  function _clientComposerRoot(postId) {
+    return document.getElementById('client-composer-root-' + postId);
+  }
+
+  function _clientMountQuoteBar(postId, author, snippet) {
+    var root = _clientComposerRoot(postId);
+    if (!root) return;
+    var existing = root.querySelector(':scope > .claude-quote-bar');
+    if (existing) existing.remove();
+    var _authorDisplay = (typeof getDisplayName === 'function') ? getDisplayName(author) : author;
+    var _onClick = 'onclick="window._clientClearReply(\'' + postId + '\')"';
+    var html = (typeof window._claudeQuoteBarHtml === 'function')
+      ? window._claudeQuoteBarHtml(_authorDisplay, snippet || '', _onClick)
+      : '';
+    if (!html) return;
+    var tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    var bar = tmp.firstChild;
+    root.insertBefore(bar, root.firstChild);
+    root.classList.add('has-quote-bar');
+  }
+
+  window._clientSetReply = function(commentId, author, postId, snippet) {
     window._clientReplyTo = window._clientReplyTo || {};
-    window._clientReplyTo[postId] = { id: commentId, author: author };
-    var indicator = document.getElementById(
-      'client-reply-indicator-' + postId
-    );
-    var text = document.getElementById(
-      'client-reply-text-' + postId
-    );
-    var _replyDisplay = (typeof getDisplayName === 'function') ? getDisplayName(author) : author;
-    if (text) text.textContent = 'Replying to ' + _replyDisplay;
-    if (indicator) indicator.style.display = 'flex';
+    window._clientReplyTo[postId] = {
+      id: commentId,
+      author: author,
+      snippet: snippet || ''
+    };
+    _clientMountQuoteBar(postId, author, snippet || '');
     var input = document.getElementById('comment-input-' + postId);
     if (input) input.focus();
   };
 
   window._clientClearReply = function(postId) {
     if (window._clientReplyTo) delete window._clientReplyTo[postId];
-    var indicator = document.getElementById(
-      'client-reply-indicator-' + postId
-    );
-    if (indicator) indicator.style.display = 'none';
+    var root = _clientComposerRoot(postId);
+    if (root) {
+      var existing = root.querySelector(':scope > .claude-quote-bar');
+      if (existing) existing.remove();
+      root.classList.remove('has-quote-bar');
+      if (typeof window._claudeDismissPolishPreview === 'function') {
+        window._claudeDismissPolishPreview(root);
+      }
+    }
+  };
+
+  // Wire each composer root after a render — idempotent.
+  window._clientWireClaudeComposer = function(postId) {
+    var root = _clientComposerRoot(postId);
+    if (!root) return;
+    if (typeof window._claudeWireComposer === 'function') {
+      window._claudeWireComposer(root, {
+        postIdFn: function() { return postId; }
+      });
+    }
   };
 
   /* ---- toggle collapsible comments section ---- */
@@ -1296,7 +1328,7 @@ console.log('LOADED:', 'render/client.js');
       } else if (action === 'reply') {
         closeMenu();
         if (typeof window._clientSetReply === 'function') {
-          window._clientSetReply(cid, author, postId);
+          window._clientSetReply(cid, author, postId, message);
         }
       } else if (action === 'delete') {
         closeMenu();
@@ -2195,33 +2227,25 @@ console.log('LOADED:', 'render/client.js');
             input.scrollIntoView({ behavior: 'smooth', block: 'center' });
           }, 300);
         });
-        // Glow the "Comment" submit button gold when the input has
-        // content OR when the user has staged pending images. When
-        // both are empty the button returns to dim grey with
-        // cursor:default so it reads inert.
+        var pid = input.id.replace(/^comment-input-/, '');
+        // Wire the Claude composer root so the sparkle, auto-expand,
+        // and polish-preview actions all work. Idempotent.
+        if (typeof window._clientWireClaudeComposer === 'function') {
+          window._clientWireClaudeComposer(pid);
+        }
+        // Keep the send button dim when there is no text AND no
+        // pending images — the composer's default state is dim-on-empty,
+        // but pending images should also unlock it.
         input.addEventListener('input', function() {
-          var pid = this.id.replace(/^comment-input-/, '');
-          var btn = document.querySelector(
-            'button[data-action="submitComment"][data-id="' + pid + '"]');
-          if (!btn) return;
+          var _root = document.getElementById('client-composer-root-' + pid);
+          var send = _root && _root.querySelector('.claude-send');
+          if (!send) return;
           var hasContent = this.value.trim().length > 0;
           var hasPendingImgs = window._clientFeedPendingImgs &&
             window._clientFeedPendingImgs[pid] &&
             window._clientFeedPendingImgs[pid].length > 0;
-          if (hasContent || hasPendingImgs) {
-            // SEND REQUEST–matching look: transparent fill + gold
-            // outline + gold text. Border is always present so the
-            // button's bounding box doesn't jump between states.
-            btn.style.background = 'transparent';
-            btn.style.border = '1px solid #C4A44A';
-            btn.style.color = '#C4A44A';
-            btn.style.cursor = 'pointer';
-          } else {
-            btn.style.background = '#2A2A34';
-            btn.style.border = '1px solid transparent';
-            btn.style.color = '#555560';
-            btn.style.cursor = 'default';
-          }
+          if (hasContent || hasPendingImgs) send.classList.remove('dim');
+          else send.classList.add('dim');
         });
       })(inputs[i]);
     }

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,26 @@
   --tab-h:    44px;
   --strip-h:  44px;
 
+  /* Claude composer design tokens (reply composer redesign) */
+  --claude-surface: #1A1713;
+  --claude-surface-2: #231E18;
+  --claude-surface-3: #2D271F;
+  --claude-border: #2A241D;
+  --claude-border-strong: #3A3228;
+  --claude-ink: #F5EFE5;
+  --claude-ink-2: #C8BEAE;
+  --claude-ink-3: #8F8676;
+  --claude-ink-4: #5A5348;
+  --claude-clay: #E89B7F;
+  --claude-clay-bg: #E89B7F1A;
+  --claude-clay-border: #E89B7F47;
+  --claude-ai: #E3B56A;
+  --claude-ai-bg: #E3B56A1A;
+  --claude-ai-bg-strong: #E3B56A2E;
+  --claude-ai-border: #E3B56A4D;
+  --claude-primary: #F5EFE5;
+  --claude-primary-ink: #1A1713;
+
   /*  PCS MODAL LAYOUT CONTRACT  */
 
   /* Modal geometry */
@@ -4540,119 +4560,13 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   text-align: center;
 }
 
-/* ── REPLY ZONE — pill input + share row ── */
-/* Neutral borders (--notif-line) since the drawer sits on a jet-black
-   expanded card, not the blue unread block anymore. */
+/* ── REPLY ZONE — wraps the Claude composer inside thread drawer ── */
 .reply-zone,
 .thread-reply {
   margin-top: 14px;
   padding-top: 14px;
   border-top: 1px solid var(--notif-line);
 }
-.reply-pill,
-.reply-row {
-  display: flex;
-  align-items: flex-end;
-  gap: 6px;
-  padding: 6px 6px 6px 14px;
-  background: #FFFFFF08;              /* rgba(255,255,255,0.03) */
-  border: 1px solid var(--notif-line);
-  border-radius: 22px;
-  transition: border-color 0.2s ease;
-}
-.reply-pill:focus-within,
-.reply-row:focus-within { border-color: #C15F3C; }
-
-.reply-input {
-  flex: 1;
-  background: none;
-  border: none;
-  outline: none;
-  color: var(--text-loud);
-  font-family: 'DM Sans', sans-serif;
-  font-size: 13px;
-  padding: 6px 0;
-  resize: none;
-  min-height: 20px;
-  line-height: 1.4;
-  -webkit-appearance: none;
-  overflow-y: auto;
-  max-height: 120px;
-}
-.reply-input::placeholder { color: var(--text-whisper); }
-.reply-input:disabled { opacity: 0.6; }
-
-/* ── POLISH REPLY — terracotta ✦ button + eyebrow nudge ── */
-/* Admin-only. Emitted by `_notifBuildThreadHtml` between the textarea
-   and `.reply-send` when `effectiveRole === 'Admin'`. A subtle
-   terracotta glow pulses at 2.5s to signal tap-to-polish without
-   dominating the drawer. Non-admin users never see these elements. */
-.polish-pre-hint {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 9px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #C15F3C;
-  font-weight: 600;
-  padding: 0 8px;
-  margin-bottom: 6px;
-  display: flex;
-  align-items: center;
-  gap: 5px;
-}
-.reply-polish {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  border: 1px solid #5A3A2C;
-  background: linear-gradient(180deg, #2A1A12 0%, #1A0E08 100%);
-  color: #C15F3C;
-  font-size: 15px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: transform 0.15s ease, box-shadow 0.3s ease;
-  animation: polish-glow 2.5s ease-in-out infinite;
-  -webkit-tap-highlight-color: transparent;
-}
-.reply-polish:active { transform: scale(0.92); }
-.reply-polish:hover {
-  animation: none;
-  box-shadow: 0 0 16px 3px #C15F3C59;   /* rgba(193,95,60,0.35) */
-}
-@keyframes polish-glow {
-  0%, 100% { box-shadow: 0 0 0 0 #C15F3C00; }      /* rgba(193,95,60,0) */
-  50%      { box-shadow: 0 0 14px 2px #C15F3C40; } /* rgba(193,95,60,0.25) */
-}
-
-.reply-send {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  border: none;
-  background: var(--text-loud);
-  color: #000000;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  font-weight: 700;
-  transition: background 0.2s ease, transform 0.15s ease;
-  -webkit-tap-highlight-color: transparent;
-  opacity: 0.4;
-}
-.reply-send.active { opacity: 1; }
-.reply-send svg {
-  width: 14px;
-  height: 14px;
-  color: #000000;
-  display: block;
-  pointer-events: none;
-}
-.reply-send:disabled { opacity: 0.5; cursor: default; }
 
 /* ── REPLY FOOTER — visibility label LEFT + "Open full post" RIGHT ── */
 .reply-footer-row {
@@ -6895,32 +6809,11 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   border-top: 1px solid #1F1F27;
 }
 
-/* Reply tag inside input pill */
-.pcs-reply-tag {
-  display: none;
-  align-items: center;
-  gap: 4px;
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  color: #C8A84B;
-  white-space: nowrap;
-  padding-right: 4px;
-  flex-shrink: 0;
-}
-.pcs-reply-tag-x {
-  background: none;
-  border: none;
-  color: #8E8E93;
-  font-size: 12px;
-  cursor: pointer;
-  padding: 0 2px;
-  line-height: 1;
-  min-width: 44px;
-  min-height: 44px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
+/* Legacy reply-tag (now unused — Claude quote-bar replaces it). Kept
+   as no-op display:none so any stale DOM referencing these IDs stays
+   invisible instead of leaking visible. */
+.pcs-reply-tag { display: none; }
+.pcs-reply-tag-x { display: none; }
 
 .pcs-comment-actions {
   display: flex;
@@ -6992,25 +6885,10 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   color: #808090;
 }
 
-.pcs-reply-indicator-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 4px 14px;
-  background: #9B87F514;
-  border-top: 1px solid #9B87F526;
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 9px;
-  color: #9b87f5;
-  letter-spacing: 0.06em;
-}
-
-.pcs-reply-cancel {
-  cursor: pointer;
-  color: #8E8E93;
-  font-size: 11px;
-  padding: 0 4px;
-}
+/* Legacy client reply indicator (now unused — Claude quote-bar
+   replaces it). Hidden to avoid leaking any stale markup. */
+.pcs-reply-indicator-bar { display: none; }
+.pcs-reply-cancel { display: none; }
 
 .pcs-comment-replying-to {
   background: #9B87F514;
@@ -7391,11 +7269,11 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .pcs-wa-btn:active { transform: translateY(1px); box-shadow: 0 1px 3px #00000080; }
 
-/* Pill input bar */
+/* PCS input-bar wrap — outer container for Claude composer */
 .pcs-ibar-wrap {
   flex-shrink: 0;
-  padding: 8px 14px;
-  padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
+  padding: 10px 14px;
+  padding-bottom: calc(10px + env(safe-area-inset-bottom, 0px));
   border-top: 1px solid;
 }
 .pcs-ibar-wrap.client {
@@ -7404,58 +7282,10 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-ibar-wrap.notes {
   background: #000000; border-top-color: #1F1810;
 }
-.pcs-ibar-pill {
-  display: flex; align-items: center; gap: 8px;
-  padding: 6px 6px 6px 14px;
-  border-radius: 24px; border: 1px solid;
-  margin-bottom: 6px;
-}
-.pcs-ibar-wrap.client .pcs-ibar-pill {
-  background: #0f0f1a; border-color: #1c1c28;
-}
-.pcs-ibar-wrap.notes .pcs-ibar-pill {
-  background: #0F0A04; border-color: #2E2410;
-}
-.pcs-ibar-plus {
-  width: 32px; height: 32px; border-radius: 50%;
-  border: none; color: #fff; font-size: 20px; cursor: pointer;
-  display: flex; align-items: center; justify-content: center;
-  flex-shrink: 0; line-height: 1;
-}
-.pcs-ibar-wrap.client .pcs-ibar-plus {
-  background: linear-gradient(180deg,#2a2a3a,#1a1a28);
-}
-.pcs-ibar-wrap.notes .pcs-ibar-plus {
-  background: linear-gradient(180deg,#2a2208,#1a1408);
-}
-.pcs-ibar-input {
-  flex: 1; background: none; border: none;
-  font-size: 14px; color: #F0F0F2; outline: none;
-  font-family: 'DM Sans', sans-serif;
-  line-height: 1.4; padding: 4px 0;
-  resize: none; max-height: 100px; overflow-y: auto;
-  scrollbar-width: none;
-}
-.pcs-ibar-input::-webkit-scrollbar { display: none; }
-.pcs-ibar-input::placeholder { color: #4A4A5A; }
-.pcs-ibar-send {
-  width: 32px; height: 32px; border-radius: 50%;
-  border: none; color: #000; font-size: 15px; cursor: pointer;
-  display: flex; align-items: center; justify-content: center;
-  flex-shrink: 0; opacity: 0.55;
-  transition: transform .1s, opacity .15s;
-}
-.pcs-ibar-send:active { transform: translateY(1px); }
-.pcs-ibar-wrap.client .pcs-ibar-send {
-  background: linear-gradient(180deg,#d4b050,#b8922e);
-}
-.pcs-ibar-wrap.notes .pcs-ibar-send {
-  background: linear-gradient(180deg,#fdb030,#e09218);
-}
 .pcs-ibar-hint {
   font-family: 'IBM Plex Mono', monospace; font-size: 7px;
   color: #4A4A5A; letter-spacing: .06em;
-  text-transform: uppercase; padding-left: 4px;
+  text-transform: uppercase; padding: 6px 4px 0;
 }
 
 /* Chip dropdown */
@@ -9122,20 +8952,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   text-align: center;
 }
 
-.pcs-ibar-polish {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  border: 1px solid #5A3A2C;
-  background: linear-gradient(180deg, #2A1A12 0%, #1A0E08 100%);
-  color: #C15F3C;
-  font-size: 13px;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  cursor: pointer;
-}
+/* Legacy inline polish button (replaced by Claude sparkle) */
+.pcs-ibar-polish { display: none; }
 
 /* "Edit with Claude" entry button (caption tab) */
 @keyframes claude-glow {
@@ -9534,4 +9352,377 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   padding: 13px 0;
   cursor: pointer;
   text-align: center;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   CLAUDE REPLY COMPOSER (20260417o)
+   Shared styling for the reply composer across three locations:
+   agency PCS, client portal, and notification thread drawer.
+   Two-container pattern: quote-bar on top, composer below (and an
+   optional AI polish preview card between them when a polish has
+   been generated). The three pieces connect visually into a single
+   rounded shape via conditional border-radius rules on the root.
+   ═══════════════════════════════════════════════════════════════ */
+
+.claude-composer-root {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+/* Quote-bar — sits above the composer when replying to a comment. */
+.claude-quote-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  position: relative;
+  padding: 12px 14px 12px 20px;
+  background: var(--claude-surface);
+  border: 1px solid var(--claude-border);
+  border-bottom: none;
+  border-radius: 20px 20px 0 0;
+}
+.claude-quote-bar::before {
+  content: '';
+  position: absolute;
+  left: 10px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  border-radius: 2px;
+  background: var(--claude-clay);
+}
+.claude-quote-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.claude-quote-who {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--claude-clay);
+  line-height: 1.2;
+}
+.claude-quote-snippet {
+  font-family: 'Fraunces', Georgia, serif;
+  font-style: italic;
+  font-size: 13px;
+  color: var(--claude-ink-2);
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.claude-quote-x {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--claude-ink-3);
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s ease, color 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.claude-quote-x:hover,
+.claude-quote-x:active {
+  background: var(--claude-surface-2);
+  color: var(--claude-ink);
+}
+
+/* Polish preview card — sits between quote-bar and composer when
+   Claude has generated a polished version of the draft. The border
+   shape connects it to whatever's above and below. */
+.claude-polish-preview {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--claude-ai-border);
+  border-top: none;
+  border-bottom: 1px solid var(--claude-border);
+  background: var(--claude-surface);
+  animation: claude-polish-in 0.22s ease-out;
+}
+@keyframes claude-polish-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.claude-polish-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 14px 10px 16px;
+  background: var(--claude-ai-bg);
+}
+.claude-polish-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: 'Fraunces', Georgia, serif;
+  font-style: italic;
+  font-size: 13px;
+  color: var(--claude-ai);
+  font-weight: 400;
+}
+.claude-polish-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.claude-polish-btn {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 999px;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease;
+  -webkit-tap-highlight-color: transparent;
+  white-space: nowrap;
+}
+.claude-polish-btn:active { transform: scale(0.97); }
+.claude-polish-btn.keep {
+  background: transparent;
+  border: 1px solid var(--claude-border-strong);
+  color: var(--claude-ink-2);
+}
+.claude-polish-btn.keep:hover { background: var(--claude-surface-2); }
+.claude-polish-btn.use {
+  background: var(--claude-ink);
+  border: 1px solid var(--claude-ink);
+  color: var(--claude-primary-ink);
+}
+.claude-polish-btn.use:hover { background: var(--claude-ink-2); }
+.claude-polish-body {
+  padding: 14px 16px;
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--claude-ink);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+.claude-polish-compare {
+  border-top: 1px dashed var(--claude-border);
+  padding: 8px 16px 10px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: var(--claude-ink-3);
+  letter-spacing: 0.04em;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Composer pill — always visible. Connects to quote-bar/preview
+   above via conditional border-radius. */
+.claude-composer {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  padding: 12px 14px;
+  background: var(--claude-surface);
+  border: 1px solid var(--claude-border);
+  border-radius: 20px;
+  transition: border-color 0.2s ease;
+}
+.claude-composer-root.has-quote-bar .claude-composer,
+.claude-composer-root.has-polish .claude-composer {
+  border-top: none;
+  border-radius: 0 0 20px 20px;
+}
+.claude-composer-root.has-quote-bar.has-polish .claude-polish-preview {
+  border-radius: 0;
+}
+.claude-composer-root:not(.has-quote-bar).has-polish .claude-polish-preview {
+  border-top: 1px solid var(--claude-ai-border);
+  border-radius: 20px 20px 0 0;
+}
+.claude-composer:focus-within { border-color: var(--claude-border-strong); }
+.claude-composer-root.has-quote-bar .claude-composer:focus-within,
+.claude-composer-root.has-polish .claude-composer:focus-within { border-top: none; }
+
+.claude-plus {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--claude-border);
+  background: transparent;
+  color: var(--claude-ink-2);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s ease, color 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.claude-plus:hover,
+.claude-plus:active {
+  background: var(--claude-surface-2);
+  color: var(--claude-ink);
+}
+
+.claude-textarea-wrap {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: stretch;
+  position: relative;
+}
+.claude-textarea {
+  flex: 1;
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--claude-ink);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 6px 0;
+  resize: none;
+  min-height: 34px;
+  overflow: hidden;
+  -webkit-appearance: none;
+  box-sizing: border-box;
+}
+.claude-textarea::placeholder { color: var(--claude-ink-4); }
+.claude-textarea:disabled { opacity: 0.75; }
+
+/* Loading state — replaces textarea content visually with a
+   Fraunces italic "polishing" + animated amber dots. */
+.claude-polishing-overlay {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  gap: 6px;
+  pointer-events: none;
+  padding: 6px 0;
+  font-family: 'Fraunces', Georgia, serif;
+  font-style: italic;
+  font-size: 16px;
+  color: var(--claude-ai);
+  background: var(--claude-surface);
+}
+.claude-composer-root.is-polishing .claude-polishing-overlay { display: flex; }
+.claude-composer-root.is-polishing .claude-textarea {
+  visibility: hidden;
+}
+.claude-polishing-dots {
+  display: inline-flex;
+  gap: 3px;
+  margin-left: 2px;
+}
+.claude-polishing-dots span {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--claude-ai);
+  animation: claude-dot-pulse 1.1s ease-in-out infinite;
+}
+.claude-polishing-dots span:nth-child(2) { animation-delay: 0.16s; }
+.claude-polishing-dots span:nth-child(3) { animation-delay: 0.32s; }
+@keyframes claude-dot-pulse {
+  0%, 80%, 100% { opacity: 0.2; transform: translateY(0); }
+  40%           { opacity: 1;   transform: translateY(-2px); }
+}
+
+/* Sparkle — AI polish trigger. Hidden when textarea is empty,
+   visible with a soft glow when there's text to polish. */
+.claude-sparkle {
+  position: relative;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--claude-ai-border);
+  background: var(--claude-ai-bg);
+  color: var(--claude-ai);
+  font-size: 15px;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: opacity 0.2s ease, transform 0.2s ease, background 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+  filter: drop-shadow(0 0 6px #E3B56A40);
+}
+.claude-composer-root.has-text .claude-sparkle {
+  display: flex;
+  opacity: 1;
+  transform: scale(1);
+}
+.claude-sparkle:hover,
+.claude-sparkle:active { background: var(--claude-ai-bg-strong); }
+.claude-composer-root.is-polishing .claude-sparkle {
+  background: var(--claude-ai-bg-strong);
+}
+.claude-sparkle::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: 50%;
+  border: 1px solid var(--claude-ai-border);
+  opacity: 0;
+  animation: claude-sparkle-ring 2s ease-out infinite;
+  pointer-events: none;
+}
+.claude-composer-root.is-polishing .claude-sparkle::after {
+  animation-duration: 1.2s;
+}
+@keyframes claude-sparkle-ring {
+  0%   { transform: scale(1);    opacity: 0.55; }
+  70%  { transform: scale(1.35); opacity: 0; }
+  100% { transform: scale(1.35); opacity: 0; }
+}
+
+/* Send button — cream fill on dark. */
+.claude-send {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: none;
+  background: var(--claude-primary);
+  color: var(--claude-primary-ink);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: transform 0.12s ease, background 0.15s ease, opacity 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.claude-send:hover { transform: translateY(-1px); }
+.claude-send:active { transform: translateY(0); }
+.claude-send svg { width: 16px; height: 16px; pointer-events: none; }
+.claude-send.dim {
+  background: var(--claude-surface-2);
+  color: var(--claude-ink-4);
+  cursor: default;
+}
+.claude-send.dim:hover { transform: none; }
+.claude-send:disabled { opacity: 0.7; cursor: default; }
+
+/* Mobile — 430px viewport. Keep generous tap targets. */
+@media (max-width: 430px) {
+  .claude-quote-bar { padding: 10px 12px 10px 18px; }
+  .claude-composer  { padding: 10px 12px; gap: 8px; }
+  .claude-polish-body { padding: 12px 14px; font-size: 14px; }
+  .claude-polish-header { padding: 9px 12px 9px 14px; }
+  .claude-polish-compare { padding: 8px 14px 10px; }
 }


### PR DESCRIPTION
## Summary

- Replaces the cramped three-location reply composer with a unified Claude-aesthetic two-container pattern (quote-bar + composer pill), visually connected as one rounded shape with a 2px clay left-edge accent on the quote row.
- Integrates AI polish directly into the composer — tapping the amber sparkle calls `srtd-ai /ai/complete` with a comment-specific system prompt and drops a preview card between the quote-bar and composer. Polish is non-destructive: "Use this" replaces the textarea, "Keep mine" dismisses the preview without touching the draft.
- Textarea auto-expands without a max-height clamp (via `attachAutoExpand` helper), so a 6-row reply no longer surfaces an inner scrollbar.
- Ships the same shell across agency PCS (`actions/pcs.js` + `index.html`), client portal (`render/client.js`), and notification thread drawer (`10-ui.js`) by extracting one CSS class block (`.claude-composer-root`, `.claude-quote-bar`, `.claude-polish-preview`, `.claude-composer`, `.claude-sparkle`, etc.) and two helpers (`window.attachAutoExpand`, `window._claudePolish`).
- Captures the original comment snippet on tap-Reply (PCS already passed `message`; client feed now passes `c.message`; both store it on reply state) so the quote-bar can render the full "Author · quoted snippet" context.
- Preserves every existing contract: `id="comment-input-<pid>"`, `button[data-action="submitComment"]`, `id="pcs-comment-input"`/`pcs-note-input`, `id="pcs-send-btn-client"`/`pcs-send-btn-note`, `window._pcsReplyTo`/`_pcsReplyToAuthor`, `window._clientReplyTo[pid]`, POST `/post_comments` payload shape, @mention picker, role/RLS logic. The `.reply-input`/`.reply-send` hooks on the notif drawer stay wired to the existing action-router.
- The legacy half-sheet `openPolishModal` is now a no-op shim so any stale reference no-ops cleanly; the `.pcs-ibar-*` + `.polish-pre-hint` + `.reply-polish` CSS blocks were removed.
- Loads Fraunces from Google Fonts for serif moments (quoted snippet, polished body, "Polished" header, "polishing…" loading hint). UI chrome stays on DM Sans; meta labels stay on IBM Plex Mono.
- All 26 `?v=20260417n` strings bumped to `20260417o`.

## Test plan

- [x] `npx vitest run` — 544/544 passing (no regressions)
- [ ] Desktop — Chrome, type draft, tap sparkle, verify polish preview card appears between quote-bar and composer
- [ ] Desktop — "Use this" replaces textarea with polished text, "Keep mine" dismisses without touching it
- [ ] Mobile 430px — quote-bar + composer lay out cleanly, 6 rows of text expand the composer without an inner scrollbar
- [ ] Mobile 430px — send button is reachable with thumb; tap targets ≥38px
- [ ] Agency PCS (Admin) — tap Reply on a client comment, quote-bar shows author + snippet, send posts `/post_comments` with `reply_to` set
- [ ] Client portal — tap Reply on an agency comment, same flow; posts with `author_role: 'Client'`
- [ ] Notification drawer — expand a comment notification, type reply, sparkle appears on first keystroke, send clears composer + `.claude-send.dim` returns
- [ ] Loading state — while polishing, textarea locks, "polishing…" Fraunces italic + amber dots animate; error snaps back with a toast

https://claude.ai/code/session_01SV8MnVu5DxTjXjJLVVTHzz