### PR TITLE
fix(ai): _cwLoadMemory reads ai_memory by runtime workspace uuid

### DIFF
--- a/actions/pcs-claude-caption.js
+++ b/actions/pcs-claude-caption.js
@@ -614,7 +614,7 @@ function _cwSaveMemory(trigger, instruction) {
 async function _cwLoadMemory() {
   try {
     var rows = await apiFetch(
-      '/ai_memory?workspace_id=eq.default&order=created_at.desc&limit=50&select=type,content'
+      `/ai_memory?workspace_id=eq.${window.AppState.workspace.id}&order=created_at.desc&limit=50&select=type,content`
     );
     if (!Array.isArray(rows) || rows.length === 0) {
       window._captionWS.memoryPrompt = '';

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260426i">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260426i">
+ <link rel="stylesheet" href="styles.css?v=20260426j">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260426j">
 
 </head>
 <body>
@@ -1286,27 +1286,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260426i"></script>
-<script src="00-appstate-compat.js?v=20260426i"></script>
-<script src="01-config.js?v=20260426i" defer></script>
-<script src="02-session.js?v=20260426i" defer></script>
-<script src="utils.js?v=20260426i" defer></script>
-<script src="12-profiles.js?v=20260426i" defer></script>
-<script src="03-auth.js?v=20260426i" defer></script>
-<script src="05-api.js?v=20260426i" defer></script>
-<script src="10-ui.js?v=20260426i" defer></script>
+<script src="00-appstate.js?v=20260426j"></script>
+<script src="00-appstate-compat.js?v=20260426j"></script>
+<script src="01-config.js?v=20260426j" defer></script>
+<script src="02-session.js?v=20260426j" defer></script>
+<script src="utils.js?v=20260426j" defer></script>
+<script src="12-profiles.js?v=20260426j" defer></script>
+<script src="03-auth.js?v=20260426j" defer></script>
+<script src="05-api.js?v=20260426j" defer></script>
+<script src="10-ui.js?v=20260426j" defer></script>
 
-<script src="06-post-create.js?v=20260426i" defer></script>
-<script defer src="render/dashboard.js?v=20260426i"></script>
-<script defer src="render/client.js?v=20260426i"></script>
-<script defer src="render/pipeline.js?v=20260426i"></script>
-<script defer src="render/brief.js?v=20260426i"></script>
-<script defer src="actions/pcs.js?v=20260426i"></script>
-<script defer src="actions/pcs-longpress.js?v=20260426i"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260426i"></script>
-<script defer src="actions/pcs-polish.js?v=20260426i"></script>
-<script defer src="actions/pcs-select.js?v=20260426i"></script>
-<script src="ai-config.js?v=20260426i" defer></script>
+<script src="06-post-create.js?v=20260426j" defer></script>
+<script defer src="render/dashboard.js?v=20260426j"></script>
+<script defer src="render/client.js?v=20260426j"></script>
+<script defer src="render/pipeline.js?v=20260426j"></script>
+<script defer src="render/brief.js?v=20260426j"></script>
+<script defer src="actions/pcs.js?v=20260426j"></script>
+<script defer src="actions/pcs-longpress.js?v=20260426j"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260426j"></script>
+<script defer src="actions/pcs-polish.js?v=20260426j"></script>
+<script defer src="actions/pcs-select.js?v=20260426j"></script>
+<script src="ai-config.js?v=20260426j" defer></script>
 <script>
   (function() {
     try {
@@ -1318,12 +1318,12 @@ window.setPcsVisibility = function(el, vis) {
     } catch (e) {}
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260426i" defer></script>
-<script src="07-post-load.js?v=20260426i" defer></script>
-<script src="08-post-actions.js?v=20260426i" defer></script>
-<script src="09-library.js?v=20260426i" defer></script>
-<script src="09-approval.js?v=20260426i" defer></script>
-<script src="04-router.js?v=20260426i" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260426j" defer></script>
+<script src="07-post-load.js?v=20260426j" defer></script>
+<script src="08-post-actions.js?v=20260426j" defer></script>
+<script src="09-library.js?v=20260426j" defer></script>
+<script src="09-approval.js?v=20260426j" defer></script>
+<script src="04-router.js?v=20260426j" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 


### PR DESCRIPTION
## Summary
- `actions/pcs-claude-caption.js:617` `_cwLoadMemory` hardcoded `workspace_id=eq.default` against `ai_memory.workspace_id` (uuid) → PostgREST 400 `invalid input syntax for type uuid: "default"`. Memory load was silently dead (try/catch swallowed → empty `memoryPrompt` / `correctionsPrompt`).
- Replaced with backtick template literal reading runtime `window.AppState.workspace.id` — matches the write-path shape already used at lines 555 / 588.
- Bumped all 28 `?v=` strings `20260426i -> 20260426j` per CLAUDE.md §7.

## Verification
- `grep -n "eq.default\|='default'\|=\"default\"" actions/pcs-claude-caption.js` → 0 hits
- `grep -n "workspace_id=eq" actions/pcs-claude-caption.js` → only the new template literal at 617
- `grep -c "?v=20260426j" index.html` → 28 / `?v=20260426i` → 0

## Test plan
- [ ] Load Caption Workspace as agency user; confirm memory rows fetch (network tab: 200 against `/ai_memory?workspace_id=eq.<uuid>...`).
- [ ] Confirm `window._captionWS.memoryPrompt` populates when ai_memory rows exist for the workspace.
- [ ] Confirm no PostgREST 400 in console on Caption Workspace open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvMpwByY2UaVdM83snBEJE)_