### PR TITLE
fix: migrate Supabase URL + anon key from Seoul to Mumbai project

### DIFF
--- a/00-appstate.js
+++ b/00-appstate.js
@@ -82,8 +82,8 @@ window.logError = function(message, stack, action) {
     action:        String(action || 'uncaught'),
     app_version:   _version
   };
-  var _url = 'https://ozptjplxbyswclolbxyn.supabase.co/rest/v1/error_log';
-  var _key = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im96cHRqcGx4Ynlzd2Nsb2xieHluIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY0NzU0ODAsImV4cCI6MjA5MjA1MTQ4MH0.BCiqZAP64ZiJggcXT-vNAeagTlnUiybfgI5BEEoLDWA';
+  var _url = 'https://vxokfscjzytpgdrmertk.supabase.co/rest/v1/error_log';
+  var _key = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ4b2tmc2Nqenl0cGdkcm1lcnRrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMzE2NzAsImV4cCI6MjA4ODkwNzY3MH0.j1LKb2FOarLIi5DDChiWF_DTihKdLCEQMKdy9M5JQkw';
   fetch(_url, {
     method: 'POST',
     headers: {

--- a/01-config.js
+++ b/01-config.js
@@ -8,8 +8,8 @@ console.log("LOADED:", "01-config.js");
 if (window.AppState.ui.modalOpen === undefined)      window.AppState.ui.modalOpen = false;
 if (window._deferredRender === undefined) window._deferredRender = false;
 
-const SUPABASE_URL          = 'https://ozptjplxbyswclolbxyn.supabase.co';
-const SUPABASE_KEY          = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im96cHRqcGx4Ynlzd2Nsb2xieHluIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY0NzU0ODAsImV4cCI6MjA5MjA1MTQ4MH0.BCiqZAP64ZiJggcXT-vNAeagTlnUiybfgI5BEEoLDWA';
+const SUPABASE_URL          = 'https://vxokfscjzytpgdrmertk.supabase.co';
+const SUPABASE_KEY          = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ4b2tmc2Nqenl0cGdkcm1lcnRrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMzE2NzAsImV4cCI6MjA4ODkwNzY3MH0.j1LKb2FOarLIi5DDChiWF_DTihKdLCEQMKdy9M5JQkw';
 const APP_URL               = 'https://guneygaar.github.io';
 const READY_TO_SEND_TARGET  = 30;
 const CLIENT_REQUEST_FORM_URL = '';

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260420a">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260420a">
+ <link rel="stylesheet" href="styles.css?v=20260420b">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260420b">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260420a"></script>
-<script src="00-appstate-compat.js?v=20260420a"></script>
-<script src="01-config.js?v=20260420a" defer></script>
-<script src="02-session.js?v=20260420a" defer></script>
-<script src="utils.js?v=20260420a" defer></script>
-<script src="12-profiles.js?v=20260420a" defer></script>
-<script src="03-auth.js?v=20260420a" defer></script>
-<script src="05-api.js?v=20260420a" defer></script>
-<script src="10-ui.js?v=20260420a" defer></script>
+<script src="00-appstate.js?v=20260420b"></script>
+<script src="00-appstate-compat.js?v=20260420b"></script>
+<script src="01-config.js?v=20260420b" defer></script>
+<script src="02-session.js?v=20260420b" defer></script>
+<script src="utils.js?v=20260420b" defer></script>
+<script src="12-profiles.js?v=20260420b" defer></script>
+<script src="03-auth.js?v=20260420b" defer></script>
+<script src="05-api.js?v=20260420b" defer></script>
+<script src="10-ui.js?v=20260420b" defer></script>
 
-<script src="06-post-create.js?v=20260420a" defer></script>
-<script defer src="render/dashboard.js?v=20260420a"></script>
-<script defer src="render/client.js?v=20260420a"></script>
-<script defer src="render/pipeline.js?v=20260420a"></script>
-<script defer src="render/brief.js?v=20260420a"></script>
-<script defer src="actions/pcs.js?v=20260420a"></script>
-<script defer src="actions/pcs-longpress.js?v=20260420a"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260420a"></script>
-<script defer src="actions/pcs-polish.js?v=20260420a"></script>
-<script defer src="actions/pcs-select.js?v=20260420a"></script>
-<script src="ai-config.js?v=20260420a" defer></script>
+<script src="06-post-create.js?v=20260420b" defer></script>
+<script defer src="render/dashboard.js?v=20260420b"></script>
+<script defer src="render/client.js?v=20260420b"></script>
+<script defer src="render/pipeline.js?v=20260420b"></script>
+<script defer src="render/brief.js?v=20260420b"></script>
+<script defer src="actions/pcs.js?v=20260420b"></script>
+<script defer src="actions/pcs-longpress.js?v=20260420b"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260420b"></script>
+<script defer src="actions/pcs-polish.js?v=20260420b"></script>
+<script defer src="actions/pcs-select.js?v=20260420b"></script>
+<script src="ai-config.js?v=20260420b" defer></script>
 <script>
   (function() {
     try {
@@ -1318,12 +1318,12 @@ window.setPcsVisibility = function(el, vis) {
     } catch (e) {}
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260420a" defer></script>
-<script src="07-post-load.js?v=20260420a" defer></script>
-<script src="08-post-actions.js?v=20260420a" defer></script>
-<script src="09-library.js?v=20260420a" defer></script>
-<script src="09-approval.js?v=20260420a" defer></script>
-<script src="04-router.js?v=20260420a" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260420b" defer></script>
+<script src="07-post-load.js?v=20260420b" defer></script>
+<script src="08-post-actions.js?v=20260420b" defer></script>
+<script src="09-library.js?v=20260420b" defer></script>
+<script src="09-approval.js?v=20260420b" defer></script>
+<script src="04-router.js?v=20260420b" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/preview/index.html
+++ b/preview/index.html
@@ -426,8 +426,8 @@ body {
 
 <script>
 (function() {
-  var SUPABASE_URL = 'https://ozptjplxbyswclolbxyn.supabase.co';
-  var SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im96cHRqcGx4Ynlzd2Nsb2xieHluIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY0NzU0ODAsImV4cCI6MjA5MjA1MTQ4MH0.BCiqZAP64ZiJggcXT-vNAeagTlnUiybfgI5BEEoLDWA';
+  var SUPABASE_URL = 'https://vxokfscjzytpgdrmertk.supabase.co';
+  var SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ4b2tmc2Nqenl0cGdkcm1lcnRrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMzE2NzAsImV4cCI6MjA4ODkwNzY3MH0.j1LKb2FOarLIi5DDChiWF_DTihKdLCEQMKdy9M5JQkw';
   var LOGO_URL = 'https://pub-6a2a4aa8073d454ab9aeee69ef841635.r2.dev/post-assets/Godavari.jpg';
 
   var app = document.getElementById('app');

--- a/sorted-preview-worker/src/index.js
+++ b/sorted-preview-worker/src/index.js
@@ -1,5 +1,5 @@
-const SUPABASE_URL = 'https://ozptjplxbyswclolbxyn.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im96cHRqcGx4Ynlzd2Nsb2xieHluIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY0NzU0ODAsImV4cCI6MjA5MjA1MTQ4MH0.BCiqZAP64ZiJggcXT-vNAeagTlnUiybfgI5BEEoLDWA';
+const SUPABASE_URL = 'https://vxokfscjzytpgdrmertk.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ4b2tmc2Nqenl0cGdkcm1lcnRrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMzE2NzAsImV4cCI6MjA4ODkwNzY3MH0.j1LKb2FOarLIi5DDChiWF_DTihKdLCEQMKdy9M5JQkw';
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',

--- a/sql/007-post-comments-image-type.sql
+++ b/sql/007-post-comments-image-type.sql
@@ -1,5 +1,5 @@
 -- PR: fix-pcs-bugs (BUG 5 — comment image type mismatch)
--- Project: ozptjplxbyswclolbxyn
+-- Project: vxokfscjzytpgdrmertk
 --
 -- post_comments.attachments is jsonb that holds an array of blocks, e.g.
 --   [{"type":"images","urls":["https://..."]}, {"type":"task", ...}]

--- a/srtd-ai-worker/src/index.js
+++ b/srtd-ai-worker/src/index.js
@@ -13,7 +13,7 @@
 //   *                  → 404
 // ═══════════════════════════════════════════════════════════════
 
-const SUPABASE_URL = 'https://ozptjplxbyswclolbxyn.supabase.co';
+const SUPABASE_URL = 'https://vxokfscjzytpgdrmertk.supabase.co';
 // Service-role key — required for workspace_settings reads + ai_usage
 // writes with the current (loose) table permissions. Consistent with
 // the hardcoded-Supabase-creds pattern used by sorted-preview-worker.

--- a/tests/e2e/live-smoke.spec.js
+++ b/tests/e2e/live-smoke.spec.js
@@ -3,7 +3,7 @@ const { test, expect } = require('@playwright/test');
 // ── Environment ─────────────────────────────────────────────
 const ADMIN_EMAIL   = process.env.SORTED_ADMIN_EMAIL;
 const CLIENT_EMAIL  = process.env.SORTED_CLIENT_EMAIL;
-const SUPABASE_URL  = 'https://ozptjplxbyswclolbxyn.supabase.co';
+const SUPABASE_URL  = 'https://vxokfscjzytpgdrmertk.supabase.co';
 const SUPABASE_KEY  = process.env.SORTED_SUPABASE_KEY;
 
 // ── Guard: skip entire suite if env vars missing ────────────


### PR DESCRIPTION
## Summary

Migrate every in-repo reference to the old Seoul Supabase project (`ozptjplxbyswclolbxyn`) to the new Mumbai project (`vxokfscjzytpgdrmertk`). URL + anon key swapped in lockstep where both are hardcoded; URL-only where the file sources the key from a different path (env var / already-Mumbai service-role key).

Branched directly off `main-/-root` (commit `c5531e7`) so the diff is scoped to just this migration — no unrelated open-PR content.

## Audit — occurrences of `ozptjplxbyswclolbxyn` on baseline

```
00-appstate.js:85                      → URL
00-appstate.js:86                      → anon key JWT (payload ref:ozp…)
01-config.js:11                        → URL
01-config.js:12                        → anon key JWT
preview/index.html:429                 → URL
preview/index.html:430                 → anon key JWT
sorted-preview-worker/src/index.js:1   → URL
sorted-preview-worker/src/index.js:2   → anon key JWT
srtd-ai-worker/src/index.js:16         → URL only (line 20 = Mumbai
                                          service-role key, untouched)
tests/e2e/live-smoke.spec.js:6         → URL only (key from env)
sql/007-post-comments-image-type.sql:2 → "-- Project:" comment only
```
7 files, 11 line hits.

## Files changed
| File | Scope | Why |
|---|---|---|
| `01-config.js`                         | URL + anon key | Browser Supabase creds |
| `00-appstate.js`                       | URL + anon key | `error_log` sink that bypasses `apiFetch` |
| `preview/index.html`                   | URL + anon key | Public preview page |
| `sorted-preview-worker/src/index.js`   | URL + anon key | `srtd-og-inject` Worker |
| `srtd-ai-worker/src/index.js`          | URL only       | Service-role key on line 20 already has `ref:vxokfscjzytpgdrmertk` baked into its JWT payload — overwriting with the anon key would break `workspace_settings` reads + `ai_usage` writes that require elevated perms |
| `tests/e2e/live-smoke.spec.js`         | URL only       | `SUPABASE_KEY` reads from `process.env.SORTED_SUPABASE_KEY` |
| `sql/007-post-comments-image-type.sql` | `-- Project:` line | Documentary comment — included so a future `grep` is clean |
| `index.html`                           | `?v=20260420a → ?v=20260420b` ×28 | Cache bust |

## Verification
Post-edit:
```
grep -rn 'ozptjplxbyswclolbxyn' . (excluding .git) : 0 hits
grep -rn 'BCiqZAP64ZiJggcXT'     . (excluding .git) : 0 hits
grep -c   '?v=20260420b' index.html                : 28
grep -c   '?v=20260420a' index.html                :  0
```

CLAUDE.md: untouched per task brief.

## Housekeeping
Closed PR #981 (the earlier attempt, branched off an accumulated-history branch) — this PR supersedes it with a clean diff against `main-/-root`.

## Deploy / follow-ups (outside this PR)
1. Redeploy both Workers (`srtd-og-inject`, `srtd-ai-worker`) via `wrangler deploy` / Cloudflare dashboard so the new constants take effect on the live bindings.
2. Rotate the GitHub Actions secret `SORTED_SUPABASE_KEY` to the Mumbai anon key before the next scheduled live-smoke run.
3. Cloudflare cache purge post-deploy; hard-refresh on each device.
4. Spot-check a Client session and confirm every `/rest/v1/*` + `/auth/v1/*` request targets `vxokfscjzytpgdrmertk.supabase.co`.

https://claude.ai/code