### PR TITLE
PCS: dedup Claude entry, filter chips Client/Internal with scroll-to

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -604,25 +604,12 @@ window._renderPCS = function(postId) {
     }
   }
 
-  // f3) Zone 1 (AI) — Admin + AppState.workspace.ai_enabled only.
-  //     Injected into the dedicated #pcs-zone-ai-container (added to
-  //     index.html in this PR) which sits inside the #pcs-caption-scroll
-  //     wrapper, above the non-scrolling .pcs-zone-manual footer. The
-  //     container's innerHTML is rewritten on every render so there is
-  //     no per-post id-guard; cross-post accumulation is also handled
-  //     defensively by forcePCSReset() stripping every
-  //     [id^="pcs-ai-section-"] node on PCS close.
-  var aiZoneContainer = document.getElementById('pcs-zone-ai-container');
-  if (aiZoneContainer) {
-    if (isAdmin && window.AppState.workspace && window.AppState.workspace.ai_enabled) {
-      var _commentCount = Array.isArray(post.post_comments)
-        ? post.post_comments.filter(function(c) { return c && !c.deleted; }).length
-        : (typeof post._commentCount === 'number' ? post._commentCount : 0);
-      aiZoneContainer.innerHTML = _pcsBuildAiZoneHtml(id, _commentCount);
-    } else {
-      aiZoneContainer.innerHTML = '';
-    }
-  }
+  // f3) Zone 1 (AI card) — REMOVED. The legacy .pcs-claude-entry card
+  //     was replaced by the ✦ Claude chip in .pcs-cap-actions (see
+  //     pcs-cap-actions-container populate above). The scaffold
+  //     <div id="pcs-zone-ai-container"> remains in index.html so the
+  //     slot can be reused by a future AI surface; _pcsBuildAiZoneHtml
+  //     is kept as dead code in case we want the card back later.
 
   // g) Show comments section (compatibility)
   var commSection = document.getElementById('pcs-comments-section');
@@ -1328,8 +1315,7 @@ function _pcsEnsureCommentsHeader(list) {
     var filterBar = document.createElement('div');
     filterBar.className = 'pcs-filter-bar';
     filterBar.innerHTML =
-      '<span class="pcs-fchip pcs-fchip--on" data-filter="all">All</span>' +
-      '<span class="pcs-fchip" data-filter="client">Client</span>' +
+      '<span class="pcs-fchip pcs-fchip--on" data-filter="client">Client</span>' +
       '<span class="pcs-fchip" data-filter="internal">Internal</span>';
     filterBar.querySelectorAll('.pcs-fchip').forEach(function(chip) {
       chip.addEventListener('click', function() {
@@ -1337,14 +1323,31 @@ function _pcsEnsureCommentsHeader(list) {
         chip.classList.add('pcs-fchip--on');
         var f = chip.dataset.filter;
         document.querySelectorAll('.pcs-comment-item').forEach(function(el) {
-          el.style.display = (f === 'all' || f === 'client') ? '' : 'none';
+          el.style.display = (f === 'client') ? '' : 'none';
         });
         document.querySelectorAll('.pcs-note-item').forEach(function(el) {
-          el.style.display = (f === 'all' || f === 'internal') ? '' : 'none';
+          el.style.display = (f === 'internal') ? '' : 'none';
         });
+        var scroller = document.getElementById('pcs-scroll');
+        var targetId = (f === 'client') ? 'pcs-pane-client' : 'pcs-pane-internal';
+        var target = document.getElementById(targetId);
+        if (scroller && target) {
+          var top = target.getBoundingClientRect().top - scroller.getBoundingClientRect().top + scroller.scrollTop;
+          scroller.scrollTo({ top: top, behavior: 'smooth' });
+        }
       });
     });
     parent.insertBefore(filterBar, list);
+    // CHANGE 4: default state — Client chip selected, notes hidden on
+    // initial render (the Client chip already carries pcs-fchip--on in
+    // the innerHTML above; this is a defensive reassertion + hides
+    // every .pcs-note-item so only client comments show until the user
+    // taps Internal).
+    var clientChip = filterBar.querySelector('[data-filter="client"]');
+    if (clientChip) clientChip.classList.add('pcs-fchip--on');
+    document.querySelectorAll('.pcs-note-item').forEach(function(el) {
+      el.style.display = 'none';
+    });
   }
 }
 
@@ -1786,6 +1789,14 @@ window.loadPcsComments = async function(postId) {
 
     list.innerHTML = clientHtml;
 
+    // Reapply current filter state so fresh .pcs-comment-item nodes
+    // inherit the selected chip's visibility.
+    var _activeFchipC = document.querySelector('.pcs-fchip.pcs-fchip--on');
+    var _activeFilterC = _activeFchipC ? _activeFchipC.dataset.filter : 'client';
+    list.querySelectorAll('.pcs-comment-item').forEach(function(el) {
+      el.style.display = (_activeFilterC === 'client') ? '' : 'none';
+    });
+
     var countEl = document.getElementById('pcs-comments-count');
     if (countEl) {
       countEl.textContent = activeClientRows.length;
@@ -1830,6 +1841,15 @@ window.loadPcsComments = async function(postId) {
       }
 
       notesList.innerHTML = notesHtml;
+
+      // Reapply current filter state so fresh .pcs-note-item nodes
+      // inherit the selected chip's visibility (default: hidden when
+      // Client chip is active; visible when Internal chip is active).
+      var _activeFchip = document.querySelector('.pcs-fchip.pcs-fchip--on');
+      var _activeFilter = _activeFchip ? _activeFchip.dataset.filter : 'client';
+      notesList.querySelectorAll('.pcs-note-item').forEach(function(el) {
+        el.style.display = (_activeFilter === 'internal') ? '' : 'none';
+      });
 
       var notesCountEl = document.getElementById('pcs-notes-count');
       if (notesCountEl) {

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260419e">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419e">
+ <link rel="stylesheet" href="styles.css?v=20260419f">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419f">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260419e"></script>
-<script src="00-appstate-compat.js?v=20260419e"></script>
-<script src="01-config.js?v=20260419e" defer></script>
-<script src="02-session.js?v=20260419e" defer></script>
-<script src="utils.js?v=20260419e" defer></script>
-<script src="12-profiles.js?v=20260419e" defer></script>
-<script src="03-auth.js?v=20260419e" defer></script>
-<script src="05-api.js?v=20260419e" defer></script>
-<script src="10-ui.js?v=20260419e" defer></script>
+<script src="00-appstate.js?v=20260419f"></script>
+<script src="00-appstate-compat.js?v=20260419f"></script>
+<script src="01-config.js?v=20260419f" defer></script>
+<script src="02-session.js?v=20260419f" defer></script>
+<script src="utils.js?v=20260419f" defer></script>
+<script src="12-profiles.js?v=20260419f" defer></script>
+<script src="03-auth.js?v=20260419f" defer></script>
+<script src="05-api.js?v=20260419f" defer></script>
+<script src="10-ui.js?v=20260419f" defer></script>
 
-<script src="06-post-create.js?v=20260419e" defer></script>
-<script defer src="render/dashboard.js?v=20260419e"></script>
-<script defer src="render/client.js?v=20260419e"></script>
-<script defer src="render/pipeline.js?v=20260419e"></script>
-<script defer src="render/brief.js?v=20260419e"></script>
-<script defer src="actions/pcs.js?v=20260419e"></script>
-<script defer src="actions/pcs-longpress.js?v=20260419e"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260419e"></script>
-<script defer src="actions/pcs-polish.js?v=20260419e"></script>
-<script defer src="actions/pcs-select.js?v=20260419e"></script>
-<script src="ai-config.js?v=20260419e" defer></script>
+<script src="06-post-create.js?v=20260419f" defer></script>
+<script defer src="render/dashboard.js?v=20260419f"></script>
+<script defer src="render/client.js?v=20260419f"></script>
+<script defer src="render/pipeline.js?v=20260419f"></script>
+<script defer src="render/brief.js?v=20260419f"></script>
+<script defer src="actions/pcs.js?v=20260419f"></script>
+<script defer src="actions/pcs-longpress.js?v=20260419f"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260419f"></script>
+<script defer src="actions/pcs-polish.js?v=20260419f"></script>
+<script defer src="actions/pcs-select.js?v=20260419f"></script>
+<script src="ai-config.js?v=20260419f" defer></script>
 <script>
   (function() {
     try {
@@ -1321,12 +1321,12 @@ window.setPcsVisibility = function(el, vis) {
     }
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260419e" defer></script>
-<script src="07-post-load.js?v=20260419e" defer></script>
-<script src="08-post-actions.js?v=20260419e" defer></script>
-<script src="09-library.js?v=20260419e" defer></script>
-<script src="09-approval.js?v=20260419e" defer></script>
-<script src="04-router.js?v=20260419e" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260419f" defer></script>
+<script src="07-post-load.js?v=20260419f" defer></script>
+<script src="08-post-actions.js?v=20260419f" defer></script>
+<script src="09-library.js?v=20260419f" defer></script>
+<script src="09-approval.js?v=20260419f" defer></script>
+<script src="04-router.js?v=20260419f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary

Surgical follow-up to merged PR #951. Removes the duplicate legacy "Edit with Claude" card, narrows the filter chip bar to Client + Internal, and gives each chip a smooth-scroll to its section.

Scope: `actions/pcs.js` + `index.html` (version bump). No CSS changes, no business logic changes.

### Changes
1. **Kill duplicate Claude entry card** — deleted the `#pcs-zone-ai-container` populate block in `pcs.js` (was lines 615-625). Admin users were seeing BOTH the legacy `.pcs-claude-entry` card AND the new `✦ Claude` chip in `.pcs-cap-actions`. The chip is now the sole entry point. Scaffold `<div id="pcs-zone-ai-container">` in `index.html` is kept as a reusable slot; `_pcsBuildAiZoneHtml` kept as dead code for future reuse.
2. **Filter chip bar** — dropped "All"; ships only Client + Internal. Client is default (`pcs-fchip--on`).
3. **Smooth scroll** — click handler now:
    - toggles `.pcs-comment-item` visibility on `client`
    - toggles `.pcs-note-item` visibility on `internal`
    - smooth-scrolls `#pcs-scroll` to the relevant pane (`#pcs-pane-client` / `#pcs-pane-internal`) via `getBoundingClientRect` delta + `scroller.scrollTop` — math independent of the offsetParent chain.
4. **Initial state** — on first render the Client chip is force-marked active and all `.pcs-note-item` are hidden. Because comments/notes render async AFTER the filter bar mounts, the visibility reassertion also runs immediately after `list.innerHTML` (for `.pcs-comment-item`) and `notesList.innerHTML` (for `.pcs-note-item`) so fresh nodes always inherit the active chip's state.
5. **Version** — bumped 28 `?v=` strings `20260419e -> 20260419f`.

### Pre-flight
- No person names hardcoded. No new deps. No `/sorted/` paths.
- CSS untouched; no new tokens or rules.
- `_pcsBuildAiZoneHtml` left in place so a future AI surface can reclaim the slot; only the call site was removed.

## Test plan
- [ ] Admin user with `workspace.ai_enabled`: caption area shows ONLY the `✦ Claude` pill, no legacy card above it.
- [ ] Filter chip bar shows two chips: Client (active default) and Internal.
- [ ] Tap Internal: notes become visible, client comments hide, scroller smooth-scrolls to `#pcs-pane-internal`.
- [ ] Tap Client: reverse — client comments visible, notes hide, scroller smooth-scrolls to `#pcs-pane-client`.
- [ ] Post a new client comment: it inherits the active chip's visibility without manual re-toggle.
- [ ] Post a new note: same.
- [ ] Client role: no Claude chip, no Internal chip seen when applicable (existing role gates unchanged).
- [ ] Hard refresh picks up `20260419f` cache-bust.

https://claude.ai/code/session_01Ujrg4Fgm3mnHFGHLcD5xnv