### PR TITLE
Add auto-merge workflow for claude/* branches

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,20 @@
+name: Auto Merge PR
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Enable Auto-Merge
+        if: startsWith(github.head_ref, 'claude/')
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --auto \
+            --squash \
+            --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Enables GitHub auto-merge on PRs whose head_ref starts with claude/, squashing once branch-protection checks pass. Gated so only Claude orchestrator branches auto-merge; human PRs remain untouched.

https://claude.ai/code/session_014dYj7s7seYg9LYNGENDwgk