### PR TITLE
[CUTOVER] Supabase Seoul -> Mumbai: frontend config swap

### DIFF
--- a/00-appstate.js
+++ b/00-appstate.js
@@ -82,8 +82,8 @@ window.logError = function(message, stack, action) {
     action:        String(action || 'uncaught'),
     app_version:   _version
   };
-  var _url = 'https://vxokfscjzytpgdrmertk.supabase.co/rest/v1/error_log';
-  var _key = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ4b2tmc2Nqenl0cGdkcm1lcnRrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMzE2NzAsImV4cCI6MjA4ODkwNzY3MH0.j1LKb2FOarLIi5DDChiWF_DTihKdLCEQMKdy9M5JQkw';
+  var _url = 'https://ozptjplxbyswclolbxyn.supabase.co/rest/v1/error_log';
+  var _key = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im96cHRqcGx4Ynlzd2Nsb2xieHluIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY0NzU0ODAsImV4cCI6MjA5MjA1MTQ4MH0.BCiqZAP64ZiJggcXT-vNAeagTlnUiybfgI5BEEoLDWA';
   fetch(_url, {
     method: 'POST',
     headers: {

--- a/01-config.js
+++ b/01-config.js
@@ -8,8 +8,8 @@ console.log("LOADED:", "01-config.js");
 if (window.AppState.ui.modalOpen === undefined)      window.AppState.ui.modalOpen = false;
 if (window._deferredRender === undefined) window._deferredRender = false;
 
-const SUPABASE_URL          = 'https://vxokfscjzytpgdrmertk.supabase.co';
-const SUPABASE_KEY          = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ4b2tmc2Nqenl0cGdkcm1lcnRrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMzE2NzAsImV4cCI6MjA4ODkwNzY3MH0.j1LKb2FOarLIi5DDChiWF_DTihKdLCEQMKdy9M5JQkw';
+const SUPABASE_URL          = 'https://ozptjplxbyswclolbxyn.supabase.co';
+const SUPABASE_KEY          = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im96cHRqcGx4Ynlzd2Nsb2xieHluIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY0NzU0ODAsImV4cCI6MjA5MjA1MTQ4MH0.BCiqZAP64ZiJggcXT-vNAeagTlnUiybfgI5BEEoLDWA';
 const APP_URL               = 'https://guneygaar.github.io';
 const READY_TO_SEND_TARGET  = 30;
 const CLIENT_REQUEST_FORM_URL = '';

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260417p">
+ <link rel="stylesheet" href="styles.css?v=20260418a">
 
 </head>
 <body>
@@ -1275,32 +1275,32 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260417p"></script>
-<script src="00-appstate-compat.js?v=20260417p"></script>
-<script src="01-config.js?v=20260417p" defer></script>
-<script src="02-session.js?v=20260417p" defer></script>
-<script src="utils.js?v=20260417p" defer></script>
-<script src="12-profiles.js?v=20260417p" defer></script>
-<script src="03-auth.js?v=20260417p" defer></script>
-<script src="05-api.js?v=20260417p" defer></script>
-<script src="10-ui.js?v=20260417p" defer></script>
+<script src="00-appstate.js?v=20260418a"></script>
+<script src="00-appstate-compat.js?v=20260418a"></script>
+<script src="01-config.js?v=20260418a" defer></script>
+<script src="02-session.js?v=20260418a" defer></script>
+<script src="utils.js?v=20260418a" defer></script>
+<script src="12-profiles.js?v=20260418a" defer></script>
+<script src="03-auth.js?v=20260418a" defer></script>
+<script src="05-api.js?v=20260418a" defer></script>
+<script src="10-ui.js?v=20260418a" defer></script>
 
-<script src="06-post-create.js?v=20260417p" defer></script>
-<script defer src="render/dashboard.js?v=20260417p"></script>
-<script defer src="render/client.js?v=20260417p"></script>
-<script defer src="render/pipeline.js?v=20260417p"></script>
-<script defer src="render/brief.js?v=20260417p"></script>
-<script defer src="actions/pcs.js?v=20260417p"></script>
-<script defer src="actions/pcs-longpress.js?v=20260417p"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260417p"></script>
-<script defer src="actions/pcs-polish.js?v=20260417p"></script>
-<script defer src="actions/pcs-select.js?v=20260417p"></script>
-<script src="ai-config.js?v=20260417p" defer></script>
-<script src="07-post-load.js?v=20260417p" defer></script>
-<script src="08-post-actions.js?v=20260417p" defer></script>
-<script src="09-library.js?v=20260417p" defer></script>
-<script src="09-approval.js?v=20260417p" defer></script>
-<script src="04-router.js?v=20260417p" defer></script>
+<script src="06-post-create.js?v=20260418a" defer></script>
+<script defer src="render/dashboard.js?v=20260418a"></script>
+<script defer src="render/client.js?v=20260418a"></script>
+<script defer src="render/pipeline.js?v=20260418a"></script>
+<script defer src="render/brief.js?v=20260418a"></script>
+<script defer src="actions/pcs.js?v=20260418a"></script>
+<script defer src="actions/pcs-longpress.js?v=20260418a"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260418a"></script>
+<script defer src="actions/pcs-polish.js?v=20260418a"></script>
+<script defer src="actions/pcs-select.js?v=20260418a"></script>
+<script src="ai-config.js?v=20260418a" defer></script>
+<script src="07-post-load.js?v=20260418a" defer></script>
+<script src="08-post-actions.js?v=20260418a" defer></script>
+<script src="09-library.js?v=20260418a" defer></script>
+<script src="09-approval.js?v=20260418a" defer></script>
+<script src="04-router.js?v=20260418a" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/preview/index.html
+++ b/preview/index.html
@@ -426,8 +426,8 @@ body {
 
 <script>
 (function() {
-  var SUPABASE_URL = 'https://vxokfscjzytpgdrmertk.supabase.co';
-  var SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ4b2tmc2Nqenl0cGdkcm1lcnRrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMzE2NzAsImV4cCI6MjA4ODkwNzY3MH0.j1LKb2FOarLIi5DDChiWF_DTihKdLCEQMKdy9M5JQkw';
+  var SUPABASE_URL = 'https://ozptjplxbyswclolbxyn.supabase.co';
+  var SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im96cHRqcGx4Ynlzd2Nsb2xieHluIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY0NzU0ODAsImV4cCI6MjA5MjA1MTQ4MH0.BCiqZAP64ZiJggcXT-vNAeagTlnUiybfgI5BEEoLDWA';
   var LOGO_URL = 'https://pub-6a2a4aa8073d454ab9aeee69ef841635.r2.dev/post-assets/Godavari.jpg';
 
   var app = document.getElementById('app');

--- a/sorted-preview-worker/src/index.js
+++ b/sorted-preview-worker/src/index.js
@@ -1,5 +1,5 @@
-const SUPABASE_URL = 'https://vxokfscjzytpgdrmertk.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ4b2tmc2Nqenl0cGdkcm1lcnRrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMzE2NzAsImV4cCI6MjA4ODkwNzY3MH0.j1LKb2FOarLIi5DDChiWF_DTihKdLCEQMKdy9M5JQkw';
+const SUPABASE_URL = 'https://ozptjplxbyswclolbxyn.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im96cHRqcGx4Ynlzd2Nsb2xieHluIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY0NzU0ODAsImV4cCI6MjA5MjA1MTQ4MH0.BCiqZAP64ZiJggcXT-vNAeagTlnUiybfgI5BEEoLDWA';
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',

--- a/srtd-ai-worker/src/index.js
+++ b/srtd-ai-worker/src/index.js
@@ -12,7 +12,7 @@
 //   *                  → 404
 // ═══════════════════════════════════════════════════════════════
 
-const SUPABASE_URL = 'https://vxokfscjzytpgdrmertk.supabase.co';
+const SUPABASE_URL = 'https://ozptjplxbyswclolbxyn.supabase.co';
 // Service-role key — required for workspace_settings reads + ai_usage
 // writes with the current (loose) table permissions. Consistent with
 // the hardcoded-Supabase-creds pattern used by sorted-preview-worker.

--- a/tests/e2e/live-smoke.spec.js
+++ b/tests/e2e/live-smoke.spec.js
@@ -3,7 +3,7 @@ const { test, expect } = require('@playwright/test');
 // ── Environment ─────────────────────────────────────────────
 const ADMIN_EMAIL   = process.env.SORTED_ADMIN_EMAIL;
 const CLIENT_EMAIL  = process.env.SORTED_CLIENT_EMAIL;
-const SUPABASE_URL  = 'https://vxokfscjzytpgdrmertk.supabase.co';
+const SUPABASE_URL  = 'https://ozptjplxbyswclolbxyn.supabase.co';
 const SUPABASE_KEY  = process.env.SORTED_SUPABASE_KEY;
 
 // ── Guard: skip entire suite if env vars missing ────────────


### PR DESCRIPTION
## Summary

Final frontend step of the Seoul (ap-northeast-2) → Mumbai (ap-south-1) Supabase migration. DB, edge functions, workers, and triggers are already cut over. This PR flips every client-side reference.

## Changes

**Seoul → Mumbai URL** (`https://vxokfscjzytpgdrmertk.supabase.co` → `https://ozptjplxbyswclolbxyn.supabase.co`) — 6 refs across 6 files:
- `00-appstate.js` — 1 ref (error_log endpoint)
- `01-config.js` — 1 ref (SUPABASE_URL constant)
- `preview/index.html` — 1 ref (preview page SUPABASE_URL)
- `sorted-preview-worker/src/index.js` — 1 ref (WhatsApp OG worker)
- `srtd-ai-worker/src/index.js` — 1 ref (AI worker)
- `tests/e2e/live-smoke.spec.js` — 1 ref (smoke test)

**Seoul → Mumbai anon key** — 4 refs across 4 files:
- `00-appstate.js`, `01-config.js`, `preview/index.html`, `sorted-preview-worker/src/index.js`

**Version bump** — `index.html`: all 26 `?v=YYYYMMDDx` strings bumped `?v=20260417p` → `?v=20260418a` in one atomic sweep.

## Audit

- Seoul refs remaining: **0**
- Mumbai refs present: **6**
- Seoul anon key refs remaining: **0**
- Mumbai anon key refs present: **4**
- Total `?v=` in index.html: **26**
- `?v=20260418a` count: **26**

## Post-merge action

**PURGE CLOUDFLARE CACHE IMMEDIATELY AFTER MERGE:**
dash.cloudflare.com → srtd.io → Caching → Purge Everything

Then hard-refresh every device. Until the purge completes, cached `index.html` will still reference the old `?v=20260417p` script URLs and users may see a broken mix of Seoul+Mumbai assets.

## Test plan

- [ ] Cloudflare purge completed
- [ ] Load srtd.io in a logged-out browser, open DevTools → Network, confirm every request goes to `ozptjplxbyswclolbxyn.supabase.co` (zero `vxokfscjzytpgdrmertk`)
- [ ] Magic-link login works (agency + client)
- [ ] Posts load on dashboard / pipeline / client feed
- [ ] Realtime WebSocket connects (no 10s polling fallback firing)
- [ ] Create a new post, assign owner, move stage, add comment — no 401s
- [ ] `srtd.io/p/XXXX` short URL still renders WhatsApp OG preview (sorted-preview-worker hitting Mumbai)
- [ ] Error log writes from `window.logError` land in Mumbai `error_log` table

https://claude.ai/code/session_01QT4xy3Hhz3cTLqRE2BjaTS