### PR TITLE
feat(create-post): Claude-native caption + expand-to-workspace

### DIFF
--- a/06-post-create.js
+++ b/06-post-create.js
@@ -22,6 +22,11 @@ const DRAFT_KEY = 'hinglish_new_post_draft';
 let _draftTimer = null;
 let _draftDebounce = null;
 
+// Session window for stamping detached ai_usage rows onto the new post_id
+// after submit. Captured at modal open, cleared at close/submit.
+var _npcSessionStart = null;
+var _npcSessionEmail = null;
+
 // PR 4 — Gmail import state. Mirrored onto window.* so handlers
 // wired via inline onclick can read/write them.
 var _npsSelectedOptIdx = 0;   // 1 | 2 | 3 — which AI caption option is picked
@@ -44,6 +49,7 @@ stage:    document.getElementById('new-post-stage')?.value    || '',
 date:     document.getElementById('new-post-date')?.value     || '',
 postLink: document.getElementById('new-post-link')?.value     || '',
 format:   document.getElementById('new-post-format')?.value   || '',
+caption:  document.getElementById('new-post-caption')?.value  || '',
 savedAt:  Date.now(),
 };
 
@@ -77,6 +83,9 @@ if (_el('new-post-date'))     _el('new-post-date').value     = d.date     || '';
 
 if (_el('new-post-link'))     _el('new-post-link').value     = d.postLink || '';
 if (_el('new-post-format'))   _el('new-post-format').value   = d.format   || '';
+if (_el('new-post-caption') && typeof d.caption === 'string') {
+  _el('new-post-caption').value = d.caption;
+}
 
 showDraftStatus('Draft restored');
 _npsOwnerChange();
@@ -610,6 +619,12 @@ if (captionEl) {
   captionEl.style.height = captionEl.scrollHeight + 'px';
 }
 
+_npcSessionStart = new Date().toISOString();
+_npcSessionEmail = (window.AppState && window.AppState.user && window.AppState.user.email) || '';
+_npcWireCaption();
+_npcUpdateWordMeter();
+_npcRefreshCostChip();
+
 setTimeout(() => document.getElementById('new-post-title')?.focus(), 60);
 }
 
@@ -660,6 +675,10 @@ if (emailList) emailList.style.display = 'none';
 var proc = document.getElementById('nps-gmail-processing');
 if (proc) proc.style.display = 'none';
 document.querySelectorAll('.nps-ai-tag').forEach(function(el) { el.style.display = 'none'; });
+
+_npcSessionStart = null;
+_npcSessionEmail = null;
+// Do NOT clear window._captionWS.sessionCost here — the workspace owns its own lifecycle.
 
 _drainDeferredRender();
 }
@@ -771,6 +790,25 @@ body: JSON.stringify(payload)
 });
 
 console.log('[submitNewPost] API SUCCESS');
+
+// Stamp any null-post_id ai_usage rows from this Create Post session
+// onto the newly created post. Fire-and-forget — must not block submit.
+// If it fails, the rows stay null-post_id (still counted globally).
+if (_npcSessionStart && _npcSessionEmail && payload && payload.post_id) {
+  var _stampPath = '/ai_usage?post_id=is.null&created_by=eq.' +
+    encodeURIComponent(_npcSessionEmail) +
+    '&created_at=gte.' + encodeURIComponent(_npcSessionStart);
+  apiFetch(_stampPath, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      'Prefer': 'return=minimal'
+    },
+    body: JSON.stringify({ post_id: payload.post_id })
+  }).catch(function(err) {
+    if (window.logError) window.logError(err && err.message, err && err.stack, 'npc-ai-usage-stamp');
+  });
+}
 
 var _newPostTitle = payload.title || '';
 var _newPostImage = (Array.isArray(payload.images) && payload.images.length) ? payload.images[0] : '';
@@ -958,3 +996,86 @@ function clearPostAsset() {
   _renderNewPostAssetGrid();
 }
 window.clearPostAsset = clearPostAsset;
+
+// ═══════════════════════════════════════════════════════════════
+// Caption Workspace bridge — inline caption stays MANUAL ONLY.
+// The ⤢ button opens the full workspace with postId: null; any
+// "Use this" tap inside the workspace routes back via onUse into
+// the textarea instead of PATCHing /posts.
+// ═══════════════════════════════════════════════════════════════
+function _npcWireCaption() {
+  var ta = document.getElementById('new-post-caption');
+  if (ta && !ta._npcWired) {
+    ta._npcWired = true;
+    // Additive: keep captionWire.oninput (saveDraftDebounced + autogrow) intact.
+    ta.addEventListener('input', function() { _npcUpdateWordMeter(); });
+  }
+  var expandBtn = document.getElementById('npc-expand-btn');
+  if (expandBtn && !expandBtn._npcWired) {
+    expandBtn._npcWired = true;
+    expandBtn.addEventListener('click', _npcOpenWorkspace);
+  }
+}
+
+function _npcUpdateWordMeter() {
+  var ta = document.getElementById('new-post-caption');
+  var meter = document.getElementById('npc-word-meter');
+  if (!ta || !meter) return;
+  var words = (ta.value.trim().match(/\S+/g) || []).length;
+  var countEl = meter.querySelector('.npc-wc-count');
+  if (countEl) countEl.textContent = words;
+  meter.classList.remove('green', 'amber', 'red');
+  if (words >= 80 && words <= 100) meter.classList.add('green');
+  else if (words > 100 && words <= 125) meter.classList.add('amber');
+  else if (words > 125) meter.classList.add('red');
+}
+
+function _npcOpenWorkspace() {
+  var ta = document.getElementById('new-post-caption');
+  if (!ta) return;
+  if (typeof window.openCaptionWorkspace !== 'function') {
+    if (typeof showToast === 'function') showToast('Caption Workspace unavailable', 'error');
+    return;
+  }
+  var currentCaption = ta.value || '';
+  var mode = currentCaption.trim().length === 0 ? 'write' : 'chat';
+  window.openCaptionWorkspace(mode, {
+    postId: null,
+    initialCaption: currentCaption,
+    title: (document.getElementById('new-post-title') || {}).value || 'New post — no title yet',
+    syntheticContext: {
+      title: (document.getElementById('new-post-title') || {}).value || '',
+      content_pillar: (document.getElementById('new-post-pillar') || {}).value || '',
+      location: (document.getElementById('new-post-location') || {}).value || '',
+      internal_notes: (document.getElementById('new-post-comments') || {}).value || ''
+    },
+    onUse: function(newCaption) {
+      ta.value = newCaption;
+      // Kick the existing oninput (auto-grow + saveDraftDebounced).
+      var evt = new Event('input', { bubbles: true });
+      ta.dispatchEvent(evt);
+      _npcUpdateWordMeter();
+      _npcRefreshCostChip();
+    },
+    onClose: function() { _npcRefreshCostChip(); }
+  });
+}
+
+function _npcRefreshCostChip() {
+  var chip = document.getElementById('npc-cost-chip');
+  if (!chip) return;
+  var sessionCost = (window._captionWS && typeof window._captionWS.sessionCost === 'number')
+    ? window._captionWS.sessionCost
+    : 0;
+  var fmt = (typeof window._cwFormatINR === 'function') ? window._cwFormatINR : _npcFallbackFormatINR;
+  var amountEl = chip.querySelector('.npc-amount');
+  if (amountEl) amountEl.textContent = fmt(sessionCost);
+  if (sessionCost > 0) chip.classList.add('active');
+  else chip.classList.remove('active');
+}
+
+function _npcFallbackFormatINR(inr) {
+  if (!inr || inr < 1) return '\u20B90';
+  if (inr < 1000) return '\u20B9' + Math.round(inr);
+  return '\u20B9' + Math.round(inr).toLocaleString('en-IN');
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Root:
 - `03-auth.js` — magic link, OTP, refreshSession (typed errors, 400-is-token-reuse recovery), cross-tab refresh lock, visibilitychange refresh, normalizeRole, single canonical `window._tokenRefreshTimer` (50-min proactive refresh, installed at top of activateRole, torn down in logout / _clearSessionAndLogin)
 - `04-router.js` — routing, deep-link handling (must be LAST script)
 - `05-api.js` — apiFetch (no-cache headers, 401 retry), uploadPostAsset, logActivity, normalise
-- `06-post-create.js` — new post form, asset input, WhatsApp KV preview seed
+- `06-post-create.js` — new post form, asset input, WhatsApp KV preview seed. Caption field (`.npc-caption-wrap` + `#new-post-caption`): inline textarea is manual-only; ⤢ `#npc-expand-btn` opens `openCaptionWorkspace(mode, {postId:null, initialCaption, onUse, onClose})` in detached mode, routing "Use this" back into the textarea via `onUse` instead of PATCHing `/posts`. Word meter `#npc-word-meter` colors 80–100 green / 101–125 amber / 126+ red; cost chip `#npc-cost-chip` reads `window._captionWS.sessionCost` formatted via `window._cwFormatINR` (×100 unchanged). `saveDraft`/`loadDraft` round-trip caption. On submit, fire-and-forget PATCH to `/ai_usage?post_id=is.null&created_by=X&created_at=gte.Y` stamps this session's detached ai_usage rows with the new `post_id`.
 - `07-post-load.js` — loadPosts(fromPoll), loadPostsForClient(skipRenderIfUnchanged, fromPoll), mergePosts, startRealtime (installs agency Realtime then wires a 10s polling fallback gated on `window._agencyRealtimeChannel`), startAgencyRealtime/stopAgencyRealtime (agency Supabase Realtime WebSocket — 4 postgres_changes listeners, replaces the 10s poll + the 20s notifBadgeTimer for agency users), _agencyRealtimeRefresh (400 ms debounced loadPosts(true), stashes into _postsPollStash when a modal is open), _onAgencyNotificationInsert, startClientRealtime/stopClientRealtime (client Supabase Realtime WebSocket — 4 postgres_changes listeners, no polling), _initSupabaseRealtimeClient (shared by agency + client), _clientRealtimeRefresh (400 ms debounced loadPostsForClient), _onClientNotificationInsert, _postsFingerprint, _clientPostsFingerprint, _drainPollStash, _renderBackgroundViews, bottom sheets, _cardClickDelegate
 - `08-post-actions.js` — quickStage, updatePost, clientApprove, _confirmPublish, _sendStageNotif, _startSaveTimeout/_clearSaveTimeout
 - `09-approval.js` — client approval flow, submitApproval
@@ -221,7 +221,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 26 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 25 scripts). Current: `?v=20260416o`. The Supabase JS SDK `<script>` tag sits ABOVE the versioned block and is pinned to an external jsDelivr URL — do NOT add a `?v=` to it.
+1. Bump ALL 26 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 25 scripts). Current: `?v=20260417p`. The Supabase JS SDK `<script>` tag sits ABOVE the versioned block and is pinned to an external jsDelivr URL — do NOT add a `?v=` to it.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -16,7 +16,12 @@ window._captionWS = {
   _rewriteComments: null,
   correctionsPrompt: '',
   memoryPrompt: '',
-  caption: ''
+  caption: '',
+  // Detached mode — used by Create Post ⤢ expand. No post exists yet,
+  // so Use-this routes through onUseCallback instead of PATCHing /posts.
+  isDetached: false,
+  onUseCallback: null,
+  onCloseCallback: null
 };
 
 var _CW_USD_TO_INR = 100;
@@ -50,6 +55,9 @@ window.openCaptionWorkspace = async function(mode, context) {
 
   var ws = window._captionWS;
   var isResume = mode === 'resume' && ws.messages.length > 0;
+  // Detached mode — Create Post ⤢ opens with postId: null and routes
+  // "Use this" back through onUse instead of PATCHing /posts.
+  var isDetached = context && context.postId === null;
 
   if (!isResume) {
     ws.messages = [];
@@ -57,7 +65,12 @@ window.openCaptionWorkspace = async function(mode, context) {
     ws.postId = context.postId || null;
     ws.mode = mode;
     ws._rewriteComments = null;
-    ws.caption = context.caption || '';
+    // In detached mode the caller passes initialCaption; fall back to
+    // the legacy .caption key for all post-scoped callers.
+    ws.caption = (isDetached ? (context.initialCaption || '') : (context.caption || ''));
+    ws.isDetached = !!isDetached;
+    ws.onUseCallback = (typeof context.onUse === 'function') ? context.onUse : null;
+    ws.onCloseCallback = (typeof context.onClose === 'function') ? context.onClose : null;
   }
   ws.isOpen = true;
 
@@ -68,7 +81,13 @@ window.openCaptionWorkspace = async function(mode, context) {
   overlay.style.transform = 'translateY(0)';
 
   var titleEl = document.getElementById('cw-context-title');
-  if (titleEl) titleEl.textContent = context.title || 'Untitled post';
+  if (titleEl) {
+    var hdrTitle = context.title;
+    if (isDetached && !hdrTitle && context.syntheticContext) {
+      hdrTitle = context.syntheticContext.title || '';
+    }
+    titleEl.textContent = hdrTitle || (isDetached ? 'New post \u2014 no title yet' : 'Untitled post');
+  }
 
   _cwUpdateSessionMeter();
   _cwFetchCostTotals();
@@ -146,7 +165,15 @@ window.closeCaptionWorkspace = function() {
     overlay.style.display = 'none';
     overlay.style.transition = '';
   }, 290);
-  window._captionWS.isOpen = false;
+  var ws = window._captionWS;
+  ws.isOpen = false;
+  var onClose = ws.onCloseCallback;
+  ws.onCloseCallback = null;
+  ws.onUseCallback = null;
+  ws.isDetached = false;
+  if (typeof onClose === 'function') {
+    try { onClose(); } catch (e) {}
+  }
 };
 
 // ─── send message ────────────────────────────────────────────
@@ -424,6 +451,20 @@ window._cwHandleChip = function(chipType, draftNum) {
 
 window._cwApplyDraft = async function(text) {
   var ws = window._captionWS;
+  // Detached mode — no post exists yet. Hand the caption back via the
+  // onUse callback and close. Skip the PATCH /posts path entirely.
+  if (ws.isDetached) {
+    var cb = ws.onUseCallback;
+    ws.caption = text;
+    if (typeof cb === 'function') {
+      try { cb(text); } catch (e) {
+        window.logError && window.logError(e && e.message, e && e.stack, 'cw-apply-draft-detached');
+      }
+    }
+    if (typeof showToast === 'function') showToast('Caption added', 'success');
+    window.closeCaptionWorkspace();
+    return;
+  }
   var post = (window.AppState.posts.all || []).find(function(p) {
     return (p.post_id || p.id) === ws.postId;
   });
@@ -714,3 +755,8 @@ async function _cwFetchCostTotals() {
     }
   });
 })();
+
+// Expose cost helpers so external callers (Create Post cost chip)
+// format consistently with the workspace meter.
+window._cwFormatINR = _cwFormatINR;
+window._cwCalcINR = _cwCalcINR;

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417o">
+ <link rel="stylesheet" href="styles.css?v=20260417p">
 
 </head>
 <body>
@@ -612,13 +612,32 @@
 
       </div>
 
-      <div class="nps-full">
-        <div style="font-family:'IBM Plex Mono',monospace;font-size:9px;color:#C8A84B;letter-spacing:0.1em;text-transform:uppercase;margin-bottom:1px;">05</div>
-        <span class="nps-label">Copy / Caption <span class="nps-label-hint">(goes to client)</span></span>
-        <textarea class="nps-textarea nps-caption-area" id="new-post-caption"
-          placeholder="Write the LinkedIn caption here..."
-          rows="6"
-          oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';"></textarea>
+      <div class="nps-full npc-caption-wrap">
+        <div class="npc-caption-header">
+          <div class="npc-label-group">
+            <div class="npc-field-label"><span class="npc-num">05</span> Copy <span class="npc-opt">goes to client</span></div>
+            <div class="npc-caption-title">Write the caption</div>
+          </div>
+          <div class="npc-header-right">
+            <div class="npc-word-meter" id="npc-word-meter"><span class="npc-wc-count">0</span> / 80&ndash;100</div>
+            <button type="button" class="npc-expand-btn" id="npc-expand-btn" aria-label="Open Caption Workspace">
+              <svg viewBox="0 0 24 24">
+                <path d="M3 9V4a1 1 0 011-1h5M21 9V4a1 1 0 00-1-1h-5M3 15v5a1 1 0 001 1h5M21 15v5a1 1 0 01-1 1h-5"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <textarea id="new-post-caption"
+          placeholder="Write the LinkedIn caption..."
+          rows="6"></textarea>
+
+        <div class="npc-tools-row">
+          <div class="npc-cost-chip" id="npc-cost-chip">
+            <span class="npc-dot"></span>
+            <span class="npc-amount">&#x20B9;0</span>
+          </div>
+        </div>
 
         <!-- AI caption options — shown after Gmail import, hidden by default -->
         <div id="nps-caption-opts" style="display:none;flex-direction:column;gap:1px;margin-top:6px">
@@ -1256,32 +1275,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417o"></script>
-<script src="00-appstate-compat.js?v=20260417o"></script>
-<script src="01-config.js?v=20260417o" defer></script>
-<script src="02-session.js?v=20260417o" defer></script>
-<script src="utils.js?v=20260417o" defer></script>
-<script src="12-profiles.js?v=20260417o" defer></script>
-<script src="03-auth.js?v=20260417o" defer></script>
-<script src="05-api.js?v=20260417o" defer></script>
-<script src="10-ui.js?v=20260417o" defer></script>
+<script src="00-appstate.js?v=20260417p"></script>
+<script src="00-appstate-compat.js?v=20260417p"></script>
+<script src="01-config.js?v=20260417p" defer></script>
+<script src="02-session.js?v=20260417p" defer></script>
+<script src="utils.js?v=20260417p" defer></script>
+<script src="12-profiles.js?v=20260417p" defer></script>
+<script src="03-auth.js?v=20260417p" defer></script>
+<script src="05-api.js?v=20260417p" defer></script>
+<script src="10-ui.js?v=20260417p" defer></script>
 
-<script src="06-post-create.js?v=20260417o" defer></script>
-<script defer src="render/dashboard.js?v=20260417o"></script>
-<script defer src="render/client.js?v=20260417o"></script>
-<script defer src="render/pipeline.js?v=20260417o"></script>
-<script defer src="render/brief.js?v=20260417o"></script>
-<script defer src="actions/pcs.js?v=20260417o"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417o"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417o"></script>
-<script defer src="actions/pcs-polish.js?v=20260417o"></script>
-<script defer src="actions/pcs-select.js?v=20260417o"></script>
-<script src="ai-config.js?v=20260417o" defer></script>
-<script src="07-post-load.js?v=20260417o" defer></script>
-<script src="08-post-actions.js?v=20260417o" defer></script>
-<script src="09-library.js?v=20260417o" defer></script>
-<script src="09-approval.js?v=20260417o" defer></script>
-<script src="04-router.js?v=20260417o" defer></script>
+<script src="06-post-create.js?v=20260417p" defer></script>
+<script defer src="render/dashboard.js?v=20260417p"></script>
+<script defer src="render/client.js?v=20260417p"></script>
+<script defer src="render/pipeline.js?v=20260417p"></script>
+<script defer src="render/brief.js?v=20260417p"></script>
+<script defer src="actions/pcs.js?v=20260417p"></script>
+<script defer src="actions/pcs-longpress.js?v=20260417p"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260417p"></script>
+<script defer src="actions/pcs-polish.js?v=20260417p"></script>
+<script defer src="actions/pcs-select.js?v=20260417p"></script>
+<script src="ai-config.js?v=20260417p" defer></script>
+<script src="07-post-load.js?v=20260417p" defer></script>
+<script src="08-post-actions.js?v=20260417p" defer></script>
+<script src="09-library.js?v=20260417p" defer></script>
+<script src="09-approval.js?v=20260417p" defer></script>
+<script src="04-router.js?v=20260417p" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -9726,3 +9726,160 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   .claude-polish-header { padding: 9px 12px 9px 14px; }
   .claude-polish-compare { padding: 8px 14px 10px; }
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Create Post — Caption Section (Claude-native warm-ink styling)
+   Namespace: .npc-* (new-post-caption). Keeps .cp-* (client portal)
+   untouched. Palette matches the Caption Workspace: #1A1816 bg,
+   #C15F3C accent. Zero border-radius on inputs. No rgba().
+   ═══════════════════════════════════════════════════════════════ */
+.npc-caption-wrap {
+  background: #1A1816;
+  border-top: 1px solid #2F271F;
+  border-bottom: 1px solid #2F271F;
+  padding: 20px 22px;
+  margin: 12px 0 0;
+}
+
+.npc-caption-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 14px;
+  gap: 12px;
+}
+
+.npc-label-group {
+  flex: 1;
+  min-width: 0;
+}
+
+.npc-field-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #5F584D;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.npc-field-label .npc-num { color: #C15F3C; }
+.npc-field-label .npc-opt {
+  color: #3A342C;
+  margin-left: 4px;
+  font-weight: normal;
+}
+
+.npc-caption-title {
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 19px;
+  font-weight: 500;
+  color: #F2EDE4;
+  letter-spacing: -0.015em;
+}
+
+.npc-header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.npc-word-meter {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: #5F584D;
+}
+.npc-word-meter .npc-wc-count { color: #C8C0B2; }
+.npc-word-meter.green .npc-wc-count { color: #7DBE8A; }
+.npc-word-meter.amber .npc-wc-count { color: #D4A15C; }
+.npc-word-meter.red   .npc-wc-count { color: #E67463; }
+
+.npc-expand-btn {
+  width: 30px;
+  height: 30px;
+  background: transparent;
+  border: 1px solid #2F271F;
+  color: #8E8578;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+.npc-expand-btn:hover {
+  border-color: #C15F3C40;
+  color: #C15F3C;
+}
+.npc-expand-btn svg {
+  width: 13px;
+  height: 13px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Caption textarea override — scoped to .npc-caption-wrap only. */
+.npc-caption-wrap textarea#new-post-caption {
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 15.5px;
+  line-height: 1.65;
+  color: #F2EDE4;
+  background: transparent;
+  border: none;
+  border-top: 1px solid #2F271F;
+  padding: 14px 0 0;
+  resize: none;
+  min-height: 160px;
+  width: 100%;
+}
+.npc-caption-wrap textarea#new-post-caption::placeholder {
+  color: #5F584D;
+  font-style: italic;
+}
+.npc-caption-wrap textarea#new-post-caption:focus {
+  outline: none;
+}
+
+.npc-tools-row {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.npc-cost-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid #2F271F;
+  background: transparent;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: #5F584D;
+  cursor: default;
+}
+.npc-cost-chip .npc-dot {
+  width: 5px;
+  height: 5px;
+  background: #3A342C;
+  border-radius: 50%;
+}
+.npc-cost-chip.active {
+  color: #C8C0B2;
+}
+.npc-cost-chip.active .npc-dot {
+  background: #C15F3C;
+}
+.npc-cost-chip.active .npc-amount {
+  color: #F2EDE4;
+  font-weight: 600;
+}

--- a/tests/post-create.test.js
+++ b/tests/post-create.test.js
@@ -112,3 +112,81 @@ describe('PCS — _buildDriveLinkCard', function() {
     expect(htmlSrc).toContain('id="pcs-drive-link-wrap"');
   });
 });
+
+describe('Create Post Caption — ⤢ expand + session cost + word counter', function() {
+
+  var captionSrc = readFileSync(resolve(__dirname, '..', 'actions', 'pcs-claude-caption.js'), 'utf8');
+  var cssSrc = readFileSync(resolve(__dirname, '..', 'styles.css'), 'utf8');
+
+  it('14. 06-post-create.js wires expand button + detached open helpers', function() {
+    expect(src).toContain('_npcOpenWorkspace');
+    expect(src).toContain('_npcUpdateWordMeter');
+    expect(src).toContain('_npcRefreshCostChip');
+    expect(src).toContain('npc-expand-btn');
+    expect(src).toContain('onUse:');
+  });
+
+  it('15. submitNewPost fires post_id=is.null ai_usage stamp PATCH', function() {
+    expect(src).toContain('post_id=is.null');
+    expect(src).toContain('/ai_usage?post_id=is.null');
+  });
+
+  it('16. saveDraft + loadDraft round-trip caption', function() {
+    // Anchor on function boundaries by name — both functions sit between
+    // the 'function saveDraft' / 'function loadDraft' lines and the next
+    // 'function ' declaration. This avoids nested-brace regex pitfalls.
+    var saveStart = src.indexOf('function saveDraft()');
+    var saveEnd = src.indexOf('function loadDraft()');
+    var loadStart = saveEnd;
+    var loadEnd = src.indexOf('function clearDraft()');
+    expect(saveStart).toBeGreaterThan(-1);
+    expect(saveEnd).toBeGreaterThan(saveStart);
+    expect(loadEnd).toBeGreaterThan(loadStart);
+    var saveBody = src.slice(saveStart, saveEnd);
+    var loadBody = src.slice(loadStart, loadEnd);
+    expect(saveBody).toContain("'new-post-caption'");
+    expect(saveBody).toContain('caption:');
+    expect(loadBody).toContain("'new-post-caption'");
+    expect(loadBody).toContain('d.caption');
+  });
+
+  it('17. no .cp-* caption class regression (client-portal namespace)', function() {
+    expect(src).not.toContain('cp-caption');
+  });
+
+  it('18. no ₹85 multiplier regression — USD→INR stays at ×100', function() {
+    expect(src).not.toContain('* 85');
+    expect(src).not.toContain('× 85');
+    expect(captionSrc).toContain('_CW_USD_TO_INR = 100');
+    expect(captionSrc).not.toContain('_CW_USD_TO_INR = 85');
+  });
+
+  it('19. no unauthorized font regressions (Source Serif / JetBrains Mono)', function() {
+    expect(src).not.toContain('Source Serif');
+    expect(src).not.toContain('JetBrains Mono');
+    expect(cssSrc).not.toContain('Source Serif');
+    expect(cssSrc).not.toContain('JetBrains Mono');
+  });
+
+  it('20. Caption Workspace supports detached mode (isDetached + callbacks)', function() {
+    expect(captionSrc).toContain('isDetached');
+    expect(captionSrc).toContain('onUseCallback');
+    expect(captionSrc).toContain('onCloseCallback');
+  });
+
+  it('21. index.html has ⤢ expand button + word meter + cost chip', function() {
+    expect(htmlSrc).toContain('id="npc-expand-btn"');
+    expect(htmlSrc).toContain('id="npc-word-meter"');
+    expect(htmlSrc).toContain('id="npc-cost-chip"');
+    expect(htmlSrc).toContain('npc-caption-wrap');
+  });
+
+  it('22. .npc-* CSS block exists + no rgba() + Fraunces 500 on caption body', function() {
+    var npcStart = cssSrc.indexOf('.npc-caption-wrap');
+    expect(npcStart).toBeGreaterThan(-1);
+    var npcBlock = cssSrc.slice(npcStart);
+    expect(npcBlock).not.toMatch(/rgba\(/);
+    expect(npcBlock).toContain("'Fraunces'");
+    expect(npcBlock).toContain("font-weight: 500");
+  });
+});


### PR DESCRIPTION
## Summary
- New `.npc-*` warm-ink styling for the Create Post caption section (palette + fonts match the existing Caption Workspace: `#1A1816` bg, `#C15F3C` accent, Fraunces + IBM Plex Mono — no new fonts, no new palette).
- ⤢ expand button opens `openCaptionWorkspace(mode, {postId:null, initialCaption, onUse, onClose})` in **detached mode** — `_cwApplyDraft` skips the PATCH `/posts` path and routes "Use this" back into the Create Post textarea via the `onUse` callback.
- Mode picker: `'write'` when textarea empty, `'chat'` when it has content.
- Word meter (80–100 green / 101–125 amber / 126+ red) updates on every keystroke.
- Session cost chip reads `window._captionWS.sessionCost` and formats via `window._cwFormatINR` (USD→INR ×100, unchanged).
- On submit: fire-and-forget `PATCH /ai_usage?post_id=is.null&created_by=X&created_at=gte.Y` stamps this session's detached ai_usage rows with the newly created `post_id`. Non-blocking.
- `saveDraft`/`loadDraft` extended to round-trip the caption, so an AI-drafted caption survives a mid-session refresh.

## Files changed
- `styles.css` — new `.npc-*` block appended (no `rgba()`, zero border-radius on form controls)
- `index.html` — caption field wrapper replaced with `.npc-caption-wrap` markup (header + textarea + cost-chip row). `#nps-caption-opts` Gmail-refine strip preserved as sibling. All 26 `?v=` strings bumped to `?v=20260417p`.
- `06-post-create.js` — session state, `_npcWireCaption` / `_npcUpdateWordMeter` / `_npcOpenWorkspace` / `_npcRefreshCostChip`, ai_usage stamp after `POST /posts` success, caption in saveDraft/loadDraft
- `actions/pcs-claude-caption.js` — accepts `postId: null` + `initialCaption` + `onUse` + `onClose`; detached branch at top of `_cwApplyDraft`; `onCloseCallback` fired in `closeCaptionWorkspace`; exposes `_cwFormatINR` + `_cwCalcINR` on window
- `tests/post-create.test.js` — 9 new source-pattern tests (now 553 passing across 22 files)
- `CLAUDE.md` — single-line append under `06-post-create.js` bullet + version-bump line in §7

## Not touched
- srtd-ai Worker (Worker already accepts `post_id: null`)
- Supabase edge functions, schema, RLS
- Reply composers (client, internal-note, notification-drawer)
- PCS caption card (visually unchanged)
- Gmail import strip `#nps-gmail-wrap`
- Create Post fields 01, 02, 03, 04, 06, 07, 08

## Test plan
- [x] `npx vitest run` — 553/553 passing
- [ ] iPhone Safari: open Create Post → type 80–100 words → meter turns green
- [ ] iPhone Safari: empty caption + tap ⤢ → workspace opens in `write` mode → generate 3 options → tap "✓ Use this" → caption appears in textarea, workspace closes
- [ ] iPhone Safari: partial caption + tap ⤢ → workspace opens in `chat` mode → refine → Use this → updated caption in textarea
- [ ] iPhone Safari: workspace session cost flows back into `#npc-cost-chip` after close
- [ ] iPhone Safari: mid-draft refresh → caption restored by `loadDraft`
- [ ] Supabase: confirm `ai_usage` rows with `post_id=null` get stamped to the new `post_id` after submit (check `ai_usage` table by `created_by` + `created_at` window)

https://claude.ai/code/session_01YQkrDEDXzPkHH4GpLsuEPm