### PR TITLE
docs: clean up Seoul refs in CLAUDE.md + sql/007; bump ?v= to 20260420i

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Team: Shubham (Admin), Chitra (Servicing), Pranav (Creative), Manisha + Shivangi
 
 ## 2 — DB SCHEMA
 
-Supabase: `vxokfscjzytpgdrmertk.supabase.co`. Always `apiFetch()`, never raw `fetch()`. PostgREST `eq.` is CASE-SENSITIVE — use Title Case roles (`Admin`, `Servicing`, `Creative`, `Client`).
+Supabase: `ozptjplxbyswclolbxyn.supabase.co`. Always `apiFetch()`, never raw `fetch()`. PostgREST `eq.` is CASE-SENSITIVE — use Title Case roles (`Admin`, `Servicing`, `Creative`, `Client`).
 
 **posts** — PK `post_id` text
 | col | type | notes |

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260420h">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260420h">
+ <link rel="stylesheet" href="styles.css?v=20260420i">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260420i">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260420h"></script>
-<script src="00-appstate-compat.js?v=20260420h"></script>
-<script src="01-config.js?v=20260420h" defer></script>
-<script src="02-session.js?v=20260420h" defer></script>
-<script src="utils.js?v=20260420h" defer></script>
-<script src="12-profiles.js?v=20260420h" defer></script>
-<script src="03-auth.js?v=20260420h" defer></script>
-<script src="05-api.js?v=20260420h" defer></script>
-<script src="10-ui.js?v=20260420h" defer></script>
+<script src="00-appstate.js?v=20260420i"></script>
+<script src="00-appstate-compat.js?v=20260420i"></script>
+<script src="01-config.js?v=20260420i" defer></script>
+<script src="02-session.js?v=20260420i" defer></script>
+<script src="utils.js?v=20260420i" defer></script>
+<script src="12-profiles.js?v=20260420i" defer></script>
+<script src="03-auth.js?v=20260420i" defer></script>
+<script src="05-api.js?v=20260420i" defer></script>
+<script src="10-ui.js?v=20260420i" defer></script>
 
-<script src="06-post-create.js?v=20260420h" defer></script>
-<script defer src="render/dashboard.js?v=20260420h"></script>
-<script defer src="render/client.js?v=20260420h"></script>
-<script defer src="render/pipeline.js?v=20260420h"></script>
-<script defer src="render/brief.js?v=20260420h"></script>
-<script defer src="actions/pcs.js?v=20260420h"></script>
-<script defer src="actions/pcs-longpress.js?v=20260420h"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260420h"></script>
-<script defer src="actions/pcs-polish.js?v=20260420h"></script>
-<script defer src="actions/pcs-select.js?v=20260420h"></script>
-<script src="ai-config.js?v=20260420h" defer></script>
+<script src="06-post-create.js?v=20260420i" defer></script>
+<script defer src="render/dashboard.js?v=20260420i"></script>
+<script defer src="render/client.js?v=20260420i"></script>
+<script defer src="render/pipeline.js?v=20260420i"></script>
+<script defer src="render/brief.js?v=20260420i"></script>
+<script defer src="actions/pcs.js?v=20260420i"></script>
+<script defer src="actions/pcs-longpress.js?v=20260420i"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260420i"></script>
+<script defer src="actions/pcs-polish.js?v=20260420i"></script>
+<script defer src="actions/pcs-select.js?v=20260420i"></script>
+<script src="ai-config.js?v=20260420i" defer></script>
 <script>
   (function() {
     try {
@@ -1318,12 +1318,12 @@ window.setPcsVisibility = function(el, vis) {
     } catch (e) {}
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260420h" defer></script>
-<script src="07-post-load.js?v=20260420h" defer></script>
-<script src="08-post-actions.js?v=20260420h" defer></script>
-<script src="09-library.js?v=20260420h" defer></script>
-<script src="09-approval.js?v=20260420h" defer></script>
-<script src="04-router.js?v=20260420h" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260420i" defer></script>
+<script src="07-post-load.js?v=20260420i" defer></script>
+<script src="08-post-actions.js?v=20260420i" defer></script>
+<script src="09-library.js?v=20260420i" defer></script>
+<script src="09-approval.js?v=20260420i" defer></script>
+<script src="04-router.js?v=20260420i" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/sql/007-post-comments-image-type.sql
+++ b/sql/007-post-comments-image-type.sql
@@ -1,5 +1,5 @@
 -- PR: fix-pcs-bugs (BUG 5 — comment image type mismatch)
--- Project: vxokfscjzytpgdrmertk
+-- Project: ozptjplxbyswclolbxyn
 --
 -- post_comments.attachments is jsonb that holds an array of blocks, e.g.
 --   [{"type":"images","urls":["https://..."]}, {"type":"task", ...}]


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #987 (Seoul -> Mumbai migration).
- `CLAUDE.md:19` and `sql/007-post-comments-image-type.sql:2` updated to reference the new Mumbai project ref `ozptjplxbyswclolbxyn` so docs match the live runtime.
- `index.html` — all 28 `?v=` cache-bust strings bumped `20260420h` -> `20260420i` so every browser re-fetches the bundle that points at Mumbai after the merge.
- `srtd-next` rebuilt for confirmation; `dist/sorted-react.js` and `dist/style.css` output was byte-identical to the prior build (no source edits), so no bundle bytes change in this PR.

## Not touched (intentional)
- `CLAUDE-archive-20260411.md` — historical archive, still carries the Seoul name on purpose.
- `PROJECT_AUDIT.txt` — audit snapshot, left as-is.
- `.github/workflows/pr-conflict-guard.yml:125` — Seoul ref is the intentional canary that flags any future re-introduction of the old project ref.

## Verification
`srtd-next/src/` contains no Supabase URL/key of its own; `core/bridges/realtime.js:9` reuses `window._supabaseClient` and `core/api/client.js:9` wraps `window.apiFetch`, both initialised from vanilla `01-config.js` which PR #987 already pointed at Mumbai with the Mumbai-signed anon JWT.

## Test plan
- [ ] After merge: purge Cloudflare cache and hard-refresh; confirm `srtd.io/index.html` serves `?v=20260420i`.
- [ ] After merge: smoke-test login, post feed load, comment post, Realtime push.
- [ ] After merge: `live-smoke.spec.js` passes against Mumbai in the 30-min smoke workflow.

https://claude.ai/code/session_01VLKyCLhjca4VvkCaKZK5wb