### PR TITLE
PCS: composer follows filter, kill vis selector, clip caption ellipsis

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1331,6 +1331,18 @@ function _pcsEnsureCommentsHeader(list) {
         document.querySelectorAll('.pcs-note-item').forEach(function(el) {
           el.style.display = (f === 'internal') ? '' : 'none';
         });
+        // Toggle composers so only the active zone's composer is in flow.
+        var clientComposer = document.getElementById('pcs-composer-root-client');
+        var noteComposer = document.getElementById('pcs-composer-root-note');
+        var clientIbar = clientComposer ? clientComposer.closest('.pcs-ibar-wrap') : null;
+        var noteIbar = noteComposer ? noteComposer.closest('.pcs-ibar-wrap') : null;
+        if (f === 'client') {
+          if (clientIbar) clientIbar.style.display = '';
+          if (noteIbar) noteIbar.style.display = 'none';
+        } else if (f === 'internal') {
+          if (clientIbar) clientIbar.style.display = 'none';
+          if (noteIbar) noteIbar.style.display = '';
+        }
         var scroller = document.getElementById('pcs-scroll');
         var targetId = (f === 'client') ? 'pcs-pane-client' : 'pcs-pane-internal';
         var target = document.getElementById(targetId);
@@ -1345,12 +1357,17 @@ function _pcsEnsureCommentsHeader(list) {
     // initial render (the Client chip already carries pcs-fchip--on in
     // the innerHTML above; this is a defensive reassertion + hides
     // every .pcs-note-item so only client comments show until the user
-    // taps Internal).
+    // taps Internal). Also pre-hides the notes composer so only the
+    // client composer sits in the page flow on first open.
     var clientChip = filterBar.querySelector('[data-filter="client"]');
     if (clientChip) clientChip.classList.add('pcs-fchip--on');
     document.querySelectorAll('.pcs-note-item').forEach(function(el) {
       el.style.display = 'none';
     });
+    var _clientIbar = document.querySelector('.pcs-ibar-wrap.client');
+    var _noteIbar = document.querySelector('.pcs-ibar-wrap.notes');
+    if (_clientIbar) _clientIbar.style.display = '';
+    if (_noteIbar) _noteIbar.style.display = 'none';
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260419g">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419g">
+ <link rel="stylesheet" href="styles.css?v=20260419h">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419h">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260419g"></script>
-<script src="00-appstate-compat.js?v=20260419g"></script>
-<script src="01-config.js?v=20260419g" defer></script>
-<script src="02-session.js?v=20260419g" defer></script>
-<script src="utils.js?v=20260419g" defer></script>
-<script src="12-profiles.js?v=20260419g" defer></script>
-<script src="03-auth.js?v=20260419g" defer></script>
-<script src="05-api.js?v=20260419g" defer></script>
-<script src="10-ui.js?v=20260419g" defer></script>
+<script src="00-appstate.js?v=20260419h"></script>
+<script src="00-appstate-compat.js?v=20260419h"></script>
+<script src="01-config.js?v=20260419h" defer></script>
+<script src="02-session.js?v=20260419h" defer></script>
+<script src="utils.js?v=20260419h" defer></script>
+<script src="12-profiles.js?v=20260419h" defer></script>
+<script src="03-auth.js?v=20260419h" defer></script>
+<script src="05-api.js?v=20260419h" defer></script>
+<script src="10-ui.js?v=20260419h" defer></script>
 
-<script src="06-post-create.js?v=20260419g" defer></script>
-<script defer src="render/dashboard.js?v=20260419g"></script>
-<script defer src="render/client.js?v=20260419g"></script>
-<script defer src="render/pipeline.js?v=20260419g"></script>
-<script defer src="render/brief.js?v=20260419g"></script>
-<script defer src="actions/pcs.js?v=20260419g"></script>
-<script defer src="actions/pcs-longpress.js?v=20260419g"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260419g"></script>
-<script defer src="actions/pcs-polish.js?v=20260419g"></script>
-<script defer src="actions/pcs-select.js?v=20260419g"></script>
-<script src="ai-config.js?v=20260419g" defer></script>
+<script src="06-post-create.js?v=20260419h" defer></script>
+<script defer src="render/dashboard.js?v=20260419h"></script>
+<script defer src="render/client.js?v=20260419h"></script>
+<script defer src="render/pipeline.js?v=20260419h"></script>
+<script defer src="render/brief.js?v=20260419h"></script>
+<script defer src="actions/pcs.js?v=20260419h"></script>
+<script defer src="actions/pcs-longpress.js?v=20260419h"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260419h"></script>
+<script defer src="actions/pcs-polish.js?v=20260419h"></script>
+<script defer src="actions/pcs-select.js?v=20260419h"></script>
+<script src="ai-config.js?v=20260419h" defer></script>
 <script>
   (function() {
     try {
@@ -1321,12 +1321,12 @@ window.setPcsVisibility = function(el, vis) {
     }
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260419g" defer></script>
-<script src="07-post-load.js?v=20260419g" defer></script>
-<script src="08-post-actions.js?v=20260419g" defer></script>
-<script src="09-library.js?v=20260419g" defer></script>
-<script src="09-approval.js?v=20260419g" defer></script>
-<script src="04-router.js?v=20260419g" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260419h" defer></script>
+<script src="07-post-load.js?v=20260419h" defer></script>
+<script src="08-post-actions.js?v=20260419h" defer></script>
+<script src="09-library.js?v=20260419h" defer></script>
+<script src="09-approval.js?v=20260419h" defer></script>
+<script src="04-router.js?v=20260419h" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -9957,7 +9957,10 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 #pcs-pane-client,
 #pcs-pane-internal { display: block !important; overflow: visible !important; }
 
-/* CHANGE 2: caption typography + 2-line clamp */
+/* CHANGE 2: caption typography + 2-line clamp (no ellipsis — the
+   See More button signals truncation). Uses pure max-height + overflow
+   hidden instead of -webkit-line-clamp so the browser does not paint
+   the "..." suffix at the cutoff. */
 .pcs-caption-text {
   font-family: 'Fraunces', serif;
   font-size: 15px;
@@ -9965,10 +9968,9 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   color: #C9C5BA;
   white-space: pre-wrap;
   word-break: break-word;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  display: block;
   overflow: hidden;
+  text-overflow: clip;
   max-height: calc(1.6em * 2);
 }
 .pcs-caption-text.expanded {
@@ -10153,3 +10155,9 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
   min-height: 160px;
   outline: none;
 }
+
+/* CHANGE 1 (20260419h): the ALL/ADMIN/SERV/CREATIVE visibility
+   selector inside #pcs-pane-internal is hidden — the filter chip
+   bar at the top + the single CLIENT + AGENCY label in the section
+   header replace it. */
+#pcs-vis-selector { display: none !important; }


### PR DESCRIPTION
## Summary

Styling + filter-handler tweaks on top of merged PR #954. Scope: `actions/pcs.js` + `styles.css` + `index.html` (version bump). No data / business logic changes.

### Changes
1. **Hide `#pcs-vis-selector`** — the ALL/ADMIN/SERV/CREATIVE chip row that used to live in `#pcs-pane-internal` is now hidden globally via `display:none !important`. The single "CLIENT + AGENCY" label in the section header + the top filter chip bar cover the same information; this removes the redundant row.
2. **Composer follows filter** — the `.pcs-fchip` click handler now also toggles the `.pcs-ibar-wrap` wrappers so only the active zone's composer sits in the page flow. Matching initial-state block defensively shows `.pcs-ibar-wrap.client` and hides `.pcs-ibar-wrap.notes` so first open mirrors the Client-default chip.
3. **Caption 2-line clamp loses the auto ellipsis** — `.pcs-caption-text` drops `-webkit-line-clamp` in favour of a pure `max-height: calc(1.6em * 2)` + `overflow:hidden` + `text-overflow: clip`. The browser-rendered "..." at the 2-line cutoff is gone; the See More button is the sole truncation cue. `.pcs-caption-text.expanded` still flips to `display:block` + `max-height:none` so the full caption unfurls on tap.
4. **Version** — 28 `?v=` strings bumped `20260419g -> 20260419h`.

### Pre-flight
- No person names hardcoded. No new deps. No `/sorted/` paths.
- No `rgba()` introduced; all alpha colors go through existing tokens.
- The `_pcsEnsureCommentsHeader` helper is still idempotent — hitting a second PCS open doesn't stack composers or filter bars.

## Test plan
- [ ] Internal pane no longer shows the ALL/ADMIN/SERV/CREATIVE chip row.
- [ ] First open on a post with unresolved comments: client composer visible, notes composer hidden.
- [ ] Tap Internal chip: client composer hides, notes composer appears, scroll lands on `#pcs-pane-internal`.
- [ ] Tap Client: reverse.
- [ ] Long caption (100+ chars): 2 lines, no "..." tail; tap "See More" to unfurl.
- [ ] Short caption (under 100 chars): no See More pill; full caption visible.
- [ ] Hard refresh picks up `20260419h` cache-bust.

https://claude.ai/code/session_01Ujrg4Fgm3mnHFGHLcD5xnv