### PR TITLE
PCS comments header count breakdown + inline resolved threads

### DIFF
--- a/actions/pcs.js
+++ b/actions/pcs.js
@@ -1358,10 +1358,14 @@ window._pcsSectionCounts = window._pcsSectionCounts || { client: 0, internal: 0 
 function _pcsUpdateSectionCount(client, internal) {
   if (client !== null && client !== undefined) window._pcsSectionCounts.client = client;
   if (internal !== null && internal !== undefined) window._pcsSectionCounts.internal = internal;
+  var clientCount = window._pcsSectionCounts.client;
+  var internalCount = window._pcsSectionCounts.internal;
   var cEl = document.getElementById('pcs-section-count');
-  var iEl = document.getElementById('pcs-section-internal');
-  if (cEl) cEl.textContent = window._pcsSectionCounts.client;
-  if (iEl) iEl.textContent = 'Internal ' + window._pcsSectionCounts.internal;
+  var cClientEl = document.getElementById('pcs-section-client-count');
+  var iEl = document.getElementById('pcs-section-internal-count');
+  if (cEl) cEl.textContent = clientCount;
+  if (cClientEl) cClientEl.textContent = clientCount + ' client';
+  if (iEl) iEl.textContent = internalCount + ' internal';
 }
 
 // Inject section header + filter chip bar above comments list, idempotent.
@@ -1372,11 +1376,12 @@ function _pcsEnsureCommentsHeader(list) {
     var header = document.createElement('div');
     header.className = 'pcs-comments-section-header';
     header.innerHTML =
-      '<span class="pcs-section-title">Comments</span>' +
-      '<span class="pcs-section-count" id="pcs-section-count">0</span>' +
+      '<span class="pcs-section-title">Comments <span class="pcs-section-count" id="pcs-section-count">0</span></span>' +
       '<span class="pcs-section-sep">\u00B7</span>' +
-      '<span class="pcs-section-internal" id="pcs-section-internal">Internal 0</span>' +
-      '<span class="pcs-section-vis">CLIENT + AGENCY</span>';
+      '<span class="pcs-section-client-count" id="pcs-section-client-count">0 client</span>' +
+      '<span class="pcs-section-sep">\u00B7</span>' +
+      '<span class="pcs-section-internal-count" id="pcs-section-internal-count">0 internal</span>' +
+      '<span class="pcs-section-vis">Client + Agency</span>';
     parent.insertBefore(header, list);
   }
   if (!parent.querySelector('.pcs-filter-bar')) {
@@ -1877,15 +1882,7 @@ window.loadPcsComments = async function(postId) {
     var clientHtml = _renderClientThread(activeClientRows, emptyClient);
 
     if (resolvedClientRows.length) {
-      clientHtml +=
-        '<details class="pcs-resolved-wrap">' +
-        '<summary class="pcs-resolved-summary">' +
-        '\u21B3 ' + resolvedClientRows.length +
-        ' Resolved Comment' +
-        (resolvedClientRows.length > 1 ? 's' : '') +
-        ' (click to expand)</summary>' +
-        _renderClientThread(resolvedClientRows, '') +
-        '</details>';
+      clientHtml += _renderClientThread(resolvedClientRows, '');
     }
 
     list.innerHTML = clientHtml;
@@ -1930,15 +1927,7 @@ window.loadPcsComments = async function(postId) {
       var notesHtml = _renderNoteThread(activeRows, emptyNotes);
 
       if (resolvedRows.length) {
-        notesHtml +=
-          '<details class="pcs-resolved-wrap">' +
-          '<summary class="pcs-resolved-summary">' +
-          '\u21B3 ' + resolvedRows.length +
-          ' Resolved Note' +
-          (resolvedRows.length > 1 ? 's' : '') +
-          ' (click to expand)</summary>' +
-          _renderNoteThread(resolvedRows, '') +
-          '</details>';
+        notesHtml += _renderNoteThread(resolvedRows, '');
       }
 
       notesList.innerHTML = notesHtml;

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260419i">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419i">
+ <link rel="stylesheet" href="styles.css?v=20260419j">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260419j">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260419i"></script>
-<script src="00-appstate-compat.js?v=20260419i"></script>
-<script src="01-config.js?v=20260419i" defer></script>
-<script src="02-session.js?v=20260419i" defer></script>
-<script src="utils.js?v=20260419i" defer></script>
-<script src="12-profiles.js?v=20260419i" defer></script>
-<script src="03-auth.js?v=20260419i" defer></script>
-<script src="05-api.js?v=20260419i" defer></script>
-<script src="10-ui.js?v=20260419i" defer></script>
+<script src="00-appstate.js?v=20260419j"></script>
+<script src="00-appstate-compat.js?v=20260419j"></script>
+<script src="01-config.js?v=20260419j" defer></script>
+<script src="02-session.js?v=20260419j" defer></script>
+<script src="utils.js?v=20260419j" defer></script>
+<script src="12-profiles.js?v=20260419j" defer></script>
+<script src="03-auth.js?v=20260419j" defer></script>
+<script src="05-api.js?v=20260419j" defer></script>
+<script src="10-ui.js?v=20260419j" defer></script>
 
-<script src="06-post-create.js?v=20260419i" defer></script>
-<script defer src="render/dashboard.js?v=20260419i"></script>
-<script defer src="render/client.js?v=20260419i"></script>
-<script defer src="render/pipeline.js?v=20260419i"></script>
-<script defer src="render/brief.js?v=20260419i"></script>
-<script defer src="actions/pcs.js?v=20260419i"></script>
-<script defer src="actions/pcs-longpress.js?v=20260419i"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260419i"></script>
-<script defer src="actions/pcs-polish.js?v=20260419i"></script>
-<script defer src="actions/pcs-select.js?v=20260419i"></script>
-<script src="ai-config.js?v=20260419i" defer></script>
+<script src="06-post-create.js?v=20260419j" defer></script>
+<script defer src="render/dashboard.js?v=20260419j"></script>
+<script defer src="render/client.js?v=20260419j"></script>
+<script defer src="render/pipeline.js?v=20260419j"></script>
+<script defer src="render/brief.js?v=20260419j"></script>
+<script defer src="actions/pcs.js?v=20260419j"></script>
+<script defer src="actions/pcs-longpress.js?v=20260419j"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260419j"></script>
+<script defer src="actions/pcs-polish.js?v=20260419j"></script>
+<script defer src="actions/pcs-select.js?v=20260419j"></script>
+<script src="ai-config.js?v=20260419j" defer></script>
 <script>
   (function() {
     try {
@@ -1321,12 +1321,12 @@ window.setPcsVisibility = function(el, vis) {
     }
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260419i" defer></script>
-<script src="07-post-load.js?v=20260419i" defer></script>
-<script src="08-post-actions.js?v=20260419i" defer></script>
-<script src="09-library.js?v=20260419i" defer></script>
-<script src="09-approval.js?v=20260419i" defer></script>
-<script src="04-router.js?v=20260419i" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260419j" defer></script>
+<script src="07-post-load.js?v=20260419j" defer></script>
+<script src="08-post-actions.js?v=20260419j" defer></script>
+<script src="09-library.js?v=20260419j" defer></script>
+<script src="09-approval.js?v=20260419j" defer></script>
+<script src="04-router.js?v=20260419j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -10233,12 +10233,20 @@ body.client-mode .stage-chip[data-stage="brief_done"] {
 }
 .pcs-section-sep {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 11px;
+  opacity: 0.4;
 }
 .pcs-section-internal {
   font-family: var(--sans);
   font-size: 13px;
   font-weight: 500;
+  color: var(--text-muted);
+}
+.pcs-section-client-count,
+.pcs-section-internal-count {
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 400;
   color: var(--text-muted);
 }
 .pcs-section-vis {


### PR DESCRIPTION
## Summary

- **Comments header** — `_pcsEnsureCommentsHeader` + `_pcsUpdateSectionCount` in `actions/pcs.js` now render `Comments N · N client · N internal` (with `Client + Agency` pushed right) instead of the older `Comments N · Internal N`. Spans use new IDs `pcs-section-client-count` / `pcs-section-internal-count` so updates are idempotent.
- **Resolved threads inline** — removed the `<details>/<summary>` collapsible wrappers around resolved client comments and resolved internal notes. They now render directly after the active rows and keep the `.pcs-resolved` / `.pcs-resolved-label` visual treatment.
- **Styles** — added `.pcs-section-client-count` / `.pcs-section-internal-count` typography (13px, muted) and softened `.pcs-section-sep` to 11px with `opacity:0.4` in `styles.css`.
- **Version bump** — all 28 `?v=` strings in `index.html` rolled `20260419i -> 20260419j`.

## Test plan

- [x] `npx vitest run` — 553/553 passing
- [ ] Open PCS on a post with both active + resolved client comments: header reads `Comments N · N client · M internal`; resolved comments render inline below active ones with the greyed-out treatment.
- [ ] Same check on the Internal tab — resolved notes render inline, no collapsible summary.
- [ ] Hard-refresh a client device and confirm the version chip reads `20260419j`.

https://claude.ai/code/session_01MMMZsP7aghefToeZ4AnEqP