### PR TITLE
PCS inline caption edit: pen icon, no full-pane edit, drop Done, Clau…

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -595,7 +595,7 @@ window._renderPCS = function(postId) {
     if (canManage) {
       capActionsContainer.innerHTML =
         '<div class="pcs-cap-actions">' +
-        '<button class="pcs-cap-btn pcs-cap-btn--bright" onclick="window._startCaptionEdit(\'' + esc(id) + '\')">Edit</button>' +
+        '<button class="pcs-cap-btn pcs-cap-btn--ai" onclick="window.openCaptionWorkspace(\'chat\',{postId:\'' + esc(id) + '\',caption:(getPostById(\'' + esc(id) + '\')||{}).caption||\'\',title:getTitle(getPostById(\'' + esc(id) + '\'))})">\u2726 Claude</button>' +
         '<button class="pcs-cap-btn pcs-cap-btn--bright" onclick="window._pcsCopyCaption(\'' + esc(id) + '\')">Copy</button>' +
         (post.caption ? '<button class="pcs-cap-btn pcs-cap-btn--danger" onclick="window._pcsConfirmClearCaption(\'' + esc(id) + '\')">Clear</button>' : '') +
         '</div>';
@@ -810,7 +810,7 @@ function _buildChipsRow(post, canEdit, canEditCreative, id) {
     var ownerLC = (post.owner || '').toLowerCase();
     if (ownerLC === 'servicing') ownerColor = ' pcs-mv--cyan';
     else if (ownerLC === 'creative') ownerColor = ' pcs-mv--purple';
-    else if (ownerLC === 'client') ownerColor = ' pcs-mv--red';
+    else if (ownerLC === 'client') ownerColor = ' pcs-mv--amber';
     items.push('<span class="pcs-mv' + ownerColor + '"' +
       (canEdit ? ' onclick="event.stopPropagation();window._pcsChipDrop(this,\'owner\',\'' + esc(id) + '\')"' : '') +
       '>' + esc(typeof formatOwner === 'function' ? formatOwner(post.owner) : post.owner) +
@@ -1045,12 +1045,16 @@ window._pcsDateChange = function(postId, dateValue) {
 // -- Caption section builder --
 function _buildCaptionHtml(post, canEdit, canEditCreative, id) {
   if (!post.caption && !canEdit && !canEditCreative) return '';
+  var canManage = canEdit || canEditCreative;
   var captionTrim = (post.caption || '').trim();
   var wc = captionTrim ? captionTrim.split(/\s+/).filter(Boolean).length : 0;
   var needsClamp = captionTrim.length > 100;
   var headerRow = '<div class="pcs-caption-header-row">' +
     '<span class="pcs-caption-label">Caption</span>' +
+    '<div style="display:flex;align-items:center;gap:10px;">' +
     (post.caption ? '<span class="pcs-caption-wc">' + wc + ' word' + (wc === 1 ? '' : 's') + '</span>' : '') +
+    (canManage ? '<button class="pcs-caption-edit-icon" onclick="window._startCaptionEdit(\'' + esc(id) + '\')" title="Edit caption"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></button>' : '') +
+    '</div>' +
   '</div>';
   return '<div id="pcs-caption-section" style="padding:12px 14px 8px;border-bottom:1px solid #323244;">' +
     headerRow +
@@ -2502,8 +2506,8 @@ window._startCaptionEdit = function(postId) {
   textEl.style.display = 'none';
   var seeMore = document.getElementById('pcs-caption-see-more');
   if (seeMore) seeMore.style.display = 'none';
-  var zoneManual = document.querySelector('#pcs-pane-caption .pcs-zone-manual');
-  if (zoneManual) zoneManual.style.display = 'none';
+  var editIcon = document.querySelector('#pcs-caption-section .pcs-caption-edit-icon');
+  if (editIcon) editIcon.style.display = 'none';
 
   var ta = document.createElement('textarea');
   ta.id = 'pcs-caption-textarea';
@@ -2532,8 +2536,8 @@ window._cancelCaptionEdit = function() {
   if (btnRow)  btnRow.remove();
   var seeMore = document.getElementById('pcs-caption-see-more');
   if (seeMore) seeMore.style.display = '';
-  var zoneManual = document.querySelector('#pcs-pane-caption .pcs-zone-manual');
-  if (zoneManual) zoneManual.style.display = '';
+  var editIcon = document.querySelector('#pcs-caption-section .pcs-caption-edit-icon');
+  if (editIcon) editIcon.style.display = '';
 }
 
 window._saveCaptionEdit = async function(postId) {

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260419d">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419d">
+ <link rel="stylesheet" href="styles.css?v=20260419e">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419e">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260419d"></script>
-<script src="00-appstate-compat.js?v=20260419d"></script>
-<script src="01-config.js?v=20260419d" defer></script>
-<script src="02-session.js?v=20260419d" defer></script>
-<script src="utils.js?v=20260419d" defer></script>
-<script src="12-profiles.js?v=20260419d" defer></script>
-<script src="03-auth.js?v=20260419d" defer></script>
-<script src="05-api.js?v=20260419d" defer></script>
-<script src="10-ui.js?v=20260419d" defer></script>
+<script src="00-appstate.js?v=20260419e"></script>
+<script src="00-appstate-compat.js?v=20260419e"></script>
+<script src="01-config.js?v=20260419e" defer></script>
+<script src="02-session.js?v=20260419e" defer></script>
+<script src="utils.js?v=20260419e" defer></script>
+<script src="12-profiles.js?v=20260419e" defer></script>
+<script src="03-auth.js?v=20260419e" defer></script>
+<script src="05-api.js?v=20260419e" defer></script>
+<script src="10-ui.js?v=20260419e" defer></script>
 
-<script src="06-post-create.js?v=20260419d" defer></script>
-<script defer src="render/dashboard.js?v=20260419d"></script>
-<script defer src="render/client.js?v=20260419d"></script>
-<script defer src="render/pipeline.js?v=20260419d"></script>
-<script defer src="render/brief.js?v=20260419d"></script>
-<script defer src="actions/pcs.js?v=20260419d"></script>
-<script defer src="actions/pcs-longpress.js?v=20260419d"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260419d"></script>
-<script defer src="actions/pcs-polish.js?v=20260419d"></script>
-<script defer src="actions/pcs-select.js?v=20260419d"></script>
-<script src="ai-config.js?v=20260419d" defer></script>
+<script src="06-post-create.js?v=20260419e" defer></script>
+<script defer src="render/dashboard.js?v=20260419e"></script>
+<script defer src="render/client.js?v=20260419e"></script>
+<script defer src="render/pipeline.js?v=20260419e"></script>
+<script defer src="render/brief.js?v=20260419e"></script>
+<script defer src="actions/pcs.js?v=20260419e"></script>
+<script defer src="actions/pcs-longpress.js?v=20260419e"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260419e"></script>
+<script defer src="actions/pcs-polish.js?v=20260419e"></script>
+<script defer src="actions/pcs-select.js?v=20260419e"></script>
+<script src="ai-config.js?v=20260419e" defer></script>
 <script>
   (function() {
     try {
@@ -1321,12 +1321,12 @@ window.setPcsVisibility = function(el, vis) {
     }
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260419d" defer></script>
-<script src="07-post-load.js?v=20260419d" defer></script>
-<script src="08-post-actions.js?v=20260419d" defer></script>
-<script src="09-library.js?v=20260419d" defer></script>
-<script src="09-approval.js?v=20260419d" defer></script>
-<script src="04-router.js?v=20260419d" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260419e" defer></script>
+<script src="07-post-load.js?v=20260419e" defer></script>
+<script src="08-post-actions.js?v=20260419e" defer></script>
+<script src="09-library.js?v=20260419e" defer></script>
+<script src="09-approval.js?v=20260419e" defer></script>
+<script src="04-router.js?v=20260419e" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -7383,23 +7383,30 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   border-color: #FF4B4B4D;
   color: var(--red);
 }
+.pcs-cap-btn--ai {
+  background: #E3B56A14;
+  border-color: #E3B56A38;
+  color: #E3B56A;
+}
 
-/* Done button (CHANGE 2: clean pill) */
-.pcs-close-btn {
-  display: block;
-  width: calc(100% - 32px);
-  margin: 8px 16px 12px;
-  padding: 12px;
-  font-family: var(--sans);
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--text2);
-  background: var(--surface2);
-  border: 1px solid var(--border);
-  border-radius: 12px;
+/* Caption header inline edit icon (CHANGE 1: pen) */
+.pcs-caption-edit-icon {
+  background: none;
+  border: none;
+  padding: 2px 4px;
   cursor: pointer;
-  text-align: center;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  border-radius: 6px;
+  transition: color 0.15s ease;
+}
+.pcs-caption-edit-icon:active { color: var(--text); }
+
+/* Done button — hidden in single-scroll mode; the topbar X is the
+   only exit. (CHANGE 4) */
+.pcs-close-btn {
+  display: none !important;
 }
 
 /* FIX 5: Pane overflow */


### PR DESCRIPTION
…de in actions

Styling-only follow-up to PR #948. Replaces the modal-style caption edit with a true inline replacement and tightens the caption action row.

- CHANGE 1: caption header gets an inline pen-icon button (.pcs-caption-edit-icon) on the right of the word count, gated by canManage. Calls window._startCaptionEdit. Style: ghost icon, 14px pen SVG, var(--text-muted) -> var(--text) on press.
- CHANGE 2: window._startCaptionEdit no longer hides .pcs-zone-manual (which would have wiped the cap-actions row on edit). It now hides only #pcs-caption-text, #pcs-caption-see-more, and the new .pcs-caption-edit-icon. window._cancelCaptionEdit symmetrically restores those three. Textarea + Save/Cancel pill row injected in-place after #pcs-caption-text.
- CHANGE 3: caption action row drops Edit (now lives as the pen icon in the header) and gains a leading "✦ Claude" pill that opens the Caption Workspace in chat mode. New .pcs-cap-btn--ai variant (#E3B56A14 / #E3B56A38, 8-digit hex per project rule).
- CHANGE 4: .pcs-close-btn -> display:none !important. The topbar X is the only exit; the Done button was redundant in single-scroll mode.
- CHANGE 5: verified — no JS ellipsis concatenation in caption text rendering. Visual "..." comes from -webkit-line-clamp: 2 (browser- rendered, not in DOM). No-op.
- CHANGE 6: client owner chip switched from .pcs-mv--red to .pcs-mv--amber so it stops reading as an error state.
- CHANGE 7: bumped 28 ?v= strings 20260419d -> 20260419e.

https://claude.ai/code/session_01Ujrg4Fgm3mnHFGHLcD5xnv