### PR TITLE
srtd-ai worker: await ai_usage log + enable web search

### DIFF
--- a/srtd-ai-worker/src/index.js
+++ b/srtd-ai-worker/src/index.js
@@ -213,7 +213,19 @@ function buildSystemPrompt(feature, approvedContext, brandGuide, memoryContext) 
 
 // ─── Anthropic call ──────────────────────────────────────────
 
-async function callAnthropic(env, systemPrompt, messages) {
+async function callAnthropic(env, systemPrompt, messages, feature) {
+  const useWebSearch = feature !== 'email_brief';
+
+  const requestBody = {
+    model: ANTHROPIC_MODEL,
+    max_tokens: ANTHROPIC_MAX_TOKENS,
+    system: systemPrompt,
+    messages: messages
+  };
+  if (useWebSearch) {
+    requestBody.tools = [{ type: 'web_search_20250305', name: 'web_search' }];
+  }
+
   const res = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: {
@@ -221,12 +233,7 @@ async function callAnthropic(env, systemPrompt, messages) {
       'anthropic-version': '2023-06-01',
       'content-type': 'application/json'
     },
-    body: JSON.stringify({
-      model: ANTHROPIC_MODEL,
-      max_tokens: ANTHROPIC_MAX_TOKENS,
-      system: systemPrompt,
-      messages: messages
-    })
+    body: JSON.stringify(requestBody)
   });
   if (!res.ok) {
     const txt = await res.text().catch(function() { return ''; });
@@ -234,14 +241,6 @@ async function callAnthropic(env, systemPrompt, messages) {
     throw new Error('anthropic ' + res.status + ': ' + txt.slice(0, 500));
   }
   return res.json();
-}
-
-// ─── fire-and-forget usage logger ────────────────────────────
-
-function logUsage(payload) {
-  supabasePost('/ai_usage', payload).catch(function(err) {
-    console.error('[srtd-ai] ai_usage log failed:', err && err.message);
-  });
 }
 
 // ─── route handlers ──────────────────────────────────────────
@@ -311,26 +310,36 @@ async function handleComplete(request, env) {
       ? systemPrompt + '\n\n' + systemExtras
       : systemPrompt;
 
-    const anthropicRes = await callAnthropic(env, combinedSystem, userAsstMessages);
+    const anthropicRes = await callAnthropic(env, combinedSystem, userAsstMessages, feature);
 
     const contentBlocks = anthropicRes && anthropicRes.content;
-    const responseText  = (Array.isArray(contentBlocks) && contentBlocks[0] && contentBlocks[0].text)
-      ? contentBlocks[0].text
+    const responseText  = Array.isArray(contentBlocks)
+      ? contentBlocks
+          .filter(b => b.type === 'text')
+          .map(b => b.text || '')
+          .join('\n\n')
+          .trim()
       : '';
     const usage         = (anthropicRes && anthropicRes.usage) || {};
     const inputTokens   = Number(usage.input_tokens)  || 0;
     const outputTokens  = Number(usage.output_tokens) || 0;
 
-    // Fire-and-forget: never block the response on the log write.
-    logUsage({
-      workspace_id:  workspaceId,
-      post_id:       postId,
-      feature:       feature,
-      tokens_input:  inputTokens,
-      tokens_output: outputTokens,
-      cost_usd:      calcCostUsd(inputTokens, outputTokens),
-      created_by:    createdBy
-    });
+    // Awaited usage log — every completion must leave a billing
+    // footprint. Failure is logged to Worker logs but never
+    // bubbles up to the caller.
+    try {
+      await supabasePost('/ai_usage', {
+        workspace_id:  workspaceId,
+        post_id:       postId,
+        feature:       feature,
+        tokens_input:  inputTokens,
+        tokens_output: outputTokens,
+        cost_usd:      calcCostUsd(inputTokens, outputTokens),
+        created_by:    createdBy
+      });
+    } catch (logErr) {
+      console.error('[srtd-ai] ai_usage log failed:', logErr && logErr.message);
+    }
 
     return jsonResponse({
       success: true,
@@ -623,7 +632,7 @@ async function handleGmailBrief(request, env) {
                threadContext
     }];
 
-    const anthropicRes = await callAnthropic(env, systemPrompt, messages);
+    const anthropicRes = await callAnthropic(env, systemPrompt, messages, 'email_brief');
     const rawText = (anthropicRes.content && anthropicRes.content[0] && anthropicRes.content[0].text) || '';
 
     let parsed;
@@ -634,19 +643,24 @@ async function handleGmailBrief(request, env) {
       return errorResponse('Claude did not return valid JSON: ' + rawText.slice(0, 200), 500);
     }
 
-    // Fire-and-forget usage telemetry — never blocks the response.
+    // Awaited usage log — every completion must leave a billing
+    // footprint. Failure is logged but not surfaced to the caller.
     const usage = anthropicRes.usage || {};
     const inputTokens  = Number(usage.input_tokens)  || 0;
     const outputTokens = Number(usage.output_tokens) || 0;
-    logUsage({
-      workspace_id:  workspaceId,
-      post_id:       null,
-      feature:       'email_brief',
-      tokens_input:  inputTokens,
-      tokens_output: outputTokens,
-      cost_usd:      calcCostUsd(inputTokens, outputTokens),
-      created_by:    createdBy
-    });
+    try {
+      await supabasePost('/ai_usage', {
+        workspace_id:  workspaceId,
+        post_id:       null,
+        feature:       'email_brief',
+        tokens_input:  inputTokens,
+        tokens_output: outputTokens,
+        cost_usd:      calcCostUsd(inputTokens, outputTokens),
+        created_by:    createdBy
+      });
+    } catch (logErr) {
+      console.error('[srtd-ai] ai_usage log failed:', logErr && logErr.message);
+    }
 
     return jsonResponse({
       success:          true,


### PR DESCRIPTION
## Summary

Worker-only. Two fixes to `srtd-ai-worker/src/index.js`.

**FIX 1 — Reliable `ai_usage` logging**
- `logUsage()` helper deleted.
- `handleComplete()` and `handleGmailBrief()` now each call `await supabasePost('/ai_usage', ...)` inside a try/catch **before** their success `return`. A Supabase failure logs to the Worker console but never surfaces to the caller.
- Ensures every completion leaves a billing footprint — even if the Workers runtime reclaims the isolate before a fire-and-forget promise resolves.

**FIX 2 — Web search on non-email features**
- `callAnthropic(env, systemPrompt, messages, feature)` — new `feature` arg.
- `useWebSearch = feature !== 'email_brief'`; when true, the request body includes `tools: [{ type: 'web_search_20250305', name: 'web_search' }]`.
- `handleComplete()` threads its `feature` through. `handleGmailBrief()` passes `'email_brief'` explicitly so email parsing stays web-search-free.
- `handleComplete()` response extraction switched to multi-block: `contentBlocks.filter(b => b.type === 'text').map(b => b.text || '').join('\n\n').trim()`. With `web_search` enabled, Claude may emit `tool_use` + `tool_result` blocks alongside `text`; the old `contentBlocks[0].text` read would sometimes land on a non-text block and drop the caption entirely.
- `handleGmailBrief()` keeps its existing `contentBlocks[0].text` extraction — email_brief doesn't use web_search, so Claude still returns a single text block there.

**Not touched**
- `handleLog()` route, CORS, feature gating, workspace_settings, pricing, any prompt builder.

**Deploy**
- No React `?v=` bump needed — this is Worker-only. Deploy via Cloudflare dashboard (`wrangler deploy` or the manual "Redeploy" button) after merge.

## Test plan
- [ ] Deploy Worker; confirm `/ai/complete` with `feature: 'writer'` still returns content (not empty string because of the new multi-block extractor).
- [ ] Immediately after a call, check `select count(*) from ai_usage where created_at > now() - interval '1 minute'` — expect 1 row per completion.
- [ ] Verify web search actually fires for a prompt that needs it (e.g. "Write a caption about the biggest news in Indian biorefineries this week") — look for a `server_tool_use` block in the Anthropic dashboard trace.
- [ ] `feature: 'email_brief'` still returns structured JSON without web search (Gmail import flow unaffected).

https://claude.ai/code/session_01XGKEk65Doy8SEpfZ1u6HVH