### PR TITLE
Auto-deploy srtd-ai Worker via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,30 @@
+name: Deploy srtd-ai Worker
+
+on:
+  push:
+    branches: [main, main-/-root]
+    paths:
+      - 'srtd-ai-worker/**'
+  workflow_dispatch:
+
+jobs:
+  deploy-srtd-ai:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install worker deps
+        working-directory: srtd-ai-worker
+        run: npm install
+
+      - name: Deploy worker
+        working-directory: srtd-ai-worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler deploy

--- a/srtd-ai-worker/package.json
+++ b/srtd-ai-worker/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "srtd-ai-worker",
+  "private": true,
+  "description": "Cloudflare Worker fronting Anthropic + R2 + Supabase for every AI feature in Sorted. Deploy tooling only — source lives in src/index.js.",
+  "scripts": {
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^3.90.0"
+  }
+}


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/deploy-worker.yml` auto-deploys the srtd-ai Cloudflare Worker on every push to `main` / `main-/-root`, filtered to paths `srtd-ai-worker/**` so no other change triggers a deploy. Also supports `workflow_dispatch` so Shubham can re-deploy manually from the Actions tab.
- Steps: checkout → setup-node@v4 (node 18) → `npm install` in `srtd-ai-worker` → `npx wrangler deploy` in `srtd-ai-worker` with `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` injected from repo secrets.
- Added a minimal `srtd-ai-worker/package.json` (private, single `wrangler` devDependency). The worker directory previously had only `src/index.js` + `wrangler.toml` — without a `package.json` the `npm install` step would error. No runtime code change.

## ⚠️ Required manual setup before this workflow can deploy

Add **two repository secrets** at Settings → Secrets and variables → Actions → New repository secret:

1. **`CLOUDFLARE_API_TOKEN`**
   - dash.cloudflare.com → My Profile → API Tokens → Create Token
   - Use the **"Edit Cloudflare Workers"** template (pre-scoped to Workers Scripts + R2 + Account read)
   - Account Resources: `Include → <your account>`
   - Zone Resources: `All zones` (or leave default)
   - Copy the token ONCE (it's shown only immediately after creation)

2. **`CLOUDFLARE_ACCOUNT_ID`**
   - dash.cloudflare.com → open any page → right sidebar → **Account ID** (a 32-char hex string)
   - Copy and paste as-is

Until both secrets exist, the workflow will fail with `Authentication error` or `No account id found` on the wrangler step.

## What triggers a deploy

- Merging any PR that changes files under `srtd-ai-worker/**` into `main` or `main-/-root`
- Manual run from Actions → "Deploy srtd-ai Worker" → Run workflow

## What does NOT trigger a deploy

- Changes anywhere else in the repo (index.html, srtd-next, render/*, actions/*, sql/*, etc.) — they don't touch the Worker, so they shouldn't redeploy it
- Pushes to feature branches or PR commits before merge

## Files touched

- `.github/workflows/deploy-worker.yml` (new, 33 lines)
- `srtd-ai-worker/package.json` (new, 10 lines — strictly deploy tooling, no code)

## Files deliberately untouched

- `index.html` — no version bump needed, no client code changes
- `srtd-ai-worker/src/index.js` — zero Worker code changes
- `srtd-ai-worker/wrangler.toml` — existing config is correct
- `CLAUDE.md` — no new architectural invariant (deploy mechanics, not runtime behaviour)
- Existing workflows `smoke.yml` and `test.yml` — unchanged

## Test plan

- [ ] Add `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` secrets
- [ ] Merge this PR → confirm workflow does NOT run (no `srtd-ai-worker/**` change in this PR's merge commit)
  - Actually, the merge commit itself adds `srtd-ai-worker/package.json` which IS under the path filter, so the first run will fire on merge. That's fine — it will re-deploy the currently-deployed code with no behaviour change.
- [ ] Next time any `srtd-ai-worker/**` file changes on `main-/-root`, confirm the job runs and turns green in the Actions tab
- [ ] Dispatch manually via Actions → "Deploy srtd-ai Worker" → Run workflow to sanity-check

https://claude.ai/code/session_015QWEC99fG2AZiGwPKzYzP6