### PR TITLE
bump ?v= strings 20260420i -> 20260420j

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260420i">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260420i">
+ <link rel="stylesheet" href="styles.css?v=20260420j">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260420j">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260420i"></script>
-<script src="00-appstate-compat.js?v=20260420i"></script>
-<script src="01-config.js?v=20260420i" defer></script>
-<script src="02-session.js?v=20260420i" defer></script>
-<script src="utils.js?v=20260420i" defer></script>
-<script src="12-profiles.js?v=20260420i" defer></script>
-<script src="03-auth.js?v=20260420i" defer></script>
-<script src="05-api.js?v=20260420i" defer></script>
-<script src="10-ui.js?v=20260420i" defer></script>
+<script src="00-appstate.js?v=20260420j"></script>
+<script src="00-appstate-compat.js?v=20260420j"></script>
+<script src="01-config.js?v=20260420j" defer></script>
+<script src="02-session.js?v=20260420j" defer></script>
+<script src="utils.js?v=20260420j" defer></script>
+<script src="12-profiles.js?v=20260420j" defer></script>
+<script src="03-auth.js?v=20260420j" defer></script>
+<script src="05-api.js?v=20260420j" defer></script>
+<script src="10-ui.js?v=20260420j" defer></script>
 
-<script src="06-post-create.js?v=20260420i" defer></script>
-<script defer src="render/dashboard.js?v=20260420i"></script>
-<script defer src="render/client.js?v=20260420i"></script>
-<script defer src="render/pipeline.js?v=20260420i"></script>
-<script defer src="render/brief.js?v=20260420i"></script>
-<script defer src="actions/pcs.js?v=20260420i"></script>
-<script defer src="actions/pcs-longpress.js?v=20260420i"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260420i"></script>
-<script defer src="actions/pcs-polish.js?v=20260420i"></script>
-<script defer src="actions/pcs-select.js?v=20260420i"></script>
-<script src="ai-config.js?v=20260420i" defer></script>
+<script src="06-post-create.js?v=20260420j" defer></script>
+<script defer src="render/dashboard.js?v=20260420j"></script>
+<script defer src="render/client.js?v=20260420j"></script>
+<script defer src="render/pipeline.js?v=20260420j"></script>
+<script defer src="render/brief.js?v=20260420j"></script>
+<script defer src="actions/pcs.js?v=20260420j"></script>
+<script defer src="actions/pcs-longpress.js?v=20260420j"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260420j"></script>
+<script defer src="actions/pcs-polish.js?v=20260420j"></script>
+<script defer src="actions/pcs-select.js?v=20260420j"></script>
+<script src="ai-config.js?v=20260420j" defer></script>
 <script>
   (function() {
     try {
@@ -1318,12 +1318,12 @@ window.setPcsVisibility = function(el, vis) {
     } catch (e) {}
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260420i" defer></script>
-<script src="07-post-load.js?v=20260420i" defer></script>
-<script src="08-post-actions.js?v=20260420i" defer></script>
-<script src="09-library.js?v=20260420i" defer></script>
-<script src="09-approval.js?v=20260420i" defer></script>
-<script src="04-router.js?v=20260420i" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260420j" defer></script>
+<script src="07-post-load.js?v=20260420j" defer></script>
+<script src="08-post-actions.js?v=20260420j" defer></script>
+<script src="09-library.js?v=20260420j" defer></script>
+<script src="09-approval.js?v=20260420j" defer></script>
+<script src="04-router.js?v=20260420j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- Bumps all 28 versioned-asset `?v=` strings in `index.html` from `20260420j` (was `20260420i`) for Cloudflare cache-bust.
- Verified `srtd-next/src/flows/pcs/utils/attachments.js` already double-parses double-encoded attachment JSON (matches target spec).
- Verified no `[DEBUG-ATT]` console.log exists anywhere in the repo (CommentRow.jsx or otherwise).
- `npm run build` produced byte-identical `dist/sorted-react.js` + `dist/style.css` (no source drift).

## Test plan
- [ ] Cloudflare purge after merge
- [ ] Hard refresh on iOS Safari + desktop Chrome
- [ ] Verify comment attachments still render (double-encoded JSON rows)

https://claude.ai/code/session_01NmBQhUD3uCCgE96nzyGSfr