### PR TITLE
Bump deploy-worker action node 18 -> 20

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install worker deps
         working-directory: srtd-ai-worker


### PR DESCRIPTION
## Summary

One-line change: `.github/workflows/deploy-worker.yml` `node-version: 18` → `20`. Wrangler v4 (just bumped in #949) requires Node 20+, so the deploy step was failing on the `npx wrangler deploy` line under the previous Node 18 runner. Brings this workflow in line with `smoke.yml` which already pins Node 20.

## What I verified

- `.github/workflows/deploy-worker.yml:19` — only one occurrence of `node-version`; safe to edit in place.
- `.github/workflows/smoke.yml:18` — already on Node 20, so the bump is consistent across workflows.
- Nothing else touched.

## Test plan

- [ ] Merge → "Deploy srtd-ai Worker" workflow runs (PR touches `.github/workflows/**`, not `srtd-ai-worker/**`, so the path filter does NOT trigger this run; the next worker-code change will be the real test)
- [ ] Manually dispatch via Actions → Deploy srtd-ai Worker → Run workflow to verify the runner now boots Node 20 and `npx wrangler deploy` reaches the auth step

https://claude.ai/code/session_015QWEC99fG2AZiGwPKzYzP6