### PR TITLE
PCS: word-count format, section header redesign, flat comment actions

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1039,7 +1039,7 @@ function _buildCaptionHtml(post, canEdit, canEditCreative, id) {
   var headerRow = '<div class="pcs-caption-header-row">' +
     '<span class="pcs-caption-label">Caption</span>' +
     '<div style="display:flex;align-items:center;gap:10px;">' +
-    (post.caption ? '<span class="pcs-caption-wc">' + wc + ' word' + (wc === 1 ? '' : 's') + '</span>' : '') +
+    (post.caption ? '<span class="pcs-caption-wc">' + wc + ' / 125 words</span>' : '') +
     (canManage ? '<button class="pcs-caption-edit-icon" onclick="window._startCaptionEdit(\'' + esc(id) + '\')" title="Edit caption"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></button>' : '') +
     '</div>' +
   '</div>';
@@ -1287,16 +1287,16 @@ window._saveLiUrlInline = function(postId) {
 }
 
 // -- PCS Comments --------------------------------------------------
-// Track latest counts so the combined "N client · M internal" label stays
-// in sync across the two async branches in loadPcsComments.
+// Track latest counts so the "Comments N · Internal M" header stays in
+// sync across the two async branches in loadPcsComments.
 window._pcsSectionCounts = window._pcsSectionCounts || { client: 0, internal: 0 };
 function _pcsUpdateSectionCount(client, internal) {
   if (client !== null && client !== undefined) window._pcsSectionCounts.client = client;
   if (internal !== null && internal !== undefined) window._pcsSectionCounts.internal = internal;
-  var el = document.getElementById('pcs-section-count');
-  if (el) {
-    el.textContent = window._pcsSectionCounts.client + ' client \u00B7 ' + window._pcsSectionCounts.internal + ' internal';
-  }
+  var cEl = document.getElementById('pcs-section-count');
+  var iEl = document.getElementById('pcs-section-internal');
+  if (cEl) cEl.textContent = window._pcsSectionCounts.client;
+  if (iEl) iEl.textContent = 'Internal ' + window._pcsSectionCounts.internal;
 }
 
 // Inject section header + filter chip bar above comments list, idempotent.
@@ -1308,7 +1308,10 @@ function _pcsEnsureCommentsHeader(list) {
     header.className = 'pcs-comments-section-header';
     header.innerHTML =
       '<span class="pcs-section-title">Comments</span>' +
-      '<span class="pcs-section-count" id="pcs-section-count">0 client &middot; 0 internal</span>';
+      '<span class="pcs-section-count" id="pcs-section-count">0</span>' +
+      '<span class="pcs-section-sep">\u00B7</span>' +
+      '<span class="pcs-section-internal" id="pcs-section-internal">Internal 0</span>' +
+      '<span class="pcs-section-vis">CLIENT + AGENCY</span>';
     parent.insertBefore(header, list);
   }
   if (!parent.querySelector('.pcs-filter-bar')) {
@@ -1558,13 +1561,16 @@ window.loadPcsComments = async function(postId) {
           _imgHtml +
           _resolvedLabel +
           '<div class="pcs-comment-actions">' +
-            '<span class="pcs-comment-reply-btn" ' +
+            '<button class="pcs-comment-act like' + (_myReact ? ' pcs-reacted' : '') + '" data-comment-id="' + esc(c.id) + '" onclick="window._pcsShowEmojiPicker(this)">' + (_myReact ? 'Liked' : 'Like') + (_reactCount > 0 ? ' ' + _reactCount : '') + '</button>' +
+            '<span class="pcs-comment-act-sep">\u00B7</span>' +
+            '<button class="pcs-comment-act pcs-comment-reply-btn reply" ' +
               'onclick="window._pcsSetReply(\'client\',\'' +
               esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
-              _escapedMsg + '\')">Reply</span>' +
-            '<span class="pcs-comment-resolve-btn" ' +
+              _escapedMsg + '\')">Reply</button>' +
+            '<span class="pcs-comment-act-sep">\u00B7</span>' +
+            '<button class="pcs-comment-act pcs-comment-resolve-btn ' + (c.resolved ? 'unresolve' : 'resolve') + '" ' +
               'onclick="toggleTaskResolve(\'' + esc(c.id) + '\',\'' + esc(postId) + '\',false)">' +
-              _resolveBtnLabel + '</span>' +
+              _resolveBtnLabel + '</button>' +
           '</div>' +
         '</div>' +
         '<div class="pcs-cmt-rt pcs-comment-react' + (_myReact ? ' pcs-reacted' : '') + '" data-comment-id="' + esc(c.id) + '" onclick="window._pcsShowEmojiPicker(this)">' +
@@ -1705,13 +1711,16 @@ window.loadPcsComments = async function(postId) {
           _imgHtml +
           _resolvedLabel +
           '<div class="pcs-comment-actions">' +
-            '<span class="pcs-comment-reply-btn" ' +
+            '<button class="pcs-comment-act like' + (_myReact ? ' pcs-reacted' : '') + '" data-comment-id="' + esc(c.id) + '" onclick="window._pcsShowEmojiPicker(this)">' + (_myReact ? 'Liked' : 'Like') + (_reactCount > 0 ? ' ' + _reactCount : '') + '</button>' +
+            '<span class="pcs-comment-act-sep">\u00B7</span>' +
+            '<button class="pcs-comment-act pcs-comment-reply-btn reply" ' +
               'onclick="window._pcsSetReply(\'note\',\'' +
               esc(c.id) + '\',\'' + esc(c.author) + '\',\'' +
-              _escapedMsg + '\')">Reply</span>' +
-            '<span class="pcs-comment-resolve-btn" ' +
+              _escapedMsg + '\')">Reply</button>' +
+            '<span class="pcs-comment-act-sep">\u00B7</span>' +
+            '<button class="pcs-comment-act pcs-comment-resolve-btn ' + (c.resolved ? 'unresolve' : 'resolve') + '" ' +
               'onclick="toggleTaskResolve(\'' + esc(c.id) + '\',\'' + esc(postId) + '\',true)">' +
-              _resolveBtnLabel + '</span>' +
+              _resolveBtnLabel + '</button>' +
           '</div>' +
         '</div>' +
         '<div class="pcs-cmt-rt pcs-comment-react' + (_myReact ? ' pcs-reacted' : '') + '" data-comment-id="' + esc(c.id) + '" onclick="window._pcsShowEmojiPicker(this)">' +

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260419f">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419f">
+ <link rel="stylesheet" href="styles.css?v=20260419g">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419g">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260419f"></script>
-<script src="00-appstate-compat.js?v=20260419f"></script>
-<script src="01-config.js?v=20260419f" defer></script>
-<script src="02-session.js?v=20260419f" defer></script>
-<script src="utils.js?v=20260419f" defer></script>
-<script src="12-profiles.js?v=20260419f" defer></script>
-<script src="03-auth.js?v=20260419f" defer></script>
-<script src="05-api.js?v=20260419f" defer></script>
-<script src="10-ui.js?v=20260419f" defer></script>
+<script src="00-appstate.js?v=20260419g"></script>
+<script src="00-appstate-compat.js?v=20260419g"></script>
+<script src="01-config.js?v=20260419g" defer></script>
+<script src="02-session.js?v=20260419g" defer></script>
+<script src="utils.js?v=20260419g" defer></script>
+<script src="12-profiles.js?v=20260419g" defer></script>
+<script src="03-auth.js?v=20260419g" defer></script>
+<script src="05-api.js?v=20260419g" defer></script>
+<script src="10-ui.js?v=20260419g" defer></script>
 
-<script src="06-post-create.js?v=20260419f" defer></script>
-<script defer src="render/dashboard.js?v=20260419f"></script>
-<script defer src="render/client.js?v=20260419f"></script>
-<script defer src="render/pipeline.js?v=20260419f"></script>
-<script defer src="render/brief.js?v=20260419f"></script>
-<script defer src="actions/pcs.js?v=20260419f"></script>
-<script defer src="actions/pcs-longpress.js?v=20260419f"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260419f"></script>
-<script defer src="actions/pcs-polish.js?v=20260419f"></script>
-<script defer src="actions/pcs-select.js?v=20260419f"></script>
-<script src="ai-config.js?v=20260419f" defer></script>
+<script src="06-post-create.js?v=20260419g" defer></script>
+<script defer src="render/dashboard.js?v=20260419g"></script>
+<script defer src="render/client.js?v=20260419g"></script>
+<script defer src="render/pipeline.js?v=20260419g"></script>
+<script defer src="render/brief.js?v=20260419g"></script>
+<script defer src="actions/pcs.js?v=20260419g"></script>
+<script defer src="actions/pcs-longpress.js?v=20260419g"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260419g"></script>
+<script defer src="actions/pcs-polish.js?v=20260419g"></script>
+<script defer src="actions/pcs-select.js?v=20260419g"></script>
+<script src="ai-config.js?v=20260419g" defer></script>
 <script>
   (function() {
     try {
@@ -1321,12 +1321,12 @@ window.setPcsVisibility = function(el, vis) {
     }
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260419f" defer></script>
-<script src="07-post-load.js?v=20260419f" defer></script>
-<script src="08-post-actions.js?v=20260419f" defer></script>
-<script src="09-library.js?v=20260419f" defer></script>
-<script src="09-approval.js?v=20260419f" defer></script>
-<script src="04-router.js?v=20260419f" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260419g" defer></script>
+<script src="07-post-load.js?v=20260419g" defer></script>
+<script src="08-post-actions.js?v=20260419g" defer></script>
+<script src="09-library.js?v=20260419g" defer></script>
+<script src="09-approval.js?v=20260419g" defer></script>
+<script src="04-router.js?v=20260419g" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -6822,29 +6822,37 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-reply-tag { display: none; }
 .pcs-reply-tag-x { display: none; }
 
+/* CHANGE 8: comment actions — Like / Reply / Resolve inline, same weight, dot separators */
 .pcs-comment-actions {
   display: flex;
   align-items: center;
-  gap: 16px;
-  margin-top: 5px;
+  gap: 4px;
+  margin-top: 6px;
 }
-
-.pcs-comment-actions .pcs-comment-reply-btn {
-  margin-top: 0;
-}
-
-.pcs-comment-resolve-btn {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 9px;
-  color: #8E8E93;
-  letter-spacing: .04em;
+.pcs-comment-act {
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px 0;
   background: none;
   border: none;
-  cursor: pointer;
-  padding: 0;
 }
-.pcs-comment-resolve-btn:active {
-  color: #AEAEB2;
+.pcs-comment-act:active { color: var(--text); }
+.pcs-comment-act-sep {
+  color: var(--text-muted);
+  font-size: 10px;
+  opacity: 0.4;
+}
+.pcs-comment-act.resolve,
+.pcs-comment-act.unresolve { color: var(--green); }
+.pcs-comment-act.like.pcs-reacted { color: var(--red); }
+
+/* Legacy classes kept for back-compat (still present on the buttons) */
+.pcs-comment-actions .pcs-comment-reply-btn,
+.pcs-comment-actions .pcs-comment-resolve-btn {
+  margin-top: 0;
 }
 
 .pcs-comment-action {
@@ -6855,11 +6863,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   color: #8E8E93;
   cursor: pointer;
 }
-
 .pcs-comment-action:hover,
-.pcs-comment-action:active {
-  color: #AEAEB2;
-}
+.pcs-comment-action:active { color: #AEAEB2; }
 
 .pcs-comment-reply {
   margin-left: 0;
@@ -10004,6 +10009,8 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 .pcs-caption-wc {
   font-family: var(--mono);
   font-size: 10px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
   color: var(--green);
   font-weight: 500;
 }
@@ -10051,24 +10058,48 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   margin-left: 6px;
 }
 
-/* CHANGE 6: comments section header */
+/* CHANGE 6 + 7: comments section header — "Comments N · Internal M"
+   with visibility label pushed right. */
 .pcs-comments-section-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 16px 18px 4px;
+  gap: 8px;
+  padding: 16px 16px 8px;
 }
 .pcs-section-title {
   font-family: var(--sans);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 700;
   color: var(--text);
 }
 .pcs-section-count {
-  font-family: var(--mono);
-  font-size: 11px;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 700;
   color: #C15F3C;
 }
+.pcs-section-sep {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.pcs-section-internal {
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+.pcs-section-vis {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* CHANGE 7: composer meta line removed — visibility moved to the
+   section header above. */
+.pcs-ibar-hint { display: none; }
 
 /* =========================================================================
    PCS Polish (20260419c): caption edit pill buttons + textarea class,


### PR DESCRIPTION
## Summary

Typography + structural polish on top of merged PR #952. All `styles.css` + `actions/pcs.js` (+ `index.html` for version bump). No business logic changes.

### Changes
1. **Caption word count** — reformatted `.pcs-caption-wc` text to `N / 125 words` (targets the GBL 125-word cap). Styling: Mono 10 / 0.10em / uppercase / `var(--green)` so it reads as an eyebrow chip.
2. **Section header redesign** — header split into `Comments` (sans 14 / 700 / `var(--text)`) · terracotta `.pcs-section-count` (the live client count) · `var(--text-muted)` sep dot · `Internal N` muted sans suffix. `_pcsUpdateSectionCount` writes `pcs-section-count` + `pcs-section-internal` IDs independently so the two async branches of `loadPcsComments` stay in sync.
3. **Visibility label moved to header** — right-aligned `.pcs-section-vis` ("CLIENT + AGENCY") pushed to the far right of the header via `margin-left: auto`. The below-composer `.pcs-ibar-hint` meta line (in `index.html`) is CSS-hidden so the information lives in one place instead of two.
4. **Flat comment actions** — every `.pcs-comment-item` and `.pcs-note-item` now emits `Like · Reply · Resolve` as three `.pcs-comment-act` buttons with `.pcs-comment-act-sep` dots between them. Like wires to `_pcsShowEmojiPicker` (reuses the existing react handler) and swaps to `Liked N` when the current user has reacted. Resolve/Unresolve carries a semantic class so the green state applies. Legacy `.pcs-comment-reply-btn` / `.pcs-comment-resolve-btn` classes kept on the buttons for back-compat with any outside callers.
5. **Version** — 28 `?v=` strings bumped `20260419f -> 20260419g`.

### Pre-flight
- No person names hardcoded. No new deps. No `/sorted/` paths.
- All alpha colors through existing tokens; no `rgba()` introduced.
- `_pcsBuildAiZoneHtml` still kept as dead code for future reuse.
- CHANGES 1-4 from the spec (dedup card + filter chips + scroll + default state) are already shipped in merged PR #952; this PR layers the remaining 5-9.

## Test plan
- [ ] Caption header shows pen icon on the right, with `N / 125 WORDS` in green Mono eyebrow just left of it.
- [ ] Comments section header reads `Comments 4 · Internal 1   CLIENT + AGENCY` with the client number in terracotta and the visibility label right-aligned.
- [ ] Section counts update live when a new comment / note lands.
- [ ] Each comment + note shows `Like · Reply · Resolve` with same typographic weight + muted dots between.
- [ ] Tap Like: emoji picker opens; after selecting an emoji, the Like label reads `Liked N` in red.
- [ ] Resolve / Unresolve renders in green.
- [ ] No `Client + Agency · Visible to all` strip under the composer.
- [ ] Hard refresh picks up `20260419g` cache-bust.

https://claude.ai/code/session_01Ujrg4Fgm3mnHFGHLcD5xnv