### PR TITLE
PCS visual upgrade: single-scroll, caption collapse, filter chips

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -671,13 +671,14 @@ window._pcsTabSwitch = function(tab) {
       if (tab === 'internal') t.classList.add('amber');
     }
   });
-  // Toggle panes
+  // Tab bar is hidden in single-scroll mode; keep chip state updates
+  // but never hide panes (all three are rendered in scroll order).
   var pCaption = document.getElementById('pcs-pane-caption');
   var pClient = document.getElementById('pcs-pane-client');
   var pInternal = document.getElementById('pcs-pane-internal');
-  if (pCaption) pCaption.style.display = tab === 'caption' ? '' : 'none';
-  if (pClient) pClient.style.display = tab === 'client' ? '' : 'none';
-  if (pInternal) pInternal.style.display = tab === 'internal' ? '' : 'none';
+  if (pCaption) pCaption.style.display = '';
+  if (pClient) pClient.style.display = '';
+  if (pInternal) pInternal.style.display = '';
   if (tab === 'client' && typeof _updateSelectStripVisibility === 'function') _updateSelectStripVisibility();
   if (tab !== 'client' && typeof exitCommentSelectMode === 'function' && window._commentSelectMode && window._commentSelectMode.active) exitCommentSelectMode();
 }
@@ -1044,26 +1045,23 @@ window._pcsDateChange = function(postId, dateValue) {
 // -- Caption section builder --
 function _buildCaptionHtml(post, canEdit, canEditCreative, id) {
   if (!post.caption && !canEdit && !canEditCreative) return '';
+  var captionTrim = (post.caption || '').trim();
+  var wc = captionTrim ? captionTrim.split(/\s+/).filter(Boolean).length : 0;
+  var needsClamp = captionTrim.length > 100;
+  var headerRow = '<div class="pcs-caption-header-row">' +
+    '<span class="pcs-caption-label">Caption</span>' +
+    (post.caption ? '<span class="pcs-caption-wc">' + wc + ' word' + (wc === 1 ? '' : 's') + '</span>' : '') +
+  '</div>';
   return '<div id="pcs-caption-section" style="padding:12px 14px 8px;border-bottom:1px solid #323244;">' +
+    headerRow +
     (post.caption ?
-      '<div id="pcs-caption-text" data-raw="' + esc(post.caption) + '" style="font-family:\'DM Sans\',sans-serif;' +
-      'font-size:13px;color:#B8B8C0;line-height:1.6;white-space:pre-wrap;word-wrap:break-word;' +
-      'overflow-wrap:break-word;word-break:break-word;max-width:100%;' +
-      'max-height:200px;overflow:hidden;' +
-      '-webkit-mask-image:linear-gradient(to bottom,black 160px,transparent 198px);' +
-      'mask-image:linear-gradient(to bottom,black 160px,transparent 198px);">' +
+      '<div id="pcs-caption-text" class="pcs-caption-text' + (needsClamp ? '' : ' expanded') + '" data-raw="' + esc(post.caption) + '">' +
       esc(post.caption) + '</div>' +
-      '<button id="pcs-caption-see-more" onclick="(function(){' +
-      'var t=document.getElementById(\'pcs-caption-text\');' +
-      'var b=document.getElementById(\'pcs-caption-see-more\');' +
-      'if(!t||!b)return;' +
-      'if(t.style.maxHeight===\'200px\'){t.style.maxHeight=\'none\';t.style.webkitMaskImage=\'none\';t.style.maskImage=\'none\';t.style.overflow=\'visible\';b.textContent=\'See Less\';}' +
-      'else{t.style.maxHeight=\'200px\';t.style.overflow=\'hidden\';t.style.webkitMaskImage=\'linear-gradient(to bottom,black 160px,transparent 198px)\';t.style.maskImage=\'linear-gradient(to bottom,black 160px,transparent 198px)\';b.textContent=\'See More\';}' +
-      '})()" style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;letter-spacing:0.1em;' +
-      'text-transform:uppercase;color:#F6A623;background:transparent;border:none;cursor:pointer;' +
-      'padding:6px 0 0 0;">See More</button>'
+      (needsClamp ?
+        '<button id="pcs-caption-see-more" class="pcs-caption-see-more" onclick="(function(b){var t=document.getElementById(\'pcs-caption-text\');if(t){t.classList.add(\'expanded\');}b.style.display=\'none\';})(this)">See More</button>'
+        : '')
       :
-      '<div id="pcs-caption-text" style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#4A4A5A;letter-spacing:0.06em;">No copy yet</div>'
+      '<div id="pcs-caption-text" class="pcs-caption-text expanded" style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;color:#4A4A5A;letter-spacing:0.06em;">No copy yet</div>'
     ) + '</div>';
 }
 
@@ -1298,11 +1296,62 @@ window._saveLiUrlInline = function(postId) {
 }
 
 // -- PCS Comments --------------------------------------------------
+// Track latest counts so the combined "N client · M internal" label stays
+// in sync across the two async branches in loadPcsComments.
+window._pcsSectionCounts = window._pcsSectionCounts || { client: 0, internal: 0 };
+function _pcsUpdateSectionCount(client, internal) {
+  if (client !== null && client !== undefined) window._pcsSectionCounts.client = client;
+  if (internal !== null && internal !== undefined) window._pcsSectionCounts.internal = internal;
+  var el = document.getElementById('pcs-section-count');
+  if (el) {
+    el.textContent = window._pcsSectionCounts.client + ' client \u00B7 ' + window._pcsSectionCounts.internal + ' internal';
+  }
+}
+
+// Inject section header + filter chip bar above comments list, idempotent.
+function _pcsEnsureCommentsHeader(list) {
+  if (!list || !list.parentNode) return;
+  var parent = list.parentNode;
+  if (!parent.querySelector('.pcs-comments-section-header')) {
+    var header = document.createElement('div');
+    header.className = 'pcs-comments-section-header';
+    header.innerHTML =
+      '<span class="pcs-section-title">Comments</span>' +
+      '<span class="pcs-section-count" id="pcs-section-count">0 client &middot; 0 internal</span>';
+    parent.insertBefore(header, list);
+  }
+  if (!parent.querySelector('.pcs-filter-bar')) {
+    var filterBar = document.createElement('div');
+    filterBar.className = 'pcs-filter-bar';
+    filterBar.innerHTML =
+      '<span class="pcs-fchip pcs-fchip--on" data-filter="all">All</span>' +
+      '<span class="pcs-fchip" data-filter="client">Client</span>' +
+      '<span class="pcs-fchip" data-filter="internal">Internal</span>';
+    filterBar.querySelectorAll('.pcs-fchip').forEach(function(chip) {
+      chip.addEventListener('click', function() {
+        filterBar.querySelectorAll('.pcs-fchip').forEach(function(c) { c.classList.remove('pcs-fchip--on'); });
+        chip.classList.add('pcs-fchip--on');
+        var f = chip.dataset.filter;
+        document.querySelectorAll('.pcs-comment-item').forEach(function(el) {
+          el.style.display = (f === 'all' || f === 'client') ? '' : 'none';
+        });
+        document.querySelectorAll('.pcs-note-item').forEach(function(el) {
+          el.style.display = (f === 'all' || f === 'internal') ? '' : 'none';
+        });
+      });
+    });
+    parent.insertBefore(filterBar, list);
+  }
+}
+
 window.loadPcsComments = async function(postId) {
   var section = document.getElementById('pcs-comments-section');
   var list = document.getElementById('pcs-comments-list');
   var notesList = document.getElementById('pcs-notes-list');
   if (!section || !list) return;
+
+  // Inject single-scroll section header + filter chip bar once per pane.
+  _pcsEnsureCommentsHeader(list);
 
   if (window._pcsCommentsLoading) return;
   window._pcsCommentsLoading = true;
@@ -1639,6 +1688,7 @@ window.loadPcsComments = async function(postId) {
             : '') +
           '<div class="pcs-comment-meta">' +
             '<span class="pcs-comment-author">' + esc(_authorDisplay) + '</span>' +
+            '<span class="pcs-note-internal-badge">Internal</span>' +
             '<span class="pcs-comment-time">' + _formatTs(c) + '</span>' +
             _visTag +
           '</div>' +
@@ -1743,6 +1793,9 @@ window.loadPcsComments = async function(postId) {
       tabClientCount.textContent = clientRows.length > 0 ? clientRows.length : '';
     }
 
+    // Combined section-header count (single-scroll mode)
+    _pcsUpdateSectionCount(activeClientRows.length, null);
+
     if (notesList && _roleLower !== 'client') {
       var _activeVis = window._pcsNoteVisibility || 'all';
       var filteredNotes = _activeVis === 'all'
@@ -1784,6 +1837,9 @@ window.loadPcsComments = async function(postId) {
       if (tabNotesCount) {
         tabNotesCount.textContent = internalRows.length > 0 ? internalRows.length : '';
       }
+
+      // Combined section-header count (single-scroll mode)
+      _pcsUpdateSectionCount(null, activeRows.length);
 
       // Vis chips: keep static HTML, do not rebuild with counts
     }

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260419a">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419a">
+ <link rel="stylesheet" href="styles.css?v=20260419b">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419b">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260419a"></script>
-<script src="00-appstate-compat.js?v=20260419a"></script>
-<script src="01-config.js?v=20260419a" defer></script>
-<script src="02-session.js?v=20260419a" defer></script>
-<script src="utils.js?v=20260419a" defer></script>
-<script src="12-profiles.js?v=20260419a" defer></script>
-<script src="03-auth.js?v=20260419a" defer></script>
-<script src="05-api.js?v=20260419a" defer></script>
-<script src="10-ui.js?v=20260419a" defer></script>
+<script src="00-appstate.js?v=20260419b"></script>
+<script src="00-appstate-compat.js?v=20260419b"></script>
+<script src="01-config.js?v=20260419b" defer></script>
+<script src="02-session.js?v=20260419b" defer></script>
+<script src="utils.js?v=20260419b" defer></script>
+<script src="12-profiles.js?v=20260419b" defer></script>
+<script src="03-auth.js?v=20260419b" defer></script>
+<script src="05-api.js?v=20260419b" defer></script>
+<script src="10-ui.js?v=20260419b" defer></script>
 
-<script src="06-post-create.js?v=20260419a" defer></script>
-<script defer src="render/dashboard.js?v=20260419a"></script>
-<script defer src="render/client.js?v=20260419a"></script>
-<script defer src="render/pipeline.js?v=20260419a"></script>
-<script defer src="render/brief.js?v=20260419a"></script>
-<script defer src="actions/pcs.js?v=20260419a"></script>
-<script defer src="actions/pcs-longpress.js?v=20260419a"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260419a"></script>
-<script defer src="actions/pcs-polish.js?v=20260419a"></script>
-<script defer src="actions/pcs-select.js?v=20260419a"></script>
-<script src="ai-config.js?v=20260419a" defer></script>
+<script src="06-post-create.js?v=20260419b" defer></script>
+<script defer src="render/dashboard.js?v=20260419b"></script>
+<script defer src="render/client.js?v=20260419b"></script>
+<script defer src="render/pipeline.js?v=20260419b"></script>
+<script defer src="render/brief.js?v=20260419b"></script>
+<script defer src="actions/pcs.js?v=20260419b"></script>
+<script defer src="actions/pcs-longpress.js?v=20260419b"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260419b"></script>
+<script defer src="actions/pcs-polish.js?v=20260419b"></script>
+<script defer src="actions/pcs-select.js?v=20260419b"></script>
+<script src="ai-config.js?v=20260419b" defer></script>
 <script>
   (function() {
     try {
@@ -1321,12 +1321,12 @@ window.setPcsVisibility = function(el, vis) {
     }
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260419a" defer></script>
-<script src="07-post-load.js?v=20260419a" defer></script>
-<script src="08-post-actions.js?v=20260419a" defer></script>
-<script src="09-library.js?v=20260419a" defer></script>
-<script src="09-approval.js?v=20260419a" defer></script>
-<script src="04-router.js?v=20260419a" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260419b" defer></script>
+<script src="07-post-load.js?v=20260419b" defer></script>
+<script src="08-post-actions.js?v=20260419b" defer></script>
+<script src="09-library.js?v=20260419b" defer></script>
+<script src="09-approval.js?v=20260419b" defer></script>
+<script src="04-router.js?v=20260419b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -9883,3 +9883,135 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   color: #F2EDE4;
   font-weight: 600;
 }
+
+/* =========================================================================
+   PCS Visual Upgrade (20260419a): single-scroll mode, caption collapse,
+   comments filter chips, section header, internal note badge.
+   ========================================================================= */
+
+/* CHANGE 1: hide the 3-tab bar; keep all three panes always visible in scroll order */
+.pcs-tab-bar { display: none !important; }
+#pcs-pane-caption,
+#pcs-pane-client,
+#pcs-pane-internal { display: block !important; overflow: visible !important; }
+
+/* CHANGE 2: caption collapse / expand (2-line clamp) */
+.pcs-caption-text {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  max-height: calc(1.6em * 2);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  color: #B8B8C0;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
+}
+.pcs-caption-text.expanded {
+  display: block;
+  overflow: visible;
+  -webkit-line-clamp: unset;
+  max-height: none;
+}
+.pcs-caption-see-more {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: #C15F3C;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 6px;
+  display: inline-block;
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+/* CHANGE 3: caption header row — label left, word count right */
+.pcs-caption-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+.pcs-caption-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.pcs-caption-wc {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--green);
+  font-weight: 500;
+}
+
+/* CHANGE 4: filter chips above comments (All / Client / Internal) */
+.pcs-filter-bar {
+  display: flex;
+  gap: 6px;
+  padding: 10px 18px 6px;
+}
+.pcs-fchip {
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  background: transparent;
+  font-family: var(--sans);
+  transition: var(--transition);
+}
+.pcs-fchip--on {
+  background: var(--surface2);
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+/* CHANGE 5: internal notes inline styling — amber left border + subtle wash + badge */
+.pcs-note-item {
+  border-left: 2px solid #F6A62340;
+  background: #F6A62308;
+}
+.pcs-note-internal-badge {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--amber);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--amber-bg);
+  border: 1px solid #F6A62340;
+  margin-left: 6px;
+}
+
+/* CHANGE 6: comments section header */
+.pcs-comments-section-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 18px 4px;
+}
+.pcs-section-title {
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+}
+.pcs-section-count {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: #C15F3C;
+}


### PR DESCRIPTION
## Summary

Styling-only visual upgrade for the Post Creation Sheet (PCS). No data fetching, no Supabase queries, no comment/note submission paths were touched. Scope: `actions/pcs.js` + `styles.css` (+ `index.html` for the version bump).

### Changes
1. **Single-scroll layout** — hide `.pcs-tab-bar`, force `#pcs-pane-caption / #pcs-pane-client / #pcs-pane-internal` to `display:block !important`. `_pcsTabSwitch` no longer toggles pane display (chip state updates kept, harmless).
2. **Caption collapse / expand** — `.pcs-caption-text` uses `-webkit-line-clamp:2` with a `.expanded` override. Rebuilt `_buildCaptionHtml` so the inline mask-gradient pattern is gone; See More button emits only when caption > 100 chars, toggles the class inline, and hides itself.
3. **Caption header row** — `.pcs-caption-header-row` with `.pcs-caption-label` (mono eyebrow, left) + `.pcs-caption-wc` (green word count, right).
4. **Comment filter chips** — new idempotent `_pcsEnsureCommentsHeader()` injects `.pcs-filter-bar` (All / Client / Internal) above `#pcs-comments-list`. Chips globally toggle display on `.pcs-comment-item` and `.pcs-note-item`.
5. **Internal note badge + amber wash** — `_renderSingleNote` emits `.pcs-note-internal-badge` after the author span. `.pcs-note-item` gains amber left border + subtle amber background.
6. **Comments section header** — same helper injects `.pcs-comments-section-header` with title + combined "N client · M internal" count. `_pcsUpdateSectionCount()` keeps both sides in sync across the two async branches.
7. **Version bump** — all 28 `?v=` strings bumped `20260419a -> 20260419b`. Target per spec was `20260419a`, but `main` already consumed that letter via the earlier cost-meter PR #941; `b` is needed for the cache-bust to actually land. 8-digit hex used throughout (no `rgba()`).

### Pre-flight
- `pcs-claude-caption.js` was grepped for `pcs-tab|pcs-pane-|pcs-caption-text|pcs-caption-see-more|pcs-comments-*|pcs-note-item|pcs-filter|pcs-fchip|pcs-section-*|pcs-caption-label|pcs-caption-wc|pcs-caption-header` — zero hits. No token updates needed there.
- No person names hardcoded. No `/sorted/` paths. No new deps. No Worker/SQL changes.
- CLAUDE.md not updated this PR per the explicit scope "styles.css + actions/pcs.js only".

## Test plan
- [ ] Open PCS on iPhone: tab bar gone, caption → WA → AI zone → comments → notes scroll as one stream.
- [ ] Long caption clamps to 2 lines with "See More" pill; tap expands inline, pill disappears.
- [ ] Caption header shows `CAPTION` eyebrow + green `N words`.
- [ ] Filter chips above comments: All / Client / Internal toggle visibility of `.pcs-comment-item` and `.pcs-note-item`.
- [ ] Internal notes show amber left border + "Internal" pill next to author name.
- [ ] Section header reads `Comments  N client · M internal`, updates live when a new reply or note lands.
- [ ] `pcs-claude-caption.js` overlay still opens / QC / Rewrite still wired.
- [ ] Hard refresh picks up the `20260419b` cache-bust.

https://claude.ai/code/session_01Ujrg4Fgm3mnHFGHLcD5xnv