### PR TITLE
Fix workflow branch triggers (main → main-/-root) + widen sed regex

### DIFF
--- a/.github/workflows/cloudflare-purge.yml
+++ b/.github/workflows/cloudflare-purge.yml
@@ -3,7 +3,7 @@ name: Purge Cloudflare Cache
 on:
   push:
     branches:
-      - main
+      - main-/-root
 
 jobs:
   purge-cache:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -3,7 +3,7 @@ name: Auto Version Bump
 on:
   push:
     branches:
-      - main
+      - main-/-root
 
 jobs:
   bump-version:
@@ -17,7 +17,7 @@ jobs:
       - name: Bump ?v= strings in index.html
         run: |
           DATE=$(date +'%Y%m%d')
-          sed -i "s/?v=[0-9]*/?v=${DATE}1/g" index.html
+          sed -i "s/?v=[0-9A-Za-z]*/?v=${DATE}1/g" index.html
 
       - name: Commit and push if changed
         run: |


### PR DESCRIPTION
## Summary
- `cloudflare-purge.yml`: branch trigger `main` → `main-/-root` (actual deploy branch)
- `version-bump.yml`: branch trigger `main` → `main-/-root`
- `version-bump.yml`: sed regex `[0-9]*` → `[0-9A-Za-z]*` so trailing letter suffix (e.g. `z` in `?v=20260418z`) is stripped cleanly

No other files touched. No version strings bumped. CLAUDE.md unchanged per instructions.

## Test plan
- [ ] Merge this PR, verify Actions tab shows both workflows triggering on the merge commit into `main-/-root`
- [ ] Confirm version-bump produces `?v=YYYYMMDD1` format (no stray trailing letter)
- [ ] Confirm Cloudflare dashboard shows a purge event

https://claude.ai/code/session_01AadDkY7DGj9gR3s4EMUafy