### PR TITLE
trigger: redeploy srtd-ai worker post PR-2

### DIFF
--- a/srtd-ai-worker/wrangler.toml
+++ b/srtd-ai-worker/wrangler.toml
@@ -6,6 +6,7 @@ compatibility_date = "2026-04-14"
 # Bootstrap workspace uuid — single source of truth for the worker.
 # Mirrors the workspaces.id row whose slug='default'. Keeps the bootstrap
 # uuid out of the source code (CLAUDE.md scalability rule).
+# Redeploy trigger: post PR-2 cutover (2026-04-26) — workspace_settings → workspaces.
 BOOTSTRAP_WORKSPACE_ID = "69065eef-f823-4338-96c6-057d493b447b"
 
 [[r2_buckets]]


### PR DESCRIPTION
## Summary

- PR-2 (`25f6c23`) flipped `srtd-ai-worker/src/index.js` from `/workspace_settings?workspace_id=eq.<id>` → `/workspaces?id=eq.<id>` and added `BOOTSTRAP_WORKSPACE_ID = "69065eef-f823-4338-96c6-057d493b447b"` to `srtd-ai-worker/wrangler.toml [vars]`.
- The `.github/workflows/deploy-worker.yml` path filter is correctly scoped to `srtd-ai-worker/**`, but the production Cloudflare Worker is still serving the pre-PR-2 build that calls `/workspace_settings` (404 → persistent AI error toast).
- Worker source on `main-/-root` is **already correct** — line 173 reads `/workspaces?id=eq.`, lines 411 / 548 / 707 / 871 fall back to `env.BOOTSTRAP_WORKSPACE_ID`. No code patch needed; this PR only retriggers the deploy.

## Changes

- Adds a single-line trace comment above `BOOTSTRAP_WORKSPACE_ID` in `srtd-ai-worker/wrangler.toml` so the `paths: ['srtd-ai-worker/**']` filter on `deploy-worker.yml` matches and `npx wrangler deploy` runs against `main-/-root`. No runtime behaviour change.

## Audit (pre-PR)

- `git log --oneline origin/main-/-root -- srtd-ai-worker/` confirms PR-2 (`25f6c23`) modified `srtd-ai-worker/src/index.js` (18 lines) and `srtd-ai-worker/wrangler.toml` (6 lines).
- Workflow file: `.github/workflows/deploy-worker.yml`, trigger `on: push: branches: [main, main-/-root], paths: ['srtd-ai-worker/**']` plus `workflow_dispatch`.
- `gh pr list --state open --base main-/-root` (via MCP `list_pull_requests`): empty, so ONE PR RULE satisfied.

## Test plan

- [ ] On merge, GitHub Actions → `Deploy srtd-ai Worker` job runs and `npx wrangler deploy` reports a fresh upload timestamp.
- [ ] Hit any AI button in the app (Caption Workspace `write`, Chat, QC, etc.) and confirm the persistent AI error toast clears — i.e. worker `checkWorkspaceEnabled` resolves the workspace via `/workspaces?id=eq.<uuid>` instead of 404'ing on `/workspace_settings`.

https://claude.ai/code/session_01KM1KPLFFxt3KDsGM9TCJ8u

---
_Generated by [Claude Code](https://claude.ai/code/session_01KM1KPLFFxt3KDsGM9TCJ8u)_