### PR TITLE
PR B2: wire FAB to respect window.ENABLE_REACT_NEW_POST flag

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -2799,6 +2799,17 @@ document.addEventListener('DOMContentLoaded', function() {
   var createPost = document.getElementById('fab-create-post');
   if (createPost) createPost.addEventListener('click', function() {
     closeFabMenu();
+    // React strangler-fig: route to React Create Post when flag
+    // is true and the React flow is fully mounted. Falls through
+    // to vanilla openNewPostModal() in every other case.
+    if (window.ENABLE_REACT_NEW_POST === true
+        && window.SortedReact
+        && window.SortedReact.flows
+        && window.SortedReact.flows.createPost
+        && typeof window.SortedReact.flows.createPost.open === 'function') {
+      window.SortedReact.flows.createPost.open();
+      return;
+    }
     if (typeof openNewPostModal === 'function') openNewPostModal();
   });
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,7 @@ Email: Resend, FROM `hinglish@srtd.io`.
 
 ## 7 — DEPLOY RULES
 
-1. Bump ALL 27 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 26 scripts). Current: `?v=20260418f`. The Supabase JS SDK `<script>` tag sits ABOVE the versioned block and is pinned to an external jsDelivr URL — do NOT add a `?v=` to it.
+1. Bump ALL 27 `?v=YYYYMMDDx` strings in `index.html` together (1 stylesheet + 26 scripts). Current: `?v=20260418g`. The Supabase JS SDK `<script>` tag sits ABOVE the versioned block and is pinned to an external jsDelivr URL — do NOT add a `?v=` to it.
 2. After every merge: Cloudflare dash → srtd.io → Caching → Purge Everything. Hard refresh every device.
 3. Deploy path: merge PR → GitHub Pages publishes from `main-/-root` branch.
 4. One PR at a time. TDD mandatory. Never raw `fetch()` — always `apiFetch()`.

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260418f">
+ <link rel="stylesheet" href="styles.css?v=20260418g">
 
 </head>
 <body>
@@ -1283,33 +1283,33 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260418f"></script>
-<script src="00-appstate-compat.js?v=20260418f"></script>
-<script src="01-config.js?v=20260418f" defer></script>
-<script src="02-session.js?v=20260418f" defer></script>
-<script src="utils.js?v=20260418f" defer></script>
-<script src="12-profiles.js?v=20260418f" defer></script>
-<script src="03-auth.js?v=20260418f" defer></script>
-<script src="05-api.js?v=20260418f" defer></script>
-<script src="10-ui.js?v=20260418f" defer></script>
+<script src="00-appstate.js?v=20260418g"></script>
+<script src="00-appstate-compat.js?v=20260418g"></script>
+<script src="01-config.js?v=20260418g" defer></script>
+<script src="02-session.js?v=20260418g" defer></script>
+<script src="utils.js?v=20260418g" defer></script>
+<script src="12-profiles.js?v=20260418g" defer></script>
+<script src="03-auth.js?v=20260418g" defer></script>
+<script src="05-api.js?v=20260418g" defer></script>
+<script src="10-ui.js?v=20260418g" defer></script>
 
-<script src="06-post-create.js?v=20260418f" defer></script>
-<script defer src="render/dashboard.js?v=20260418f"></script>
-<script defer src="render/client.js?v=20260418f"></script>
-<script defer src="render/pipeline.js?v=20260418f"></script>
-<script defer src="render/brief.js?v=20260418f"></script>
-<script defer src="actions/pcs.js?v=20260418f"></script>
-<script defer src="actions/pcs-longpress.js?v=20260418f"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260418f"></script>
-<script defer src="actions/pcs-polish.js?v=20260418f"></script>
-<script defer src="actions/pcs-select.js?v=20260418f"></script>
-<script src="ai-config.js?v=20260418f" defer></script>
-<script src="/pcs-next/dist/sorted-react.js?v=20260418f" defer></script>
-<script src="07-post-load.js?v=20260418f" defer></script>
-<script src="08-post-actions.js?v=20260418f" defer></script>
-<script src="09-library.js?v=20260418f" defer></script>
-<script src="09-approval.js?v=20260418f" defer></script>
-<script src="04-router.js?v=20260418f" defer></script>
+<script src="06-post-create.js?v=20260418g" defer></script>
+<script defer src="render/dashboard.js?v=20260418g"></script>
+<script defer src="render/client.js?v=20260418g"></script>
+<script defer src="render/pipeline.js?v=20260418g"></script>
+<script defer src="render/brief.js?v=20260418g"></script>
+<script defer src="actions/pcs.js?v=20260418g"></script>
+<script defer src="actions/pcs-longpress.js?v=20260418g"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260418g"></script>
+<script defer src="actions/pcs-polish.js?v=20260418g"></script>
+<script defer src="actions/pcs-select.js?v=20260418g"></script>
+<script src="ai-config.js?v=20260418g" defer></script>
+<script src="/pcs-next/dist/sorted-react.js?v=20260418g" defer></script>
+<script src="07-post-load.js?v=20260418g" defer></script>
+<script src="08-post-actions.js?v=20260418g" defer></script>
+<script src="09-library.js?v=20260418g" defer></script>
+<script src="09-approval.js?v=20260418g" defer></script>
+<script src="04-router.js?v=20260418g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/brief.js
+++ b/render/brief.js
@@ -1233,8 +1233,16 @@ window._createPostFromBrief = function(briefPostId) {
   if (overlay) overlay.remove();
   document.body.style.overflow = '';
 
-  // Open new post form
-  if (typeof openNewPostModal === 'function') {
+  // Open new post form. React strangler-fig: route to React Create
+  // Post when the flag is true and the flow is mounted; fall back
+  // to vanilla openNewPostModal() otherwise.
+  if (window.ENABLE_REACT_NEW_POST === true
+      && window.SortedReact
+      && window.SortedReact.flows
+      && window.SortedReact.flows.createPost
+      && typeof window.SortedReact.flows.createPost.open === 'function') {
+    window.SortedReact.flows.createPost.open();
+  } else if (typeof openNewPostModal === 'function') {
     openNewPostModal();
   }
 


### PR DESCRIPTION
## Summary

First PR that modifies **live production JS**. Replaces the FAB → Create Post click handler (`10-ui.js:2800-2803`) and the brief-import post-opener (`render/brief.js:1237-1239`) with flag-gated branches that route to React when available, falling back to vanilla `openNewPostModal()` in every other case.

Feature flag still defaults **false**. Users see nothing change.

> **Stacks on #908 → … → #915 → this.** Merge order: all A-series + B1 first, then #916.

## Guard pattern (identical in both files)

```js
if (window.ENABLE_REACT_NEW_POST === true
    && window.SortedReact
    && window.SortedReact.flows
    && window.SortedReact.flows.createPost
    && typeof window.SortedReact.flows.createPost.open === 'function') {
  window.SortedReact.flows.createPost.open();
  return;  // 10-ui.js only — early-return within click handler
}
if (typeof openNewPostModal === 'function') openNewPostModal();
```

Five AND-chained guards ensure the React path only fires when the flag is flipped AND the bundle loaded AND core mounted AND the flow namespace wired AND `open()` is a function. Any partial state falls through to vanilla. **FAB can never become dead.**

## Files changed (exactly 4)

- `10-ui.js` — FAB click listener at line 2802 wrapped with flag guard
- `render/brief.js` — brief-to-post opener at line 1237 wrapped with same guard
- `index.html` — all 27 `?v=20260418f` → `?v=20260418g`
- `CLAUDE.md` — 1-char bump in §7

## Pre-flight audit (all passed)

- `10-ui.js:2802` contained the exact pattern from CLAUDE.md §4 audit
- `render/brief.js:1237` contained the exact pattern from audit
- Only **one** `window.ENABLE_REACT_NEW_POST` reference existed before this PR (the index.html declaration from A4)
- `grep -c '?v=20260418f' index.html` → 27

## Syntax validation post-edit

```
node --check 10-ui.js         → exit 0
node --check render/brief.js  → exit 0
```

## Verification

| Check | Result |
|---|---|
| `grep -c 'ENABLE_REACT_NEW_POST' 10-ui.js` | 1 (line 2805) |
| `grep -c 'ENABLE_REACT_NEW_POST' render/brief.js` | 1 (line 1239) |
| `grep -c 'SortedReact.flows.createPost.open' 10-ui.js` | 2 (typeof + call) |
| `grep -c 'SortedReact.flows.createPost.open' render/brief.js` | 2 (typeof + call) |
| `grep -c '?v=20260418g' index.html` | 27 |
| `grep -c '?v=20260418f' index.html` | 0 |
| `wc -l CLAUDE.md` | 242 (unchanged) |
| `npm test` | **553/553 passing** |
| `sha256 pcs-next/dist/sorted-react.js` | `ae099b1e…0c5bc18` (unchanged vs B1) |
| `git status` lines | exactly 4 |

Spec said each file's `grep -c 'SortedReact.flows.createPost.open'` should be **1**, but the spec's own guard pattern contains the string **twice** (typeof check + actual call). So 2 per file is what the spec's body specifies — count matches intent.

## Zero live-app behaviour change

- `ENABLE_REACT_NEW_POST` defaults `false` → early-return branch never taken → vanilla `openNewPostModal()` runs exactly as before.
- `/pcs-next/` byte-identical to B1.
- `pcs-next/dist/sorted-react.js` SHA unchanged (`ae099b1e…`).
- `pcs-next/vite.config.js`, `package.json`, `package-lock.json` unchanged.
- Root `/package.json` + `/package-lock.json` SHA unchanged.
- `CLAUDE.md` unchanged line count at 242.
- Unit tests still pass 553/553.

## Post-merge test script for Shubham

1. Cloudflare Purge Everything; hard-refresh srtd.io
2. DevTools console:
   ```js
   window.SortedReact.mounted              // true
   window.ENABLE_REACT_NEW_POST = true     // flip manually
   ```
3. Tap FAB → Create Post → **React** modal opens
4. Close it (Cancel or ✕) → vanilla app remains unaffected
5. `window.ENABLE_REACT_NEW_POST = false`
6. Tap FAB → Create Post → **vanilla** modal opens (old flow)

Works in Admin role. Works in any role with access to the FAB.

## Test plan

- [x] Root Vitest 553/553
- [x] `node --check` passes on both modified live JS files
- [x] Only 4 files in git status
- [x] `/pcs-next/` untouched (SHA verified)
- [x] All version strings at `?v=20260418g`, zero stragglers
- [ ] Post-merge: Cloudflare Purge Everything
- [ ] Post-merge: Shubham runs the test script above on iPhone

https://claude.ai/code/session_01XGKEk65Doy8SEpfZ1u6HVH