### PR TITLE
fix(client): Request → Brief rename + drop name-required block on submit

### DIFF
--- a/03-auth.js
+++ b/03-auth.js
@@ -540,7 +540,7 @@ function _buildUserMenu() {
 
   // Client gets a dedicated slim menu
   if (_roleLower === 'client') {
-    html += '<button class="user-menu-item" onclick="openClientRequestForm(); closeUserMenu()" style="color:#C8A84B;">+ New Request</button>';
+    html += '<button class="user-menu-item" onclick="openClientRequestForm(); closeUserMenu()" style="color:#C8A84B;">+ New Brief</button>';
     html += '<div class="um-divider"></div>';
     html += '<button class="user-menu-item" onclick="toggleTheme(); closeUserMenu()"><span id="theme-icon">\u2600</span> Dark / Light</button>';
     html += '<div class="um-divider"></div>';

--- a/08-post-actions.js
+++ b/08-post-actions.js
@@ -332,7 +332,7 @@ async function submitClientRequest() {
   var reqDate = document.getElementById('req-date')?.value || null;
   var reqName = (document.getElementById('req-name') || {}).value || '';
   var now = new Date();
-  var fallbackTitle = 'Request - ' +
+  var fallbackTitle = 'Brief - ' +
     now.toLocaleDateString('en-IN', { day:'numeric', month:'short', timeZone:'Asia/Kolkata' }) +
     ' - ' +
     now.toLocaleTimeString('en-IN', { hour:'numeric', minute:'2-digit', timeZone:'Asia/Kolkata' });
@@ -340,7 +340,7 @@ async function submitClientRequest() {
     '#req-overlay button[data-action="reqChip"][style*="rgb(200, 168, 75)"]'
   );
   var contentType = selectedChip ? selectedChip.textContent.trim() : null;
-  var _reqTitle = reqName || 'New request';
+  var _reqTitle = reqName || fallbackTitle;
 
   // Optimistic: show success screen immediately
   var overlay = document.getElementById('req-overlay');
@@ -351,7 +351,7 @@ async function submitClientRequest() {
       'justify-content:center;gap:14px;">' +
       '<div style="font-size:32px;color:#C8A84B;line-height:1;">&#x2713;</div>' +
       '<div style="font-family:\'DM Sans\',sans-serif;font-size:22px;' +
-      'font-weight:600;color:#e8e2d9;letter-spacing:-0.01em;">Request sent.</div>' +
+      'font-weight:600;color:#e8e2d9;letter-spacing:-0.01em;">Brief sent.</div>' +
       '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:8px;' +
       'letter-spacing:0.18em;text-transform:uppercase;color:#555;">' +
       'We\'ll get started shortly.</div>' +
@@ -386,7 +386,7 @@ async function submitClientRequest() {
       body: JSON.stringify(payload),
     });
     console.log('[REQUEST] API SUCCESS');
-    await logActivity({ post_id: reqId, actor: email, actor_role: 'Client', action: 'New request: ' + brief.substring(0, 60) });
+    await logActivity({ post_id: reqId, actor: email, actor_role: 'Client', action: 'New brief: ' + brief.substring(0, 60) });
     var _reqActor = (typeof getCanonicalActor === 'function')
       ? getCanonicalActor(email || (window.AppState.user && window.AppState.user.email))
       : '';
@@ -396,7 +396,7 @@ async function submitClientRequest() {
         user_role: 'Servicing',
         post_id: reqId,
         type: 'new_request',
-        message: _reqActor + ' submitted a new request: ' + _reqTitle,
+        message: _reqActor + ' submitted a new brief: ' + _reqTitle,
         actor: _reqActor,
         read: false
       })
@@ -407,7 +407,7 @@ async function submitClientRequest() {
         user_role: 'Admin',
         post_id: reqId,
         type: 'new_request',
-        message: _reqActor + ' submitted a new request: ' + _reqTitle,
+        message: _reqActor + ' submitted a new brief: ' + _reqTitle,
         actor: _reqActor,
         read: false
       })
@@ -425,7 +425,7 @@ async function submitClientRequest() {
     // Roll back: hide success screen, show error toast, re-enable form
     if (overlay) overlay.style.display = 'none';
     showToast('Failed - try again', 'error');
-    // _closeReqForm resets button to -- SEND REQUEST and clears fields
+    // _closeReqForm resets button to -- SEND BRIEF and clears fields
     if (typeof _closeReqForm === 'function') _closeReqForm();
     if (typeof openClientRequestForm === 'function') openClientRequestForm();
   }

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260426x">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260426x">
+ <link rel="stylesheet" href="styles.css?v=20260502a">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260502a">
 
 </head>
 <body>
@@ -1290,27 +1290,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260426x"></script>
-<script src="00-appstate-compat.js?v=20260426x"></script>
-<script src="01-config.js?v=20260426x" defer></script>
-<script src="02-session.js?v=20260426x" defer></script>
-<script src="utils.js?v=20260426x" defer></script>
-<script src="12-profiles.js?v=20260426x" defer></script>
-<script src="03-auth.js?v=20260426x" defer></script>
-<script src="05-api.js?v=20260426x" defer></script>
-<script src="10-ui.js?v=20260426x" defer></script>
+<script src="00-appstate.js?v=20260502a"></script>
+<script src="00-appstate-compat.js?v=20260502a"></script>
+<script src="01-config.js?v=20260502a" defer></script>
+<script src="02-session.js?v=20260502a" defer></script>
+<script src="utils.js?v=20260502a" defer></script>
+<script src="12-profiles.js?v=20260502a" defer></script>
+<script src="03-auth.js?v=20260502a" defer></script>
+<script src="05-api.js?v=20260502a" defer></script>
+<script src="10-ui.js?v=20260502a" defer></script>
 
-<script src="06-post-create.js?v=20260426x" defer></script>
-<script defer src="render/dashboard.js?v=20260426x"></script>
-<script defer src="render/client.js?v=20260426x"></script>
-<script defer src="render/pipeline.js?v=20260426x"></script>
-<script defer src="render/brief.js?v=20260426x"></script>
-<script defer src="actions/pcs.js?v=20260426x"></script>
-<script defer src="actions/pcs-longpress.js?v=20260426x"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260426x"></script>
-<script defer src="actions/pcs-polish.js?v=20260426x"></script>
-<script defer src="actions/pcs-select.js?v=20260426x"></script>
-<script src="ai-config.js?v=20260426x" defer></script>
+<script src="06-post-create.js?v=20260502a" defer></script>
+<script defer src="render/dashboard.js?v=20260502a"></script>
+<script defer src="render/client.js?v=20260502a"></script>
+<script defer src="render/pipeline.js?v=20260502a"></script>
+<script defer src="render/brief.js?v=20260502a"></script>
+<script defer src="actions/pcs.js?v=20260502a"></script>
+<script defer src="actions/pcs-longpress.js?v=20260502a"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260502a"></script>
+<script defer src="actions/pcs-polish.js?v=20260502a"></script>
+<script defer src="actions/pcs-select.js?v=20260502a"></script>
+<script src="ai-config.js?v=20260502a" defer></script>
 <script>
   (function() {
     try {
@@ -1322,12 +1322,12 @@ window.setPcsVisibility = function(el, vis) {
     } catch (e) {}
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260426x" defer></script>
-<script src="07-post-load.js?v=20260426x" defer></script>
-<script src="08-post-actions.js?v=20260426x" defer></script>
-<script src="09-library.js?v=20260426x" defer></script>
-<script src="09-approval.js?v=20260426x" defer></script>
-<script src="04-router.js?v=20260426x" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260502a" defer></script>
+<script src="07-post-load.js?v=20260502a" defer></script>
+<script src="08-post-actions.js?v=20260502a" defer></script>
+<script src="09-library.js?v=20260502a" defer></script>
+<script src="09-approval.js?v=20260502a" defer></script>
+<script src="04-router.js?v=20260502a" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/render/client.js
+++ b/render/client.js
@@ -1070,7 +1070,7 @@ console.log('LOADED:', 'render/client.js');
         '<div style="position:relative;">' +
           '<button data-action="top-menu-toggle" style="background:none;border:none;color:#707078;cursor:pointer;padding:2px 4px;font-size:14px;line-height:1;display:inline-flex;align-items:center;">' + ICON_DOTS + '</button>' +
           '<div data-top-menu style="display:none;position:fixed;background:#0d0d0d;border:1px solid #2A2A34;border-radius:0;min-width:160px;z-index:999999;box-shadow:0 8px 24px #00000099;">' +
-            '<button data-action="new-request" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#ccc;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;">New Request</button>' +
+            '<button data-action="new-request" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#ccc;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;">New Brief</button>' +
             '<button data-action="light-mode" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#555;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;border-top:1px solid #2A2A34;">Light Mode</button>' +
             '<button data-action="sign-out" style="display:block;width:100%;text-align:left;padding:10px 14px;background:none;border:none;color:#888;font-family:\'DM Sans\',sans-serif;font-size:13px;cursor:pointer;border-top:1px solid #2A2A34;">Sign Out</button>' +
           '</div>' +
@@ -2268,7 +2268,7 @@ console.log('LOADED:', 'render/client.js');
     overlay.innerHTML =
       /* HEADER */
       '<div style="display:flex;align-items:center;justify-content:space-between;padding:10px 16px;border-bottom:1px solid #1c1c1c;">' +
-        '<div><span style="font-family:' + mono + ';font-size:10px;letter-spacing:0.12em;text-transform:uppercase;color:#C8A84B;">NEW REQUEST</span>' +
+        '<div><span style="font-family:' + mono + ';font-size:10px;letter-spacing:0.12em;text-transform:uppercase;color:#C8A84B;">NEW BRIEF</span>' +
         '<span style="font-family:' + mono + ';font-size:10px;letter-spacing:0.08em;color:#555;"> -- WE\'LL HANDLE EVERYTHING</span></div>' +
         '<button data-action="reqClose" style="background:none;border:none;color:#AEAEB2;font-size:16px;cursor:pointer;padding:4px;">&#x2715;</button>' +
       '</div>' +
@@ -2277,7 +2277,7 @@ console.log('LOADED:', 'render/client.js');
         /* FIELD 01 */
         '<div style="' + fieldBorder + '">' +
           '<div style="' + numStyle + '">01</div>' +
-          '<div style="' + labelStyle + '">Name this request <span style="color:#FF4B4B;">*</span></div>' +
+          '<div style="' + labelStyle + '">Name the brief</div>' +
           '<input id="req-name" type="text" maxlength="30" placeholder="e.g. Somaiya Diaries, Women\'s Day" style="' + inputStyle + '">' +
           '<div style="font-family:' + mono + ';font-size:9px;letter-spacing:0.08em;color:#8E8E93;margin-top:3px;text-transform:uppercase;">MAX 30 CHARACTERS -- BECOMES THE POST TITLE</div>' +
         '</div>' +
@@ -2340,7 +2340,7 @@ console.log('LOADED:', 'render/client.js');
       /* STICKY FOOTER */
       '<div style="position:sticky;bottom:0;padding:8px 16px 20px;border-top:1px solid #1c1c1c;background:#080808;display:grid;grid-template-columns:1fr 2.2fr;gap:8px;">' +
         '<button data-action="reqClose" style="font-family:' + mono + ';font-size:10px;letter-spacing:0.1em;text-transform:uppercase;color:#8E8E93;background:none;border:1px dotted #444;padding:11px;cursor:pointer;">CANCEL</button>' +
-        '<button id="req-submit-btn" disabled data-action="reqSubmit" style="font-family:' + mono + ';font-size:10px;letter-spacing:0.1em;font-weight:700;text-transform:uppercase;color:#333;background:none;border:1px dotted #2a2a2a;padding:11px;cursor:not-allowed;">-- SEND REQUEST</button>' +
+        '<button id="req-submit-btn" disabled data-action="reqSubmit" style="font-family:' + mono + ';font-size:10px;letter-spacing:0.1em;font-weight:700;text-transform:uppercase;color:#333;background:none;border:1px dotted #2a2a2a;padding:11px;cursor:not-allowed;">-- SEND BRIEF</button>' +
       '</div>';
     document.body.appendChild(overlay);
     // Wire delegated events on request overlay
@@ -2483,7 +2483,7 @@ console.log('LOADED:', 'render/client.js');
       html += '<div style="padding:48px 16px;text-align:center;font-family:\'IBM Plex Mono\',monospace;font-size:11px;letter-spacing:0.06em;color:#FFFFFF59;">All caught up. Nothing pending.</div>';
     } else {
       if (buckets.requests && buckets.requests.length) {
-        html += '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:#505058;font-weight:600;padding:18px 16px 8px;">YOUR REQUESTS <span style="color:#C8A84B;font-weight:700;">' + buckets.requests.length + '</span></div>';
+        html += '<div style="font-family:\'IBM Plex Mono\',monospace;font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:#505058;font-weight:600;padding:18px 16px 8px;">YOUR BRIEFS <span style="color:#C8A84B;font-weight:700;">' + buckets.requests.length + '</span></div>';
         for (var r = 0; r < buckets.requests.length; r++) {
           html += _briefCardHtml(buckets.requests[r]);
         }
@@ -2856,7 +2856,7 @@ window._closeReqForm = function() {
     btn.style.background = 'none';
     btn.style.border = '1px dotted #2a2a2a';
     btn.style.cursor = 'not-allowed';
-    btn.textContent = '-- SEND REQUEST';
+    btn.textContent = '-- SEND BRIEF';
   }
 }
 
@@ -3036,18 +3036,17 @@ window._reqUpdatePhotoCount = function() {
 }
 
 window._reqValidate = function() {
-  var name = (document.getElementById('req-name') || {}).value || '';
   var brief = (document.getElementById('req-topic') || {}).value || '';
   var btn = document.getElementById('req-submit-btn');
   if (!btn) return;
-  var valid = name.trim().length > 0 && brief.trim().length > 0;
+  var valid = brief.trim().length > 0;
   if (valid) {
     btn.disabled = false;
     btn.style.color = '#C8A84B';
     btn.style.background = 'none';
     btn.style.border = '1px dotted #C8A84B';
     btn.style.cursor = 'pointer';
-    btn.textContent = '-- SEND REQUEST';
+    btn.textContent = '-- SEND BRIEF';
   } else {
     btn.disabled = true;
     btn.style.color = '#333';

--- a/tests/client-comment.test.js
+++ b/tests/client-comment.test.js
@@ -510,7 +510,7 @@ describe('error handling pass 2', function() {
     expect(match).toBeTruthy();
     var catchBlock = match[0].match(/catch\s*\(err\)[\s\S]*?\}/);
     expect(catchBlock).toBeTruthy();
-    expect(catchBlock[0]).toMatch(/SEND REQUEST/);
+    expect(catchBlock[0]).toMatch(/SEND BRIEF/);
   });
 
   it('55. renderClientView() wrapped in try/catch', function() {


### PR DESCRIPTION
## Summary

- Click bug fix: `_reqValidate` (render/client.js) used to require BOTH `req-name` AND `req-topic` to be non-empty. With the name field labelled `Name this request *` (red asterisk) but actually optional from a DB standpoint, leaving it blank silently blocked submit. Validation now requires only `req-topic`. `fallbackTitle` ("Brief - 2 May - 6:30 PM") in 08-post-actions.js already covered empty titles cleanly — `_reqTitle` now falls through to it too so notifications get a real-looking title.
- Field 01 stays — it's the brief title, not a user name. Label renamed to `Name the brief`, asterisk removed. The `req-name` input, reset logic, listener, and lookup all stay intact.
- Surface rename: `NEW REQUEST` → `NEW BRIEF`, `-- SEND REQUEST` → `-- SEND BRIEF`, `YOUR REQUESTS` → `YOUR BRIEFS`, `Request sent.` → `Brief sent.`, `New Request` → `New Brief` (top-menu + auth menu), `New request: …` activity log → `New brief: …`, `submitted a new request: …` notification message → `submitted a new brief: …`, `'Request - '` fallback prefix → `'Brief - '`. `type: 'new_request'` event-type enum on the two notification POSTs left untouched (it's an enum, not user copy).

## Out of scope

- `/requests` table, fetch URLs, payload columns, status enum, `_isRequest` flag, `_bucket()` logic — untouched.
- `10-ui.js openRequestSheet` (separate agency rush flow) — untouched.
- `posts.brief_id`, `posts.stage='brief'` lifecycle wiring — left for a later PR.
- No srtd-next/ React file touched.

## Version bump

28 `?v=` strings in `index.html` bumped `20260426x` → `20260502a`. Confirmed via `grep -c "?v=20260502a" index.html` = 28, `grep -c "?v=20260426x" index.html` = 0.

## Tests

`npx vitest run` — **552/552 passing** across 22 files. One existing assertion in `tests/client-comment.test.js` (#54) was pinned to the literal string `SEND REQUEST` inside `submitClientRequest`'s catch block; updated to `SEND BRIEF` to match the rename.

## Test plan

- [ ] Open req-overlay, leave `Name the brief` empty, type only in `What's the brief?` → submit enables.
- [ ] Submit succeeds, success screen reads `Brief sent.`
- [ ] DB row title with empty name = `Brief - <date> - <time>` (e.g. `Brief - 2 May - 6:30 PM`).
- [ ] DB row title with name filled = whatever was typed.
- [ ] Notification `message` reads `<actor> submitted a new brief: <title>`.
- [ ] Top-of-feed menu in client view shows `New Brief`.
- [ ] Client feed section header reads `YOUR BRIEFS`.
- [ ] User menu (3-dot) shows `+ New Brief` for client role.
- [ ] No console errors.

## Post-merge

Cloudflare dash → srtd.io → Caching → Purge Everything. Then Settings → Safari → Clear History and Website Data.

https://claude.ai/code/session_01TcCnfyA4e7iAuhspKeE8qm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcCnfyA4e7iAuhspKeE8qm)_