### PR TITLE
PCS polish: Anthropic stage pill, Done pill, caption edit classes, Fraunces body

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -2310,25 +2310,14 @@ window._pcsDoReplace = function(postId) {
   if (editBtn) editBtn.style.display = 'none';
   var ta = document.createElement('textarea');
   ta.id = 'pcs-caption-textarea';
+  ta.className = 'pcs-caption-textarea';
   ta.value = '';
   ta.placeholder = 'Paste new caption here...';
-  ta.style.cssText = 'width:100%;min-height:80px;background:#111116;' +
-    'border:1px solid #3a3a4a;color:#FFFFFF;' +
-    'font-family:\'DM Sans\',sans-serif;font-size:13px;' +
-    'padding:12px;resize:vertical;';
   var btnRow = document.createElement('div');
   btnRow.id = 'pcs-caption-btnrow';
-  btnRow.style.cssText = 'display:flex;gap:8px;margin-top:8px;';
   btnRow.innerHTML =
-    '<button onclick="_saveCaptionEdit(\'' + postId + '\')" ' +
-      'style="font-family:\'IBM Plex Mono\',monospace;font-size:10px;' +
-      'color:#3ECF8E;border:1px solid #3ECF8E;' +
-      'background:transparent;padding:6px 12px;cursor:pointer;">SAVE</button>' +
-    '<button onclick="_cancelCaptionEdit()" ' +
-      'style="font-family:\'IBM Plex Mono\',monospace;font-size:10px;' +
-      'color:#8E8E93;border:1px solid #4a4a5a;' +
-      'background:transparent;padding:6px 12px;cursor:pointer;' +
-      'margin-left:6px;">CANCEL</button>';
+    '<button class="pcs-caption-save-btn" onclick="_saveCaptionEdit(\'' + postId + '\')">Save</button>' +
+    '<button class="pcs-caption-cancel-btn" onclick="_cancelCaptionEdit()">Cancel</button>';
   textEl.parentNode.insertBefore(ta, textEl.nextSibling);
   textEl.parentNode.insertBefore(btnRow, ta.nextSibling);
   ta.focus();
@@ -2518,24 +2507,8 @@ window._startCaptionEdit = function(postId) {
 
   var ta = document.createElement('textarea');
   ta.id = 'pcs-caption-textarea';
+  ta.className = 'pcs-caption-textarea';
   ta.value = currentText;
-  ta.style.cssText = [
-    'width:100%',
-    'background:transparent',
-    'border:none',
-    'border-bottom:1px solid #C8A84B4D',
-    'color:#e8e2d9',
-    'font-family:\'DM Sans\',sans-serif',
-    'font-size:14px',
-    'line-height:1.7',
-    'padding:8px 0 10px',
-    'outline:none',
-    'resize:none',
-    'overflow:hidden',
-    'min-height:120px',
-    'height:auto',
-    'caret-color:#C8A84B'
-  ].join(';');
   ta.oninput = function() { this.style.height='auto'; this.style.height=this.scrollHeight+'px'; };
   textEl.parentNode.insertBefore(ta, textEl.nextSibling);
   ta.style.height = 'auto';
@@ -2543,16 +2516,9 @@ window._startCaptionEdit = function(postId) {
 
   var btnRow = document.createElement('div');
   btnRow.id = 'pcs-caption-btnrow';
-  btnRow.style.cssText = 'display:flex;gap:8px;margin-top:8px;';
   btnRow.innerHTML =
-    '<button onclick="_saveCaptionEdit(\'' + postId + '\')" ' +
-    'style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
-    'color:#3ECF8E;border:1px dotted #3ECF8E66;' +
-    'background:transparent;padding:14px 20px;min-height:44px;cursor:pointer;">SAVE</button>' +
-    '<button onclick="_cancelCaptionEdit()" ' +
-    'style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;' +
-    'color:#8E8E93;border:1px dotted #FFFFFF26;' +
-    'background:transparent;padding:14px 20px;min-height:44px;cursor:pointer;">CANCEL</button>';
+    '<button class="pcs-caption-save-btn" onclick="_saveCaptionEdit(\'' + postId + '\')">Save</button>' +
+    '<button class="pcs-caption-cancel-btn" onclick="_cancelCaptionEdit()">Cancel</button>';
   ta.parentNode.insertBefore(btnRow, ta.nextSibling);
   ta.focus();
 }

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260419c">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419c">
+ <link rel="stylesheet" href="styles.css?v=20260419d">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419d">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260419c"></script>
-<script src="00-appstate-compat.js?v=20260419c"></script>
-<script src="01-config.js?v=20260419c" defer></script>
-<script src="02-session.js?v=20260419c" defer></script>
-<script src="utils.js?v=20260419c" defer></script>
-<script src="12-profiles.js?v=20260419c" defer></script>
-<script src="03-auth.js?v=20260419c" defer></script>
-<script src="05-api.js?v=20260419c" defer></script>
-<script src="10-ui.js?v=20260419c" defer></script>
+<script src="00-appstate.js?v=20260419d"></script>
+<script src="00-appstate-compat.js?v=20260419d"></script>
+<script src="01-config.js?v=20260419d" defer></script>
+<script src="02-session.js?v=20260419d" defer></script>
+<script src="utils.js?v=20260419d" defer></script>
+<script src="12-profiles.js?v=20260419d" defer></script>
+<script src="03-auth.js?v=20260419d" defer></script>
+<script src="05-api.js?v=20260419d" defer></script>
+<script src="10-ui.js?v=20260419d" defer></script>
 
-<script src="06-post-create.js?v=20260419c" defer></script>
-<script defer src="render/dashboard.js?v=20260419c"></script>
-<script defer src="render/client.js?v=20260419c"></script>
-<script defer src="render/pipeline.js?v=20260419c"></script>
-<script defer src="render/brief.js?v=20260419c"></script>
-<script defer src="actions/pcs.js?v=20260419c"></script>
-<script defer src="actions/pcs-longpress.js?v=20260419c"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260419c"></script>
-<script defer src="actions/pcs-polish.js?v=20260419c"></script>
-<script defer src="actions/pcs-select.js?v=20260419c"></script>
-<script src="ai-config.js?v=20260419c" defer></script>
+<script src="06-post-create.js?v=20260419d" defer></script>
+<script defer src="render/dashboard.js?v=20260419d"></script>
+<script defer src="render/client.js?v=20260419d"></script>
+<script defer src="render/pipeline.js?v=20260419d"></script>
+<script defer src="render/brief.js?v=20260419d"></script>
+<script defer src="actions/pcs.js?v=20260419d"></script>
+<script defer src="actions/pcs-longpress.js?v=20260419d"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260419d"></script>
+<script defer src="actions/pcs-polish.js?v=20260419d"></script>
+<script defer src="actions/pcs-select.js?v=20260419d"></script>
+<script src="ai-config.js?v=20260419d" defer></script>
 <script>
   (function() {
     try {
@@ -1321,12 +1321,12 @@ window.setPcsVisibility = function(el, vis) {
     }
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260419c" defer></script>
-<script src="07-post-load.js?v=20260419c" defer></script>
-<script src="08-post-actions.js?v=20260419c" defer></script>
-<script src="09-library.js?v=20260419c" defer></script>
-<script src="09-approval.js?v=20260419c" defer></script>
-<script src="04-router.js?v=20260419c" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260419d" defer></script>
+<script src="07-post-load.js?v=20260419d" defer></script>
+<script src="08-post-actions.js?v=20260419d" defer></script>
+<script src="09-library.js?v=20260419d" defer></script>
+<script src="09-approval.js?v=20260419d" defer></script>
+<script src="04-router.js?v=20260419d" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6211,14 +6211,16 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   flex-wrap: wrap;
 }
 .pcs-comment-author {
-  font-size: 14px;
+  font-family: var(--sans);
+  font-size: 13px;
   font-weight: 600;
-  color: #F0F0F2;
+  color: var(--text);
 }
 .pcs-comment-time {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  color: #78788C;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
   margin-left: 8px;
 }
 .pcs-vis-tag {
@@ -6236,8 +6238,9 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-vis--serv { color: #22D3EE; border-color: #22D3EE33; }
 .pcs-vis--creat { color: #9b87f5; border-color: #9b87f533; }
 .pcs-comment-text {
-  font-size: 14px;
-  color: #B8B8C0;
+  font-family: 'Fraunces', serif;
+  font-size: 15px;
+  color: var(--text2);
   line-height: 1.55;
   margin-top: 4px;
   white-space: pre-wrap;
@@ -6464,6 +6467,10 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   display: flex;
   align-items: flex-start;
   gap: 4px;
+  font-family: 'Fraunces', serif;
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--text2);
 }
 .pcs-task-text.pcs-task-done {
   text-decoration: line-through;
@@ -6901,7 +6908,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 
 .pcs-deleted-msg {
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Fraunces', serif;
   font-size: 12px;
   color: #8E8E93;
   font-style: italic;
@@ -6917,22 +6924,34 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
    PCS v2 Design — approved v11
    =============================================== */
 
-/* Topbar pills */
+/* Topbar pills (CHANGE 1: Anthropic chip style) */
 .pcs-stage-pill {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px;
-  letter-spacing: .08em;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.10em;
   text-transform: uppercase;
+  font-weight: 500;
+  background: #C8A84B1A;
+  border: 1px solid #C8A84B47;
   color: #C8A84B;
   cursor: pointer;
-  background: none;
-  border: none;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  gap: 4px;
 }
-.pcs-stage-pill .pcs-pill-arr { font-size: 6px; opacity: .6; }
+.pcs-stage-pill .pcs-pill-arr {
+  font-size: 8px;
+  opacity: 0.5;
+}
+.pcs-topbar-overdue {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--red);
+}
 .pcs-od-pill {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 7px;
@@ -6971,7 +6990,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   justify-content: center;
   aspect-ratio: 5/3;
   background: #0c0c11;
-  border: 1px dashed #2e2e3a;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
   cursor: pointer;
   font-family: 'IBM Plex Mono', monospace;
   font-size: 9px;
@@ -7364,13 +7384,22 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   color: var(--red);
 }
 
-/* Done button */
+/* Done button (CHANGE 2: clean pill) */
 .pcs-close-btn {
-  display: block; width: calc(100% - 32px); margin: 0 16px 8px;
-  padding: 14px; font-family: 'IBM Plex Mono', monospace;
-  font-size: 8px; letter-spacing: .08em; text-transform: uppercase;
-  color: #8E8E93; background: none; border: 1px solid #2A2A35;
-  cursor: pointer; text-align: center;
+  display: block;
+  width: calc(100% - 32px);
+  margin: 8px 16px 12px;
+  padding: 12px;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text2);
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: center;
 }
 
 /* FIX 5: Pane overflow */
@@ -7424,7 +7453,7 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   padding: 10px 16px 4px;
 }
 .pcs-udrop-item {
-  font-family: 'DM Sans', sans-serif; font-size: 14px;
+  font-family: var(--sans); font-size: 14px;
   color: #E8E8E8; padding: 11px 16px; cursor: pointer;
   border-bottom: 1px solid #191924;
 }
@@ -7456,16 +7485,16 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   padding: 24px 16px 40px;
 }
 .pcs-bc-title {
-  font-family: 'DM Sans', sans-serif; font-size: 16px;
-  font-weight: 700; color: #E8E8E8; margin-bottom: 6px;
+  font-family: 'Fraunces', serif; font-size: 16px;
+  font-weight: 600; color: #E8E8E8; margin-bottom: 6px;
 }
 .pcs-bc-sub {
-  font-family: 'DM Sans', sans-serif; font-size: 13px;
+  font-family: 'Fraunces', serif; font-size: 13px;
   color: #8E8E93; margin-bottom: 20px;
 }
 .pcs-bc-btns { display: flex; gap: 10px; }
 .pcs-bc-cancel, .pcs-bc-action {
-  flex: 1; font-family: 'DM Sans', sans-serif; font-size: 14px;
+  flex: 1; font-family: var(--sans); font-size: 14px;
   padding: 13px; border: none; cursor: pointer;
 }
 .pcs-bc-cancel { background: #191924; color: #E8E8E8; }
@@ -10032,4 +10061,57 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   font-family: var(--mono);
   font-size: 11px;
   color: #C15F3C;
+}
+
+/* =========================================================================
+   PCS Polish (20260419c): caption edit pill buttons + textarea class,
+   Fraunces body text, Anthropic stage pill, done pill, photos empty border.
+   ========================================================================= */
+
+/* CHANGE 3: caption edit save/cancel pill buttons */
+#pcs-caption-btnrow {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+.pcs-caption-save-btn {
+  flex: 1;
+  padding: 11px;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--bg);
+  background: var(--green);
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+}
+.pcs-caption-cancel-btn {
+  flex: 1;
+  padding: 11px;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text2);
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+/* CHANGE 4: caption edit textarea — class-based, no inline styles */
+.pcs-caption-textarea,
+#pcs-caption-textarea {
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-family: 'Fraunces', serif;
+  font-size: 15px;
+  line-height: 1.6;
+  padding: 8px 0;
+  resize: none;
+  min-height: 160px;
+  outline: none;
 }


### PR DESCRIPTION
## Summary

Styling-only follow-up to the merged PRs #942 (single-scroll, filter chips, internal badge) and #945 (Fraunces typography, pill redesign). Fixes the remaining visual gaps found in the audit — stage pill, Done button, caption edit inline styles, textarea, Fraunces body text, empty photo state.

Scope: `styles.css` + surgical inline-style removal at two caption-edit call sites in `actions/pcs.js`. No data / business logic touched.

### Changes
1. **Stage pill** — `.pcs-stage-pill` becomes an amber chip (`#C8A84B1A` / `#C8A84B47`, Mono 10/500, pill padding). New `.pcs-topbar-overdue` rule so the overdue stamp matches the chip typography.
2. **Done button** — `.pcs-close-btn` becomes a clean sans 13/600 pill on `var(--surface2)` with 12px radius. Replaces the cramped 8px Mono strip.
3. **Caption edit SAVE / CANCEL** — both call sites (`_pcsStartCaptionEditInline` at pcs.js:2308, `_startCaptionEdit` at pcs.js:2495) replaced with classes `pcs-caption-save-btn` + `pcs-caption-cancel-btn`. Inline dotted-border styles gone. Pill buttons via `var(--green)` + `var(--surface2)`. New `#pcs-caption-btnrow` rule.
4. **Caption textarea** — class `pcs-caption-textarea` on both call sites; inline `cssText` blocks removed. Single CSS rule provides Fraunces 15/1.6, warm border, transparent background.
5. **Typography gaps** — `.pcs-deleted-msg` / `.pcs-bc-title` / `.pcs-bc-sub` flipped to Fraunces for body-text contexts. `.pcs-udrop-item` + `.pcs-bc-cancel / .pcs-bc-action` moved to `var(--sans)` token (kept sans — UI chrome / action buttons).
6. **Photos empty state** — `.pcs-photos-empty` gains `border-radius: 12px` and `border: 1px dashed var(--border)` so the empty tile picks up the rounded design language.
7. **Comment body text** — `.pcs-comment-text` and `.pcs-task-text` -> Fraunces 15/1.55 / `var(--text2)`.
8. **Comment author + time** — `.pcs-comment-author` -> `var(--sans)` 13/600 `var(--text)`. `.pcs-comment-time` -> `var(--mono)` 10 / 0.06em / `var(--text-muted)`.
9. **Version** — bumped 28 `?v=` strings `20260419c -> 20260419d`. Target per spec was `c`, but `main` already consumed that letter via recent Worker PRs; `d` is needed for the cache-bust to land.

### Pre-flight
- Project rule "NO `rgba()` — use 8-digit hex" followed throughout (`rgba(200,168,75,0.10)` -> `#C8A84B1A`, `rgba(200,168,75,0.28)` -> `#C8A84B47`).
- No person names hardcoded. No JS logic touched outside the two inline-style sites.
- `pcs-claude-caption.js` untouched; its `claude-*` overlay classes are separate from the trigger.

## Test plan
- [ ] Topbar stage pill renders as amber chip (rounded pill, proper padding).
- [ ] Overdue stamp matches the chip typography (Mono 10 / 0.10em / red).
- [ ] Done button reads as a clean sans pill on `var(--surface2)`.
- [ ] Caption Edit flow: textarea is transparent-bg Fraunces with warm bottom border; Save = green pill, Cancel = neutral pill. No dotted borders.
- [ ] Confirm sheet (remove photo / clear caption): title + sub render in Fraunces.
- [ ] Deleted comment message renders in Fraunces italic.
- [ ] Comment body / task body text renders in Fraunces 15px.
- [ ] Comment author 13px sans, timestamp 10px mono — spacing clear.
- [ ] Empty photo tile: dashed `var(--border)` outline + 12px rounded corners.
- [ ] Hard refresh picks up `20260419d` cache-bust.

https://claude.ai/code/session_01Ujrg4Fgm3mnHFGHLcD5xnv