### PR TITLE
Add Cloudflare cache purge workflow on push to main

### DIFF
--- a/.github/workflows/cloudflare-purge.yml
+++ b/.github/workflows/cloudflare-purge.yml
@@ -1,0 +1,17 @@
+name: Purge Cloudflare Cache
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  purge-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Purge Cloudflare Cache
+        run: |
+          curl -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_CACHE_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}'


### PR DESCRIPTION
## Summary
- New GitHub Actions workflow at `.github/workflows/cloudflare-purge.yml`
- Triggers on push to `main`, hits Cloudflare `purge_cache` API with `purge_everything:true`
- Requires repo secrets: `CLOUDFLARE_ZONE_ID`, `CLOUDFLARE_CACHE_TOKEN`
- No version strings bumped, no other files touched

## Test plan
- [ ] Confirm both repo secrets are set before first push
- [ ] Merge this PR, then verify the workflow run succeeds in Actions tab
- [ ] Confirm Cloudflare dashboard shows a recent purge event

https://claude.ai/code/session_01AadDkY7DGj9gR3s4EMUafy