### PR TITLE
chore: install caveman plugin via project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "caveman": {
+      "source": {
+        "source": "github",
+        "repo": "JuliusBrussee/caveman"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "caveman@caveman": true
+  }
+}


### PR DESCRIPTION
## Summary

Equivalent of running:

```
claude plugin marketplace add JuliusBrussee/caveman
claude plugin install caveman@caveman
```

Adds `.claude/settings.json` registering the `JuliusBrussee/caveman` GitHub repo as the `caveman` marketplace and enabling `caveman@caveman` so the plugin auto-loads for anyone using Claude Code in this repo.

## Files changed
- `.claude/settings.json` (new) — `extraKnownMarketplaces.caveman` + `enabledPlugins["caveman@caveman"]: true`

## Notes
- No app/runtime code touched; nothing to bump in `index.html` `?v=` strings.
- No test changes — this is a Claude Code harness config file.
- Marketplace name defaults to repo name; the second `caveman` in `caveman@caveman` is the marketplace key, not a duplicated plugin name.

## Test plan
- [ ] Pull the branch in Claude Code, confirm `/plugin` lists `caveman@caveman` as enabled without re-running `marketplace add` / `install`.
- [ ] Confirm the plugin's commands/skills are available in a fresh session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeBztbaHKxx92YKd9XgRNU)_