### PR TITLE
docs: raise CLAUDE.md hygiene cap from 250 to 320

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,7 +265,7 @@ When a single PR contains multiple distinct changes, each change gets its own on
 ## CLAUDE.md HYGIENE — NON-NEGOTIABLE
 CLAUDE.md is for architecture facts, schema, and gotchas — NOT PR history. Every update follows these rules:
 
-1. Hard cap: 250 lines. If a change would push CLAUDE.md over 250 lines, archive the oldest `Last updated` entries to `CLAUDE-archive-YYYYMMDD.md` in the SAME PR (match the existing `CLAUDE-archive-20260411.md` / `CLAUDE-archive-20260503.md` pattern). Pre-merge check: run `wc -l CLAUDE.md`. If >250, the PR cannot merge until rotation is done.
+1. Hard cap: 320 lines. If a change would push CLAUDE.md over 320 lines, archive the oldest `Last updated` entries to `CLAUDE-archive-YYYYMMDD.md` in the SAME PR (match the existing `CLAUDE-archive-20260411.md` / `CLAUDE-archive-20260503.md` pattern). Pre-merge check: run `wc -l CLAUDE.md`. If >320, the PR cannot merge until rotation is done.
 
 2. `Last updated` entries are ephemeral context, not permanent record. Keep at most 3 at the top of the file. The 4th one shipping triggers rotation under rule 1.
 


### PR DESCRIPTION
PR #1110 introduced the 250-line hard cap on CLAUDE.md, but the file shipped at 302 lines after the rotation in that same PR — the rule was unsatisfiable the day it landed. Architecture sections 1-9 alone are ~280 lines, so 250 was below the irreducible floor. This raises the cap to 320, which keeps a real ceiling with a small buffer above the architecture floor and makes the rule honest enforcement instead of a known-broken gate.

Single-fix, docs-only. No code, tests, schema, HTML, or `?v=` strings touched. No new `Last updated` entry — per rule 3 in the same section, in-place rule changes don't append a `Last updated` block.

https://claude.ai/code/session_01BRCZybEsChjzEWCBsynRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRCZybEsChjzEWCBsynRyC)_