### PR TITLE
PR A3: prove Vite IIFE build with probe entry

### DIFF
--- a/pcs-next/dist/sorted-react.js
+++ b/pcs-next/dist/sorted-react.js
@@ -1,0 +1,14 @@
+var SortedReact = function(exports) {
+  "use strict";
+  function probe() {
+    console.log("[sorted-react] probe ok");
+    return { version: "0.1.0", built: true };
+  }
+  if (typeof window !== "undefined") {
+    console.log("[sorted-react] bundle loaded, v0.1.0");
+  }
+  exports.probe = probe;
+  Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+  return exports;
+}({});
+//# sourceMappingURL=sorted-react.js.map

--- a/pcs-next/src/_probe.js
+++ b/pcs-next/src/_probe.js
@@ -1,0 +1,7 @@
+// PR A3 probe. Confirms Vite IIFE builds and executes.
+// Will be replaced in PR A5 when real React mounting arrives.
+
+export function probe() {
+  console.log('[sorted-react] probe ok');
+  return { version: '0.1.0', built: true };
+}

--- a/pcs-next/src/index.js
+++ b/pcs-next/src/index.js
@@ -1,0 +1,10 @@
+// Sorted React bundle entry. Exported names become
+// properties of window.SortedReact in the IIFE build.
+
+import { probe } from './_probe.js';
+
+if (typeof window !== 'undefined') {
+  console.log('[sorted-react] bundle loaded, v0.1.0');
+}
+
+export { probe };

--- a/pcs-next/vite.config.js
+++ b/pcs-next/vite.config.js
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vite';
+
+// Vite config for Sorted React runtime.
+//
+// PR A3: single-entry IIFE bundle, unminified, for probe
+//        verification. No React imports yet.
+//
+// Future PRs (A5+) will expand this to multi-entry and split
+// React/Zustand into a shared vendor bundle.
+//
+// Output format MUST stay IIFE. The Sorted app loads this via
+// <script src="...">, not <script type="module">, because the
+// rest of the frontend is non-module.
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/index.js',
+      formats: ['iife'],
+      name: 'SortedReact',
+      fileName: () => 'sorted-react.js'
+    },
+    outDir: 'dist',
+    emptyOutDir: true,
+    minify: false,
+    sourcemap: true,
+    target: 'es2020'
+  }
+});


### PR DESCRIPTION
## Summary

Third of ~24 micro-PRs for the React strangler-fig migration. Wires Vite into `/pcs-next/` and commits the first built bundle. **No React code yet.** Purely a build-pipeline smoke test.

> **Stacks on #908 (A1) and #909 (A2).** Until both merge, this PR's diff shows A1 + A2 + A3 together. Merge order: #908 → #909 → #910.

## Source files added

| File | Lines | Purpose |
|---|---|---|
| `pcs-next/vite.config.js` | 29 | IIFE build config (name=`SortedReact`, unminified, sourcemap on, es2020) |
| `pcs-next/src/index.js` | 10 | Bundle entry — re-exports `probe` |
| `pcs-next/src/_probe.js` | 7 | `probe()` returns `{ version, built }` — placeholder, replaced in A5 |

## Built artefact

| File | Size | Committed |
|---|---|---|
| `pcs-next/dist/sorted-react.js` | **435 B** | ✅ yes (GitHub Pages will serve it) |
| `pcs-next/dist/sorted-react.js.map` | 797 B | ❌ gitignored by `dist/*.map` from PR A1 |

## Build output

```
vite v5.4.21 building for production...
✓ 2 modules transformed.
dist/sorted-react.js  0.44 kB │ gzip: 0.28 kB │ map: 0.80 kB
✓ built in 60ms
```

## Bundle validation

- `node --check pcs-next/dist/sorted-react.js` → exit 0 (syntactically valid JS)
- First line: `var SortedReact = function(exports) {` ← IIFE pattern ✓
- `grep -c 'createElement' …` → **0** (no React runtime leaked)
- `grep -c 'React' …` → **1**, and it's line 1's `SortedReact` global name itself. Confirms tree-shaking worked.
- 435 bytes is 65 bytes below the spec's 500 B verification floor but well above the `<300 B` stop-condition. The intent (minimal probe, no React leaked, valid IIFE) is met; flagging the exact size for transparency.

Full bundle contents (13 lines):
```js
var SortedReact = function(exports) {
  "use strict";
  function probe() {
    console.log("[sorted-react] probe ok");
    return { version: "0.1.0", built: true };
  }
  if (typeof window !== "undefined") {
    console.log("[sorted-react] bundle loaded, v0.1.0");
  }
  exports.probe = probe;
  Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
  return exports;
}({});
```

## Zero live-app impact

- `index.html` unchanged — nothing loads `sorted-react.js` yet (A4 does that).
- `CLAUDE.md` unchanged — reconciliation still deferred to A4.
- Root `/package.json` and root `/package-lock.json` byte-identical to `main-/-root` (SHA256 verified pre/post).
- `pcs-next/{.gitignore, README.md, package.json, package-lock.json}` from A1/A2 — byte-identical SHA256 to their A1/A2 commits.
- **`npm test` at repo root → 553/553 passing** (22 test files).

## Verification summary

- ✅ 3 source files created in `/pcs-next/src/` and `/pcs-next/` root
- ✅ 1 built file committed (`dist/sorted-react.js`)
- ✅ `dist/*.map` ignored (`git check-ignore -v pcs-next/dist/sorted-react.js.map` → matched by `pcs-next/.gitignore:2:dist/*.map`)
- ✅ `dist/sorted-react.js` NOT ignored (tracked normally)
- ✅ 4 files staged, 60 insertions total
- ✅ No file outside `/pcs-next/` modified
- ✅ Root test suite 553/553

## Test plan

- [x] Vite build succeeds with exit 0
- [x] `node --check` passes on the bundle
- [x] Bundle is IIFE format with `SortedReact` global
- [x] No React/createElement in the bundle (tree-shaking)
- [x] `.map` sourcemap gitignored
- [x] Root Vitest 553/553
- [ ] Merge after #908 and #909 land

https://claude.ai/code/session_01XGKEk65Doy8SEpfZ1u6HVH