### PR TITLE
fix(comments): double-parse double-encoded attachments JSON in vanilla renderers

### DIFF
--- a/10-ui.js
+++ b/10-ui.js
@@ -1253,6 +1253,7 @@ function _notifBuildThreadHtml(n, post, postTitle) {
 function _agencyCommentImgHtml(c) {
   try {
     var att = typeof c.attachments === 'string' ? JSON.parse(c.attachments) : c.attachments;
+    if (typeof att === 'string') { try { att = JSON.parse(att); } catch(e) { return ''; } }
     if (!att || att.type !== 'images' || !Array.isArray(att.urls) || !att.urls.length) return '';
     return '<div class="pcs-comment-imgs">' +
       att.urls.map(function(u, i) {

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260420e">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260420e">
+ <link rel="stylesheet" href="styles.css?v=20260420f">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260420f">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260420e"></script>
-<script src="00-appstate-compat.js?v=20260420e"></script>
-<script src="01-config.js?v=20260420e" defer></script>
-<script src="02-session.js?v=20260420e" defer></script>
-<script src="utils.js?v=20260420e" defer></script>
-<script src="12-profiles.js?v=20260420e" defer></script>
-<script src="03-auth.js?v=20260420e" defer></script>
-<script src="05-api.js?v=20260420e" defer></script>
-<script src="10-ui.js?v=20260420e" defer></script>
+<script src="00-appstate.js?v=20260420f"></script>
+<script src="00-appstate-compat.js?v=20260420f"></script>
+<script src="01-config.js?v=20260420f" defer></script>
+<script src="02-session.js?v=20260420f" defer></script>
+<script src="utils.js?v=20260420f" defer></script>
+<script src="12-profiles.js?v=20260420f" defer></script>
+<script src="03-auth.js?v=20260420f" defer></script>
+<script src="05-api.js?v=20260420f" defer></script>
+<script src="10-ui.js?v=20260420f" defer></script>
 
-<script src="06-post-create.js?v=20260420e" defer></script>
-<script defer src="render/dashboard.js?v=20260420e"></script>
-<script defer src="render/client.js?v=20260420e"></script>
-<script defer src="render/pipeline.js?v=20260420e"></script>
-<script defer src="render/brief.js?v=20260420e"></script>
-<script defer src="actions/pcs.js?v=20260420e"></script>
-<script defer src="actions/pcs-longpress.js?v=20260420e"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260420e"></script>
-<script defer src="actions/pcs-polish.js?v=20260420e"></script>
-<script defer src="actions/pcs-select.js?v=20260420e"></script>
-<script src="ai-config.js?v=20260420e" defer></script>
+<script src="06-post-create.js?v=20260420f" defer></script>
+<script defer src="render/dashboard.js?v=20260420f"></script>
+<script defer src="render/client.js?v=20260420f"></script>
+<script defer src="render/pipeline.js?v=20260420f"></script>
+<script defer src="render/brief.js?v=20260420f"></script>
+<script defer src="actions/pcs.js?v=20260420f"></script>
+<script defer src="actions/pcs-longpress.js?v=20260420f"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260420f"></script>
+<script defer src="actions/pcs-polish.js?v=20260420f"></script>
+<script defer src="actions/pcs-select.js?v=20260420f"></script>
+<script src="ai-config.js?v=20260420f" defer></script>
 <script>
   (function() {
     try {
@@ -1318,12 +1318,12 @@ window.setPcsVisibility = function(el, vis) {
     } catch (e) {}
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260420e" defer></script>
-<script src="07-post-load.js?v=20260420e" defer></script>
-<script src="08-post-actions.js?v=20260420e" defer></script>
-<script src="09-library.js?v=20260420e" defer></script>
-<script src="09-approval.js?v=20260420e" defer></script>
-<script src="04-router.js?v=20260420e" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260420f" defer></script>
+<script src="07-post-load.js?v=20260420f" defer></script>
+<script src="08-post-actions.js?v=20260420f" defer></script>
+<script src="09-library.js?v=20260420f" defer></script>
+<script src="09-approval.js?v=20260420f" defer></script>
+<script src="04-router.js?v=20260420f" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -603,9 +603,11 @@ console.log('LOADED:', 'render/client.js');
 
   function _parseCommentAttachments(c) {
     try {
-      return typeof c.attachments === 'string'
+      var att = typeof c.attachments === 'string'
         ? JSON.parse(c.attachments)
         : c.attachments;
+      if (typeof att === 'string') att = JSON.parse(att);
+      return att;
     } catch (e) { return null; }
   }
 


### PR DESCRIPTION
## Summary

- `post_comments.attachments` arrives JSON-encoded TWICE from the DB. After one `JSON.parse` the result is still a string, so the `type === 'images'` check silently skips and image attachments never render in the client feed or the agency notification thread.
- `render/client.js _parseCommentAttachments` and `10-ui.js _agencyCommentImgHtml` now run a second `JSON.parse` when the first result is still a string — mirroring the React-side fix already in `srtd-next/src/flows/pcs/utils/attachments.js normalizeAttachments()`.
- PR #985 already shipped Bug 2 (drop non-existent `owner_user_id` FK), so this PR covers only the vanilla comment-image regression.

## Changes

- `render/client.js` — `_parseCommentAttachments` does a second parse if the first result is a string.
- `10-ui.js` — `_agencyCommentImgHtml` does the same defensive second parse, returns `''` on parse failure.
- `index.html` — 28 `?v=` strings bumped `20260420e -> 20260420f`.

## Test plan

- [x] `npx vitest run` — 553/553 unit tests pass
- [x] `cd srtd-next && npm run build` — bundle builds cleanly (no JSX changed, dist hash unchanged)
- [ ] Manual: verify image attachments render in client feed comments
- [ ] Manual: verify image attachments render in agency notification thread drawer
