### PR TITLE
fix: make Create Post FAB clickable (lift above Plan overlay)

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
- <link rel="stylesheet" href="styles.css?v=20260502m">
- <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260502m">
+ <link rel="stylesheet" href="styles.css?v=20260502o">
+ <link rel="stylesheet" href="/srtd-next/dist/style.css?v=20260502o">
 
 </head>
 <body>
@@ -1290,27 +1290,27 @@ window.setPcsVisibility = function(el, vis) {
 <!-- Required for the client-side Realtime subscriptions in 07-post-load.js. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.js"></script>
 <!-- JS versions: bump ALL v= strings together on every deploy -->
-<script src="00-appstate.js?v=20260502m"></script>
-<script src="00-appstate-compat.js?v=20260502m"></script>
-<script src="01-config.js?v=20260502m" defer></script>
-<script src="02-session.js?v=20260502m" defer></script>
-<script src="utils.js?v=20260502m" defer></script>
-<script src="12-profiles.js?v=20260502m" defer></script>
-<script src="03-auth.js?v=20260502n" defer></script>
-<script src="05-api.js?v=20260502m" defer></script>
-<script src="10-ui.js?v=20260502m" defer></script>
+<script src="00-appstate.js?v=20260502o"></script>
+<script src="00-appstate-compat.js?v=20260502o"></script>
+<script src="01-config.js?v=20260502o" defer></script>
+<script src="02-session.js?v=20260502o" defer></script>
+<script src="utils.js?v=20260502o" defer></script>
+<script src="12-profiles.js?v=20260502o" defer></script>
+<script src="03-auth.js?v=20260502o" defer></script>
+<script src="05-api.js?v=20260502o" defer></script>
+<script src="10-ui.js?v=20260502o" defer></script>
 
-<script src="06-post-create.js?v=20260502m" defer></script>
-<script defer src="render/dashboard.js?v=20260502m"></script>
-<script defer src="render/client.js?v=20260502m"></script>
-<script defer src="render/pipeline.js?v=20260502m"></script>
-<script defer src="render/brief.js?v=20260502m"></script>
-<script defer src="actions/pcs.js?v=20260502m"></script>
-<script defer src="actions/pcs-longpress.js?v=20260502m"></script>
-<script defer src="actions/pcs-claude-caption.js?v=20260502m"></script>
-<script defer src="actions/pcs-polish.js?v=20260502m"></script>
-<script defer src="actions/pcs-select.js?v=20260502m"></script>
-<script src="ai-config.js?v=20260502m" defer></script>
+<script src="06-post-create.js?v=20260502o" defer></script>
+<script defer src="render/dashboard.js?v=20260502o"></script>
+<script defer src="render/client.js?v=20260502o"></script>
+<script defer src="render/pipeline.js?v=20260502o"></script>
+<script defer src="render/brief.js?v=20260502o"></script>
+<script defer src="actions/pcs.js?v=20260502o"></script>
+<script defer src="actions/pcs-longpress.js?v=20260502o"></script>
+<script defer src="actions/pcs-claude-caption.js?v=20260502o"></script>
+<script defer src="actions/pcs-polish.js?v=20260502o"></script>
+<script defer src="actions/pcs-select.js?v=20260502o"></script>
+<script src="ai-config.js?v=20260502o" defer></script>
 <script>
   (function() {
     try {
@@ -1322,12 +1322,12 @@ window.setPcsVisibility = function(el, vis) {
     } catch (e) {}
   })();
 </script>
-<script src="/srtd-next/dist/sorted-react.js?v=20260502m" defer></script>
-<script src="07-post-load.js?v=20260502m" defer></script>
-<script src="08-post-actions.js?v=20260502m" defer></script>
-<script src="09-library.js?v=20260502m" defer></script>
-<script src="09-approval.js?v=20260502m" defer></script>
-<script src="04-router.js?v=20260502m" defer></script>
+<script src="/srtd-next/dist/sorted-react.js?v=20260502o" defer></script>
+<script src="07-post-load.js?v=20260502o" defer></script>
+<script src="08-post-actions.js?v=20260502o" defer></script>
+<script src="09-library.js?v=20260502o" defer></script>
+<script src="09-approval.js?v=20260502o" defer></script>
+<script src="04-router.js?v=20260502o" defer></script>
 
 <div class="chase-toast" id="chase-toast"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -2897,7 +2897,9 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  z-index: 200;
+  /* Above Plan home overlay (z-index 1400); below CreatePost/PCS
+     modals (1500/1501) and Plan sheets (2200+) so they still cover it. */
+  z-index: 1450;
   transition: transform 0.22s cubic-bezier(0.34,1.56,0.64,1), background 0.2s;
 }
 .action-bar { display: none; }
@@ -2912,10 +2914,10 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .fab-icon { color: #080808; font-size: 22px; font-weight: 300; line-height: 1; user-select: none; }
 
 /* FAB menu */
-.fab-backdrop { position: fixed; inset: 0; background: #00000000; z-index: 198; pointer-events: none; transition: background 0.2s; }
+.fab-backdrop { position: fixed; inset: 0; background: #00000000; z-index: 1448; pointer-events: none; transition: background 0.2s; }
 .fab-backdrop.open { background: #0000008C; pointer-events: all; }
 
-.fab-menu { position: fixed; bottom: 134px; right: max(20px, calc(50% - 175px)); display: flex; flex-direction: column; gap: 10px; align-items: flex-end; z-index: 199; pointer-events: none; opacity: 0; transform: translateY(10px); transition: opacity 0.18s, transform 0.18s; }
+.fab-menu { position: fixed; bottom: 134px; right: max(20px, calc(50% - 175px)); display: flex; flex-direction: column; gap: 10px; align-items: flex-end; z-index: 1449; pointer-events: none; opacity: 0; transform: translateY(10px); transition: opacity 0.18s, transform 0.18s; }
 .fab-menu.open { pointer-events: all; opacity: 1; transform: translateY(0); }
 .fab-option { display: flex; align-items: center; gap: 10px; cursor: pointer; }
 .fab-option-label { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text2); background: #0d0d12; border: 1px dotted var(--dotline); padding: 7px 14px; white-space: nowrap; backdrop-filter: blur(8px); transition: color 0.15s, border-color 0.15s; }


### PR DESCRIPTION
## Problem

The "+" FAB and its **Create Post** option are completely unclickable.

**Root cause — z-index burial.** The Plan React surface mounts a full-screen overlay (`position:fixed; inset:0; z-index:1400`, `Plan.jsx:414-428`) and is on by default for every user (`planEnabled = plan_react !== '0'`). The vanilla FAB stack sits far below it:

| element | old z-index |
|---|---|
| `#fab` | 200 |
| `#fab-menu` | 199 |
| `#fab-backdrop` | 198 |

Plan's overlay paints over the entire FAB stack, so it receives zero pointer events.

## Fix (surgical, CSS-only)

Raise the FAB stack above the Plan overlay:

| element | new z-index |
|---|---|
| `#fab` | 1450 |
| `#fab-menu` | 1449 |
| `#fab-backdrop` | 1448 |

1450 is **above** Plan (1400) but **below** the CreatePost/PCS modals (1500/1501) and Plan sheets (2200+), so those still correctly cover the FAB when open.

No JS change needed — `10-ui.js`'s existing `#fab-create-post` handler already routes to the React Create Post modal (renders at z-index 1500, above Plan). The button just needed to be reachable.

## Notes

- Vanilla `#new-post-overlay` fallback (z-index 1000) is still below Plan — only reachable if the React bundle fails to load. Pre-existing, not a regression; left out of scope to keep this surgical.
- 28 `?v=` strings bumped `20260502m/n -> 20260502o`.

## Test plan

- [ ] Vitest: 579 passing (1 pre-existing env/transform failure in `appstate-sync.test.js`, unrelated — fails on clean tree too)
- [ ] Tap "+" FAB → menu opens over Plan home
- [ ] Tap "Create Post" → React Create Post modal opens above Plan
- [ ] Open Create Post / PCS / a Plan sheet → FAB correctly hidden behind it

https://claude.ai/code/session_01RtDNQakWVypAqwgUhgp3Na

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtDNQakWVypAqwgUhgp3Na)_