### PR TITLE
Add auto-merge workflow for claude/* branches

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,20 @@
+name: Auto Merge PR
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Enable Auto-Merge
+        if: startsWith(github.head_ref, 'claude/')
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --auto \
+            --squash \
+            --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/auto-merge.yml` — enables GitHub auto-merge (squash) on PRs whose `head_ref` starts with `claude/`.
- Gated on branch prefix so only Claude orchestrator PRs auto-merge; human PRs are untouched.
- `--auto` respects branch protection, so required checks (Tests, e2e on core-logic files) still gate the merge.

## Files changed
- `.github/workflows/auto-merge.yml` (new, 20 lines)

## Test plan
- [ ] Merge this PR manually once (auto-merge can't merge itself until the workflow exists on `main-/-root`).
- [ ] Open a follow-up `claude/*` PR; confirm the `Auto Merge PR` workflow runs and the PR shows "Auto-merge enabled".
- [ ] Confirm it squash-merges after `Tests` passes.
- [ ] Open a non-`claude/*` PR (e.g. `feature/foo`); confirm the `Enable Auto-Merge` step is skipped by the `if: startsWith(...)` guard.

https://claude.ai/code/session_014dYj7s7seYg9LYNGENDwgk