### PR TITLE
docs: audit actions workflows and document index.html cache-bypass invariant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,13 @@ Other: `index.html`, `styles.css`, `r2-upload-worker.js`, `wrangler.toml`, `pack
 
 ## 4 — ARCHITECTURE RULES AND GOTCHAS
 
+### Cloudflare cache invariant — `index.html` must NEVER be cached
+- `index.html` is the cache-busting anchor for every versioned asset (the 28 `?v=YYYYMMDDx` strings). If Cloudflare serves a stale `index.html`, users get the OLD `?v=` query strings, and browsers happily hand back the OLD cached JS/CSS — deploys ship but no one sees them.
+- **Rule (set MANUALLY in Cloudflare dashboard — not in this repo):** dash.cloudflare.com → `srtd.io` → Caching → Cache Rules → Create rule → `URL Path` `equals` `/index.html` → Cache eligibility: **Bypass cache**. Save + Deploy.
+- Do NOT encode this rule in `wrangler.toml` or any Worker — the two Workers in this repo (`srtd-r2-upload`, `srtd-og-inject`) don't sit in front of `srtd.io/index.html`; the origin is GitHub Pages via Cloudflare's edge, so the rule lives at the zone level.
+- `.github/workflows/cloudflare-purge.yml` purges everything on every push to `main-/-root` as a belt-and-braces fallback, but the Cache Rule is the primary defence — purges race with user traffic, rules do not.
+- If the Cache Rule is ever removed by accident, users WILL see stale builds until they hard-refresh. Re-create it immediately.
+
 ### AppState shape (`00-appstate.js`)
 ```
 window.AppState = {


### PR DESCRIPTION
## Summary
- Audited `.github/workflows/` — `auto-merge.yml` and `cloudflare-purge.yml` both look correct (trigger + secret names verified).
- Added a Cloudflare cache invariant section to `CLAUDE.md` §4 explaining why `index.html` must be bypassed at the edge and how to set the Cache Rule manually in the Cloudflare dashboard.

## Workflow audit findings
- **`cloudflare-purge.yml`** — trigger `push` to `main-/-root`. Calls `POST https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/purge_cache` with `{"purge_everything":true}`, auth `Bearer $CLOUDFLARE_CACHE_TOKEN`. Secret names: `CLOUDFLARE_ZONE_ID` + `CLOUDFLARE_CACHE_TOKEN` — consistent, no typos.
- **`auto-merge.yml`** — trigger `pull_request` opened/synchronize/reopened. Gated on `startsWith(github.head_ref, 'claude/')`, runs `gh pr merge --auto --squash` with the default `GITHUB_TOKEN`.
- **`version-bump.yml`**, **`deploy-worker.yml`**, **`smoke.yml`**, **`test.yml`** — also scanned, unchanged, no issues spotted.

## Why the cache rule matters
`index.html` anchors the 28 `?v=YYYYMMDDx` query strings. If Cloudflare serves a stale `index.html`, the browser pulls stale JS/CSS from cache because the `?v=` hasn't changed. Purge-everything on push is a fallback; a standing Cache Rule (`/index.html` → Bypass cache) is the primary defence.

## Test plan
- [ ] Verify CLAUDE.md renders the new §4 subsection cleanly
- [ ] Manually add the Cache Rule in Cloudflare dashboard (`dash.cloudflare.com → srtd.io → Caching → Cache Rules → Create rule → URL Path equals /index.html → Bypass cache`)
- [ ] Confirm `cloudflare-purge.yml` still fires on next merge to `main-/-root`

https://claude.ai/code/session_01TPzig2vNgLDCSK6VBdjx65