### PR TITLE
PR A1: add /pcs-next/ folder skeleton

### DIFF
--- a/pcs-next/.gitignore
+++ b/pcs-next/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/*.map
+.DS_Store

--- a/pcs-next/README.md
+++ b/pcs-next/README.md
@@ -1,0 +1,34 @@
+# pcs-next
+
+Sorted's React runtime. Strangler-fig migration target.
+
+All legacy vanilla JS at the repo root stays untouched until the
+corresponding flow is fully ported here and its vanilla counterpart
+is deleted.
+
+## Status
+
+PR A1 — folder skeleton only. No build tool, no React, no JS.
+
+## Planned structure (future PRs will populate)
+
+    /pcs-next/
+    ├── package.json       (PR A2)
+    ├── vite.config.js     (PR A3)
+    ├── src/
+    │   ├── core/          (PR A6-A8)
+    │   ├── flows/         (PR B1+)
+    │   └── index.js       (PR A3)
+    ├── dist/              (built output, committed from PR A3)
+    └── README.md
+
+## Build
+
+    Not yet. See PR A2 and PR A3.
+
+## Why not at repo root
+
+Root already owns `package.json` for Vitest/Playwright dev deps.
+Nesting a separate `package.json` here keeps the React build
+fully isolated from root dev tooling and from the live vanilla
+app.


### PR DESCRIPTION
## Summary

First micro-PR of the ~24-step React strangler-fig migration. Creates a new top-level `/pcs-next/` directory containing **only two static text files**:

- `pcs-next/.gitignore` — 3 lines (`node_modules/`, `dist/*.map`, `.DS_Store`)
- `pcs-next/README.md` — status + planned structure for future PRs

## Zero live-app impact

- No build tool, no React, no JS, no JSX, no HTML changes, no CSS changes.
- No version bumps (`?v=20260418a` unchanged across all 26 strings).
- No feature flag added.
- `index.html` is byte-identical to `main-/-root`.
- `CLAUDE.md` is byte-identical to `main-/-root` (reconciliation deferred to PR A4 per the plan).
- Nothing in the live app loads these files, so production behaviour is byte-identical.

## Verification

- `ls -laF pcs-next/` → `.gitignore` (35 B) + `README.md` (948 B) only.
- `cat pcs-next/.gitignore` → matches spec exactly.
- `cat pcs-next/README.md` → matches spec exactly.
- `git diff --cached --stat` → 2 files changed, 37 insertions(+), 0 deletions.
- `git status` → only `pcs-next/` staged; no other paths modified.
- `npm test` → **553/553 passing** across 22 test files (no new tests in this PR; no existing test touches `pcs-next/`).

## Test plan

- [x] Unit tests pass at 100% (`npm test` — 553/553)
- [x] No file outside `/pcs-next/` modified (confirmed via `git diff --cached --name-only`)
- [x] Branch pushed to `origin/claude/react-a1-folder-skeleton`
- [ ] Merge to `main-/-root` — no Cloudflare purge needed (no runtime asset added)

https://claude.ai/code/session_01XGKEk65Doy8SEpfZ1u6HVH